### PR TITLE
refactor(install): remove clone install mode entirely

### DIFF
--- a/.agents/skills/update-agent-infra/SKILL.md
+++ b/.agents/skills/update-agent-infra/SKILL.md
@@ -25,7 +25,7 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
 脚本读取 `.agent-infra/config.json`（含 `templateSource`，默认 `templates/`），自动完成：
-- git pull 拉取最新模板
+- 检测模板源版本
 - 同步文件注册表（`defaults.json` → `.agent-infra/config.json`）
 - 处理所有 managed 文件（语言选择 → 排除 merged/ejected → 占位符渲染 → 覆盖写入）
 - 处理 ejected 文件（仅首次安装时创建）

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -2,7 +2,7 @@
 /**
  * sync-templates.js — Deterministic template sync for managed & ejected files.
  *
- * Handles SKILL steps: 2 (git pull), 3.0 (registry sync), 4 (managed),
+ * Handles SKILL steps: 2 (detect template source version), 3.0 (registry sync), 4 (managed),
  * 6 (ejected), 7 (.agent-infra/config.json update).
  *
  * Merged files (step 5) are NOT handled — they require AI semantic merge.
@@ -16,23 +16,8 @@
 
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-// Keep these helpers aligned with lib/paths.js for clone installs.
-function resolveInstallDir() {
-  return path.join(os.homedir(), '.agent-infra');
-}
-
-function resolveTemplateDir() {
-  const clonePath = path.join(resolveInstallDir(), 'templates');
-  if (fs.existsSync(clonePath)) {
-    return clonePath;
-  }
-
-  return null;
-}
 
 const RETIRED_FILE_ENTRIES = new Set([
   '.agent-workspace/README.md',
@@ -143,34 +128,17 @@ function renderPathname(p, project) {
 }
 
 function resolveProjectTemplateDir(projectRoot, templateSource) {
-  const fallbackRoot = resolveTemplateDir();
+  if (!templateSource) return null;
 
-  const candidates = [];
-  if (templateSource) {
-    if (path.isAbsolute(templateSource)) {
-      candidates.push(templateSource);
-    } else {
-      if (fallbackRoot) {
-        candidates.push(path.resolve(path.dirname(fallbackRoot), templateSource));
-      }
-      candidates.push(path.resolve(projectRoot, templateSource));
-    }
-  }
-  if (fallbackRoot) {
-    candidates.push(fallbackRoot);
-  }
+  const candidate = path.isAbsolute(templateSource)
+    ? templateSource
+    : path.resolve(projectRoot, templateSource);
 
-  for (const candidate of candidates) {
-    try {
-      if (fs.statSync(candidate).isDirectory()) {
-        return candidate;
-      }
-    } catch {
-      // Keep scanning until a valid directory is found.
-    }
+  try {
+    return fs.statSync(candidate).isDirectory() ? candidate : null;
+  } catch {
+    return null;
   }
-
-  return null;
 }
 
 function isBinary(fp) {
@@ -252,34 +220,9 @@ function syncTemplates(projectRoot) {
   pruneRetiredConfig(cfg);
   const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
   if (!templateRoot) {
-    return { error: 'Template source not found. Install: curl -fsSL https://raw.githubusercontent.com/fitlab-ai/agent-infra/main/install.sh | sh' };
+    return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
-  const installDir = resolveInstallDir();
-
-  const hasGit = fs.existsSync(path.join(installDir, '.git'));
-  if (hasGit) {
-    try { childProcess.execSync('git fetch --tags --quiet', { cwd: installDir, stdio: 'pipe' }); } catch { /* network */ }
-  }
-
-  let version = 'unknown';
-  if (hasGit) {
-    let tagOutput;
-    try {
-      tagOutput = childProcess.execSync('git tag --sort=-v:refname', {
-        cwd: installDir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-      }).trim();
-    } catch {
-      return { error: 'Failed to list tags in agent-infra repository. Please check git installation.' };
-    }
-    const latestTag = tagOutput.split('\n')[0];
-    if (!latestTag) {
-      return { error: 'No tags found in agent-infra repository. This is unexpected — please reinstall.' };
-    }
-    try { childProcess.execFileSync('git', ['checkout', latestTag, '--quiet'], { cwd: installDir, stdio: 'pipe' }); } catch { /* ignore */ }
-    version = latestTag;
-  } else {
-    version = INSTALLER_VERSION || version;
-  }
+  const version = INSTALLER_VERSION;
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -435,8 +378,7 @@ function syncTemplates(projectRoot) {
   );
 
   const projUrl = gitUrl(projectRoot);
-  const instUrl = gitUrl(installDir);
-  report.selfUpdate = !!(projUrl && instUrl && projUrl === instUrl);
+  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Open the project in any AI TUI and run `update-agent-infra`:
 | Gemini CLI | `/{{project}}:update-agent-infra` |
 | OpenCode | `/update-agent-infra` |
 
-This pulls the latest templates and renders all managed files. The same command is used both for first-time setup and for future template upgrades.
+This detects the packaged template version and renders all managed files. The same command is used both for first-time setup and for future template upgrades.
 
 <a id="architecture-overview"></a>
 
