### PR TITLE
refactor(skills): redesign sync-pr with metadata sync and idempotent summary

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -94,7 +94,18 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 
 **b) 同步 type label**
 
-复用 `sync-pr` 的 type label 映射。
+根据 task.md 的 `type` 字段按下表映射：
+
+| task.md type | GitHub label |
+|---|---|
+| bug、bugfix | `type: bug` |
+| feature | `type: feature` |
+| enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
+| documentation | `type: documentation` |
+| dependency-upgrade | `type: dependency-upgrade` |
+| task | `type: task` |
+| 其他 | 跳过 |
 
 如果 task.md 的 `type` 可以映射到标准 type label，执行：
 

--- a/.agents/skills/sync-issue/SKILL.md
+++ b/.agents/skills/sync-issue/SKILL.md
@@ -158,10 +158,11 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 | bug、bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| 其他（含 refactoring 等） | 跳过 |
+| 其他 | 跳过 |
 
 如果映射到具体 label，执行：
 

--- a/.agents/skills/sync-pr/SKILL.md
+++ b/.agents/skills/sync-pr/SKILL.md
@@ -39,7 +39,14 @@ description: >
 - `refinement.md`、`refinement-r{N}.md` - 修复报告
 - 最高轮次的 `analysis.md` / `analysis-r{N}.md` - 需求分析（仅作为 `in:` label 的回退输入）
 
-### 4. 检查 label 体系是否已初始化
+### 4. 获取仓库坐标并检查 label 体系是否已初始化
+
+先获取仓库坐标，供后续 milestone 查询和评论同步复用：
+
+```bash
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+owner="${repo%%/*}"
+```
 
 执行：
 
@@ -60,10 +67,11 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 | bug、bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| 其他（含 refactor、refactoring） | 跳过 |
+| 其他 | 跳过 |
 
 如果映射到具体 label，执行：
 
@@ -203,11 +211,9 @@ gh issue view {issue-number} --json state
 
 ### 10. 生成或更新单条幂等审查摘要
 
-先获取仓库坐标，并拉取 PR 已有评论：
+复用步骤 4 已获取的仓库坐标，并拉取 PR 已有评论：
 
 ```bash
-repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
-owner="${repo%%/*}"
 pr_comments_jsonl="$(mktemp)"
 
 gh api "repos/$repo/issues/{pr-number}/comments" \
@@ -233,6 +239,7 @@ summary_comment_id="$(
 摘要内容要求：
 - 面向代码审查者，不重复罗列 PR diff 已经展示的文件变更
 - 从 `plan.md` 的 `## 决策`、`## 技术方法`、`## 实施步骤` 中提取 2-4 条关键技术决策
+- 关键技术决策的描述必须自包含，不要引用内部文档的编号或术语（如 `方案 A/B`）；审查者应能独立理解每条决策的含义
 - 从 `review.md`、`review-r{N}.md`、`refinement.md`、`refinement-r{N}.md` 构建审查历程表格
 - 从 `implementation.md` 或 `refinement.md` 的测试章节提取测试结果
 - 在关联表格中记录 Issue 状态
@@ -343,4 +350,5 @@ date "+%Y-%m-%d %H:%M:%S"
 - 任务未找到：提示 `Task {task-id} not found`
 - 缺少 PR 编号：提示 `Task has no pr_number field`
 - PR 未找到：提示 `PR #{number} not found`
+- PR 已关闭/已合并：提示 `PR #{number} is closed/merged, metadata sync skipped`
 - gh 认证失败：提示 `Please check GitHub CLI authentication`

--- a/templates/.agents/skills/create-pr/SKILL.md
+++ b/templates/.agents/skills/create-pr/SKILL.md
@@ -95,7 +95,18 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 
 **b) Sync the type label**
 
-Reuse the same type-label mapping as `sync-pr`.
+Map task.md `type` using this table:
+
+| task.md type | GitHub label |
+|---|---|
+| bug, bugfix | `type: bug` |
+| feature | `type: feature` |
+| enhancement | `type: enhancement` |
+| refactor, refactoring | `type: enhancement` |
+| documentation | `type: documentation` |
+| dependency-upgrade | `type: dependency-upgrade` |
+| task | `type: task` |
+| anything else | skip |
 
 If task.md `type` maps to a standard type label, run:
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -94,7 +94,18 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 
 **b) 同步 type label**
 
-复用 `sync-pr` 的 type label 映射。
+根据 task.md 的 `type` 字段按下表映射：
+
+| task.md type | GitHub label |
+|---|---|
+| bug、bugfix | `type: bug` |
+| feature | `type: feature` |
+| enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
+| documentation | `type: documentation` |
+| dependency-upgrade | `type: dependency-upgrade` |
+| task | `type: task` |
+| 其他 | 跳过 |
 
 如果 task.md 的 `type` 可以映射到标准 type label，执行：
 

--- a/templates/.agents/skills/sync-issue/SKILL.md
+++ b/templates/.agents/skills/sync-issue/SKILL.md
@@ -158,10 +158,11 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 | bug、bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| 其他（含 refactoring 等） | 跳过 |
+| 其他 | 跳过 |
 
 如果映射到具体 label，执行：
 

