### PR TITLE
fix(skills): ensure sync-issue summary comment stays last

### DIFF
--- a/.agents/skills/sync-issue/SKILL.md
+++ b/.agents/skills/sync-issue/SKILL.md
@@ -408,11 +408,13 @@ summary_comment_id="$(
 )"
 ```
 
+在步骤 9 结束前，基于上述已发布/未发布结果，预先判断 `has_unpublished_artifacts`：是否存在任何尚未发布的非 `summary` 产物。该判断在步骤 10 执行期间保持不变，仅用于决定 `summary` 是原地更新还是删除后在尾部重建。
+
 幂等要求：
 - 第一次执行时，只发布当前已存在产物对应的文件评论
 - 第二次执行时，必须跳过已发布文件，只补发新增产物（例如 `implementation-r2`、`review-r2`）
 - 如果所有产物文件评论都已发布，且 `summary` 内容没有变化，则本次不发布任何新评论
-- 如果 `summary` 已发布但交付状态发生变化，只更新原评论，不新增第二条 summary 评论
+- 如果 `summary` 已发布但交付状态发生变化：当本次有新产物发布时，删除旧 `summary` 并在尾部重建；当本次无新产物发布时，原地更新原评论
 
 ### 10. 按时间线逐条发布上下文文件
 
@@ -502,18 +504,29 @@ EOF
 )"
 ```
 
-**d) 仅更新已有 summary 评论**
+**d) 发布或重建 summary 评论**
 
-如果 `summary` 标识已存在，且新生成内容与已有内容不同，则编辑原评论：
+`summary` 必须始终保持为最后一条评论。根据以下条件决定处理方式：
+
+- `summary` 不存在：按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=true`：先删除旧 `summary` 评论，再按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且新生成内容与已有内容不同：原地更新原评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且内容相同：不做任何操作
+
+删除旧 `summary` 评论时，执行：
 
 ```bash
-gh api "repos/$repo/issues/comments/{comment-id}" -X PATCH -f body="$(cat <<'EOF'
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X DELETE
+```
+
+原地更新已有 `summary` 评论时，执行：
+
+```bash
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X PATCH -f body="$(cat <<'EOF'
 {comment-body}
 EOF
 )"
 ```
-
-如果内容相同，则不做任何操作。
 
 **e) 零操作场景**
 

--- a/templates/.agents/skills/sync-issue/SKILL.md
+++ b/templates/.agents/skills/sync-issue/SKILL.md
@@ -408,11 +408,13 @@ summary_comment_id="$(
 )"
 ```
 
+在步骤 9 结束前，基于上述已发布/未发布结果，预先判断 `has_unpublished_artifacts`：是否存在任何尚未发布的非 `summary` 产物。该判断在步骤 10 执行期间保持不变，仅用于决定 `summary` 是原地更新还是删除后在尾部重建。
+
 幂等要求：
 - 第一次执行时，只发布当前已存在产物对应的文件评论
 - 第二次执行时，必须跳过已发布文件，只补发新增产物（例如 `implementation-r2`、`review-r2`）
 - 如果所有产物文件评论都已发布，且 `summary` 内容没有变化，则本次不发布任何新评论
-- 如果 `summary` 已发布但交付状态发生变化，只更新原评论，不新增第二条 summary 评论
+- 如果 `summary` 已发布但交付状态发生变化：当本次有新产物发布时，删除旧 `summary` 并在尾部重建；当本次无新产物发布时，原地更新原评论
 
 ### 10. 按时间线逐条发布上下文文件
 
@@ -502,18 +504,29 @@ EOF
 )"
 ```
 
-**d) 仅更新已有 summary 评论**
+**d) 发布或重建 summary 评论**
 
-如果 `summary` 标识已存在，且新生成内容与已有内容不同，则编辑原评论：
+`summary` 必须始终保持为最后一条评论。根据以下条件决定处理方式：
+
+- `summary` 不存在：按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=true`：先删除旧 `summary` 评论，再按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且新生成内容与已有内容不同：原地更新原评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且内容相同：不做任何操作
+
+删除旧 `summary` 评论时，执行：
 
 ```bash
-gh api "repos/$repo/issues/comments/{comment-id}" -X PATCH -f body="$(cat <<'EOF'
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X DELETE
+```
+
+原地更新已有 `summary` 评论时，执行：
+
+```bash
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X PATCH -f body="$(cat <<'EOF'
 {comment-body}
 EOF
 )"
 ```
-
-如果内容相同，则不做任何操作。
 
 **e) 零操作场景**
 