@@ -171,7 +171,7 @@ agent-infra is intentionally simple: a bootstrap CLI creates the seed configurat
 
 1. **Install** — `npm install -g @fitlab-ai/agent-infra` (or use the shell script wrapper)
 2. **Initialize** — `ai init` in the project root to generate `.agent-infra/config.json` and install the seed command
-3. **Render** — run `update-agent-infra` in any AI TUI to pull templates and generate all managed files
+3. **Render** — run `update-agent-infra` in any AI TUI to detect the bundled template version and generate all managed files
 4. **Develop** — use 28 built-in skills to drive the full lifecycle: `analysis → design → implementation → review → fix → commit`
 5. **Update** — run `update-agent-infra` again whenever a new template version is available
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 | Gemini CLI | `/{{project}}:update-agent-infra` |
 | OpenCode | `/update-agent-infra` |
 
-该命令会拉取最新模板并渲染所有受管理文件。首次安装和后续升级都使用同一条命令。
+该命令会检测当前打包模板版本并渲染所有受管理文件。首次安装和后续升级都使用同一条命令。
 
 <a id="architecture-overview"></a>
 
@@ -171,7 +171,7 @@ agent-infra 的结构刻意保持简单：引导 CLI 负责生成种子配置，
 
 1. **安装** — `npm install -g @fitlab-ai/agent-infra`（或使用 shell 脚本便捷封装）
 2. **初始化** — 在项目根目录运行 `ai init`，生成 `.agent-infra/config.json` 并安装种子命令
-3. **渲染** — 在任意 AI TUI 中执行 `update-agent-infra`，拉取模板并生成所有受管理文件
+3. **渲染** — 在任意 AI TUI 中执行 `update-agent-infra`，检测当前打包模板版本并生成所有受管理文件
 4. **开发** — 使用 28 个内置 skill 驱动完整生命周期：`analysis → design → implementation → review → fix → commit`
 5. **升级** — 有新模板版本时再次执行 `update-agent-infra` 即可
 

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,12 @@
 set -e
 
 NPM_PACKAGE="@fitlab-ai/agent-infra"
-LEGACY_DIR="$HOME/.agent-infra"
-LEGACY_BIN_DIR="$HOME/.local/bin"
 
 # ---------- helpers ----------
 info()  { printf '  \033[1;34m>\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
 warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*"; }
 err()   { printf '  \033[1;31m✗\033[0m %s\n' "$*" >&2; }
-
-legacy_link_target() {
-  target_path=$1
-  if [ ! -L "$target_path" ]; then
-    return 1
-  fi
-  readlink "$target_path" 2>/dev/null || return 1
-}
 
 # ---------- pre-checks ----------
 if ! command -v node >/dev/null 2>&1; then
@@ -39,34 +29,6 @@ if ! command -v npm >/dev/null 2>&1; then
   err "npm is required but not found."
   err "npm is bundled with Node.js >= 18. Please reinstall Node.js: https://nodejs.org/"
   exit 1
-fi
-
-# ---------- detect legacy clone install ----------
-if [ -d "$LEGACY_DIR" ]; then
-  echo ""
-  warn "Detected legacy clone install at $LEGACY_DIR"
-  warn "This script now installs via npm. The old clone directory is no longer needed."
-  warn "After verifying the npm install works, you can remove it:"
-  echo "    rm -rf $LEGACY_DIR"
-  echo ""
-fi
-
-LEGACY_LINK_DETECTED=0
-
-for legacy_link in "$LEGACY_BIN_DIR/ai" "$LEGACY_BIN_DIR/agent-infra"; do
-  link_target=$(legacy_link_target "$legacy_link" || true)
-  case "$link_target" in
-    *".agent-infra"*)
-      LEGACY_LINK_DETECTED=1
-      ;;
-  esac
-done
-
-if [ "$LEGACY_LINK_DETECTED" -eq 1 ]; then
-  warn "Detected legacy symlink under $LEGACY_BIN_DIR"
-  warn "After verifying the npm install works, you can remove it:"
-  echo "    rm -f $LEGACY_BIN_DIR/ai $LEGACY_BIN_DIR/agent-infra"
-  echo ""
 fi
 
 # ---------- install via npm ----------

--- a/lib/init.js
+++ b/lib/init.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { info, ok, err } from './log.js';
 import { prompt, closePrompt } from './prompt.js';
-import { resolveTemplateDir, resolveInstallDir, isCloneInstall } from './paths.js';
+import { resolveTemplateDir } from './paths.js';
 import { renderFile, copySkillDir } from './render.js';
 import { VERSION } from './version.js';
 
