### PR TITLE
fix(skills): add shell safety rules for comment publishing

### DIFF
--- a/.agents/skills/sync-issue/SKILL.md
+++ b/.agents/skills/sync-issue/SKILL.md
@@ -58,6 +58,10 @@ grep -rl "^issue_number: {issue-number}$" \
 
 > 已有评论探测、隐藏标记、产物时间线、summary 评论顺序，以及绝对产物链接规则见 `reference/comment-publish.md`。发布 Issue 评论前先读取 `reference/comment-publish.md`。
 
+> **Shell 安全规则**（发布评论前必读）：
+> 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+
 ### 10. 更新任务状态
 
 获取当前时间：
@@ -77,6 +81,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 隐藏评论标记必须保持为 `<!-- sync-issue:{task-id}:{file-stem} -->`
 - 必须使用绝对链接，例如 `https://github.com/{owner}/{repo}/commit/{commit-hash}` 和 `https://github.com/{owner}/{repo}/pull/{pr-number}`
 - 产物时间线按 Activity Log 顺序构建，而不是固定的 `analysis -> plan -> implementation -> review -> summary`
+- 发布评论时遵守步骤 9 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 

--- a/.agents/skills/sync-pr/SKILL.md
+++ b/.agents/skills/sync-pr/SKILL.md
@@ -39,6 +39,10 @@ description: "将任务进度同步到 Pull Request"
 
 > 隐藏标记、幂等 summary 评论更新、review history 格式，以及评论创建/更新规则见 `reference/comment-publish.md`。发布摘要前先读取 `reference/comment-publish.md`。
 
+> **Shell 安全规则**（发布评论前必读）：
+> 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+
 ### 8. 更新任务状态
 
 获取当前时间：
@@ -58,6 +62,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 隐藏 summary 标记必须保持 `<!-- sync-pr:{task-id}:summary -->`
 - 面向 reviewer 只保留一条摘要评论
 - 如果 PR 已关闭或已合并，必须报告 `PR #{number} is closed/merged, metadata sync skipped`
+- 发布摘要时遵守步骤 7 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 

--- a/templates/.agents/skills/sync-issue/SKILL.md
+++ b/templates/.agents/skills/sync-issue/SKILL.md
@@ -58,6 +58,10 @@ If `pr_number` exists, make sure the PR body contains one of:
 
 > Existing-comment discovery, hidden markers, the artifact timeline, summary comment ordering, and absolute artifact-link rules live in `reference/comment-publish.md`. Read `reference/comment-publish.md` before publishing Issue comments.
 
+> **Shell Safety Rules** (read before publishing comments):
+> 1. `{comment-body}` must be replaced with **actual inline text**. Read the file with the Read tool first, then paste the full content into the heredoc body. **Do NOT** use `$(cat ...)`, `$(< ...)`, `$(...)`, or `${...}` inside `<<'EOF'`. Quoted heredocs suppress all command substitution and variable expansion, so those expressions will be output as literal text.
+> 2. When constructing strings that contain `<!-- -->`, **do NOT use `echo`**. In bash/zsh, `echo` escapes `!` as `\!`, which makes hidden markers visible. Build all comment content with `cat <<'EOF'` heredocs or `printf '%s\n'`.
+
 ### 10. Update Task Status
 
 Get the current time:
@@ -77,6 +81,7 @@ Summarize synced labels, milestone, development linkage, published comments, and
 - The hidden comment marker format must stay `<!-- sync-issue:{task-id}:{file-stem} -->`
 - Use absolute links such as `https://github.com/{owner}/{repo}/commit/{commit-hash}` and `https://github.com/{owner}/{repo}/pull/{pr-number}`
 - Build the artifact timeline from Activity Log order, not a fixed `analysis -> plan -> implementation -> review -> summary` sequence
+- Follow the Step 9 shell safety rules when publishing comments: do not rely on command substitution inside quoted heredocs, and do not use `echo` for HTML comment markers
 
 ## Error Handling
 

--- a/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
@@ -58,6 +58,10 @@ grep -rl "^issue_number: {issue-number}$" \
 
 > 已有评论探测、隐藏标记、产物时间线、summary 评论顺序，以及绝对产物链接规则见 `reference/comment-publish.md`。发布 Issue 评论前先读取 `reference/comment-publish.md`。
 
+> **Shell 安全规则**（发布评论前必读）：
+> 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+
 ### 10. 更新任务状态
 
 获取当前时间：
@@ -77,6 +81,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 隐藏评论标记必须保持为 `<!-- sync-issue:{task-id}:{file-stem} -->`
 - 必须使用绝对链接，例如 `https://github.com/{owner}/{repo}/commit/{commit-hash}` 和 `https://github.com/{owner}/{repo}/pull/{pr-number}`
 - 产物时间线按 Activity Log 顺序构建，而不是固定的 `analysis -> plan -> implementation -> review -> summary`
