### PR TITLE
refactor(update): remove legacy path migration from ai update

### DIFF
--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -178,41 +178,6 @@ function langSelect(rels, lang, allSet, project) {
 function syncTemplates(projectRoot) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
-  const legacyCfgPaths = [
-    path.join(projectRoot, '.airc.json'),
-    path.join(projectRoot, '.agent-infra', 'config.json')
-  ];
-  const workspacePath = path.join(configDir, 'workspace');
-  const legacyWorkspacePaths = [
-    path.join(projectRoot, '.agent-workspace'),
-    path.join(projectRoot, '.agent-infra', 'workspace')
-  ];
-
-  if (!fs.existsSync(cfgPath)) {
-    for (const legacyCfgPath of legacyCfgPaths) {
-      if (!fs.existsSync(legacyCfgPath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyCfgPath, cfgPath);
-      break;
-    }
-  }
-  if (!fs.existsSync(workspacePath)) {
-    for (const legacyWorkspacePath of legacyWorkspacePaths) {
-      if (!fs.existsSync(legacyWorkspacePath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyWorkspacePath, workspacePath);
-      break;
-    }
-  }
-
-  try {
-    const legacyConfigDir = path.join(projectRoot, '.agent-infra');
-    if (fs.existsSync(legacyConfigDir) && fs.readdirSync(legacyConfigDir).length === 0) {
-      fs.rmdirSync(legacyConfigDir);
-    }
-  } catch {
-    // Ignore cleanup failures for partially migrated directories.
-  }
 
   if (!fs.existsSync(cfgPath)) {
     return { error: 'No .agents/.airc.json in project root.' };

--- a/lib/init.js
+++ b/lib/init.js
@@ -57,11 +57,7 @@ async function cmdInit() {
   const configPath = path.join('.agents', '.airc.json');
 
   // check existing config
-  if (
-    fs.existsSync(configPath) ||
-    fs.existsSync('.airc.json') ||
-    fs.existsSync(path.join('.agent-infra', 'config.json'))
-  ) {
+  if (fs.existsSync(configPath)) {
     err('This project already has agent-infra configuration.');
     err('Use /update-agent-infra in your AI TUI to update.');
     process.exitCode = 1;

--- a/lib/update.js
+++ b/lib/update.js
@@ -10,52 +10,6 @@ const defaults = JSON.parse(
 
 const CONFIG_DIR = '.agents';
 const CONFIG_PATH = path.join(CONFIG_DIR, '.airc.json');
-const LEGACY_CONFIG_PATHS = ['.airc.json', path.join('.agent-infra', 'config.json')];
-const WORKSPACE_PATH = path.join(CONFIG_DIR, 'workspace');
-const LEGACY_WORKSPACE_PATHS = ['.agent-workspace', path.join('.agent-infra', 'workspace')];
-
-function migrateLegacyPaths() {
-  let migratedConfig = false;
-  let migratedWorkspace = false;
-  let configFrom = null;
-  let workspaceFrom = null;
-
-  if (!fs.existsSync(CONFIG_PATH)) {
-    for (const legacyPath of LEGACY_CONFIG_PATHS) {
-      if (!fs.existsSync(legacyPath)) {
-        continue;
-      }
-      fs.mkdirSync(CONFIG_DIR, { recursive: true });
-      fs.renameSync(legacyPath, CONFIG_PATH);
-      migratedConfig = true;
-      configFrom = legacyPath;
-      break;
-    }
-  }
-
-  if (!fs.existsSync(WORKSPACE_PATH)) {
-    for (const legacyPath of LEGACY_WORKSPACE_PATHS) {
-      if (!fs.existsSync(legacyPath)) {
-        continue;
-      }
-      fs.mkdirSync(CONFIG_DIR, { recursive: true });
-      fs.renameSync(legacyPath, WORKSPACE_PATH);
-      migratedWorkspace = true;
-      workspaceFrom = legacyPath;
-      break;
-    }
-  }
-
-  try {
-    if (fs.existsSync('.agent-infra') && fs.readdirSync('.agent-infra').length === 0) {
-      fs.rmdirSync('.agent-infra');
-    }
-  } catch {
-    // Ignore cleanup failures for partially migrated directories.
-  }
-
-  return { migratedConfig, migratedWorkspace, configFrom, workspaceFrom };
-}
 
 function syncFileRegistry(config) {
   config.files ||= {};
@@ -106,15 +60,6 @@ async function cmdUpdate() {
   console.log('  agent-infra update');
   console.log('  ==================================');
   console.log('');
-
-  const { migratedConfig, migratedWorkspace, configFrom, workspaceFrom } = migrateLegacyPaths();
-
-  if (migratedConfig) {
-    ok(`Migrated ${configFrom} -> ${CONFIG_PATH}`);
-  }
-  if (migratedWorkspace) {
-    ok(`Migrated ${workspaceFrom} -> ${WORKSPACE_PATH}`);
-  }
 
   // check config exists
   if (!fs.existsSync(CONFIG_PATH)) {

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -145,41 +145,6 @@ function langSelect(rels, lang, allSet, project) {
 function syncTemplates(projectRoot) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
-  const legacyCfgPaths = [
-    path.join(projectRoot, '.airc.json'),
-    path.join(projectRoot, '.agent-infra', 'config.json')
-  ];
-  const workspacePath = path.join(configDir, 'workspace');
-  const legacyWorkspacePaths = [
-    path.join(projectRoot, '.agent-workspace'),
-    path.join(projectRoot, '.agent-infra', 'workspace')
-  ];
-
-  if (!fs.existsSync(cfgPath)) {
-    for (const legacyCfgPath of legacyCfgPaths) {
-      if (!fs.existsSync(legacyCfgPath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyCfgPath, cfgPath);
-      break;
-    }
-  }
-  if (!fs.existsSync(workspacePath)) {
-    for (const legacyWorkspacePath of legacyWorkspacePaths) {
-      if (!fs.existsSync(legacyWorkspacePath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyWorkspacePath, workspacePath);
-      break;
-    }
-  }
-
-  try {
-    const legacyConfigDir = path.join(projectRoot, '.agent-infra');
-    if (fs.existsSync(legacyConfigDir) && fs.readdirSync(legacyConfigDir).length === 0) {
-      fs.rmdirSync(legacyConfigDir);
-    }
-  } catch {
-    // Ignore cleanup failures for partially migrated directories.
-  }
 
   if (!fs.existsSync(cfgPath)) {
     return { error: 'No .agents/.airc.json in project root.' };

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -178,41 +178,6 @@ function langSelect(rels, lang, allSet, project) {
 function syncTemplates(projectRoot) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
-  const legacyCfgPaths = [
-    path.join(projectRoot, '.airc.json'),
-    path.join(projectRoot, '.agent-infra', 'config.json')
-  ];
-  const workspacePath = path.join(configDir, 'workspace');
-  const legacyWorkspacePaths = [
-    path.join(projectRoot, '.agent-workspace'),
-    path.join(projectRoot, '.agent-infra', 'workspace')
-  ];
-
-  if (!fs.existsSync(cfgPath)) {
-    for (const legacyCfgPath of legacyCfgPaths) {
-      if (!fs.existsSync(legacyCfgPath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyCfgPath, cfgPath);
-      break;
-    }
-  }
-  if (!fs.existsSync(workspacePath)) {
-    for (const legacyWorkspacePath of legacyWorkspacePaths) {
-      if (!fs.existsSync(legacyWorkspacePath)) continue;
-      fs.mkdirSync(configDir, { recursive: true });
-      fs.renameSync(legacyWorkspacePath, workspacePath);
-      break;
-    }
-  }
-
-  try {
-    const legacyConfigDir = path.join(projectRoot, '.agent-infra');
-    if (fs.existsSync(legacyConfigDir) && fs.readdirSync(legacyConfigDir).length === 0) {
-      fs.rmdirSync(legacyConfigDir);
-    }
-  } catch {
-    // Ignore cleanup failures for partially migrated directories.
-  }
 
   if (!fs.existsSync(cfgPath)) {
     return { error: 'No .agents/.airc.json in project root.' };

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -209,19 +209,19 @@ test("agent-infra init rejects invalid input", () => {
 test("agent-infra update refreshes seed files and syncs file registry", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-update-"));
   const cli = filePath("bin/cli.js");
-    const config = {
-      version: "0.1.0",
-      project: "seedproj",
-      org: "seedorg",
-      language: "zh-CN",
-      templateSource: "templates/",
-      templateVersion: "stale",
-      files: {
-        managed: [],
-        merged: [],
-        ejected: []
-      }
-    };
+  const config = {
+    version: "0.1.0",
+    project: "seedproj",
+    org: "seedorg",
+    language: "zh-CN",
+    templateSource: "templates/",
+    templateVersion: "stale",
+    files: {
+      managed: [],
+      merged: [],
+      ejected: []
+    }
+  };
 
   try {
     fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
@@ -288,87 +288,6 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     assert.ok(
       fs.existsSync(path.join(tmpDir, ".opencode", "commands", "update-agent-infra.md"))
     );
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("agent-infra update migrates v0.2 legacy config and workspace paths", () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-update-legacy-"));
-  const cli = filePath("bin/cli.js");
-
-  try {
-    fs.writeFileSync(
-      path.join(tmpDir, ".airc.json"),
-      JSON.stringify({
-        project: "legacyproj",
-        org: "legacyorg",
-        language: "en",
-        templateSource: "templates/",
-        templateVersion: "stale",
-        files: {
-          managed: [],
-          merged: [],
-          ejected: []
-        }
-      }, null, 2) + "\n",
-      "utf8"
-    );
-    fs.mkdirSync(path.join(tmpDir, ".agent-workspace"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, ".agent-workspace", "README.md"), "legacy\n", "utf8");
-
-    const output = execSync(`node "${cli}" update`, {
-      cwd: tmpDir,
-      stdio: "pipe",
-      encoding: "utf8"
-    });
-
-    assert.match(output, /Migrated \.airc\.json -> \.agents\/\.airc\.json/);
-    assert.match(output, /Migrated \.agent-workspace -> \.agents\/workspace/);
-    assert.ok(fs.existsSync(path.join(tmpDir, ".agents", ".airc.json")));
-    assert.ok(fs.existsSync(path.join(tmpDir, ".agents", "workspace", "README.md")));
-    assert.ok(!fs.existsSync(path.join(tmpDir, ".airc.json")));
-    assert.ok(!fs.existsSync(path.join(tmpDir, ".agent-workspace")));
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("agent-infra update migrates v0.3 legacy config and workspace paths", () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-update-legacy-"));
-  const cli = filePath("bin/cli.js");
-
-  try {
-    fs.mkdirSync(path.join(tmpDir, ".agent-infra", "workspace"), { recursive: true });
-    fs.writeFileSync(
-      path.join(tmpDir, ".agent-infra", "config.json"),
-      JSON.stringify({
-        project: "legacyproj",
-        org: "legacyorg",
-        language: "en",
-        templateSource: "templates/",
-        templateVersion: "stale",
-        files: {
-          managed: [],
-          merged: [],
-          ejected: []
-        }
-      }, null, 2) + "\n",
-      "utf8"
-    );
-    fs.writeFileSync(path.join(tmpDir, ".agent-infra", "workspace", "README.md"), "legacy\n", "utf8");
-
-    const output = execSync(`node "${cli}" update`, {
-      cwd: tmpDir,
-      stdio: "pipe",
-      encoding: "utf8"
-    });
-
-    assert.match(output, /Migrated \.agent-infra\/config\.json -> \.agents\/\.airc\.json/);
-    assert.match(output, /Migrated \.agent-infra\/workspace -> \.agents\/workspace/);
-    assert.ok(fs.existsSync(path.join(tmpDir, ".agents", ".airc.json")));
-    assert.ok(fs.existsSync(path.join(tmpDir, ".agents", "workspace", "README.md")));
-    assert.ok(!fs.existsSync(path.join(tmpDir, ".agent-infra")));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #70

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

移除 `ai update` 和 `sync-templates` 中内置的旧版本迁移逻辑（`migrateLegacyPaths`），使其职责单一化——只做 seed 文件更新，不再承担版本间目录迁移。迁移职责交由独立的清理脚本承担（已附加到 v0.4.0 release）。

Remove legacy path migration (`migrateLegacyPaths`) from `ai update` and `sync-templates` to enforce single responsibility — update seed files only, no more cross-version directory migration. Migration is now handled by a standalone cleanup script attached to the v0.4.0 release.

## 📋 主要变更 / Brief Changelog

- Remove `migrateLegacyPaths()` function and legacy path constants from `lib/update.js`
- Simplify `lib/init.js` to only check `.agents/.airc.json` for existing config
- Remove legacy migration logic from `src/sync-templates.js` and rebuild inline artifacts
- Delete v0.2/v0.3 migration test cases from `tests/cli.test.js`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node scripts/build-inline.js --check` — 构建产物同步检查通过
2. `node --test tests/*.test.js` — 39 个测试全部通过
3. 在无配置目录运行 `ai update`，确认报错 `No .agents/.airc.json found`

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] PR 只解决一个 Issue / Your PR addresses just this issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

Closes #70

Generated with AI assistance