@@ -50,23 +50,8 @@ async function cmdInit() {
   if (!templateDir) {
     err('Template directory not found.');
     err('Install via npm: npm install -g @fitlab-ai/agent-infra');
-    err('Or via clone: curl -fsSL https://raw.githubusercontent.com/fitlab-ai/agent-infra/main/install.sh | sh');
     process.exitCode = 1;
     return;
-  }
-
-  // auto-update: only for clone installs
-  if (isCloneInstall()) {
-    const installDir = resolveInstallDir();
-    if (fs.existsSync(path.join(installDir, '.git'))) {
-      info('Updating templates to latest version...');
-      try {
-        execSync('git pull --rebase --quiet', { cwd: installDir, stdio: 'pipe' });
-        ok('Templates updated.');
-      } catch {
-        err('Failed to update templates (network issue?). Using local version.');
-      }
-    }
   }
 
   const configPath = path.join('.agent-infra', 'config.json');

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,48 +1,9 @@
-import path from 'node:path';
 import fs from 'node:fs';
-import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-function resolveBundledTemplateDir() {
-  return fileURLToPath(new URL('../templates', import.meta.url));
-}
-
-function resolveCloneTemplateDir() {
-  return path.join(os.homedir(), '.agent-infra', 'templates');
-}
-
-function normalizePath(targetPath) {
-  try {
-    return fs.realpathSync(targetPath);
-  } catch {
-    return path.resolve(targetPath);
-  }
-}
-
 function resolveTemplateDir() {
-  // npm install mode: templates shipped alongside the package
-  const npmPath = resolveBundledTemplateDir();
-  if (fs.existsSync(npmPath)) {
-    return npmPath;
-  }
-
-  // clone install mode: ~/.agent-infra/templates
-  const clonePath = resolveCloneTemplateDir();
-  if (fs.existsSync(clonePath)) {
-    return clonePath;
-  }
-
-  return null;
+  const bundledDir = fileURLToPath(new URL('../templates', import.meta.url));
+  return fs.existsSync(bundledDir) ? bundledDir : null;
 }
 
-function resolveInstallDir() {
-  return path.join(os.homedir(), '.agent-infra');
-}
-
-function isCloneInstall() {
-  const npmPath = resolveBundledTemplateDir();
-  const clonePath = resolveCloneTemplateDir();
-  return fs.existsSync(npmPath) && normalizePath(npmPath) === normalizePath(clonePath);
-}
-
-export { resolveTemplateDir, resolveInstallDir, isCloneInstall };
+export { resolveTemplateDir };

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
 import { info, ok, err } from './log.js';
-import { resolveTemplateDir, resolveInstallDir, isCloneInstall } from './paths.js';
+import { resolveTemplateDir } from './paths.js';
 import { renderFile, copySkillDir } from './render.js';
 
 const defaults = JSON.parse(
@@ -123,23 +122,8 @@ async function cmdUpdate() {
   if (!templateDir) {
     err('Template directory not found.');
     err('Install via npm: npm install -g @fitlab-ai/agent-infra');
-    err('Or via clone: curl -fsSL https://raw.githubusercontent.com/fitlab-ai/agent-infra/main/install.sh | sh');
     process.exitCode = 1;
     return;
-  }
-
-  // auto-update: only for clone installs
-  if (isCloneInstall()) {
-    const installDir = resolveInstallDir();
-    if (fs.existsSync(path.join(installDir, '.git'))) {
-      info('Updating templates to latest version...');
-      try {
-        execSync('git pull --rebase --quiet', { cwd: installDir, stdio: 'pipe' });
-        ok('Templates updated.');
-      } catch {
-        err('Failed to update templates (network issue?). Using local version.');
-      }
-    }
   }
 
   // read project config

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -2,7 +2,7 @@
 /**
  * sync-templates.js — Deterministic template sync for managed & ejected files.
  *
- * Handles SKILL steps: 2 (git pull), 3.0 (registry sync), 4 (managed),
+ * Handles SKILL steps: 2 (detect template source version), 3.0 (registry sync), 4 (managed),
  * 6 (ejected), 7 (.agent-infra/config.json update).
  *
  * Merged files (step 5) are NOT handled — they require AI semantic merge.
@@ -16,23 +16,8 @@
 
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-// Keep these helpers aligned with lib/paths.js for clone installs.
-function resolveInstallDir() {
-  return path.join(os.homedir(), '.agent-infra');
-}
-
-function resolveTemplateDir() {
-  const clonePath = path.join(resolveInstallDir(), 'templates');
-  if (fs.existsSync(clonePath)) {
-    return clonePath;
-  }
-
-  return null;
-}
 
 const RETIRED_FILE_ENTRIES = new Set([
   '.agent-workspace/README.md',
@@ -113,34 +98,17 @@ function renderPathname(p, project) {
 }
 
 function resolveProjectTemplateDir(projectRoot, templateSource) {
-  const fallbackRoot = resolveTemplateDir();
+  if (!templateSource) return null;
 
-  const candidates = [];
-  if (templateSource) {
-    if (path.isAbsolute(templateSource)) {
-      candidates.push(templateSource);
-    } else {
-      if (fallbackRoot) {
-        candidates.push(path.resolve(path.dirname(fallbackRoot), templateSource));
-      }
-      candidates.push(path.resolve(projectRoot, templateSource));
-    }
-  }
-  if (fallbackRoot) {
-    candidates.push(fallbackRoot);
-  }
+  const candidate = path.isAbsolute(templateSource)
+    ? templateSource
+    : path.resolve(projectRoot, templateSource);
 
-  for (const candidate of candidates) {
-    try {
-      if (fs.statSync(candidate).isDirectory()) {
-        return candidate;
-      }
-    } catch {
-      // Keep scanning until a valid directory is found.
-    }
+  try {
+    return fs.statSync(candidate).isDirectory() ? candidate : null;
+  } catch {
+    return null;
   }
-
-  return null;
 }
 
 function isBinary(fp) {
@@ -222,34 +190,9 @@ function syncTemplates(projectRoot) {
   pruneRetiredConfig(cfg);
   const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
   if (!templateRoot) {
-    return { error: 'Template source not found. Install: curl -fsSL https://raw.githubusercontent.com/fitlab-ai/agent-infra/main/install.sh | sh' };
+    return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
-  const installDir = resolveInstallDir();
-
-  const hasGit = fs.existsSync(path.join(installDir, '.git'));
-  if (hasGit) {
-    try { childProcess.execSync('git fetch --tags --quiet', { cwd: installDir, stdio: 'pipe' }); } catch { /* network */ }
-  }
-
-  let version = 'unknown';
-  if (hasGit) {
-    let tagOutput;
-    try {
-      tagOutput = childProcess.execSync('git tag --sort=-v:refname', {
-        cwd: installDir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-      }).trim();
-    } catch {
-      return { error: 'Failed to list tags in agent-infra repository. Please check git installation.' };
-    }
-    const latestTag = tagOutput.split('\n')[0];
-    if (!latestTag) {
-      return { error: 'No tags found in agent-infra repository. This is unexpected — please reinstall.' };
-    }
-    try { childProcess.execFileSync('git', ['checkout', latestTag, '--quiet'], { cwd: installDir, stdio: 'pipe' }); } catch { /* ignore */ }
-    version = latestTag;
-  } else {
-    version = INSTALLER_VERSION || version;
-  }
+  const version = INSTALLER_VERSION;
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -405,8 +348,7 @@ function syncTemplates(projectRoot) {
   );
 
   const projUrl = gitUrl(projectRoot);
-  const instUrl = gitUrl(installDir);
-  report.selfUpdate = !!(projUrl && instUrl && projUrl === instUrl);
+  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/templates/.agents/skills/update-agent-infra/SKILL.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.md
@@ -29,7 +29,7 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
 The script reads `.agent-infra/config.json` (including `templateSource`, default `templates/`) and automatically performs:
-- git pull to fetch latest templates
+- detect the template source version
 - File registry sync (`defaults.json` → `.agent-infra/config.json`)
 - All managed files (language selection → exclude merged/ejected → placeholder rendering → overwrite)
 - Ejected files (create only on first install)

--- a/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
@@ -25,7 +25,7 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
 脚本读取 `.agent-infra/config.json`（含 `templateSource`，默认 `templates/`），自动完成：
-- git pull 拉取最新模板
+- 检测模板源版本
 - 同步文件注册表（`defaults.json` → `.agent-infra/config.json`）
 - 处理所有 managed 文件（语言选择 → 排除 merged/ejected → 占位符渲染 → 覆盖写入）
 - 处理 ejected 文件（仅首次安装时创建）

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -2,7 +2,7 @@
 /**
  * sync-templates.js — Deterministic template sync for managed & ejected files.
  *
- * Handles SKILL steps: 2 (git pull), 3.0 (registry sync), 4 (managed),
+ * Handles SKILL steps: 2 (detect template source version), 3.0 (registry sync), 4 (managed),
  * 6 (ejected), 7 (.agent-infra/config.json update).
  *
  * Merged files (step 5) are NOT handled — they require AI semantic merge.
@@ -16,23 +16,8 @@
 
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-// Keep these helpers aligned with lib/paths.js for clone installs.
-function resolveInstallDir() {
-  return path.join(os.homedir(), '.agent-infra');
-}
-
-function resolveTemplateDir() {
-  const clonePath = path.join(resolveInstallDir(), 'templates');
-  if (fs.existsSync(clonePath)) {
-    return clonePath;
-  }
-
-  return null;
-}
 
 const RETIRED_FILE_ENTRIES = new Set([
   '.agent-workspace/README.md',
@@ -143,34 +128,17 @@ function renderPathname(p, project) {
 }
 
 function resolveProjectTemplateDir(projectRoot, templateSource) {
-  const fallbackRoot = resolveTemplateDir();
+  if (!templateSource) return null;
 
-  const candidates = [];
-  if (templateSource) {
-    if (path.isAbsolute(templateSource)) {
-      candidates.push(templateSource);
-    } else {
-      if (fallbackRoot) {
-        candidates.push(path.resolve(path.dirname(fallbackRoot), templateSource));
-      }
-      candidates.push(path.resolve(projectRoot, templateSource));
-    }
-  }
-  if (fallbackRoot) {
-    candidates.push(fallbackRoot);
-  }
+  const candidate = path.isAbsolute(templateSource)
+    ? templateSource
+    : path.resolve(projectRoot, templateSource);
 
-  for (const candidate of candidates) {
-    try {
-      if (fs.statSync(candidate).isDirectory()) {
-        return candidate;
-      }
-    } catch {
-      // Keep scanning until a valid directory is found.
-    }
+  try {
+    return fs.statSync(candidate).isDirectory() ? candidate : null;
+  } catch {
+    return null;
   }
-
-  return null;
 }
 
 function isBinary(fp) {
@@ -252,34 +220,9 @@ function syncTemplates(projectRoot) {
   pruneRetiredConfig(cfg);
   const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
   if (!templateRoot) {
-    return { error: 'Template source not found. Install: curl -fsSL https://raw.githubusercontent.com/fitlab-ai/agent-infra/main/install.sh | sh' };
+    return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
-  const installDir = resolveInstallDir();
-
-  const hasGit = fs.existsSync(path.join(installDir, '.git'));
-  if (hasGit) {
-    try { childProcess.execSync('git fetch --tags --quiet', { cwd: installDir, stdio: 'pipe' }); } catch { /* network */ }
-  }
-
-  let version = 'unknown';
-  if (hasGit) {
-    let tagOutput;
-    try {
-      tagOutput = childProcess.execSync('git tag --sort=-v:refname', {
-        cwd: installDir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-      }).trim();
-    } catch {
-      return { error: 'Failed to list tags in agent-infra repository. Please check git installation.' };
-    }
-    const latestTag = tagOutput.split('\n')[0];
-    if (!latestTag) {
-      return { error: 'No tags found in agent-infra repository. This is unexpected — please reinstall.' };
-    }
-    try { childProcess.execFileSync('git', ['checkout', latestTag, '--quiet'], { cwd: installDir, stdio: 'pipe' }); } catch { /* ignore */ }
-    version = latestTag;
-  } else {
-    version = INSTALLER_VERSION || version;
-  }
+  const version = INSTALLER_VERSION;
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -435,8 +378,7 @@ function syncTemplates(projectRoot) {
   );
 
   const projUrl = gitUrl(projectRoot);
