### PR TITLE
fix(version): unify templateVersion format with v prefix

### DIFF
--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -80,7 +80,7 @@ const DEFAULTS = {
   }
 };
 
-const INSTALLER_VERSION = "0.3.1";
+const INSTALLER_VERSION = "v0.3.1";
 
 function norm(p) { return p.replace(/\\/g, '/'); }
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
 
-const { version: VERSION } = JSON.parse(
+const { version } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8')
 );
+const VERSION = `v${version}`;
 
 export { VERSION };

--- a/scripts/build-inline.js
+++ b/scripts/build-inline.js
@@ -22,7 +22,7 @@ const DEFAULTS_EXPR = [
 ].join('\n');
 
 const VERSION_EXPR = [
-  'const INSTALLER_VERSION = JSON.parse(',
+  "const INSTALLER_VERSION = 'v' + JSON.parse(",
   "  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')",
   ').version;'
 ].join('\n');
@@ -41,7 +41,7 @@ function buildInlineContent() {
 
   return source
     .replace(DEFAULTS_EXPR, `const DEFAULTS = ${JSON.stringify(defaults, null, 2)};`)
-    .replace(VERSION_EXPR, `const INSTALLER_VERSION = ${JSON.stringify(version)};`);
+    .replace(VERSION_EXPR, `const INSTALLER_VERSION = ${JSON.stringify(`v${version}`)};`);
 }
 
 function main() {

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -38,7 +38,7 @@ const DEFAULTS = JSON.parse(
   fs.readFileSync(new URL('../lib/defaults.json', import.meta.url), 'utf8')
 );
 
-const INSTALLER_VERSION = JSON.parse(
+const INSTALLER_VERSION = 'v' + JSON.parse(
   fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
 ).version;
 

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -80,7 +80,7 @@ const DEFAULTS = {
   }
 };
 
-const INSTALLER_VERSION = "0.3.1";
+const INSTALLER_VERSION = "v0.3.1";
 
 function norm(p) { return p.replace(/\\/g, '/'); }
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -58,7 +58,7 @@ test("cli version output stays in sync with package.json", () => {
     encoding: "utf8"
   });
 
-  assert.equal(output.trim(), `agent-infra ${pkg.version}`);
+  assert.equal(output.trim(), `agent-infra v${pkg.version}`);
 });
 
 test("agent-infra init generates seed files in a temp directory", () => {
@@ -76,6 +76,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     );
     assert.equal(config.project, "testproj");
     assert.equal(config.org, "testorg");
+    assert.equal(config.templateVersion, `v${JSON.parse(read("package.json")).version}`);
     assert.ok(!config.branchPrefix, "branchPrefix should not exist");
     assert.ok(!config.source, "consumer projects should not have source: self");
     assert.ok(!config.files.managed.includes(".mailmap"), ".mailmap should not be managed");

--- a/tests/sync-templates.test.js
+++ b/tests/sync-templates.test.js
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { loadFreshEsm } from "./helpers.js";
+import { loadFreshEsm, read } from "./helpers.js";
 
 function writeFile(root, relativePath, content) {
   const fullPath = path.join(root, relativePath);
@@ -105,6 +105,56 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
     assert.deepEqual(secondReport.ejected.created, []);
     assert.deepEqual(secondReport.ejected.skipped, ["local-only.md"]);
     assert.equal(afterSecondRun, afterFirstRun);
+  } finally {
+    os.homedir = originalHomedir;
+    childProcess.execSync = originalExecSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncTemplates falls back to the installer version with a v prefix when clone metadata is unavailable", async () => {
+  const originalHomedir = os.homedir;
+  const originalExecSync = childProcess.execSync;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-installer-version-"));
+
+  try {
+    const homeDir = path.join(tmpDir, "home");
+    const projectRoot = path.join(tmpDir, "project");
+    const templateRoot = path.join(tmpDir, "template-root");
+
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.mkdirSync(templateRoot, { recursive: true });
+
+    writeFile(templateRoot, "README.md", "Hello {{project}}\n");
+    writeJson(projectRoot, ".airc.json", {
+      project: "demo",
+      org: "acme",
+      language: "en",
+      templateSource: templateRoot,
+      modules: [],
+      files: {
+        managed: ["README.md"],
+        merged: [],
+        ejected: []
+      }
+    });
+
+    os.homedir = () => homeDir;
+    childProcess.execSync = (command) => {
+      if (command === "git remote get-url origin") {
+        throw new Error("not a git repo");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    };
+
+    const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
+    const report = syncTemplates(projectRoot);
+
+    assert.equal(
+      report.templateVersion,
+      `v${JSON.parse(read("package.json")).version}`
+    );
   } finally {
     os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #10

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

release 技能写入 `.airc.json` 的 `templateVersion` 使用 `"vX.Y.Z"` 格式（带 `v` 前缀），而 `sync-templates.js` 的 `INSTALLER_VERSION` 和 `lib/version.js` 的 `VERSION` 从 `package.json` 读取时使用 `"X.Y.Z"` 格式（无 `v` 前缀）。这导致执行 `/update-agent-infra` 或首次 `init` 后 `templateVersion` 格式与 release 产出不一致。

本 PR 在三个从 `package.json` 读取版本的边界点统一添加 `v` 前缀，确保版本字符串在整个生命周期中保持一致。

## 📋 主要变更 / Brief Changelog

- `lib/version.js`：导出 `VERSION` 时添加 `v` 前缀，影响 CLI 版本显示和 init 生成的 `templateVersion`
- `src/sync-templates.js`：`INSTALLER_VERSION` 添加 `v` 前缀，修复无 git 元数据时回退路径的版本格式
- `scripts/build-inline.js`：更新 `VERSION_EXPR` 匹配模式和内联替换逻辑，确保内联产物中的版本也带 `v` 前缀
- 重新生成内联产物（`.agents/` 和 `templates/` 中的 `sync-templates.js`）
- 新增两个测试：CLI init 路径的 `templateVersion` 断言和 sync-templates 无 git 回退路径测试

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node scripts/build-inline.js --check` — 内联产物一致性验证通过
2. `node --test tests/*.test.js` — 56/56 测试通过
3. `node bin/cli.js version` — 输出 `agent-infra v0.3.1`（带 `v` 前缀）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / N/A - no breaking changes
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 7 files changed, 60 insertions(+), 8 deletions(-)
- Tests: 56 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex
- 2 review rounds, 1 refinement round

---

**审查者注意事项 / Reviewer Notes:**

- `bin/cli.js version` 的输出从 `agent-infra 0.3.1` 变为 `agent-infra v0.3.1`，这是有意对齐 release/tag 格式
- 已有 `.airc.json` 中 `templateVersion` 为无 `v` 前缀的项目，下次 sync 时会被自动修正为带 `v` 前缀（一次性无害副作用）

Generated with AI assistance

Closes #10