### PR TITLE
chore(commands): optimize disable-model-invocation markers

### DIFF
--- a/.claude/commands/block-task.md
+++ b/.claude/commands/block-task.md
@@ -1,6 +1,7 @@
 ---
 description: "标记任务为阻塞状态并记录原因"
 usage: "/block-task <task-id> [reason]"
+disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/block-task/SKILL.md` 中的 block-task 技能。

--- a/.claude/commands/check-task.md
+++ b/.claude/commands/check-task.md
@@ -1,6 +1,7 @@
 ---
 description: "查看任务的当前状态和进度"
 usage: "/check-task <task-id>"
+disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/check-task/SKILL.md` 中的 check-task 技能。

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,7 +1,6 @@
 ---
 description: "从任务文件创建 GitHub Issue"
 usage: "/create-issue <task-id>"
-disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/create-issue/SKILL.md` 中的 create-issue 技能。

--- a/templates/.claude/commands/block-task.md
+++ b/templates/.claude/commands/block-task.md
@@ -1,6 +1,7 @@
 ---
 description: "Mark a task as blocked and record the reason"
 usage: "/block-task <task-id> [reason]"
+disable-model-invocation: true
 ---
 
 Read and execute the block-task skill from `.agents/skills/block-task/SKILL.md`.

--- a/templates/.claude/commands/block-task.zh-CN.md
+++ b/templates/.claude/commands/block-task.zh-CN.md
@@ -1,6 +1,7 @@
 ---
 description: "标记任务为阻塞状态并记录原因"
 usage: "/block-task <task-id> [reason]"
+disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/block-task/SKILL.md` 中的 block-task 技能。

--- a/templates/.claude/commands/check-task.md
+++ b/templates/.claude/commands/check-task.md
@@ -1,6 +1,7 @@
 ---
 description: "Check a task's current status and progress"
 usage: "/check-task <task-id>"
+disable-model-invocation: true
 ---
 
 Read and execute the check-task skill from `.agents/skills/check-task/SKILL.md`.

--- a/templates/.claude/commands/check-task.zh-CN.md
+++ b/templates/.claude/commands/check-task.zh-CN.md
@@ -1,6 +1,7 @@
 ---
 description: "查看任务的当前状态和进度"
 usage: "/check-task <task-id>"
+disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/check-task/SKILL.md` 中的 check-task 技能。

--- a/templates/.claude/commands/create-issue.md
+++ b/templates/.claude/commands/create-issue.md
@@ -1,7 +1,6 @@
 ---
 description: "Create a GitHub Issue from a task file"
 usage: "/create-issue <task-id>"
-disable-model-invocation: true
 ---
 
 Read and execute the create-issue skill from `.agents/skills/create-issue/SKILL.md`.

--- a/templates/.claude/commands/create-issue.zh-CN.md
+++ b/templates/.claude/commands/create-issue.zh-CN.md
@@ -1,7 +1,6 @@
 ---
 description: "从任务文件创建 GitHub Issue"
 usage: "/create-issue <task-id>"
-disable-model-invocation: true
 ---
 
 读取并执行 `.agents/skills/create-issue/SKILL.md` 中的 create-issue 技能。

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -14,6 +14,48 @@ import {
   renderPlaceholders
 } from "./helpers.js";
 
+const highFrequencyCommands = [
+  "analyze-task",
+  "commit",
+  "complete-task",
+  "create-issue",
+  "create-pr",
+  "create-task",
+  "implement-task",
+  "import-issue",
+  "plan-task",
+  "refine-task",
+  "review-task",
+  "sync-issue",
+  "sync-pr",
+  "test"
+];
+
+const lowFrequencyCommands = [
+  "block-task",
+  "check-task",
+  "close-codescan",
+  "close-dependabot",
+  "create-release-note",
+  "import-codescan",
+  "import-dependabot",
+  "init-labels",
+  "init-milestones",
+  "refine-title",
+  "release",
+  "test-integration",
+  "update-agent-infra",
+  "upgrade-dependency"
+];
+
+function claudeCommandTargets(command) {
+  return [
+    `.claude/commands/${command}.md`,
+    `templates/.claude/commands/${command}.md`,
+    `templates/.claude/commands/${command}.zh-CN.md`
+  ];
+}
+
 test("required template files were migrated into templates/", () => {
   const requiredFiles = [
     "templates/.agents/workflows/feature-development.yaml",
@@ -107,6 +149,36 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     const rendered = renderPlaceholders(read(templatePath), { project, org });
 
     assert.equal(rendered, read(source), `${templatePath} is out of sync with ${source}`);
+  });
+});
+
+test("Claude command disable-model-invocation settings match command frequency", () => {
+  const expectedCommands = [...highFrequencyCommands, ...lowFrequencyCommands].sort();
+  const localCommands = listFilesRecursive(".claude/commands")
+    .filter((relativePath) => relativePath.endsWith(".md"))
+    .map((relativePath) => path.basename(relativePath, ".md"))
+    .sort();
+
+  assert.deepEqual(localCommands, expectedCommands, "command coverage should stay in sync with the frequency allowlists");
+
+  highFrequencyCommands.forEach((command) => {
+    claudeCommandTargets(command).forEach((relativePath) => {
+      assert.doesNotMatch(
+        read(relativePath),
+        /^disable-model-invocation: true$/m,
+        `${relativePath} should remain available for semantic matching`
+      );
+    });
+  });
+
+  lowFrequencyCommands.forEach((command) => {
+    claudeCommandTargets(command).forEach((relativePath) => {
+      assert.match(
+        read(relativePath),
+        /^disable-model-invocation: true$/m,
+        `${relativePath} should disable semantic preloading for low-frequency commands`
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #66

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

优化 `disable-model-invocation: true` 标记配置，使命令频率分类更准确。该标记控制命令描述是否预加载到系统提示（[Claude Code 官方文档](https://code.claude.com/docs/en/skills.md)），低频命令设置此标记可减少上下文占用。

本次调整 3 个命令的分类：
- `block-task`、`check-task`：从高频调为低频（异常分支/只读查询，总是显式调用）
- `create-issue`：从低频调为高频（需支持"为任务创建 issue"等自然语言语义匹配）

Closes #66

## 📋 主要变更 / Brief Changelog

- 为 `block-task`、`check-task` 添加 `disable-model-invocation: true`（项目 + 模板 EN/zh-CN）
- 移除 `create-issue` 的 `disable-model-invocation: true`（项目 + 模板 EN/zh-CN）
- 新增防回归测试，验证全部 28 个命令的频率分类正确性

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 41 tests passed, 0 failed
2. 验证系统提示 Skill 列表：create-issue 已出现，block-task/check-task 已移除
3. 验证模板与项目文件同步一致

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

调整后高频 14 个、低频 14 个命令（原为 15:13）。防回归测试会在新增命令时自动检测分类遗漏。

Generated with AI assistance