### PR TITLE
refactor(tests): replace keyword-based semantic assertions with structural checks

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -72,12 +71,54 @@ async function loadFreshEsm(relativePath) {
   return import(moduleUrl.href);
 }
 
-function assertContainsPatterns(relativePath, patterns) {
+function parseFrontmatter(relativePath) {
   const content = read(relativePath);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
 
-  patterns.forEach((pattern) => {
-    assert.match(content, pattern, `${relativePath} should match ${pattern}`);
-  });
+  if (!match) {
+    return null;
+  }
+
+  const lines = match[1].split(/\r?\n/);
+  let name = "";
+  let description = "";
+
+  const normalizeValue = (value) => value.replace(/^["']|["']$/g, "").trim();
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (line.startsWith("name:")) {
+      name = normalizeValue(line.slice("name:".length).trim());
+      continue;
+    }
+
+    if (!line.startsWith("description:")) {
+      continue;
+    }
+
+    const value = line.slice("description:".length).trim();
+    if (value === ">") {
+      const descriptionLines = [];
+
+      for (let offset = index + 1; offset < lines.length; offset += 1) {
+        const descriptionLine = lines[offset];
+        if (!/^\s+/.test(descriptionLine)) {
+          break;
+        }
+
+        descriptionLines.push(descriptionLine.trim());
+        index = offset;
+      }
+
+      description = descriptionLines.join(" ").trim();
+      continue;
+    }
+
+    description = normalizeValue(value);
+  }
+
+  return { name, description };
 }
 
 function skillDocPaths(skill) {
@@ -86,20 +127,6 @@ function skillDocPaths(skill) {
     `templates/.agents/skills/${skill}/SKILL.md`,
     `templates/.agents/skills/${skill}/SKILL.zh-CN.md`
   ].filter(exists);
-}
-
-function skillContentPaths(skill) {
-  const paths = [...skillDocPaths(skill)];
-  const referenceRoots = [
-    `.agents/skills/${skill}/reference`,
-    `templates/.agents/skills/${skill}/reference`
-  ].filter(exists);
-
-  referenceRoots.forEach((relativeDir) => {
-    paths.push(...listFilesRecursive(relativeDir));
-  });
-
-  return paths;
 }
 
 const commandSpecs = {
@@ -226,7 +253,6 @@ const commandSpecs = {
 };
 
 export {
-  assertContainsPatterns,
   buildCommandSyncFiles,
   commandSpecs,
   escapeRegExp,
@@ -236,8 +262,8 @@ export {
   listFilesRecursive,
   listSkillNames,
   loadFreshEsm,
+  parseFrontmatter,
   read,
   renderPlaceholders,
-  skillContentPaths,
   skillDocPaths
 };

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -1,316 +1,84 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import path from "node:path";
 
 import {
-  assertContainsPatterns,
   commandSpecs,
   escapeRegExp,
+  exists,
+  listFilesRecursive,
   listSkillNames,
+  parseFrontmatter,
   read,
-  skillContentPaths,
   skillDocPaths
 } from "./helpers.js";
 
-test("update-agent-infra instructions point to templates rendering", () => {
-  const updateSkill = read(".agents/skills/update-agent-infra/SKILL.md");
-  const geminiUpdate = read(".gemini/commands/agent-infra/update-agent-infra.toml");
+const skillDocFiles = [
+  ...listFilesRecursive(".agents/skills"),
+  ...listFilesRecursive("templates/.agents/skills")
+]
+  .filter((relativePath) => /\/SKILL(?:\.zh-CN)?\.md$/.test(relativePath))
+  .sort();
 
-  assert.match(updateSkill, /templateSource/);
-  assert.match(updateSkill, /templates\//);
-  assert.match(updateSkill, /模板源版本/);
-  assert.match(updateSkill, /ai update/);
-  assert.match(geminiUpdate, /SKILL\.md/);
+test("all SKILL.md files have valid frontmatter", () => {
+  skillDocFiles.forEach((relativePath) => {
+    const frontmatter = parseFrontmatter(relativePath);
+    const skillName = path.basename(path.dirname(relativePath));
+
+    assert.ok(frontmatter, `${relativePath} should define frontmatter`);
+    assert.equal(frontmatter.name, skillName, `${relativePath} should use the directory name as frontmatter name`);
+    assert.ok(frontmatter.description, `${relativePath} should provide a non-empty description`);
+  });
 });
 
-test("init-labels skill documents label bootstrap flow and command discovery", () => {
-  const skillDocs = [
-    ".agents/skills/init-labels/SKILL.md",
-    "templates/.agents/skills/init-labels/SKILL.md",
-    "templates/.agents/skills/init-labels/SKILL.zh-CN.md"
-  ];
-  const scriptPaths = [
-    ".agents/skills/init-labels/scripts/init-labels.sh",
-    "templates/.agents/skills/init-labels/scripts/init-labels.sh"
-  ];
-
-  skillDocs.forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /bash \.agents\/skills\/init-labels\/scripts\/init-labels\.sh/,
-      /type:/,
-      /status:/,
-      /good first issue/,
-      /dependencies/,
-      /in: core/,
-      /theme:/,
-      /question/,
-      /wontfix/,
-      /gh auth token/
-    ]);
-  });
-
-  scriptPaths.forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /gh label create .*--force/,
-      /type: bug/,
-      /status: waiting-for-triage/,
-      /status: in-progress/,
-      /status: waiting-for-internal-feedback/,
-      /good first issue/,
-      /dependencies/
-    ]);
-  });
-
-  assert.match(read("templates/.claude/CLAUDE.md"), /Available commands are auto-discovered from `\.claude\/commands\/`/);
-  assert.match(read("templates/.claude/CLAUDE.zh-CN.md"), /可用命令从 `\.claude\/commands\/` 自动发现/);
-  assert.match(read(".claude/CLAUDE.md"), /可用命令从 `\.claude\/commands\/` 自动发现/);
-  assert.match(read("templates/.gemini/commands/_project_/init-labels.toml"), /\{\{project\}\}/);
-  assert.match(read("templates/.gemini/commands/_project_/init-labels.zh-CN.toml"), /\{\{project\}\}/);
-  assert.doesNotMatch(read(".gemini/commands/agent-infra/init-labels.toml"), /\{\{project\}\}/);
-  assert.match(read(".gemini/commands/agent-infra/init-labels.toml"), /agent-infra/);
-});
-
-test("init-milestones skill documents milestone bootstrap flow and command discovery", () => {
-  const skillDocs = [
-    ".agents/skills/init-milestones/SKILL.md",
-    "templates/.agents/skills/init-milestones/SKILL.md",
-    "templates/.agents/skills/init-milestones/SKILL.zh-CN.md"
-  ];
-  const scriptPaths = [
-    ".agents/skills/init-milestones/scripts/init-milestones.sh",
-    "templates/.agents/skills/init-milestones/scripts/init-milestones.sh"
-  ];
-
-  skillDocs.forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /General Backlog/,
-      /--history/,
-      /package\.json/,
-      /0\.1\.0/,
-      /Issues that we want to resolve in .* line/,
-      /Issues that we want to release in v/,
-      /state.*closed/,
-      /bash \.agents\/skills\/init-milestones\/scripts\/init-milestones\.sh/,
-      /gh api "repos\/\$repo\/milestones"/,
-      /Milestone titles are treated as the idempotency key/
-    ]);
-  });
-
-  scriptPaths.forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /git tag --list 'v\*' --sort=-v:refname \| head -1/,
-      /git tag --list 'v\*' --sort=v:refname/,
-      /package\.json/,
-      /0\.1\.0/,
-      /gh api "repos\/\$repo\/milestones"/
-    ]);
-  });
-
-  assert.match(read("templates/.claude/CLAUDE.md"), /Type `\/` in the prompt to see the full list with descriptions/);
-  assert.match(read("templates/.claude/CLAUDE.zh-CN.md"), /输入 `\/` 查看完整列表和描述/);
-  assert.match(read(".claude/CLAUDE.md"), /输入 `\/` 查看完整列表和描述/);
-  assert.match(read("templates/.gemini/commands/_project_/init-milestones.toml"), /\{\{project\}\}/);
-  assert.match(read("templates/.gemini/commands/_project_/init-milestones.zh-CN.toml"), /\{\{project\}\}/);
-  assert.doesNotMatch(read(".gemini/commands/agent-infra/init-milestones.toml"), /\{\{project\}\}/);
-  assert.match(read(".gemini/commands/agent-infra/init-milestones.toml"), /agent-infra/);
-});
-
-test("sync-issue skill documents label sync and development linking", () => {
-  const corpus = skillContentPaths("sync-issue").map(read).join("\n");
-
-  [
-    /gh label list --search "type:"/,
-    /init-labels/,
-    /--add-label/,
-    /--remove-label/,
-    /status: blocked/,
-    /status: in-progress/,
-    /status: pending-design-work/,
-    /current_step` ∈ \{`implementation`, `code-review`, `refinement`\}/,
-    /gh issue edit \{issue-number\} --add-label "in: \{module\}"/,
-    /gh pr view \{pr-number\}/,
-    /gh issue view \{issue-number\} --json milestone/,
-    /milestone` 字段|`milestone` field/,
-    /git branch --show-current/,
-    /git branch -a \| grep -oE '\[0-9\]\+\\\.\[0-9\]\+\\\.x'/,
-    /General Backlog/,
-    /Milestone[:：]|milestone 继承|Milestone Sync/,
-    /Closes #\{issue-number\}/,
-    /Fixes #\{issue-number\}/,
-    /Resolves #\{issue-number\}/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-
-  skillDocPaths("sync-issue").forEach((relativePath) => {
-    const content = read(relativePath);
-    const stepNumbers = [...content.matchAll(/^### (\d+)\. /gm)]
+test("all skill doc files have consecutive step numbering", () => {
+  skillDocFiles.forEach((relativePath) => {
+    const stepNumbers = [...read(relativePath).matchAll(/^### (\d+)\. /gm)]
       .map((match) => Number(match[1]));
+
+    if (stepNumbers.length === 0) {
+      return;
+    }
+
     const expected = stepNumbers.map((_, index) => index + 1);
-
-    assert.deepEqual(stepNumbers, expected, `${relativePath} steps should be consecutively numbered from 1`);
-  });
-
-  assert.doesNotMatch(corpus, /gh issue edit \{issue-number\} --add-label "\{type-label\}"/);
-  assert.doesNotMatch(corpus, /\| bug(?:、|, )bugfix \| `type: bug` \|/);
-});
-
-test("sync-issue skill accepts issue numbers and keeps task-id compatibility", () => {
-  const corpus = skillContentPaths("sync-issue").map(read).join("\n");
-
-  [
-    /Accept either `task-id` or issue number input|同时接受 `task-id` 和 issue number/,
-    /grep -rl "\^issue_number: \{issue-number\}\$"/,
-    /No task found associated with Issue #\{issue-number\}/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("sync-issue skill documents issue type sync, timeline comments, and absolute links", () => {
-  const corpus = skillContentPaths("sync-issue").map(read).join("\n");
-
-  [
-    /gh api "orgs\/\$owner\/issue-types"/,
-    /Issue Type workflow|issue-types/,
-    /\| `bug`, `bugfix` \| `Bug` \|/,
-    /\| `feature`, `enhancement` \| `Feature` \|/,
-    /<!-- sync-issue:\{task-id\}:\{file-stem\} -->/,
-    /\/→\\s\+\(\\S\+\\\.md\)\\s\*\$\//,
-    /按 Activity Log 顺序构建|Activity Log order/,
-    /Only include files that still exist in the task directory|artifacts whose files still exist/,
-    /\| task lives under `blocked\/` \| add `status: blocked` \|/,
-    /\| Scenario A: completed \| add no new `status:` label \|/,
-    /\| Scenario B: PR is `OPEN` \| add `status: in-progress` \|/,
-    /\| commit is already on a protected branch \| Scenario A: Completed \|/,
-    /\| PR exists and its state is `OPEN` or `MERGED` \| Scenario B: PR stage \|/,
-    /main` or `master`|protected release line/,
-    /Inference scenarios when `task\.md` does not set `milestone` explicitly/,
-    /Scenario A: if the current branch matches `\{major\}\.\{minor\}\.x`/,
-    /Scenario B: if the current branch is `main` or `master`/,
-    /Scenario C fallback: if no branch or tag rule yields a version line, fall back to `General Backlog`/,
-    /\(X\+1\)\.0\.x/,
-    /latest `vX\.Y\.Z` tag and fall back to `X\.Y\.x`/,
-    /\| `summary` \| `交付摘要` \|/,
-    /summary 评论顺序|Keep `summary` last|`summary` is always last/,
-    /has_unpublished_artifacts=true/,
-    /delete the old `summary` and recreate it at the end/,
-    /content is unchanged, do nothing/,
-    /Do not fall back to a fixed .*summary order|fixed `analysis -> plan -> implementation -> review -> summary` order/,
-    /gh api "repos\/\$repo\/issues\/comments\/\{summary_comment_id\}" -X PATCH|Issue comments/,
-    /https:\/\/github\.com\/\{owner\}\/\{repo\}\/commit\/\{commit-hash\}/,
-    /https:\/\/github\.com\/\{owner\}\/\{repo\}\/pull\/\{pr-number\}/,
-    /implementation-r\*\.md/,
-    /review-r\*\.md/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-
-  assert.doesNotMatch(corpus, /<!-- sync-issue:\{task-id\}:\{step\} -->/);
-  assert.doesNotMatch(corpus, /类型优先级：`analysis` = 1，`plan` = 2，`implementation\*` = 3，`review\*` = 4，`summary` = 5|Type priority: `analysis` = 1, `plan` = 2, `implementation\*` = 3, `review\*` = 4, `summary` = 5/);
-  assert.doesNotMatch(corpus, /按 `analysis → plan → implementation → review → summary` 的固定顺序处理|Process steps strictly in the fixed order `analysis → plan → implementation → review → summary`\./);
-  assert.doesNotMatch(corpus, /\.\.\/\.\.\/commit\/\{commit-hash\}/);
-  assert.doesNotMatch(corpus, /\.\.\/\.\.\/pull\/\{pr-number\}/);
-});
-
-test("sync-pr skill documents metadata sync and idempotent summary", () => {
-  const corpus = skillContentPaths("sync-pr").map(read).join("\n");
-
-  [
-    /repo="\$\(gh repo view --json nameWithOwner --jq '\.nameWithOwner'\)"/,
-    /<!-- sync-pr:\{task-id\}:summary -->/,
-    /gh pr edit \{pr-number\} --add-label|type label/,
-    /gh label list --search "type:"/,
-    /init-labels|type label/,
-    /type: bug|review summary/,
-    /in: \{module\}/,
-    /--milestone/,
-    /Closes #\{issue-number\}/,
-    /gh api "repos\/\$repo\/issues\/comments\/\{comment-id\}" -X PATCH|Issues comments API/,
-    /PR #\{number\} is closed\/merged, metadata sync skipped/,
-    /date "\+%Y-%m-%d %H:%M:%S"/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-
-  skillDocPaths("sync-pr").forEach((relativePath) => {
-    const content = read(relativePath);
-    const stepNumbers = [...content.matchAll(/^### (\d+)\. /gm)]
-      .map((match) => Number(match[1]));
-    const expected = stepNumbers.map((_, index) => index + 1);
-
     assert.deepEqual(stepNumbers, expected, `${relativePath} steps should be consecutively numbered from 1`);
   });
 });
 
-test("create-pr skill documents metadata sync step", () => {
-  const corpus = skillContentPaths("create-pr").map(read).join("\n");
+test("skills with reference/ directory keep SKILL.md within size threshold", () => {
+  listSkillNames().forEach((skill) => {
+    const referenceDir = `.agents/skills/${skill}/reference`;
+    if (!exists(referenceDir)) {
+      return;
+    }
 
-  [
-    /--add-label/,
-    /--milestone/,
-    /\| bug(?:、|, )bugfix \| `type: bug` \||type label/,
-    /Closes #\{issue-number\}/,
-    /sync-pr/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-
-  assert.doesNotMatch(corpus, /复用 `sync-pr` 的 type label 映射|Reuse the same type-label mapping as `sync-pr`/);
-});
-
-test("commit skill preserves status branching, co-author mapping, and copyright examples", () => {
-  const corpus = skillContentPaths("commit").map(read).join("\n");
-
-  [
-    /reference\/task-status-update\.md/,
-    /Decision Basis|判断依据/,
-    /Case 1: final commit|情况 1：最终提交/,
-    /Case 2: more work remains|情况 2：还有后续工作/,
-    /Case 3: ready for review|情况 3：准备审查/,
-    /Case 4: ready for PR|情况 4：准备创建 PR/,
-    /\/complete-task \{task-id\}/,
-    /\/agent-infra:review-task \{task-id\}/,
-    /\$create-pr/,
-    /Co-Authored-By: Claude <noreply@anthropic\.com>/,
-    /Co-Authored-By: Codex <noreply@openai\.com>/,
-    /Co-Authored-By: Gemini <noreply@google\.com>/,
-    /Co-Authored-By: OpenCode <noreply@opencode\.ai>/,
-    /Co-Authored-By: \{Agent\} <noreply@unknown>/,
-    /Copyright \(C\) 2024-2025.*2024-\{CURRENT_YEAR\}/,
-    /Copyright \(C\) 2024.*2024-\{CURRENT_YEAR\}/,
-    /Copyright \(C\) 2025.*Copyright \(C\) \{CURRENT_YEAR\}/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
+    skillDocPaths(skill).forEach((relativePath) => {
+      const lineCount = read(relativePath).split(/\r?\n/).length;
+      assert.ok(lineCount <= 120, `${relativePath} should stay within 120 lines when using reference/`);
+    });
   });
 });
 
-test("complete-task skill uses issue_number sync hint with explicit guard", () => {
-  skillDocPaths("complete-task").forEach((relativePath) => {
+test("SKILL.md reference paths point to existing files", () => {
+  skillDocFiles.forEach((relativePath) => {
     const content = read(relativePath);
+    const references = [...content.matchAll(/reference\/[A-Za-z0-9./-]+\.md/g)]
+      .map((match) => match[0]);
 
-    assertContainsPatterns(relativePath, [
-      /issue_number` (字段，且其值不为空也不为 `N\/A`|field whose value is neither empty nor `N\/A`)/,
-      /跳过此步骤，不输出任何内容|skip this step and output nothing/,
-      /sync-issue \{issue_number\}/
-    ]);
-
-    assert.doesNotMatch(content, /关联 Issue：#\{issue_number\}|Associated Issue: #\{issue_number\}/);
-    assert.doesNotMatch(content, /sync-issue \{task-id\}/);
+    [...new Set(references)].forEach((referencePath) => {
+      const targetPath = path.join(path.dirname(relativePath), referencePath);
+      assert.ok(exists(targetPath), `${relativePath} references missing file: ${targetPath}`);
+    });
   });
 });
 
-test("block-task skill uses issue_number sync hint with explicit guard", () => {
-  skillDocPaths("block-task").forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assertContainsPatterns(relativePath, [
-      /issue_number` (字段，且其值不为空也不为 `N\/A`|field whose value is neither empty nor `N\/A`)/,
-      /跳过此步骤，不输出任何内容|skip this step and output nothing/,
-      /sync-issue \{issue_number\}/
-    ]);
-
-    assert.doesNotMatch(content, /sync-issue \{task-id\}/);
-  });
+test("template SKILL.md files provide zh-CN variants", () => {
+  listFilesRecursive("templates/.agents/skills")
+    .filter((relativePath) => /\/SKILL\.md$/.test(relativePath))
+    .forEach((relativePath) => {
+      const zhVariant = relativePath.replace(/SKILL\.md$/, "SKILL.zh-CN.md");
+      assert.ok(exists(zhVariant), `Missing zh-CN skill variant: ${zhVariant}`);
+    });
 });
 
 test("skill command templates use thin adapter bodies", () => {
@@ -409,88 +177,6 @@ test("skill command templates use thin adapter bodies", () => {
   });
 });
 
-test("artifact versioning guidance exists in repeatable workflow skills", () => {
-  [
-    ".agents/skills/implement-task/SKILL.md",
-    "templates/.agents/skills/implement-task/SKILL.md",
-    "templates/.agents/skills/implement-task/SKILL.zh-CN.md"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /implementation-r\{N\}\.md/,
-      /Implementation \(Round \{N\}\)/,
-      /\{implementation-artifact\}/
-    ]);
-  });
-
-  [
-    ".agents/skills/review-task/SKILL.md",
-    "templates/.agents/skills/review-task/SKILL.md",
-    "templates/.agents/skills/review-task/SKILL.zh-CN.md"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /review-r\{N\}\.md/,
-      /implementation-r\{N\}\.md/,
-      /Code Review \(Round \{N\}\)/
-    ]);
-  });
-
-  [
-    ".agents/skills/refine-task/SKILL.md",
-    "templates/.agents/skills/refine-task/SKILL.md",
-    "templates/.agents/skills/refine-task/SKILL.zh-CN.md"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /review-r\{N\}\.md/,
-      /Review artifact mismatch:/,
-      /\{implementation-artifact\}/
-    ]);
-  });
-
-  [
-    ".agents/skills/check-task/SKILL.md",
-    "templates/.agents/skills/check-task/SKILL.md",
-    "templates/.agents/skills/check-task/SKILL.zh-CN.md"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /implementation-r2\.md/,
-      /review-r2\.md/,
-      /latest/
-    ]);
-  });
-
-  [
-    ".agents/skills/complete-task/SKILL.md",
-    "templates/.agents/skills/complete-task/SKILL.md",
-    "templates/.agents/skills/complete-task/SKILL.zh-CN.md"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /review-r\{N\}\.md/,
-      /Approved/
-    ]);
-  });
-});
-
-test("workflows document artifact versioning for implementation, review, and fix loops", () => {
-  [
-    ".agents/workflows/feature-development.yaml",
-    ".agents/workflows/bug-fix.yaml",
-    ".agents/workflows/refactoring.yaml",
-    "templates/.agents/workflows/feature-development.yaml",
-    "templates/.agents/workflows/bug-fix.yaml",
-    "templates/.agents/workflows/refactoring.yaml",
-    "templates/.agents/workflows/feature-development.zh-CN.yaml",
-    "templates/.agents/workflows/bug-fix.zh-CN.yaml",
-    "templates/.agents/workflows/refactoring.zh-CN.yaml"
-  ].forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /artifact_versioning:/,
-      /implementation-r\{N\}\.md/,
-      /review-r\{N\}\.md/,
-      /Activity Log/
-    ]);
-  });
-});
-
 test("skills that write timestamps require date command guidance", () => {
   const timestampSkills = [
     "analyze-task",
@@ -522,209 +208,5 @@ test("skills that write timestamps require date command guidance", () => {
         `${relativePath} should require the date command for timestamp writes`
       );
     });
-  });
-});
-
-test("implement-task skill resolves the latest versioned plan artifact", () => {
-  skillDocPaths("implement-task").forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /plan\.md` or `plan-r\{N\}\.md|`plan\.md` 或 `plan-r\{N\}\.md`/,
-      /highest-round plan file|最高轮次的方案文件/,
-      /\{plan-artifact\}/,
-      /Attempt to fix the issue and re-run tests first|先尝试修复并重新运行测试/,
-      /external blocker, missing environment, or unclear requirement|外部阻塞、环境缺失或需求不明确/
-    ]);
-  });
-});
-
-test("import alert skills define boundaries and completion checklists", () => {
-  ["import-codescan", "import-dependabot"].forEach((skill) => {
-    skillDocPaths(skill).forEach((relativePath) => {
-      assertContainsPatterns(relativePath, [
-        /行为边界 \/ 关键规则|Boundary \/ Critical Rules/,
-        /完成检查清单|Completion Checklist/
-      ]);
-    });
-  });
-});
-
-test("review-task activity log guidance uses English summary fields", () => {
-  skillDocPaths("review-task").forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assert.match(
-      content,
-      /Verdict: \{Approved\/Changes Requested\/Rejected\}, blockers: \{n\}, major: \{n\}, minor: \{n\}/,
-      `${relativePath} should use English Activity Log summary fields`
-    );
-    assert.doesNotMatch(
-      content,
-      /结论：\{已批准\/需要修改\/拒绝\}，阻塞项：\{n\}，主要问题：\{n\}，次要问题：\{n\}/,
-      `${relativePath} should not use mixed-language Activity Log summary fields`
-    );
-  });
-});
-
-test("import-issue skill uses the shared boundary section format", () => {
-  skillDocPaths("import-issue").forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assertContainsPatterns(relativePath, [
-      /行为边界 \/ 关键规则|Boundary \/ Critical Rules/,
-      /唯一产出是 `task\.md`|only output is `task\.md`/,
-      /执行本技能后，你\*\*必须\*\*立即更新任务状态|After executing this skill, you \*\*must\*\* immediately update task status/
-    ]);
-
-    assert.doesNotMatch(content, /## 关键：行为边界/);
-    assert.doesNotMatch(content, /## 关键：状态更新要求/);
-  });
-});
-
-test("create-issue skill limits issue content to task.md and writes back issue_number", () => {
-  const corpus = skillContentPaths("create-issue").map(read).join("\n");
-
-  [
-    /行为边界 \/ 关键规则|Boundary \/ Critical Rules/,
-    /仅从 `task\.md` 创建|from `task\.md` only/,
-    /不要读取 `analysis\.md`、`plan\.md`、`implementation\.md`|Do not read `analysis\.md`, `plan\.md`, `implementation\.md`/,
-    /gh auth status/,
-    /ISSUE_TEMPLATE/,
-    /fallback|兜底/,
-    /`labels:`/,
-    /`milestone`/,
-    /--milestone/,
-    /issue-types/,
-    /-X PATCH -f type="\{issue-type\}"/,
-    /textarea/,
-    /dropdown/,
-    /checkboxes/,
-    /gh issue create --title/,
-    /`issue_number`/,
-    /sync-issue/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("create-issue skill keeps template candidates, fallback mappings, and sync-issue next steps", () => {
-  const corpus = skillContentPaths("create-issue").map(read).join("\n");
-
-  [
-    /bug_report\.yml/,
-    /feature_request\.yml/,
-    /\| `bug`, `bugfix` \| `type: bug` \|/,
-    /\| `feature` \| `type: feature` \|/,
-    /\| `bug`, `bugfix` \| `Bug` \|/,
-    /General Backlog/,
-    /Do not remove existing `in:` labels|Do not fail Issue creation/,
-    /\/agent-infra:sync-issue \{task-id\}/,
-    /\$sync-issue \{task-id\}/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("refine-task records the implementation artifact during prerequisite discovery", () => {
-  skillDocPaths("refine-task").forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /记录 `\{implementation-artifact\}`|Record `\{implementation-artifact\}`/
-    ]);
-  });
-});
-
-test("refine-task skill keeps re-review decision rules and output template", () => {
-  const corpus = skillContentPaths("refine-task").map(read).join("\n");
-
-  [
-    /if this round fixed any `Blocker` or `Major`, recommend re-review by default/,
-    /never present direct commit as the only next step/,
-    /\/agent-infra:review-task \{task-id\}/,
-    /\$commit/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("review-task skill keeps verdict branch templates and prohibitions", () => {
-  const corpus = skillContentPaths("review-task").map(read).join("\n");
-
-  [
-    /reference\/output-templates\.md/,
-    /if `Blocker > 0`, never output an approval template/,
-    /\/agent-infra:refine-task \{task-id\}/,
-    /\/agent-infra:implement-task \{task-id\}/,
-    /\$commit/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("create-pr skill keeps metadata sync order and ordered next steps", () => {
-  const corpus = skillContentPaths("create-pr").map(read).join("\n");
-
-  [
-    /gh issue view \{issue-number\} --json labels,milestone/,
-    /\| `refactor`, `refactoring` \| `type: enhancement` \|/,
-    /resolve milestone in order: PR -> task\.md -> Issue -> branch\/tag inference -> `General Backlog`/,
-    /never present `complete-task` as the only next step/,
-    /\/agent-infra:sync-pr \{task-id\}/,
-    /\$complete-task \{task-id\}/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("sync-pr skill keeps milestone inference and reviewer-summary content rules", () => {
-  const corpus = skillContentPaths("sync-pr").map(read).join("\n");
-
-  [
-    /\(X\+1\)\.0\.x/,
-    /inherit the Issue milestone/,
-    /self-contained technical decisions/,
-    /avoid internal shorthand such as `Plan A\/B`|避免使用 `方案 A\/B`/,
-    /review-history table/,
-    /\| 轮次 \| 结论 \| 问题统计 \| 修复状态 \||\| Round \| Verdict \| Finding Counts \| Fix Status \|/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("implement-task reference keeps the two-way test-failure handling", () => {
-  const corpus = skillContentPaths("implement-task").map(read).join("\n");
-
-  [
-    /Two-way failure handling/,
-    /implementation-caused failures/,
-    /external blockers/,
-    /do not mark implementation complete in `task\.md`/,
-    /do not output the normal success\/next-step template/
-  ].forEach((pattern) => {
-    assert.match(corpus, pattern);
-  });
-});
-
-test("plan-task clarifies how to choose the latest analysis artifact", () => {
-  skillDocPaths("plan-task").forEach((relativePath) => {
-    assertContainsPatterns(relativePath, [
-      /如果存在 `analysis-r\{N\}\.md`，读取最高 N 的文件|If any `analysis-r\{N\}\.md` exists, read the highest N file/,
-      /否则读取 `analysis\.md`|otherwise read `analysis\.md`/
-    ]);
-  });
-});
-
-test("analyze-task activity log uses the analysis artifact placeholder", () => {
-  skillDocPaths("analyze-task").forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assert.match(
-      content,
-      /Analysis completed → \{analysis-artifact\}/,
-      `${relativePath} should use the analysis-artifact placeholder`
-    );
-    assert.doesNotMatch(
-      content,
-      /\{artifact-filename\}/,
-      `${relativePath} should not use the generic artifact-filename placeholder`
-    );
   });
 });

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -7,7 +7,6 @@ import path from "node:path";
 
 import {
   buildCommandSyncFiles,
-  escapeRegExp,
   exists,
   langTemplate,
   listFilesRecursive,
@@ -116,128 +115,6 @@ test("split skill reference templates provide zh-CN variants", () => {
     const zhVariant = relativePath.replace(/\.md$/, ".zh-CN.md");
     assert.ok(exists(zhVariant), `Missing zh-CN reference variant: ${zhVariant}`);
   });
-});
-
-test("assistant template docs use import commands and analyze-task naming", () => {
-  [
-    "templates/.claude/project-rules.md",
-    "templates/.claude/project-rules.zh-CN.md",
-    "templates/.opencode/README.md",
-    "templates/.opencode/README.zh-CN.md"
-  ].forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assert.match(content, /import-issue/, `${relativePath} should reference import-issue`);
-    assert.match(content, /analyze-task/, `${relativePath} should reference analyze-task`);
-    assert.doesNotMatch(content, /analyze-issue/, `${relativePath} should not reference analyze-issue`);
-  });
-
-  [
-    "templates/.opencode/README.md",
-    "templates/.opencode/README.zh-CN.md"
-  ].forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assert.match(content, /import-dependabot/, `${relativePath} should reference import-dependabot`);
-    assert.match(content, /import-codescan/, `${relativePath} should reference import-codescan`);
-    assert.doesNotMatch(content, /analyze-dependabot/, `${relativePath} should not reference analyze-dependabot`);
-    assert.doesNotMatch(content, /analyze-codescan/, `${relativePath} should not reference analyze-codescan`);
-  });
-
-  [
-    "templates/.claude/CLAUDE.md",
-    "templates/.claude/CLAUDE.zh-CN.md"
-  ].forEach((relativePath) => {
-    const content = read(relativePath);
-
-    assert.match(content, /auto-discovered from `\.claude\/commands\/`|自动发现/, `${relativePath} should explain command auto-discovery`);
-    assert.match(content, /\/create-task.*\/complete-task/s, `${relativePath} should keep the workflow sequence hint`);
-  });
-});
-
-test("system prompt templates embed skill authoring conventions from the collaboration guide", () => {
-  [
-    {
-      heading: "## Skill Authoring Conventions",
-      comment: "<!-- Canonical source: .agents/README.md - keep in sync -->",
-      mustMatch: [
-        /When writing or updating `\.agents\/skills\/\*\/SKILL\.md` files(?: and their templates)?, keep step numbering consistent:/,
-        /1\. Use consecutive integers for top-level steps: `1\.`, `2\.`, `3\.`\./,
-        /2\. Use nested numbering only for child actions that belong to a parent step: `1\.1`, `1\.2`, `2\.1`\./,
-        /3\. Use `a`, `b`, and `c` markers for (?:branches, conditions, or alternative paths within the same step|subordinate options, conditional branches, or parallel possibilities within the same step; use them only for in-step expansion, not for naming standalone decision paths or output templates)\./,
-        /4\. Do not use intermediate numbers such as `1\.5` or `2\.5`; if a new standalone step is needed, renumber the following top-level steps\./,
-        /5\. When renumbering, update every in-document step reference so the instructions remain accurate\./,
-        /6\. Extract long bash scripts into a sibling `scripts\/` directory; the SKILL\.md should contain only a single-line invocation \(e\.g\., `bash \.agents\/skills\/<skill>\/scripts\/<script>\.sh`\) and a brief summary of the script's responsibilities\./,
-        /### SKILL\.md Size Control/,
-        /- Keep the SKILL\.md body within about 500 tokens \(roughly 80 lines \/ 2KB\)\./,
-        /- Move content beyond that threshold into a sibling `reference\/` directory\./,
-        /- Use explicit navigation in the skeleton, such as: `Read reference\/xxx\.md before executing this step\.`/,
-        /- Keep scripts in `scripts\/` and execute them instead of inlining long bash blocks\./
-      ],
-      targets: [
-        "templates/.claude/CLAUDE.md",
-        "templates/AGENTS.md"
-      ]
-    },
-    {
-      heading: "## Skill 编写规范",
-      comment: "<!-- Canonical source: .agents/README.zh-CN.md - keep in sync -->",
-      mustMatch: [
-        /编写或维护 `\.agents\/skills\/\*\/SKILL\.md`(?: 及其模板)?时，步骤编号遵循以下规则：/,
-        /1\. 顶级步骤使用连续整数：`1\.`、`2\.`、`3\.`。/,
-        /2\. 只有父步骤下的从属动作才使用子步骤：`1\.1`、`1\.2`、`2\.1`。/,
-        /3\. 同一步中的(?:分支、条件或多种可能性|从属选项、条件分支或并列可能性)使用 `a`、`b`、`c` 标记(?:；仅用于步骤内部的子项展开，不用于命名独立的决策路径或输出模板)?。/,
-        /4\. 不要使用 `1\.5`、`2\.5` 这类中间编号；如新增独立步骤，应整体顺延后续编号。/,
-        /5\. 调整编号时，必须同步更新文中的步骤引用，确保说明、命令和检查点一致。/,
-        /6\. 长 bash 脚本应从 SKILL\.md 提取到同级 `scripts\/` 目录中，SKILL\.md 只保留单行调用（如 `bash \.agents\/skills\/<skill>\/scripts\/<script>\.sh`）和对脚本职责的概要说明。/,
-        /### SKILL\.md 体积控制/,
-        /- SKILL\.md 正文控制在约 500 tokens（约 80 行 \/ 2KB）以内。/,
-        /- 超过阈值的内容拆分到同级 `reference\/` 目录。/,
-        /- 骨架中使用明确导航，例如：`执行此步骤前，先读取 reference\/xxx\.md。`/,
-        /- 长脚本继续放在 `scripts\/` 目录，优先执行脚本而不是内联大段 bash。/
-      ],
-      targets: [
-        "templates/.claude/CLAUDE.zh-CN.md",
-        "templates/AGENTS.zh-CN.md"
-      ]
-    }
-  ].forEach(({ heading, comment, mustMatch, targets }) => {
-    targets.forEach((relativePath) => {
-      const content = read(relativePath);
-
-      assert.match(content, new RegExp(escapeRegExp(heading)), `${relativePath} should include the conventions heading`);
-      mustMatch.forEach((pattern) => {
-        assert.match(content, pattern, `${relativePath} should document ${pattern}`);
-      });
-      assert.match(
-        content,
-        new RegExp(escapeRegExp(comment)),
-        `${relativePath} should keep the canonical-source marker`
-      );
-    });
-  });
-});
-
-test("README documents the bootstrap installation flow", () => {
-  const readme = read("README.md");
-  const readmeZh = read("README.zh-CN.md");
-
-  assert.match(readme, /install\.sh/);
-  assert.match(readme, /ai init/);
-  assert.match(readme, /update-agent-infra/);
-  assert.match(readme, /npm install -g @fitlab-ai\/agent-infra/);
-  assert.match(readme, /npm update -g @fitlab-ai\/agent-infra/);
-  assert.match(readme, /runs npm install -g internally/);
-  assert.doesNotMatch(readme, /npx @fitlab-ai\/agent-infra init/);
-  assert.doesNotMatch(readme, /Install from source/);
-  assert.match(readmeZh, /install\.sh/);
-  assert.match(readmeZh, /ai init/);
-  assert.match(readmeZh, /update-agent-infra/);
-  assert.match(readmeZh, /npm install -g @fitlab-ai\/agent-infra/);
-  assert.match(readmeZh, /npm update -g @fitlab-ai\/agent-infra/);
-  assert.match(readmeZh, /内部执行 npm install -g/);
-  assert.doesNotMatch(readmeZh, /npx @fitlab-ai\/agent-infra init/);
-  assert.doesNotMatch(readmeZh, /源码安装/);
 });
 
 test("version format validation hooks are wired into templates and local config", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #64

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

将 `skills.test.js` 和 `templates.test.js` 中基于硬编码关键词的语义断言替换为结构性检查，提升测试的维护性和准确性。

在 #45 的实施过程中，skill 描述和 reference 文件的措辞调整多次触发语义测试误报，需要同步更新测试中的硬编码关键词。这种耦合关系不利于后续维护。

Closes #64

## 📋 主要变更 / Brief Changelog

- 移除 `skills.test.js` 中 27 个脆弱的关键词匹配语义测试
- 移除 `templates.test.js` 中 3 个基于硬编码措辞的语义测试
- 新增 5 个结构性测试：frontmatter 格式验证、步骤编号连续性、SKILL.md 体积阈值、reference 文件存在性、模板 zh-CN 变体完整性
- 保留 `skill command templates use thin adapter bodies` 和 `skills that write timestamps require date command guidance` 两个合约性测试
- 在 `helpers.js` 中新增 `parseFrontmatter()` 辅助函数，移除不再使用的 `assertContainsPatterns` 和 `skillContentPaths`
- 保留全部模板↔工作文件同步一致性测试和版本格式验证测试

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 38 个测试全部通过
2. 确认新增的结构性检查能正确检测 frontmatter 错误、步骤编号不连续、reference 路径不存在等问题

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

---

Generated with AI assistance