### PR TITLE
refactor(sync): replace templateSource config with npm-based template discovery

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -2,7 +2,6 @@
   "project": "agent-infra",
   "org": "fitlab-ai",
   "language": "zh-CN",
-  "templateSource": "templates/",
   "templateVersion": "v0.4.0",
   "files": {
     "managed": [

--- a/.agents/skills/update-agent-infra/SKILL.md
+++ b/.agents/skills/update-agent-infra/SKILL.md
@@ -22,7 +22,7 @@ description: "更新项目 AI 协作配置"
 node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
-脚本读取 `.agents/.airc.json`（含 `templateSource`，默认 `templates/`），自动完成：
+脚本读取 `.agents/.airc.json`，并通过 npm 自动定位已安装的 `@fitlab-ai/agent-infra/templates/` 目录，然后自动完成：
 - 检测模板源版本
 - 同步文件注册表（`defaults.json` → `.agents/.airc.json`）
 - 处理所有 managed 文件（语言选择 → 排除 merged/ejected → 占位符渲染 → 覆盖写入）

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -116,18 +116,45 @@ function renderPathname(p, project) {
   return p.replace(/_project_/g, project);
 }
 
-function resolveProjectTemplateDir(projectRoot, templateSource) {
-  if (!templateSource) return null;
+function isTemplateDir(dir) {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
-  const candidate = path.isAbsolute(templateSource)
-    ? templateSource
-    : path.resolve(projectRoot, templateSource);
+function resolveInstalledTemplateDir(nodeModulesRoot) {
+  if (!nodeModulesRoot) return null;
+  const candidate = path.join(nodeModulesRoot, '@fitlab-ai', 'agent-infra', 'templates');
+  return isTemplateDir(candidate) ? candidate : null;
+}
+
+function resolveTemplateRoot(projectRoot) {
+  try {
+    const globalRoot = childProcess.execSync('npm root -g', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const globalTemplateRoot = resolveInstalledTemplateDir(globalRoot);
+    if (globalTemplateRoot) return globalTemplateRoot;
+  } catch {
+    // npm may be unavailable or not configured.
+  }
 
   try {
-    return fs.statSync(candidate).isDirectory() ? candidate : null;
+    const localRoot = childProcess.execSync('npm root', {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const localTemplateRoot = resolveInstalledTemplateDir(localRoot);
+    if (localTemplateRoot) return localTemplateRoot;
   } catch {
-    return null;
+    // npm may be unavailable or the project may not have a local install.
   }
+
+  return null;
 }
 
 function isBinary(fp) {
@@ -175,7 +202,7 @@ function langSelect(rels, lang, allSet, project) {
   return sel;
 }
 
-function syncTemplates(projectRoot) {
+function syncTemplates(projectRoot, templateRootOverride) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
 
@@ -185,11 +212,12 @@ function syncTemplates(projectRoot) {
 
   const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
   const configPathRel = norm(path.relative(projectRoot, cfgPath));
-  const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
+  const templateRoot = templateRootOverride || resolveTemplateRoot(projectRoot);
   if (!templateRoot) {
     return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
   const version = INSTALLER_VERSION;
+  const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -362,8 +390,9 @@ function syncTemplates(projectRoot) {
   cfg.files.merged  = merged;
   cfg.files.ejected = ejected;
   cfg.templateVersion = version;
+  delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,6 +57,11 @@ node --test tests/*.test.js
 - 运行命令：`node --test tests/*.test.js`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 
+### 测试编写规约
+
+1. **禁止关键词语义断言**：不要通过匹配自然语言措辞来验证 skill 文档内容（如 `assert.match(content, /某段具体描述/)`）。SKILL.md 的文案会频繁调整，绑定措辞的测试极其脆弱。只做结构性检查：frontmatter 合法性、步骤编号连续、引用完整性、体积阈值等。参见 `998edee`。
+2. **禁止反向删除断言**：已删除的功能不需要断言其不存在（如 `assert.doesNotMatch(content, /removedField/)`）。删除即彻底删除，不要用测试永久记住一个不再存在的概念，否则会形成无止境的测试债务。
+
 ## 提交与 PR 规范
 
 ### 提交信息格式（Conventional Commits）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ node --test tests/*.test.js
 - 运行命令：`node --test tests/*.test.js`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 
+### 测试编写规约
+
+1. **禁止关键词语义断言**：不要通过匹配自然语言措辞来验证 skill 文档内容（如 `assert.match(content, /某段具体描述/)`）。SKILL.md 的文案会频繁调整，绑定措辞的测试极其脆弱。只做结构性检查：frontmatter 合法性、步骤编号连续、引用完整性、体积阈值等。参见 `998edee`。
+2. **禁止反向删除断言**：已删除的功能不需要断言其不存在（如 `assert.doesNotMatch(content, /removedField/)`）。删除即彻底删除，不要用测试永久记住一个不再存在的概念，否则会形成无止境的测试债务。
+
 ## 提交与 PR 规范
 
 ### 提交信息格式（Conventional Commits）

--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ The generated `.agents/.airc.json` file is the central contract between the boot
   "project": "my-project",
   "org": "my-org",
   "language": "en",
-  "templateSource": "templates/",
   "templateVersion": "v0.4.0",
   "files": {
     "managed": [
@@ -409,7 +408,6 @@ The generated `.agents/.airc.json` file is the central contract between the boot
 | `project` | Project name used when rendering commands, paths, and templates. |
 | `org` | GitHub organization or owner used by generated metadata and links. |
 | `language` | Primary project language or locale used by rendered templates. |
-| `templateSource` | Local template root used during rendering. |
 | `templateVersion` | Installed template version for future upgrades and drift tracking. |
 | `files` | Per-path update strategy configuration for managed, merged, and ejected files. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -380,7 +380,6 @@ import-issue #42                    从 GitHub Issue 导入任务
   "project": "my-project",
   "org": "my-org",
   "language": "en",
-  "templateSource": "templates/",
   "templateVersion": "v0.4.0",
   "files": {
     "managed": [
@@ -409,7 +408,6 @@ import-issue #42                    从 GitHub Issue 导入任务
 | `project` | 用于渲染命令、路径和模板内容的项目名。 |
 | `org` | 生成元数据和链接时使用的 GitHub 组织或拥有者。 |
 | `language` | 渲染模板时采用的项目主语言或区域设置。 |
-| `templateSource` | 本地模板根目录。 |
 | `templateVersion` | 当前安装的模板版本，用于升级和差异追踪。 |
 | `files` | 针对具体路径配置 `managed`、`merged`、`ejected` 三类更新策略。 |
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -161,7 +161,6 @@ async function cmdInit() {
     project: projectName,
     org: orgName,
     language,
-    templateSource: 'templates/',
     templateVersion: VERSION,
     files: structuredClone(defaults.files)
   };

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -83,18 +83,45 @@ function renderPathname(p, project) {
   return p.replace(/_project_/g, project);
 }
 
-function resolveProjectTemplateDir(projectRoot, templateSource) {
-  if (!templateSource) return null;
+function isTemplateDir(dir) {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
-  const candidate = path.isAbsolute(templateSource)
-    ? templateSource
-    : path.resolve(projectRoot, templateSource);
+function resolveInstalledTemplateDir(nodeModulesRoot) {
+  if (!nodeModulesRoot) return null;
+  const candidate = path.join(nodeModulesRoot, '@fitlab-ai', 'agent-infra', 'templates');
+  return isTemplateDir(candidate) ? candidate : null;
+}
+
+function resolveTemplateRoot(projectRoot) {
+  try {
+    const globalRoot = childProcess.execSync('npm root -g', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const globalTemplateRoot = resolveInstalledTemplateDir(globalRoot);
+    if (globalTemplateRoot) return globalTemplateRoot;
+  } catch {
+    // npm may be unavailable or not configured.
+  }
 
   try {
-    return fs.statSync(candidate).isDirectory() ? candidate : null;
+    const localRoot = childProcess.execSync('npm root', {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const localTemplateRoot = resolveInstalledTemplateDir(localRoot);
+    if (localTemplateRoot) return localTemplateRoot;
   } catch {
-    return null;
+    // npm may be unavailable or the project may not have a local install.
   }
+
+  return null;
 }
 
 function isBinary(fp) {
@@ -142,7 +169,7 @@ function langSelect(rels, lang, allSet, project) {
   return sel;
 }
 
-function syncTemplates(projectRoot) {
+function syncTemplates(projectRoot, templateRootOverride) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
 
@@ -152,11 +179,12 @@ function syncTemplates(projectRoot) {
 
   const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
   const configPathRel = norm(path.relative(projectRoot, cfgPath));
-  const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
+  const templateRoot = templateRootOverride || resolveTemplateRoot(projectRoot);
   if (!templateRoot) {
     return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
   const version = INSTALLER_VERSION;
+  const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -329,8 +357,9 @@ function syncTemplates(projectRoot) {
   cfg.files.merged  = merged;
   cfg.files.ejected = ejected;
   cfg.templateVersion = version;
+  delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/templates/.agents/skills/update-agent-infra/SKILL.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.md
@@ -24,7 +24,7 @@ Execute the following command to handle all deterministic steps at once:
 node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
-The script reads `.agents/.airc.json` (including `templateSource`, default `templates/`) and automatically performs:
+The script reads `.agents/.airc.json`, automatically locates the installed `@fitlab-ai/agent-infra/templates/` directory via npm, and performs:
 - detect the template source version
 - File registry sync (`defaults.json` → `.agents/.airc.json`)
 - All managed files (language selection → exclude merged/ejected → placeholder rendering → overwrite)

--- a/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
@@ -22,7 +22,7 @@ description: "更新项目 AI 协作配置"
 node .agents/skills/update-agent-infra/scripts/sync-templates.js
 ```
 
-脚本读取 `.agents/.airc.json`（含 `templateSource`，默认 `templates/`），自动完成：
+脚本读取 `.agents/.airc.json`，并通过 npm 自动定位已安装的 `@fitlab-ai/agent-infra/templates/` 目录，然后自动完成：
 - 检测模板源版本
 - 同步文件注册表（`defaults.json` → `.agents/.airc.json`）
 - 处理所有 managed 文件（语言选择 → 排除 merged/ejected → 占位符渲染 → 覆盖写入）

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -116,18 +116,45 @@ function renderPathname(p, project) {
   return p.replace(/_project_/g, project);
 }
 
-function resolveProjectTemplateDir(projectRoot, templateSource) {
-  if (!templateSource) return null;
+function isTemplateDir(dir) {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
-  const candidate = path.isAbsolute(templateSource)
-    ? templateSource
-    : path.resolve(projectRoot, templateSource);
+function resolveInstalledTemplateDir(nodeModulesRoot) {
+  if (!nodeModulesRoot) return null;
+  const candidate = path.join(nodeModulesRoot, '@fitlab-ai', 'agent-infra', 'templates');
+  return isTemplateDir(candidate) ? candidate : null;
+}
+
+function resolveTemplateRoot(projectRoot) {
+  try {
+    const globalRoot = childProcess.execSync('npm root -g', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const globalTemplateRoot = resolveInstalledTemplateDir(globalRoot);
+    if (globalTemplateRoot) return globalTemplateRoot;
+  } catch {
+    // npm may be unavailable or not configured.
+  }
 
   try {
-    return fs.statSync(candidate).isDirectory() ? candidate : null;
+    const localRoot = childProcess.execSync('npm root', {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const localTemplateRoot = resolveInstalledTemplateDir(localRoot);
+    if (localTemplateRoot) return localTemplateRoot;
   } catch {
-    return null;
+    // npm may be unavailable or the project may not have a local install.
   }
+
+  return null;
 }
 
 function isBinary(fp) {
@@ -175,7 +202,7 @@ function langSelect(rels, lang, allSet, project) {
   return sel;
 }
 
-function syncTemplates(projectRoot) {
+function syncTemplates(projectRoot, templateRootOverride) {
   const configDir = path.join(projectRoot, '.agents');
   const cfgPath = path.join(configDir, '.airc.json');
 
@@ -185,11 +212,12 @@ function syncTemplates(projectRoot) {
 
   const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
   const configPathRel = norm(path.relative(projectRoot, cfgPath));
-  const templateRoot = resolveProjectTemplateDir(projectRoot, cfg.templateSource);
+  const templateRoot = templateRootOverride || resolveTemplateRoot(projectRoot);
   if (!templateRoot) {
     return { error: 'Template source not found. Install via npm: npm install -g @fitlab-ai/agent-infra' };
   }
   const version = INSTALLER_VERSION;
+  const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;
   const vars = { project, org };
@@ -362,8 +390,9 @@ function syncTemplates(projectRoot) {
   cfg.files.merged  = merged;
   cfg.files.ejected = ejected;
   cfg.templateVersion = version;
+  delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/tests/airc.test.js
+++ b/tests/airc.test.js
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 
 import { read } from "./helpers.js";
 
-test(".agents/.airc.json declares templates as the template source", () => {
+test(".agents/.airc.json does not declare templateSource", () => {
   const collaborator = JSON.parse(read(".agents/.airc.json"));
 
-  assert.equal(collaborator.templateSource, "templates/");
+  assert.ok(!("templateSource" in collaborator));
 });
 
 test(".agents/.airc.json merged patterns use recursive command globs and explicit skill paths", () => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -47,6 +47,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.equal(config.project, "testproj");
     assert.equal(config.org, "testorg");
     assert.equal(config.templateVersion, `v${JSON.parse(read("package.json")).version}`);
+    assert.ok(!("templateSource" in config), "init should not generate templateSource");
     assert.ok(!config.branchPrefix, "branchPrefix should not exist");
     assert.ok(!config.source, "consumer projects should not have source: self");
     assert.ok(
@@ -139,13 +140,30 @@ test("installed sync-templates.js executes inside a type=module project", () => 
       "module",
       "package.json should remain an ESM package after init"
     );
-    fs.mkdirSync(path.join(tmpDir, "templates"), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, "templates", "README.md"), "Hello {{project}}\n", "utf8");
+    const npmGlobalPrefix = path.join(tmpDir, ".npm-global");
+    const globalTemplateRoot = path.join(
+      npmGlobalPrefix,
+      "lib",
+      "node_modules",
+      "@fitlab-ai",
+      "agent-infra",
+      "templates"
+    );
+    const localTemplateRoot = path.join(
+      tmpDir,
+      "node_modules",
+      "@fitlab-ai",
+      "agent-infra",
+      "templates"
+    );
+    fs.mkdirSync(globalTemplateRoot, { recursive: true });
+    fs.mkdirSync(localTemplateRoot, { recursive: true });
+    fs.writeFileSync(path.join(globalTemplateRoot, "README.md"), "Hello {{project}} from global\n", "utf8");
+    fs.writeFileSync(path.join(localTemplateRoot, "README.md"), "Hello {{project}}\n", "utf8");
     fs.writeFileSync(
       path.join(tmpDir, ".agents", ".airc.json"),
       JSON.stringify({
         ...JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")),
-        templateSource: path.join(tmpDir, "templates"),
         files: {
           managed: ["README.md"],
           merged: [],
@@ -160,12 +178,18 @@ test("installed sync-templates.js executes inside a type=module project", () => 
       [path.join(".agents", "skills", "update-agent-infra", "scripts", "sync-templates.js")],
       {
         cwd: tmpDir,
-        encoding: "utf8"
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          npm_config_prefix: npmGlobalPrefix
+        }
       }
     );
     const report = JSON.parse(output);
 
     assert.ok(!report.error, "sync-templates.js should run without ESM loader errors");
+    assert.equal(report.templateRoot, globalTemplateRoot);
+    assert.equal(fs.readFileSync(path.join(tmpDir, "README.md"), "utf8"), "Hello esmproj from global\n");
     assert.ok(
       fs.existsSync(
         path.join(tmpDir, ".agents", "skills", "update-agent-infra", "scripts", "sync-templates.js")
@@ -214,7 +238,6 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     project: "seedproj",
     org: "seedorg",
     language: "zh-CN",
-    templateSource: "templates/",
     templateVersion: "stale",
     files: {
       managed: [],

--- a/tests/sync-templates.test.js
+++ b/tests/sync-templates.test.js
@@ -21,13 +21,19 @@ function normalize(targetPath) {
   return targetPath.replace(/\\/g, "/");
 }
 
-test("syncTemplates respects templateSource and stays idempotent", async () => {
+test("syncTemplates resolves template roots via npm and removes legacy templateSource", async () => {
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-"));
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(projectRoot, "custom-source");
+    const templateRoot = path.join(
+      projectRoot,
+      "node_modules",
+      "@fitlab-ai",
+      "agent-infra",
+      "templates"
+    );
 
     fs.mkdirSync(projectRoot, { recursive: true });
 
@@ -54,7 +60,14 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
       }
     });
 
-    childProcess.execSync = (command) => {
+    childProcess.execSync = (command, options = {}) => {
+      if (command === "npm root -g") {
+        return path.join(tmpDir, "missing-global-node_modules");
+      }
+      if (command === "npm root") {
+        assert.equal(options.cwd, projectRoot);
+        return path.join(projectRoot, "node_modules");
+      }
       if (command === "git remote get-url origin") {
         throw new Error("not a git repo");
       }
@@ -67,8 +80,11 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
     const afterFirstRun = fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8");
     const secondReport = syncTemplates(projectRoot);
     const afterSecondRun = fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8");
+    const parsedConfig = JSON.parse(afterSecondRun);
 
     assert.equal(normalize(firstReport.templateRoot), normalize(templateRoot));
+    assert.equal(firstReport.configUpdated, true);
+    assert.ok(!("templateSource" in parsedConfig));
     assert.ok(firstReport.registryAdded.some((entry) => entry.entry === ".agents/skills/" && entry.list === "managed"));
     assert.deepEqual(firstReport.managed.created.sort(), ["demo/script.sh", "docs/empty.txt", "docs/guide.md"]);
     assert.deepEqual(firstReport.managed.written, []);
@@ -96,6 +112,7 @@ test("syncTemplates respects templateSource and stays idempotent", async () => {
     assert.deepEqual(secondReport.managed.removed, []);
     assert.deepEqual(secondReport.ejected.created, []);
     assert.deepEqual(secondReport.ejected.skipped, ["local-only.md"]);
+    assert.equal(secondReport.configUpdated, false);
     assert.equal(afterSecondRun, afterFirstRun);
   } finally {
     childProcess.execSync = originalExecSync;
@@ -119,7 +136,6 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
       project: "demo",
       org: "acme",
       language: "en",
-      templateSource: templateRoot,
       files: {
         managed: ["README.md"],
         merged: [],
@@ -135,7 +151,7 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
     };
 
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
+    const report = syncTemplates(projectRoot, templateRoot);
 
     assert.equal(
       report.templateVersion,
@@ -167,7 +183,6 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
       project: "demo",
       org: "acme",
       language: "en",
-      templateSource: templateRoot,
       files: {
         managed: ["docs/", ".agents/", ".github/"],
         merged: ["docs/merged.md"],
@@ -192,8 +207,8 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
 
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
 
-    const firstReport = syncTemplates(projectRoot);
-    const secondReport = syncTemplates(projectRoot);
+    const firstReport = syncTemplates(projectRoot, templateRoot);
+    const secondReport = syncTemplates(projectRoot, templateRoot);
 
     assert.deepEqual(firstReport.managed.removed.sort(), ["docs/stale.md", "docs/subdir/orphan.md"]);
     assert.ok(!fs.existsSync(path.join(projectRoot, "docs/stale.md")));
@@ -228,7 +243,6 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
       project: "demo",
       org: "acme",
       language: "en",
-      templateSource: templateRoot,
       files: {
         managed: ["docs/"],
         merged: ["docs/**/*.md"],
@@ -248,7 +262,7 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
     };
 
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
+    const report = syncTemplates(projectRoot, templateRoot);
 
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/stale/note.md"), "utf8"), "keep merged glob\n");
     assert.ok(!fs.existsSync(path.join(projectRoot, "docs/stale/extra.txt")));
@@ -280,7 +294,6 @@ test("syncTemplates syncs the managed github hook as a single file", async () =>
       project: "demo",
       org: "acme",
       language: "en",
-      templateSource: templateRoot,
       files: {
         managed: [],
         merged: [],
@@ -298,7 +311,7 @@ test("syncTemplates syncs the managed github hook as a single file", async () =>
     };
 
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
+    const report = syncTemplates(projectRoot, templateRoot);
 
     assert.ok(
       report.registryAdded.some(
@@ -341,7 +354,6 @@ test("syncTemplates reports github pre-commit as a merged pending file", async (
       project: "demo",
       org: "acme",
       language: "en",
-      templateSource: templateRoot,
       files: {
         managed: [],
         merged: [],
@@ -357,7 +369,7 @@ test("syncTemplates reports github pre-commit as a merged pending file", async (
     };
 
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot);
+    const report = syncTemplates(projectRoot, templateRoot);
 
     assert.ok(
       report.registryAdded.some(


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #62

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

移除 `.agents/.airc.json` 中的 `templateSource` 字段。该字段在消费端项目中没有实际意义（消费端没有 `templates/` 目录），会误导 AI 助手将其改为绝对路径等错误操作。改为让 skill 层的 `sync-templates.js` 通过 npm 安装路径自动定位模板目录。

Remove the `templateSource` field from `.agents/.airc.json`. This field has no meaning in consumer projects (they don't have a `templates/` directory) and misleads AI assistants into incorrect actions like changing it to absolute paths. Template discovery is now handled automatically via `npm root -g` / `npm root`.

## 📋 主要变更 / Brief Changelog

- Remove `templateSource` from `.airc.json`, `init.js`, and all documentation (README, SKILL.md)
- Add `resolveTemplateRoot()` to locate templates via `npm root -g` (global) then `npm root` (local) fallback
- Auto-clean legacy `templateSource` on sync and track migration state in `configUpdated`
- Add `templateRootOverride` parameter to `syncTemplates()` for test injection
- Add two test conventions to CLAUDE.md and AGENTS.md: ban keyword semantic assertions and reverse deletion guards

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 39 个测试全部通过
2. 验证消费端项目 `.airc.json` 中残留的 `templateSource` 字段在 sync 后被自动清理
3. 验证 agent-infra 项目自身通过 `npm link` 后 `/update-agent-infra` 正常工作

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 15 files changed, +186/-60 lines
- Tests: 39 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented and refined by Codex

Closes #62

Generated with AI assistance