+- 发布评论时遵守步骤 9 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 

--- a/templates/.agents/skills/sync-pr/SKILL.md
+++ b/templates/.agents/skills/sync-pr/SKILL.md
@@ -39,6 +39,10 @@ If `issue_number` exists, ensure the PR body contains `Closes #{issue-number}` o
 
 > Hidden markers, idempotent summary comment updates, review-history formatting, and comment create/update rules live in `reference/comment-publish.md`. Read `reference/comment-publish.md` before publishing the summary.
 
+> **Shell Safety Rules** (read before publishing comments):
+> 1. `{comment-body}` must be replaced with **actual inline text**. Read the file with the Read tool first, then paste the full content into the heredoc body. **Do NOT** use `$(cat ...)`, `$(< ...)`, `$(...)`, or `${...}` inside `<<'EOF'`. Quoted heredocs suppress all command substitution and variable expansion, so those expressions will be output as literal text.
+> 2. When constructing strings that contain `<!-- -->`, **do NOT use `echo`**. In bash/zsh, `echo` escapes `!` as `\!`, which makes hidden markers visible. Build all comment content with `cat <<'EOF'` heredocs or `printf '%s\n'`.
+
 ### 8. Update Task Status
 
 Get the current time:
@@ -58,6 +62,7 @@ Report the synchronized labels, milestone, development status, summary result, a
 - The hidden summary marker must stay `<!-- sync-pr:{task-id}:summary -->`
 - Keep exactly one summary comment for reviewers
 - If the PR is already closed or merged, report `PR #{number} is closed/merged, metadata sync skipped`
+- Follow the Step 7 shell safety rules when publishing comments: do not rely on command substitution inside quoted heredocs, and do not use `echo` for HTML comment markers
 
 ## Error Handling
 

--- a/templates/.agents/skills/sync-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-pr/SKILL.zh-CN.md
@@ -39,6 +39,10 @@ description: "将任务进度同步到 Pull Request"
 
 > 隐藏标记、幂等 summary 评论更新、review history 格式，以及评论创建/更新规则见 `reference/comment-publish.md`。发布摘要前先读取 `reference/comment-publish.md`。
 
+> **Shell 安全规则**（发布评论前必读）：
+> 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+
 ### 8. 更新任务状态
 
 获取当前时间：
@@ -58,6 +62,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 隐藏 summary 标记必须保持 `<!-- sync-pr:{task-id}:summary -->`
 - 面向 reviewer 只保留一条摘要评论
 - 如果 PR 已关闭或已合并，必须报告 `PR #{number} is closed/merged, metadata sync skipped`
+- 发布摘要时遵守步骤 7 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #37

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

sync-issue 和 sync-pr 技能在发布 GitHub 评论时存在两个 shell 执行 bug：（1）AI 在带引号 heredoc（`<<'EOF'`）内使用 `$(cat ...)` 导致命令替换被阻止，评论内容变成字面 shell 文本；（2）使用 `echo` 构造含 `<!-- -->` 的 HTML 隐藏标识时，`!` 被转义为 `\!`，导致标识在 GitHub 上可见。根因是 SKILL.md 缺少对 AI 执行方式的约束。

The sync-issue and sync-pr skills had two shell execution bugs when publishing GitHub comments: (1) AI used `$(cat ...)` inside quoted heredocs (`<<'EOF'`), which suppressed command substitution and output literal shell text instead of file contents; (2) using `echo` to build `<!-- -->` HTML hidden markers caused `!` to be escaped as `\!`, making markers visible on GitHub. Root cause: SKILL.md lacked constraints on AI shell execution patterns.

## 📋 主要变更 / Brief Changelog

- 在 sync-issue 步骤 9 和 sync-pr 步骤 7 的评论发布位置前插入 Shell 安全规则，禁止在带引号 heredoc 内使用命令替换，禁止用 `echo` 构造 HTML 注释标记
- 在各 SKILL.md 的注意事项中追加交叉引用，形成双重覆盖
- 同步更新 6 个文件：2 个项目内 skill + 4 个模板文件（EN/zh-CN）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 39 个测试全部通过
2. 逐文件阅读确认安全约束段落位置正确、中英文语义一致
3. 确认项目内 skill 与 `templates/` 对应版本内容同步

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 6 files changed, +30 lines (documentation-only changes to SKILL.md files)
- Tests: 39 pass, 0 fail
- Multi-AI collaboration: analyzed, designed, and reviewed by Claude; implemented by Codex

Closes #37

Generated with AI assistance