--- a/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
@@ -158,10 +158,11 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 | bug、bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| 其他（含 refactoring 等） | 跳过 |
+| 其他 | 跳过 |
 
 如果映射到具体 label，执行：
 

--- a/templates/.agents/skills/sync-pr/SKILL.md
+++ b/templates/.agents/skills/sync-pr/SKILL.md
@@ -39,7 +39,14 @@ Check and read these files if they exist:
 - `refinement.md`, `refinement-r{N}.md` - refinement reports
 - highest-round `analysis.md` / `analysis-r{N}.md` - analysis input only as fallback for `in:` labels
 
-### 4. Check Whether the Label System Has Been Initialized
+### 4. Resolve Repository Coordinates and Check Whether the Label System Has Been Initialized
+
+Resolve repository coordinates first so later milestone queries and comment sync steps can reuse them:
+
+```bash
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+owner="${repo%%/*}"
+```
 
 Run:
 
@@ -60,10 +67,11 @@ Map task.md `type` using this table:
 | bug, bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor, refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| anything else, including refactor or refactoring | skip |
+| anything else | skip |
 
 If the value maps to a label, run:
 
@@ -203,11 +211,9 @@ If task.md does not contain `issue_number`, record `Issue: N/A`.
 
 ### 10. Create or Update the Single Idempotent Review Summary
 
-First resolve repository coordinates and fetch existing PR comments:
+Reuse the repository coordinates resolved in step 4, then fetch existing PR comments:
 
 ```bash
-repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
-owner="${repo%%/*}"
 pr_comments_jsonl="$(mktemp)"
 
 gh api "repos/$repo/issues/{pr-number}/comments" \
@@ -233,6 +239,7 @@ summary_comment_id="$(
 Summary requirements:
 - target reviewers instead of restating the full PR diff
 - extract 2-4 key technical decisions from `## Decision`, `## Technical Approach`, and `## Implementation Steps` in `plan.md`
+- each key technical decision must be self-contained; do not reference internal document labels or jargon such as `Option A/B`
 - build a review-history table from `review.md`, `review-r{N}.md`, `refinement.md`, and `refinement-r{N}.md`
 - extract test results from `implementation.md` or `refinement.md`
 - include Issue state in the relationship table
@@ -343,4 +350,5 @@ View: https://github.com/{owner}/{repo}/pull/{pr-number}
 - Task not found: `Task {task-id} not found`
 - Missing PR number: `Task has no pr_number field`
 - PR not found: `PR #{number} not found`
+- PR is closed or merged: `PR #{number} is closed/merged, metadata sync skipped`
 - GitHub CLI auth failed: `Please check GitHub CLI authentication`

--- a/templates/.agents/skills/sync-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-pr/SKILL.zh-CN.md
@@ -39,7 +39,14 @@ description: >
 - `refinement.md`、`refinement-r{N}.md` - 修复报告
 - 最高轮次的 `analysis.md` / `analysis-r{N}.md` - 需求分析（仅作为 `in:` label 的回退输入）
 
-### 4. 检查 label 体系是否已初始化
+### 4. 获取仓库坐标并检查 label 体系是否已初始化
+
+先获取仓库坐标，供后续 milestone 查询和评论同步复用：
+
+```bash
+repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+owner="${repo%%/*}"
+```
 
 执行：
 
@@ -60,10 +67,11 @@ gh label list --search "type:" --limit 1 --json name --jq 'length'
 | bug、bugfix | `type: bug` |
 | feature | `type: feature` |
 | enhancement | `type: enhancement` |
+| refactor、refactoring | `type: enhancement` |
 | documentation | `type: documentation` |
 | dependency-upgrade | `type: dependency-upgrade` |
 | task | `type: task` |
-| 其他（含 refactor、refactoring） | 跳过 |
+| 其他 | 跳过 |
 
 如果映射到具体 label，执行：
 
@@ -203,11 +211,9 @@ gh issue view {issue-number} --json state
 
 ### 10. 生成或更新单条幂等审查摘要
 
-先获取仓库坐标，并拉取 PR 已有评论：
+复用步骤 4 已获取的仓库坐标，并拉取 PR 已有评论：
 
 ```bash
-repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
-owner="${repo%%/*}"
 pr_comments_jsonl="$(mktemp)"
 
 gh api "repos/$repo/issues/{pr-number}/comments" \
@@ -233,6 +239,7 @@ summary_comment_id="$(
 摘要内容要求：
 - 面向代码审查者，不重复罗列 PR diff 已经展示的文件变更
 - 从 `plan.md` 的 `## 决策`、`## 技术方法`、`## 实施步骤` 中提取 2-4 条关键技术决策
+- 关键技术决策的描述必须自包含，不要引用内部文档的编号或术语（如 `方案 A/B`）；审查者应能独立理解每条决策的含义
 - 从 `review.md`、`review-r{N}.md`、`refinement.md`、`refinement-r{N}.md` 构建审查历程表格
 - 从 `implementation.md` 或 `refinement.md` 的测试章节提取测试结果
 - 在关联表格中记录 Issue 状态