--- a/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
@@ -408,11 +408,13 @@ summary_comment_id="$(
 )"
 ```
 
+在步骤 9 结束前，基于上述已发布/未发布结果，预先判断 `has_unpublished_artifacts`：是否存在任何尚未发布的非 `summary` 产物。该判断在步骤 10 执行期间保持不变，仅用于决定 `summary` 是原地更新还是删除后在尾部重建。
+
 幂等要求：
 - 第一次执行时，只发布当前已存在产物对应的文件评论
 - 第二次执行时，必须跳过已发布文件，只补发新增产物（例如 `implementation-r2`、`review-r2`）
 - 如果所有产物文件评论都已发布，且 `summary` 内容没有变化，则本次不发布任何新评论
-- 如果 `summary` 已发布但交付状态发生变化，只更新原评论，不新增第二条 summary 评论
+- 如果 `summary` 已发布但交付状态发生变化：当本次有新产物发布时，删除旧 `summary` 并在尾部重建；当本次无新产物发布时，原地更新原评论
 
 ### 10. 按时间线逐条发布上下文文件
 
@@ -502,18 +504,29 @@ EOF
 )"
 ```
 
-**d) 仅更新已有 summary 评论**
+**d) 发布或重建 summary 评论**
 
-如果 `summary` 标识已存在，且新生成内容与已有内容不同，则编辑原评论：
+`summary` 必须始终保持为最后一条评论。根据以下条件决定处理方式：
+
+- `summary` 不存在：按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=true`：先删除旧 `summary` 评论，再按步骤 10c 发布新的 `summary` 评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且新生成内容与已有内容不同：原地更新原评论
+- `summary` 已存在且 `has_unpublished_artifacts=false` 且内容相同：不做任何操作
+
+删除旧 `summary` 评论时，执行：
 
 ```bash
-gh api "repos/$repo/issues/comments/{comment-id}" -X PATCH -f body="$(cat <<'EOF'
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X DELETE
+```
+
+原地更新已有 `summary` 评论时，执行：
+
+```bash
+gh api "repos/$repo/issues/comments/{summary_comment_id}" -X PATCH -f body="$(cat <<'EOF'
 {comment-body}
 EOF
 )"
 ```
-
-如果内容相同，则不做任何操作。
 
 **e) 零操作场景**
 

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -183,7 +183,7 @@ test("sync-issue skill documents issue type sync, timeline comments, and absolut
       /仅当 Activity Log 引用的文件当前存在于任务目录中时，才纳入待发布集合|Only include files that still exist in the task directory/,
       /summary` 始终排在最末|`summary` is always last/,
       /不要再使用固定 5 步骤，也不要把同类型多轮次产物合并到一条评论|Do not fall back to a fixed 5-step order, and do not merge multiple rounds of the same artifact type into a single comment/,
-      /gh api "repos\/\$repo\/issues\/comments\/\{comment-id\}" -X PATCH/,
+      /gh api "repos\/\$repo\/issues\/comments\/\{summary_comment_id\}" -X PATCH/,
       /https:\/\/github\.com\/\{owner\}\/\{repo\}\/commit\/\{commit-hash\}/,
       /https:\/\/github\.com\/\{owner\}\/\{repo\}\/pull\/\{pr-number\}/,
       /implementation-r\*\.md/,


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #12

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

执行 `/sync-issue` 后，summary（交付摘要）评论出现在 Issue 评论列表的中间位置而非末尾。原因是首次同步时 summary 与早期产物一起发布排在最后，后续再次同步时新产物追加在 summary 之后，而步骤 10d 对已有 summary 执行原地更新（PATCH），导致 summary 位置固定不动。

本 PR 在步骤 9 引入 `has_unpublished_artifacts` 前置判断，在步骤 10d 实现条件删除+尾部重建策略：当有新产物发布时先删除旧 summary 再在末尾重建，无新产物时保持原地更新。

## 📋 主要变更 / Brief Changelog

- 步骤 9：新增 `has_unpublished_artifacts` 静态前置判断，基于已发布/未发布集合预先确定 summary 处理策略
- 步骤 9：更新幂等要求说明，区分有/无新产物时的 summary 处理方式
- 步骤 10d：从"仅更新已有 summary"重写为四分支条件逻辑（不存在→创建 / 存在+有新产物→删除重建 / 存在+无新产物+内容变化→原地更新 / 存在+无新产物+内容相同→跳过）
- 步骤 10d：统一 PATCH 命令占位符从 `{comment-id}` 为 `{summary_comment_id}`
- 三文件同步：项目版本、英文模板、中文模板保持一致
- 测试断言同步更新

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 56/56 通过
2. `diff` 确认三个同构技能文件完全一致
3. 场景验证：首次同步 summary 在末尾；二次同步有新产物时 summary 删除重建到末尾；无新产物时原地更新

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 4 files changed, 58 insertions(+), 19 deletions(-)
- Tests: 56 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex
- 2 review rounds, 1 refinement round

---

**审查者注意事项 / Reviewer Notes:**

- 删除旧 summary 评论会丢失该评论上的 reactions，这是有意的设计取舍（summary 是自动生成的状态摘要，不是讨论帖）
- 确认三份 SKILL.md 步骤 9 和步骤 10d 的变更保持一致

Closes #12

Generated with AI assistance