### PR TITLE
refactor(templates): embed skill authoring conventions in system prompts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -172,6 +172,19 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 **协作指南**：`.agents/README.md`
 
+## Skill 编写规范
+
+编写或维护 `.agents/skills/*/SKILL.md` 及其模板时，步骤编号遵循以下规则：
+
+1. 顶级步骤使用连续整数：`1.`、`2.`、`3.`。
+2. 只有父步骤下的从属动作才使用子步骤：`1.1`、`1.2`、`2.1`。
+3. 同一步中的分支、条件或多种可能性使用 `a`、`b`、`c` 标记。
+4. 不要使用 `1.5`、`2.5` 这类中间编号；如新增独立步骤，应整体顺延后续编号。
+5. 调整编号时，必须同步更新文中的步骤引用，确保说明、命令和检查点一致。
+6. 长 bash 脚本应从 SKILL.md 提取到同级 `scripts/` 目录中，SKILL.md 只保留单行调用（如 `bash .agents/skills/<skill>/scripts/<script>.sh`）和对脚本职责的概要说明。
+
+<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->
+
 ## 安全注意事项
 
 - 不要提交：`.env`、credentials、密钥

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,19 @@ refactor(module): refactor internal logic
 
 **技术栈**：Shell（POSIX sh）、Node.js（内置测试运行器 `node:test`）、Markdown、TOML、JSON
 