@@ -343,4 +350,5 @@ date "+%Y-%m-%d %H:%M:%S"
 - 任务未找到：提示 `Task {task-id} not found`
 - 缺少 PR 编号：提示 `Task has no pr_number field`
 - PR 未找到：提示 `PR #{number} not found`
+- PR 已关闭/已合并：提示 `PR #{number} is closed/merged, metadata sync skipped`
 - gh 认证失败：提示 `Please check GitHub CLI authentication`

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -122,6 +122,7 @@ test("sync-issue skill documents label sync and development linking", () => {
       /--remove-label/,
       /type: bug/,
       /\| bug(?:、|, )bugfix \| `type: bug` \|/,
+      /\| refactor(?:、|, )refactoring \| `type: enhancement` \|/,
       /type: feature/,
       /status: blocked/,
       /status: in-progress/,
@@ -202,16 +203,20 @@ test("sync-pr skill documents metadata sync and idempotent summary", () => {
     const content = read(relativePath);
 
     assertContainsPatterns(relativePath, [
+      /repo="\$\(gh repo view --json nameWithOwner --jq '\.nameWithOwner'\)"/,
       /<!-- sync-pr:\{task-id\}:summary -->/,
       /gh pr edit \{pr-number\} --add-label/,
       /gh label list --search "type:"/,
       /init-labels/,
       /type: bug/,
+      /\| refactor(?:、|, )refactoring \| `type: enhancement` \|/,
+      /方案 A\/B|Option A\/B/,
       /in: \{module\}/,
       /--milestone/,
       /Closes #\{issue-number\}/,
       /gh issue view \{issue-number\} --json state/,
       /gh api "repos\/\$repo\/issues\/comments\/\{comment-id\}" -X PATCH/,
+      /PR #\{number\} is closed\/merged, metadata sync skipped/,
       /date "\+%Y-%m-%d %H:%M:%S"/
     ]);
 
@@ -232,12 +237,22 @@ test("sync-pr skill documents metadata sync and idempotent summary", () => {
 
 test("create-pr skill documents metadata sync step", () => {
   skillDocPaths("create-pr").forEach((relativePath) => {
+    const content = read(relativePath);
+
     assertContainsPatterns(relativePath, [
       /--add-label/,
       /--milestone/,
+      /\| bug(?:、|, )bugfix \| `type: bug` \|/,
+      /\| refactor(?:、|, )refactoring \| `type: enhancement` \|/,
       /Closes #\{issue-number\}/,
       /sync-pr/
     ]);
+
+    assert.doesNotMatch(
+      content,
+      /复用 `sync-pr` 的 type label 映射|Reuse the same type-label mapping as `sync-pr`/,
+      `${relativePath} should inline the type-label mapping instead of delegating to sync-pr`
+    );
   });
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #6

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Redesign `sync-pr` from a free-form comment publisher into two clear responsibilities:

1. **PR Metadata Sync** — labels (type + in:), milestone, and development linking (`Closes #issue`), adapted from `sync-issue` steps 6-8 for the PR context (no status labels since PRs have native state)
2. **Single Idempotent Review Summary** — one updatable comment identified by `<!-- sync-pr:{task-id}:summary -->`, containing key technical decisions from `plan.md` and a review-history table

Additionally, embed metadata sync into `create-pr` so labels, milestone, and development linking are applied automatically at PR creation time.

## 📋 主要变更 / Brief Changelog

- Rewrite `sync-pr/SKILL.md` as a 12-step flow: metadata sync (steps 4-9) + idempotent summary (step 10)
- Add metadata sync step (step 8) to `create-pr/SKILL.md` for automatic label, milestone, and development linking
- Sync English and Chinese templates for both `sync-pr` and `create-pr` (4 template files)
- Add 2 test cases: `sync-pr skill documents metadata sync and idempotent summary` and `create-pr skill documents metadata sync step`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `node --test tests/*.test.js` — all 55 tests pass
2. Verify `sync-pr` no longer uses `gh pr comment` (old non-idempotent approach)
3. Verify `create-pr` references `--add-label`, `--milestone`, `Closes #{issue-number}`, and `sync-pr`
4. Verify step numbering is consecutive in all three `sync-pr` SKILL files

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 7 files changed, 1102 insertions(+), 209 deletions(-)
- Tests: 55 pass, 0 fail (2 new test cases added)
- Multi-AI collaboration: analyzed and reviewed by Claude, implemented and refined by Codex
- 2 review rounds, 1 refinement round — Major issues fixed: English template referencing Chinese plan.md section titles

---

**审查者注意事项 / Reviewer Notes:**

- Focus on `sync-pr` step 10 idempotent summary logic — verify the `<!-- sync-pr:{task-id}:summary -->` marker mechanism
- Confirm three `sync-pr` SKILL files (root, EN template, zh-CN template) use consistent step structure
- Verify `create-pr` step 8 metadata sync correctly references `sync-pr` strategies without duplicating full logic

Generated with AI assistance

Closes #6