### PR TITLE
refactor(hooks): optimize version check hook timing

### DIFF
--- a/.agent-infra/config.json
+++ b/.agent-infra/config.json
@@ -11,6 +11,7 @@
       ".agents/workflows/",
       ".agent-infra/workspace/README.md",
       ".claude/commands/",
+      ".claude/hooks/",
       ".gemini/commands/",
       ".opencode/commands/"
     ],

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -41,6 +41,7 @@ const DEFAULTS = {
       ".agents/workflows/",
       ".agent-infra/workspace/README.md",
       ".claude/commands/",
+      ".claude/hooks/",
       ".gemini/commands/",
       ".opencode/commands/"
     ],

--- a/.claude/hooks/check-version-format.sh
+++ b/.claude/hooks/check-version-format.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+
+input=$(cat)
+hook_command=$(
+  printf '%s' "$input" | node -e '
+    const chunks = [];
+    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("end", () => {
+      try {
+        const payload = JSON.parse(Buffer.concat(chunks).toString());
+        process.stdout.write(payload.tool_input && payload.tool_input.command || "");
+      } catch (error) {
+        process.stdout.write("");
+      }
+    });
+  ' 2>/dev/null
+) || true
+
+case "$hook_command" in
+  git\ commit | git\ commit\ *) ;;
+  *) exit 0 ;;
+esac
+
+script_dir=$(
+  CDPATH= cd -- "$(dirname -- "$0")" && pwd
+)
+repo_root=$(
+  CDPATH= cd -- "$script_dir/../.." && pwd
+)
+
+if sh "$repo_root/.github/hooks/check-version-format.sh"; then
+  echo "Claude hook: version check passed."
+  exit 0
+else
+  status=$?
+fi
+
+if [ "$status" -eq 1 ]; then
+  echo "Claude hook: blocking git commit (version format error)."
+  exit 2
+fi
+
+exit "$status"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,13 +18,13 @@
     ]
   },
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "sh .github/hooks/check-version-format.sh",
+            "command": "sh .claude/hooks/check-version-format.sh",
             "timeout": 5
           }
         ]

--- a/.github/hooks/check-version-format.sh
+++ b/.github/hooks/check-version-format.sh
@@ -47,3 +47,5 @@ if [ "${template_version#v}" != "$package_version" ]; then
   echo "Actual: templateVersion=$template_version, version=$package_version"
   exit 1
 fi
+
+echo "Version format check passed."

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -6,6 +6,7 @@
       ".agents/workflows/",
       ".agent-infra/workspace/README.md",
       ".claude/commands/",
+      ".claude/hooks/",
       ".gemini/commands/",
       ".opencode/commands/"
     ],

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -41,6 +41,7 @@ const DEFAULTS = {
       ".agents/workflows/",
       ".agent-infra/workspace/README.md",
       ".claude/commands/",
+      ".claude/hooks/",
       ".gemini/commands/",
       ".opencode/commands/"
     ],

--- a/templates/.claude/hooks/check-version-format.sh
+++ b/templates/.claude/hooks/check-version-format.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+
+input=$(cat)
+hook_command=$(
+  printf '%s' "$input" | node -e '
+    const chunks = [];
+    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("end", () => {
+      try {
+        const payload = JSON.parse(Buffer.concat(chunks).toString());
+        process.stdout.write(payload.tool_input && payload.tool_input.command || "");
+      } catch (error) {
+        process.stdout.write("");
+      }
+    });
+  ' 2>/dev/null
+) || true
+
+case "$hook_command" in
+  git\ commit | git\ commit\ *) ;;
+  *) exit 0 ;;
+esac
+
+script_dir=$(
+  CDPATH= cd -- "$(dirname -- "$0")" && pwd
+)
+repo_root=$(
+  CDPATH= cd -- "$script_dir/../.." && pwd
+)
+
+if sh "$repo_root/.github/hooks/check-version-format.sh"; then
+  echo "Claude hook: version check passed."
+  exit 0
+else
+  status=$?
+fi
+
+if [ "$status" -eq 1 ]; then
+  echo "Claude hook: blocking git commit (version format error)."
+  exit 2
+fi
+
+exit "$status"

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -18,13 +18,13 @@
     ]
   },
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "sh .github/hooks/check-version-format.sh",
+            "command": "sh .claude/hooks/check-version-format.sh",
             "timeout": 5
           }
         ]