+## Skill 编写规范
+
+编写或维护 `.agents/skills/*/SKILL.md` 及其模板时，步骤编号遵循以下规则：
+
+1. 顶级步骤使用连续整数：`1.`、`2.`、`3.`。
+2. 只有父步骤下的从属动作才使用子步骤：`1.1`、`1.2`、`2.1`。
+3. 同一步中的分支、条件或多种可能性使用 `a`、`b`、`c` 标记。
+4. 不要使用 `1.5`、`2.5` 这类中间编号；如新增独立步骤，应整体顺延后续编号。
+5. 调整编号时，必须同步更新文中的步骤引用，确保说明、命令和检查点一致。
+6. 长 bash 脚本应从 SKILL.md 提取到同级 `scripts/` 目录中，SKILL.md 只保留单行调用（如 `bash .agents/skills/<skill>/scripts/<script>.sh`）和对脚本职责的概要说明。
+
+<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->
+
 ---
 
 **基于标准**: [AGENTS.md](https://agents.md) (Linux Foundation AAIF)

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -157,6 +157,19 @@ This project supports Claude Code, Codex, Gemini CLI, OpenCode.
 
 **Collaboration guide**: `.agents/README.md`
 
+## Skill Authoring Conventions
+
+When writing or updating `.agents/skills/*/SKILL.md` files, keep step numbering consistent:
+
+1. Use consecutive integers for top-level steps: `1.`, `2.`, `3.`.
+2. Use nested numbering only for child actions that belong to a parent step: `1.1`, `1.2`, `2.1`.
+3. Use `a`, `b`, and `c` markers for branches, conditions, or alternative paths within the same step.
+4. Do not use intermediate numbers such as `1.5` or `2.5`; if a new standalone step is needed, renumber the following top-level steps.
+5. When renumbering, update every in-document step reference so the instructions remain accurate.
+6. Extract long bash scripts into a sibling `scripts/` directory; the SKILL.md should contain only a single-line invocation (e.g., `bash .agents/skills/<skill>/scripts/<script>.sh`) and a brief summary of the script's responsibilities.
+
+<!-- Canonical source: .agents/README.md - keep in sync -->
+
 ## Security
 
 - Do not commit: `.env`, credentials, keys

--- a/templates/.claude/CLAUDE.zh-CN.md
+++ b/templates/.claude/CLAUDE.zh-CN.md
@@ -157,6 +157,19 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 **协作指南**：`.agents/README.md`
 
+## Skill 编写规范
+
+编写或维护 `.agents/skills/*/SKILL.md` 时，步骤编号遵循以下规则：
+
+1. 顶级步骤使用连续整数：`1.`、`2.`、`3.`。
+2. 只有父步骤下的从属动作才使用子步骤：`1.1`、`1.2`、`2.1`。
+3. 同一步中的分支、条件或多种可能性使用 `a`、`b`、`c` 标记。
+4. 不要使用 `1.5`、`2.5` 这类中间编号；如新增独立步骤，应整体顺延后续编号。
+5. 调整编号时，必须同步更新文中的步骤引用，确保说明、命令和检查点一致。
+6. 长 bash 脚本应从 SKILL.md 提取到同级 `scripts/` 目录中，SKILL.md 只保留单行调用（如 `bash .agents/skills/<skill>/scripts/<script>.sh`）和对脚本职责的概要说明。
+
+<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->
+
 ## 安全注意事项
 
 - 不要提交：`.env`、credentials、密钥

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -86,6 +86,19 @@ All code-level content uses **English**. Documentation provides **multilingual v
 
 <!-- TODO: Add your project's tech stack here -->
 
+## Skill Authoring Conventions
+
+When writing or updating `.agents/skills/*/SKILL.md` files, keep step numbering consistent:
+
+1. Use consecutive integers for top-level steps: `1.`, `2.`, `3.`.
+2. Use nested numbering only for child actions that belong to a parent step: `1.1`, `1.2`, `2.1`.
+3. Use `a`, `b`, and `c` markers for branches, conditions, or alternative paths within the same step.
+4. Do not use intermediate numbers such as `1.5` or `2.5`; if a new standalone step is needed, renumber the following top-level steps.
+5. When renumbering, update every in-document step reference so the instructions remain accurate.
+6. Extract long bash scripts into a sibling `scripts/` directory; the SKILL.md should contain only a single-line invocation (e.g., `bash .agents/skills/<skill>/scripts/<script>.sh`) and a brief summary of the script's responsibilities.
+
+<!-- Canonical source: .agents/README.md - keep in sync -->
+
 ---
 
 **Based on standard**: [AGENTS.md](https://agents.md) (Linux Foundation AAIF)

--- a/templates/AGENTS.zh-CN.md
+++ b/templates/AGENTS.zh-CN.md
@@ -86,6 +86,19 @@ refactor(module): refactor internal logic
 
 <!-- TODO: 在此添加你的项目技术栈 -->
 
+## Skill 编写规范
+
+编写或维护 `.agents/skills/*/SKILL.md` 时，步骤编号遵循以下规则：
+
+1. 顶级步骤使用连续整数：`1.`、`2.`、`3.`。
+2. 只有父步骤下的从属动作才使用子步骤：`1.1`、`1.2`、`2.1`。
+3. 同一步中的分支、条件或多种可能性使用 `a`、`b`、`c` 标记。
+4. 不要使用 `1.5`、`2.5` 这类中间编号；如新增独立步骤，应整体顺延后续编号。
+5. 调整编号时，必须同步更新文中的步骤引用，确保说明、命令和检查点一致。
+6. 长 bash 脚本应从 SKILL.md 提取到同级 `scripts/` 目录中，SKILL.md 只保留单行调用（如 `bash .agents/skills/<skill>/scripts/<script>.sh`）和对脚本职责的概要说明。
+
+<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->
+
 ---
 
 **基于标准**: [AGENTS.md](https://agents.md) (Linux Foundation AAIF)

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   buildCommandSyncFiles,
+  escapeRegExp,
   exists,
   langTemplate,
   listFilesRecursive,
@@ -150,6 +151,63 @@ test("assistant template docs use import commands and analyze-task naming", () =
     assert.match(content, /import-codescan/, `${relativePath} should reference import-codescan`);
     assert.doesNotMatch(content, /analyze-dependabot/, `${relativePath} should not reference analyze-dependabot`);
     assert.doesNotMatch(content, /analyze-codescan/, `${relativePath} should not reference analyze-codescan`);
+  });
+});
+
+test("system prompt templates embed skill authoring conventions from the collaboration guide", () => {
+  [
+    {
+      sourcePath: "templates/.agents/README.md",
+      heading: "## Skill Authoring Conventions",
+      nextHeading: "## ",
+      comment: "<!-- Canonical source: .agents/README.md - keep in sync -->",
+      replacements: [
+        ["files and their templates, keep", "files, keep"]
+      ],
+      targets: [
+        "templates/.claude/CLAUDE.md",
+        "templates/AGENTS.md"
+      ]
+    },
+    {
+      sourcePath: "templates/.agents/README.zh-CN.md",
+      heading: "## Skill 编写规范",
+      nextHeading: "## ",
+      comment: "<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->",
+      replacements: [
+        ["及其模板时", "时"]
+      ],
+      targets: [
+        "templates/.claude/CLAUDE.zh-CN.md",
+        "templates/AGENTS.zh-CN.md"
+      ]
+    }
+  ].forEach(({ sourcePath, heading, nextHeading, comment, replacements, targets }) => {
+    const source = read(sourcePath);
+    const [, sourceSection] = source.match(
+      new RegExp(`${escapeRegExp(heading)}\\n\\n([\\s\\S]*?)(?=\\n${escapeRegExp(nextHeading)}|\\s*$)`)
+    ) ?? [];
+
+    assert.ok(sourceSection, `${sourcePath} should define the canonical conventions`);
+
+    const sectionForTemplates = (replacements ?? []).reduce(
+      (section, [from, to]) => section.replace(from, to),
+      sourceSection.trim()
+    );
+
+    const expected = [
+      heading,
+      sectionForTemplates,
+      comment
+    ].join("\n\n");
+
+    targets.forEach((relativePath) => {
+      assert.match(
+        read(relativePath),
+        new RegExp(escapeRegExp(expected)),
+        `${relativePath} should embed the canonical skill authoring conventions`
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #32

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

Skill 编写规范（步骤编号规则、脚本提取规则等）仅存在于 `.agents/README.md` 协作指南中，AI 代理在工作时加载的系统提示词（`.claude/CLAUDE.md`、`AGENTS.md`）不包含该规范，导致编写/更新 Skill 时频繁出现不规范问题。本 PR 将 Skill 编写规范嵌入系统提示词模板和本项目工作文件中，确保所有 AI 代理始终遵循规范。

## 📋 主要变更 / Brief Changelog

- 在 `templates/.claude/CLAUDE.md` 和 `templates/AGENTS.md`（英文版）中新增 `## Skill Authoring Conventions` 独立章节
- 在 `templates/.claude/CLAUDE.zh-CN.md` 和 `templates/AGENTS.zh-CN.md`（中文版）中新增 `## Skill 编写规范` 独立章节
- 模板文件中移除"及其模板" / "and their templates"字样（目标项目无模板概念）
- 在本项目工作文件 `.claude/CLAUDE.md` 和 `AGENTS.md` 中同步添加规范章节，保留"及其模板"
- 新增回归测试，从权威来源动态提取规范内容校验 4 个模板文件，使用 `replacements` 机制处理模板与权威来源的受控差异

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 57/57 通过
2. 对比 4 个模板文件内容与 `templates/.agents/README.md` 权威来源一致（除受控差异外）
3. 确认本项目工作文件包含"及其模板"，模板文件不包含

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 7 files changed, 136 insertions(+)
- Tests: 57 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex
- 4 review rounds, 3 refinement rounds

---

**审查者注意事项 / Reviewer Notes:**

- 规范内容的权威来源仍为 `.agents/README.md`，模板和工作文件中均添加了 `<!-- Canonical source -->` 注释标注同步义务
- 模板文件与权威来源有一处受控差异：模板移除了"及其模板"/"and their templates"字样，回归测试通过 `replacements` 机制显式记录该差异
- 本项目工作文件（`.claude/CLAUDE.md`、`AGENTS.md`）保留"及其模板"，因为本项目自身维护模板

Closes #32

Generated with AI assistance