-  const instUrl = gitUrl(installDir);
-  report.selfUpdate = !!(projUrl && instUrl && projUrl === instUrl);
+  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -7,43 +7,13 @@ import os from "node:os";
 
 import { exists, filePath, read } from "./helpers.js";
 
-function pathExists(targetPath) {
-  try {
-    fs.lstatSync(targetPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function ensureCloneInstallFixture() {
-  const installDir = path.join(os.homedir(), ".agent-infra");
-  const templateSource = filePath("templates");
-  const backupDir = pathExists(installDir)
-    ? `${installDir}.test-backup-${process.pid}-${Date.now()}`
-    : null;
-
-  if (backupDir) {
-    fs.renameSync(installDir, backupDir);
-  }
-
-  fs.mkdirSync(installDir, { recursive: true });
-  fs.cpSync(templateSource, path.join(installDir, "templates"), { recursive: true });
-  return () => {
-    fs.rmSync(installDir, { recursive: true, force: true });
-    if (backupDir) {
-      fs.renameSync(backupDir, installDir);
-    }
-  };
-}
-
 test("bootstrap CLI files exist", () => {
   assert.ok(exists("install.sh"), "install.sh should exist");
   assert.ok(exists("bin/cli.js"), "bin/cli.js (node) should exist");
 
   const installSh = read("install.sh");
   assert.match(installSh, /npm install/);
-  assert.match(installSh, /\.agent-infra/);
+  assert.match(installSh, /@fitlab-ai\/agent-infra/);
 
   const nodeCli = read("bin/cli.js");
   assert.match(nodeCli, /agent-infra/);
@@ -147,7 +117,6 @@ test("agent-infra init generates seed files in a temp directory", () => {
 test("installed sync-templates.js executes inside a type=module project", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-esm-"));
   const cli = filePath("bin/cli.js");
-  const cleanupCloneInstall = ensureCloneInstallFixture();
 
   try {
     fs.writeFileSync(
@@ -164,6 +133,21 @@ test("installed sync-templates.js executes inside a type=module project", () => 
       JSON.parse(fs.readFileSync(path.join(tmpDir, "package.json"), "utf8")).type,
       "module",
       "package.json should remain an ESM package after init"
+    );
+    fs.mkdirSync(path.join(tmpDir, "templates"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "templates", "README.md"), "Hello {{project}}\n", "utf8");
+    fs.writeFileSync(
+      path.join(tmpDir, ".agent-infra", "config.json"),
+      JSON.stringify({
+        ...JSON.parse(fs.readFileSync(path.join(tmpDir, ".agent-infra", "config.json"), "utf8")),
+        templateSource: path.join(tmpDir, "templates"),
+        files: {
+          managed: ["README.md"],
+          merged: [],
+          ejected: []
+        }
+      }, null, 2) + "\n",
+      "utf8"
     );
 
     const output = execFileSync(
@@ -184,7 +168,6 @@ test("installed sync-templates.js executes inside a type=module project", () => 
       "sync-templates.js should be installed into the ESM project"
     );
   } finally {
-    cleanupCloneInstall();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -1,35 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 import readline from "node:readline";
 
 import { filePath, loadFreshEsm, renderPlaceholders } from "./helpers.js";
 import * as paths from "../lib/paths.js";
 
-test("paths detect clone installs when bundled templates live under HOME", () => {
-  const originalHomedir = os.homedir;
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-home-"));
-
-  try {
-    const installDir = path.join(tmpDir, ".agent-infra");
-    fs.mkdirSync(path.join(installDir, "templates"), { recursive: true });
-
-    os.homedir = () => tmpDir;
-    assert.equal(paths.resolveInstallDir(), installDir);
-    assert.equal(paths.resolveTemplateDir(), filePath("templates"));
-    assert.equal(paths.isCloneInstall(), false);
-
-    fs.rmSync(path.join(installDir, "templates"), { recursive: true, force: true });
-    fs.symlinkSync(filePath("templates"), path.join(installDir, "templates"), "dir");
-
-    assert.equal(paths.resolveTemplateDir(), filePath("templates"));
-    assert.equal(paths.isCloneInstall(), true);
-  } finally {
-    os.homedir = originalHomedir;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
+test("resolveTemplateDir returns the bundled templates directory", () => {
+  assert.equal(paths.resolveTemplateDir(), filePath("templates"));
 });
 
 test("renderPlaceholders only replaces double-brace placeholders", () => {

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -16,7 +16,7 @@ test("update-agent-infra instructions point to templates rendering", () => {
 
   assert.match(updateSkill, /templateSource/);
   assert.match(updateSkill, /templates\//);
-  assert.match(updateSkill, /git.*pull/);
+  assert.match(updateSkill, /模板源版本/);
   assert.match(updateSkill, /ai update/);
   assert.match(geminiUpdate, /SKILL\.md/);
 });

--- a/tests/sync-templates.test.js
+++ b/tests/sync-templates.test.js
@@ -22,16 +22,13 @@ function normalize(targetPath) {
 }
 
 test("syncTemplates respects templateSource and stays idempotent", async () => {
-  const originalHomedir = os.homedir;
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-"));
 
   try {
-    const homeDir = path.join(tmpDir, "home");
     const projectRoot = path.join(tmpDir, "project");
     const templateRoot = path.join(projectRoot, "custom-source");
 
-    fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(projectRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/guide.md", "Project {{project}}\n");
@@ -57,7 +54,6 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
       }
     });
 
-    os.homedir = () => homeDir;
     childProcess.execSync = (command) => {
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
@@ -102,23 +98,19 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
     assert.deepEqual(secondReport.ejected.skipped, ["local-only.md"]);
     assert.equal(afterSecondRun, afterFirstRun);
   } finally {
-    os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates prunes retired config entries during sync", async () => {
-  const originalHomedir = os.homedir;
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-prune-"));
 
   try {
-    const homeDir = path.join(tmpDir, "home");
     const projectRoot = path.join(tmpDir, "project");
     const templateRoot = path.join(tmpDir, "template-root");
 
-    fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(projectRoot, { recursive: true });
     fs.mkdirSync(templateRoot, { recursive: true });
 
@@ -136,7 +128,6 @@ test("syncTemplates prunes retired config entries during sync", async () => {
       }
     });
 
-    os.homedir = () => homeDir;
     childProcess.execSync = (command) => {
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
@@ -152,23 +143,19 @@ test("syncTemplates prunes retired config entries during sync", async () => {
     assert.ok(!updated.files.managed.includes(".editorconfig"));
     assert.ok(!updated.files.merged.includes(".mailmap"));
   } finally {
-    os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
-test("syncTemplates falls back to the installer version with a v prefix when clone metadata is unavailable", async () => {
-  const originalHomedir = os.homedir;
+test("syncTemplates reports the bundled installer version with a v prefix", async () => {
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-installer-version-"));
 
   try {
-    const homeDir = path.join(tmpDir, "home");
     const projectRoot = path.join(tmpDir, "project");
     const templateRoot = path.join(tmpDir, "template-root");
 
-    fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(projectRoot, { recursive: true });
     fs.mkdirSync(templateRoot, { recursive: true });
 
@@ -185,7 +172,6 @@ test("syncTemplates falls back to the installer version with a v prefix when clo
       }
     });
 
-    os.homedir = () => homeDir;
     childProcess.execSync = (command) => {
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
@@ -201,235 +187,19 @@ test("syncTemplates falls back to the installer version with a v prefix when clo
       `v${JSON.parse(read("package.json")).version}`
     );
   } finally {
-    os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("syncTemplates prefers the latest tag and reports the template version when clone metadata exists", async () => {
-  const originalHomedir = os.homedir;
-  const originalExecSync = childProcess.execSync;
-  const originalExecFileSync = childProcess.execFileSync;
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-home-"));
-
-  try {
-    const homeDir = path.join(tmpDir, "home");
-    const installDir = path.join(homeDir, ".agent-infra");
-    const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
-    const commands = [];
-
-    fs.mkdirSync(path.join(installDir, ".git"), { recursive: true });
-    fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
-
-    writeFile(templateRoot, "README.md", "Hello {{project}}\n");
-    writeJson(projectRoot, ".agent-infra/config.json", {
-      project: "demo",
-      org: "acme",
-      language: "en",
-      templateSource: templateRoot,
-      files: {
-        managed: ["README.md"],
-        merged: [],
-        ejected: []
-      }
-    });
-
-    os.homedir = () => homeDir;
-    childProcess.execSync = (command, options = {}) => {
-      commands.push({ command, cwd: options.cwd });
-
-      if (command === "git fetch --tags --quiet") {
-        return "";
-      }
-      if (command === "git tag --sort=-v:refname") {
-        return "v1.0.0\nv0.9.0\n";
-      }
-      if (command === "git checkout v1.0.0 --quiet") {
-        return "";
-      }
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-    childProcess.execFileSync = (file, args, options = {}) => {
-      const command = [file, ...args].join(" ");
-      commands.push({ command, cwd: options.cwd });
-
-      if (file === "git" && args.join(" ") === "checkout v1.0.0 --quiet") {
-        return "";
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
-    const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
-
-    assert.equal(report.templateVersion, "v1.0.0");
-    assert.deepEqual(report.managed.removed, []);
-    assert.deepEqual(commands.slice(0, 3), [
-      { command: "git fetch --tags --quiet", cwd: installDir },
-      { command: "git tag --sort=-v:refname", cwd: installDir },
-      { command: "git checkout v1.0.0 --quiet", cwd: installDir }
-    ]);
-    assert.ok(!commands.some((entry) => entry.command === "git rev-parse --short HEAD"));
-  } finally {
-    os.homedir = originalHomedir;
-    childProcess.execSync = originalExecSync;
-    childProcess.execFileSync = originalExecFileSync;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("syncTemplates returns an error when no tags exist", async () => {
-  const originalHomedir = os.homedir;
-  const originalExecSync = childProcess.execSync;
-  const originalExecFileSync = childProcess.execFileSync;
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-no-tags-"));
-
-  try {
-    const homeDir = path.join(tmpDir, "home");
-    const installDir = path.join(homeDir, ".agent-infra");
-    const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
-    const commands = [];
-
-    fs.mkdirSync(path.join(installDir, ".git"), { recursive: true });
-    fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
-
-    writeFile(templateRoot, "README.md", "Hello {{project}}\n");
-    writeJson(projectRoot, ".agent-infra/config.json", {
-      project: "demo",
-      org: "acme",
-      language: "en",
-      templateSource: templateRoot,
-      files: {
-        managed: ["README.md"],
-        merged: [],
-        ejected: []
-      }
-    });
-
-    os.homedir = () => homeDir;
-    childProcess.execSync = (command, options = {}) => {
-      commands.push({ command, cwd: options.cwd });
-
-      if (command === "git fetch --tags --quiet") {
-        return "";
-      }
-      if (command === "git tag --sort=-v:refname") {
-        return "\n";
-      }
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-    childProcess.execFileSync = () => {
-      throw new Error("checkout should not run when no tags exist");
-    };
-
-    const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
-
-    assert.deepEqual(report, {
-      error: "No tags found in agent-infra repository. This is unexpected — please reinstall."
-    });
-    assert.deepEqual(commands.slice(0, 2), [
-      { command: "git fetch --tags --quiet", cwd: installDir },
-      { command: "git tag --sort=-v:refname", cwd: installDir }
-    ]);
-    assert.ok(!commands.some((entry) => entry.command.startsWith("git checkout v")));
-  } finally {
-    os.homedir = originalHomedir;
-    childProcess.execSync = originalExecSync;
-    childProcess.execFileSync = originalExecFileSync;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("syncTemplates returns an error when tag listing fails", async () => {
-  const originalHomedir = os.homedir;
-  const originalExecSync = childProcess.execSync;
-  const originalExecFileSync = childProcess.execFileSync;
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-tag-failure-"));
-
-  try {
-    const homeDir = path.join(tmpDir, "home");
-    const installDir = path.join(homeDir, ".agent-infra");
-    const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
-    const commands = [];
-
-    fs.mkdirSync(path.join(installDir, ".git"), { recursive: true });
-    fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
-
-    writeFile(templateRoot, "README.md", "Hello {{project}}\n");
-    writeJson(projectRoot, ".agent-infra/config.json", {
-      project: "demo",
-      org: "acme",
-      language: "en",
-      templateSource: templateRoot,
-      files: {
-        managed: ["README.md"],
-        merged: [],
-        ejected: []
-      }
-    });
-
-    os.homedir = () => homeDir;
-    childProcess.execSync = (command, options = {}) => {
-      commands.push({ command, cwd: options.cwd });
-
-      if (command === "git fetch --tags --quiet") {
-        return "";
-      }
-      if (command === "git tag --sort=-v:refname") {
-        throw new Error("git tag failed");
-      }
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-    childProcess.execFileSync = () => {
-      throw new Error("checkout should not run when tag listing fails");
-    };
-
-    const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
-
-    assert.deepEqual(report, {
-      error: "Failed to list tags in agent-infra repository. Please check git installation."
-    });
-    assert.deepEqual(commands.slice(0, 2), [
-      { command: "git fetch --tags --quiet", cwd: installDir },
-      { command: "git tag --sort=-v:refname", cwd: installDir }
-    ]);
-  } finally {
-    os.homedir = originalHomedir;
-    childProcess.execSync = originalExecSync;
-    childProcess.execFileSync = originalExecFileSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates removes stale managed files but preserves merged and ejected files", async () => {
-  const originalHomedir = os.homedir;
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-cleanup-"));
 
   try {
-    const homeDir = path.join(tmpDir, "home");
     const projectRoot = path.join(tmpDir, "project");
     const templateRoot = path.join(tmpDir, "template-root");
 
-    fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(projectRoot, { recursive: true });
     fs.mkdirSync(templateRoot, { recursive: true });
 
@@ -458,7 +228,6 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
     writeFile(projectRoot, ".agents/keep.md", "AI enabled\n");
     writeFile(projectRoot, ".github/workflows/release.yml", "name: custom\n");
 
-    os.homedir = () => homeDir;
     childProcess.execSync = (command) => {
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
@@ -483,23 +252,19 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
     assert.ok(secondReport.managed.unchanged.includes(".agents/keep.md"));
     assert.deepEqual(secondReport.managed.skippedMerged, [".github/workflows/release.yml"]);
   } finally {
-    os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates preserves stale files that match merged glob patterns", async () => {
-  const originalHomedir = os.homedir;
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-glob-"));
 
   try {
-    const homeDir = path.join(tmpDir, "home");
     const projectRoot = path.join(tmpDir, "project");
     const templateRoot = path.join(tmpDir, "template-root");
 
-    fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(projectRoot, { recursive: true });
     fs.mkdirSync(templateRoot, { recursive: true });
 
@@ -520,7 +285,6 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
     writeFile(projectRoot, "docs/stale/note.md", "keep merged glob\n");
     writeFile(projectRoot, "docs/stale/extra.txt", "remove non-md\n");
 
-    os.homedir = () => homeDir;
     childProcess.execSync = (command) => {
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
@@ -535,7 +299,6 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
     assert.ok(!fs.existsSync(path.join(projectRoot, "docs/stale/extra.txt")));
     assert.deepEqual(report.managed.removed, ["docs/stale/extra.txt"]);
   } finally {
-    os.homedir = originalHomedir;
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #43

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)
- [x] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

PR #46 将 install.sh 改造为 npm 薄封装后，CLI 代码中仍残留 clone 安装模式的判断逻辑、git pull 自动更新、~/.agent-infra/templates 路径回退等代码。这些代码不再有实际消费者，增加理解和维护成本。本 PR 彻底清理所有 clone 安装模式残留，完全统一为 npm 安装方式。

## 📋 主要变更 / Brief Changelog

- 删除 `lib/paths.js` 中的 `isCloneInstall()`、`resolveCloneTemplateDir()`、`resolveInstallDir()`、`normalizePath()`，仅保留 `resolveTemplateDir()` 解析 npm bundled 路径
- 删除 `lib/init.js` 和 `lib/update.js` 中的 `isCloneInstall()` 判断分支和 `git pull --rebase` 自动更新逻辑
- 简化 `src/sync-templates.js`：移除 clone 路径回退、git fetch/tag/checkout 版本解析，版本固定使用 `INSTALLER_VERSION`
- 删除 `install.sh` 中的 legacy clone 检测和迁移提示（`LEGACY_DIR`、`LEGACY_BIN_DIR`、`legacy_link_target()`、检测段）
- 更新 README 和 SKILL.md 描述：从"git pull 拉取最新模板"改为"检测模板源版本"
- 重写 clone 相关测试用例，ESM 场景测试改用项目内 `templateSource` 代替 clone fixture
- 同步更新 `templates/` 和 `.agents/` 下的 sync-templates.js 副本

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 54/54 通过
2. `node scripts/build-inline.js --check` — 构建产物同步
3. `node bin/cli.js version` — 正常输出 `agent-infra v0.3.2`

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 16 files changed, 68 insertions(+), 627 deletions(-)
- Tests: 54 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex
- `lib/paths.js` 从 48 行精简到 9 行
- `install.sh` 从 85 行精简到 47 行
- `sync-templates.js` 删除 70 行 clone 相关代码

---

**审查者注意事项 / Reviewer Notes:**

- `install.sh` 中的 legacy clone 检测和迁移提示已全部移除，不再保留缓冲期
- `selfUpdate` 检测从 installDir git remote 对比改为项目 git remote 的正则匹配 `/fitlab-ai\/agent-infra/`
- 三份 sync-templates.js 副本（`src/`、`templates/`、`.agents/`）已通过 `build-inline.js --check` 和 `diff` 验证一致性

Closes #43

Generated with AI assistance