--- a/tests/airc.test.js
+++ b/tests/airc.test.js
@@ -46,6 +46,10 @@ test(".agent-infra/config.json excludes deprecated codex prompt paths", () => {
   const collaborator = JSON.parse(read(".agent-infra/config.json"));
 
   assert.ok(
+    collaborator.files.managed.includes(".claude/hooks/"),
+    ".claude/hooks/ should be in managed list"
+  );
+  assert.ok(
     !collaborator.files.managed.includes(".codex/commands/"),
     ".codex/commands/ should not be in managed list"
   );

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -49,6 +49,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.equal(config.templateVersion, `v${JSON.parse(read("package.json")).version}`);
     assert.ok(!config.branchPrefix, "branchPrefix should not exist");
     assert.ok(!config.source, "consumer projects should not have source: self");
+    assert.ok(config.files.managed.includes(".claude/hooks/"), ".claude/hooks/ should be managed");
     assert.ok(!config.files.managed.includes(".editorconfig"), ".editorconfig should not be managed");
     assert.ok(!config.files.merged.includes(".mailmap"), ".mailmap should not be merged");
     [

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import {
   buildCommandSyncFiles,
@@ -28,6 +32,7 @@ test("required template files were migrated into templates/", () => {
     "templates/.agent-infra/workspace/README.zh-CN.md",
     "templates/.claude/CLAUDE.md",
     "templates/.claude/project-rules.md",
+    "templates/.claude/hooks/check-version-format.sh",
     "templates/.claude/settings.json",
     "templates/.claude/commands/init-milestones.md",
     "templates/.claude/commands/init-milestones.zh-CN.md",
@@ -87,6 +92,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/skills/update-agent-infra/SKILL.md", "templates/.agents/skills/update-agent-infra/SKILL.md"],
     [".agents/skills/update-agent-infra/scripts/package.json", "templates/.agents/skills/update-agent-infra/scripts/package.json"],
     [".agents/skills/update-agent-infra/scripts/sync-templates.js", "templates/.agents/skills/update-agent-infra/scripts/sync-templates.js"],
+    [".claude/hooks/check-version-format.sh", "templates/.claude/hooks/check-version-format.sh"],
     ...buildCommandSyncFiles(project)
   ];
 
@@ -214,6 +220,8 @@ test("version format validation hooks are wired into templates and local config"
   const rootClaudeSettings = JSON.parse(read(".claude/settings.json"));
   const templateClaudeSettings = JSON.parse(read("templates/.claude/settings.json"));
   const localCheckScript = read(".github/hooks/check-version-format.sh");
+  const localClaudeHook = read(".claude/hooks/check-version-format.sh");
+  const templateClaudeHook = read("templates/.claude/hooks/check-version-format.sh");
   const localPreCommit = read(".github/hooks/pre-commit");
 
   assert.equal(
@@ -234,6 +242,22 @@ test("version format validation hooks are wired into templates and local config"
     assert.match(content, /templateVersion must use v-prefixed semver/, `${relativePath} should validate the templateVersion format`);
     assert.match(content, /package\.json version must use plain semver/, `${relativePath} should validate the package version format`);
     assert.match(content, /templateVersion and package\.json version do not match/, `${relativePath} should validate version parity`);
+    assert.match(content, /Version format check passed\./, `${relativePath} should log successful validation`);
+    assert.doesNotMatch(content, /--pre-tool-use/, `${relativePath} should remain a pure git hook`);
+    assert.doesNotMatch(content, /tool_input/, `${relativePath} should not parse Claude hook payloads`);
+  });
+
+  [
+    [".claude/hooks/check-version-format.sh", localClaudeHook],
+    ["templates/.claude/hooks/check-version-format.sh", templateClaudeHook]
+  ].forEach(([relativePath, content]) => {
+    assert.match(content, /tool_input/, `${relativePath} should parse the Claude hook payload`);
+    assert.match(content, /hook_command/, `${relativePath} should use a descriptive command variable name`);
+    assert.match(content, /git\\ commit \| git\\ commit\\ \*/, `${relativePath} should precisely match git commit commands in PreToolUse mode`);
+    assert.match(content, /\.github\/hooks\/check-version-format\.sh/, `${relativePath} should delegate to the git hook`);
+    assert.match(content, /exit 2/, `${relativePath} should map git-hook failures to Claude exit code 2`);
+    assert.match(content, /Claude hook: version check passed\./, `${relativePath} should log successful Claude-hook delegation`);
+    assert.match(content, /Claude hook: blocking git commit \(version format error\)\./, `${relativePath} should log blocked Claude-hook delegation`);
   });
 
   [
@@ -248,20 +272,75 @@ test("version format validation hooks are wired into templates and local config"
     ["templates/.claude/settings.json", templateClaudeSettings]
   ].forEach(([relativePath, settings]) => {
     assert.deepEqual(
-      settings.hooks?.PostToolUse,
+      settings.hooks?.PreToolUse,
       [
         {
           matcher: "Bash",
           hooks: [
             {
               type: "command",
-              command: "sh .github/hooks/check-version-format.sh",
+              command: "sh .claude/hooks/check-version-format.sh",
               timeout: 5
             }
           ]
         }
       ],
-      `${relativePath} should configure the PostToolUse version format validation hook`
+      `${relativePath} should configure the PreToolUse version format validation hook`
     );
   });
+});
+
+test("version format validation hook only blocks git commit in PreToolUse mode", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-hook-"));
+  const hooksDir = path.join(tempRoot, ".github", "hooks");
+  const claudeHooksDir = path.join(tempRoot, ".claude", "hooks");
+  const configDir = path.join(tempRoot, ".agent-infra");
+
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.mkdirSync(claudeHooksDir, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.copyFileSync(".github/hooks/check-version-format.sh", path.join(hooksDir, "check-version-format.sh"));
+  fs.copyFileSync(".claude/hooks/check-version-format.sh", path.join(claudeHooksDir, "check-version-format.sh"));
+  fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ templateVersion: "v1.2.3" }));
+  fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ version: "1.2.3" }));
+
+  const runClaudeHook = (input) => spawnSync(
+    "sh",
+    [path.join(claudeHooksDir, "check-version-format.sh")],
+    {
+      cwd: tempRoot,
+      encoding: "utf8",
+      input
+    }
+  );
+
+  try {
+    const nonCommit = runClaudeHook(JSON.stringify({ tool_input: { command: "git status" } }));
+    assert.equal(nonCommit.status, 0, "PreToolUse should skip non-git-commit commands");
+    assert.equal(nonCommit.stdout, "", "PreToolUse should stay silent when skipping non-git-commit commands");
+
+    const commit = runClaudeHook(JSON.stringify({ tool_input: { command: "git commit -m test" } }));
+    assert.equal(commit.status, 0, "PreToolUse should validate git commit commands");
+    assert.match(commit.stdout, /Version format check passed\./, "PreToolUse should log successful validation");
+    assert.match(commit.stdout, /Claude hook: version check passed\./, "PreToolUse should log successful Claude-hook delegation");
+
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ templateVersion: "1.2.3" }));
+
+    const blockedCommit = runClaudeHook(JSON.stringify({ tool_input: { command: "git commit -m broken" } }));
+    assert.equal(blockedCommit.status, 2, "PreToolUse should block invalid git commit commands with exit 2");
+    assert.match(blockedCommit.stdout, /Claude hook: blocking git commit \(version format error\)\./, "PreToolUse should log blocked Claude-hook delegation");
+
+    const preCommit = spawnSync(
+      "sh",
+      [path.join(hooksDir, "check-version-format.sh")],
+      {
+        cwd: tempRoot,
+        encoding: "utf8",
+        input: ""
+      }
+    );
+    assert.equal(preCommit.status, 1, "git pre-commit should fail with exit 1 on invalid versions");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #50

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)

## 📝 变更目的 / Purpose of the Change

当前版本格式校验 hook 使用 `PostToolUse` + `matcher: "Bash"`，在每次 Bash 工具调用后都触发校验（包括 `ls`、`date`、`git status` 等），频率过高且成功时无日志输出。本 PR 将 hook 从"事后报告"改为"事前阻止"，仅在 `git commit` 命令前触发校验，并采用分层架构将 Git hook 和 Claude Code hook 解耦。

## 📋 主要变更 / Brief Changelog

- 将 Claude Code hook 从 `PostToolUse` 改为 `PreToolUse`，通过 stdin JSON 解析仅拦截 `git commit` 命令
- 新建 `.claude/hooks/check-version-format.sh` 作为 Claude Code PreToolUse 薄适配层，负责命令过滤、委托调用和 exit code 映射（exit 1 → exit 2）
- `.github/hooks/check-version-format.sh` 恢复为纯 Git hook，不感知任何 AI 工具协议
- 两层 hook 各自独立产出日志，互不依赖
- 将 `.claude/hooks/` 注册为 managed 模板路径，下游项目通过 `update-agent-infra` 自动获得
- 新增集成测试覆盖跳过/放行/阻止/Git pre-commit 四条执行路径

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 55/55 通过
2. `node scripts/build-inline.js --check` — 构建产物同步
3. 在 Claude Code 中执行非 `git commit` 的 Bash 命令，确认 hook 不触发校验
4. 在 Claude Code 中执行 `git commit`，确认 hook 触发校验并输出 `Claude hook: version check passed.`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 12 files changed, 185 insertions(+), 7 deletions(-)
- Tests: 55 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex

---

**审查者注意事项 / Reviewer Notes:**

- 分层架构：`.github/hooks/` 只做纯 Git 版本校验，`.claude/hooks/` 做 Claude Code PreToolUse 协议适配 + 委托调用
- `.claude/hooks/` 已加入 managed 列表，下游项目 `update-agent-infra` 时会自动分发
- `.claude/settings.json` 和 `templates/.claude/settings.json` 中 hook command 从 `.github/hooks/` 改为 `.claude/hooks/`

Closes #50

Generated with AI assistance