### PR TITLE
feat(skills): add requirement checkbox sync to workflow skills

### DIFF
--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -71,6 +71,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `current_step`：implementation
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
+- 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -54,8 +54,10 @@ description: "处理代码审查反馈并修复问题"
 date "+%Y-%m-%d %H:%M:%S"
 ```
 
-更新 task.md，并追加：
-`- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+更新 task.md：
+- 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
+- 追加：
+  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 ### 7. 告知用户
 

--- a/.agents/skills/sync-issue/SKILL.md
+++ b/.agents/skills/sync-issue/SKILL.md
@@ -50,15 +50,22 @@ grep -rl "^issue_number: {issue-number}$" \
 
 > milestone 继承、版本分支推断和 `General Backlog` 回退规则见 `reference/milestone-sync.md`。编辑 Issue milestone 前先读取 `reference/milestone-sync.md`。
 
-### 8. 发布上下文产物
+### 8. 同步需求复选框
+
+从 task.md 的 `## 需求` 段落提取已勾选的 `- [x]` 项；如果没有，跳过。
+读取 Issue 当前正文：`gh issue view {issue-number} --json body --jq '.body'`。
+按复选框文本匹配，将 Issue body 中对应的 `- [ ] {text}` 单向替换为 `- [x] {text}`；已有 `- [x]`、未匹配项和非需求复选框保持不变。
+只有在正文实际变化时，才使用 `gh api` PATCH 更新完整 body，并用 `cat <<'EOF'` heredoc 构造请求内容。
+
+### 9. 发布上下文产物
 
 > 已有评论探测、隐藏标记、产物时间线和 summary 评论顺序见 `reference/comment-publish.md`。发布 Issue 评论前先读取 `reference/comment-publish.md`。
 
 > **Shell 安全规则**（发布评论前必读）：
 > 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
-> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容以及步骤 8 的 Issue body 更新都统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
 
-### 9. 更新任务状态
+### 10. 更新任务状态
 
 获取当前时间：
 
@@ -68,7 +75,7 @@ date "+%Y-%m-%d %H:%M:%S"
 
 更新 task.md 中的 `last_synced_at`，并追加 Sync to Issue 的 Activity Log。
 
-### 10. 告知用户
+### 11. 告知用户
 
 汇总已同步的 labels、milestone、development 关联、已发布评论，并给出 Issue URL。
 
@@ -76,7 +83,7 @@ date "+%Y-%m-%d %H:%M:%S"
 
 - 隐藏评论标记必须保持为 `<!-- sync-issue:{task-id}:{file-stem} -->`
 - 产物时间线按 Activity Log 顺序构建，而不是固定的 `analysis -> plan -> implementation -> review -> summary`
-- 发布评论时遵守步骤 8 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
+- 发布评论和更新 Issue body 时遵守步骤 9 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 

--- a/templates/.agents/skills/implement-task/SKILL.md
+++ b/templates/.agents/skills/implement-task/SKILL.md
@@ -71,6 +71,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: implementation
 - `assigned_to`: {current agent}
 - `updated_at`: {current time}
+- review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are clearly satisfied by this round's implemented code and passing tests
 - record `{implementation-artifact}` for Round `{implementation-round}`
 - append:
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -71,6 +71,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `current_step`：implementation
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
+- 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`

--- a/templates/.agents/skills/refine-task/SKILL.md
+++ b/templates/.agents/skills/refine-task/SKILL.md
@@ -54,8 +54,10 @@ Get the current time:
 date "+%Y-%m-%d %H:%M:%S"
 ```
 
-Update task.md and append:
-`- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+Update task.md:
+- review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are newly satisfied by this round's fixes and passing tests
+- append:
+  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 ### 7. Inform User
 

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -54,8 +54,10 @@ description: "处理代码审查反馈并修复问题"
 date "+%Y-%m-%d %H:%M:%S"
 ```
 
-更新 task.md，并追加：
-`- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+更新 task.md：
+- 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
+- 追加：
+  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 ### 7. 告知用户
 

--- a/templates/.agents/skills/sync-issue/SKILL.md
+++ b/templates/.agents/skills/sync-issue/SKILL.md
@@ -50,15 +50,22 @@ If `pr_number` exists, make sure the PR body contains one of:
 
 > Milestone inheritance, line-branch inference, and `General Backlog` fallback rules live in `reference/milestone-sync.md`. Read `reference/milestone-sync.md` before editing the Issue milestone.
 
-### 8. Publish Context Artifacts
+### 8. Sync Requirement Checkboxes
+
+Extract checked `- [x]` items from the `## Requirements` section of task.md; if none exist, skip this step.
+Read the current Issue body with `gh issue view {issue-number} --json body --jq '.body'`.
+Match by checkbox text and replace only `- [ ] {text}` with `- [x] {text}` in the Issue body; keep existing `- [x]` items, unmatched items, and non-requirement checkboxes unchanged.
+Only when the body actually changes, update the full body with `gh api` PATCH and build the request payload with `cat <<'EOF'` heredoc.
+
+### 9. Publish Context Artifacts
 
 > Existing-comment discovery, hidden markers, the artifact timeline, and summary comment ordering live in `reference/comment-publish.md`. Read `reference/comment-publish.md` before publishing Issue comments.
 
 > **Shell Safety Rules** (read before publishing comments):
 > 1. `{comment-body}` must be replaced with **actual inline text**. Read the file with the Read tool first, then paste the full content into the heredoc body. **Do NOT** use `$(cat ...)`, `$(< ...)`, `$(...)`, or `${...}` inside `<<'EOF'`. Quoted heredocs suppress all command substitution and variable expansion, so those expressions will be output as literal text.
-> 2. When constructing strings that contain `<!-- -->`, **do NOT use `echo`**. In bash/zsh, `echo` escapes `!` as `\!`, which makes hidden markers visible. Build all comment content with `cat <<'EOF'` heredocs or `printf '%s\n'`.
+> 2. When constructing strings that contain `<!-- -->`, **do NOT use `echo`**. In bash/zsh, `echo` escapes `!` as `\!`, which makes hidden markers visible. Build all comment content and the Step 8 Issue body update with `cat <<'EOF'` heredocs or `printf '%s\n'`.
 
-### 9. Update Task Status
+### 10. Update Task Status
 
 Get the current time:
 
@@ -68,7 +75,7 @@ date "+%Y-%m-%d %H:%M:%S"
 
 Update `last_synced_at` in task.md and append the Sync to Issue Activity Log entry.
 
-### 10. Inform User
+### 11. Inform User
 
 Summarize synced labels, milestone, development linkage, published comments, and include the Issue URL.
 
@@ -76,7 +83,7 @@ Summarize synced labels, milestone, development linkage, published comments, and
 
 - The hidden comment marker format must stay `<!-- sync-issue:{task-id}:{file-stem} -->`
 - Build the artifact timeline from Activity Log order, not a fixed `analysis -> plan -> implementation -> review -> summary` sequence
-- Follow the Step 8 shell safety rules when publishing comments: do not rely on command substitution inside quoted heredocs, and do not use `echo` for HTML comment markers
+- Follow the Step 9 shell safety rules when publishing comments or updating the Issue body: do not rely on command substitution inside quoted heredocs, and do not use `echo` for HTML comment markers
 
 ## Error Handling
 

--- a/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/sync-issue/SKILL.zh-CN.md
@@ -50,15 +50,22 @@ grep -rl "^issue_number: {issue-number}$" \
 
 > milestone 继承、版本分支推断和 `General Backlog` 回退规则见 `reference/milestone-sync.md`。编辑 Issue milestone 前先读取 `reference/milestone-sync.md`。
 
-### 8. 发布上下文产物
+### 8. 同步需求复选框
+
+从 task.md 的 `## 需求` 段落提取已勾选的 `- [x]` 项；如果没有，跳过。
+读取 Issue 当前正文：`gh issue view {issue-number} --json body --jq '.body'`。
+按复选框文本匹配，将 Issue body 中对应的 `- [ ] {text}` 单向替换为 `- [x] {text}`；已有 `- [x]`、未匹配项和非需求复选框保持不变。
+只有在正文实际变化时，才使用 `gh api` PATCH 更新完整 body，并用 `cat <<'EOF'` heredoc 构造请求内容。
+
+### 9. 发布上下文产物
 
 > 已有评论探测、隐藏标记、产物时间线和 summary 评论顺序见 `reference/comment-publish.md`。发布 Issue 评论前先读取 `reference/comment-publish.md`。
 
 > **Shell 安全规则**（发布评论前必读）：
 > 1. `{comment-body}` 必须替换为**实际的内联文本**。先用 Read 工具读取文件，再将全文粘贴到 heredoc body 中。**禁止**在 `<<'EOF'` 内部使用 `$(cat ...)`、`$(< ...)`、`$(...)`、`${...}`。带引号 heredoc 会阻止所有命令替换和变量展开，它们会被当作字面文本输出。
-> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
+> 2. 构造含 `<!-- -->` 的字符串时，**禁止使用 `echo`**。bash/zsh 中 `echo` 会将 `!` 转义为 `\!`，导致隐藏标识可见。所有评论内容以及步骤 8 的 Issue body 更新都统一使用 `cat <<'EOF'` heredoc 或 `printf '%s\n'` 构造。
 
-### 9. 更新任务状态
+### 10. 更新任务状态
 
 获取当前时间：
 
@@ -68,7 +75,7 @@ date "+%Y-%m-%d %H:%M:%S"
 
 更新 task.md 中的 `last_synced_at`，并追加 Sync to Issue 的 Activity Log。
 
-### 10. 告知用户
+### 11. 告知用户
 
 汇总已同步的 labels、milestone、development 关联、已发布评论，并给出 Issue URL。
 
@@ -76,7 +83,7 @@ date "+%Y-%m-%d %H:%M:%S"
 
 - 隐藏评论标记必须保持为 `<!-- sync-issue:{task-id}:{file-stem} -->`
 - 产物时间线按 Activity Log 顺序构建，而不是固定的 `analysis -> plan -> implementation -> review -> summary`
-- 发布评论时遵守步骤 8 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
+- 发布评论和更新 Issue body 时遵守步骤 9 的 Shell 安全规则，不要在带引号 heredoc 中依赖命令替换，也不要用 `echo` 构造 HTML 注释标记
 
 ## 错误处理
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #39

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

sync-issue 同步进度到 GitHub Issue 时，未将 Issue 描述中的需求复选框根据任务完成情况勾选；同时 task.md 中的需求复选框也未在工作流各阶段被自动更新。本 PR 在三个技能中添加复选框管理逻辑，实现需求完成状态的自动追踪和同步。

Closes #39

## 📋 主要变更 / Brief Changelog

- sync-issue: 在步骤 7（同步里程碑）之后新增步骤 8（同步需求复选框），从 task.md 提取已勾选的需求项，按文本匹配单向替换 Issue body 中的对应复选框（`[ ]` → `[x]`），仅在正文变化时 PATCH
- implement-task: 在步骤 7（更新任务状态）中新增子步骤，要求实现完成后审查需求段落并勾选有代码实现和测试通过支撑的条目
- refine-task: 在步骤 6（更新任务状态）中新增子步骤，修复完成后勾选因修复而新满足的需求条目
- 同步更新 6 个模板文件（英文 SKILL.md + 中文 SKILL.zh-CN.md）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `node --test tests/*.test.js` 确认所有 39 个测试通过
2. 确认步骤编号连续性测试通过
3. 确认工作副本与 zh-CN 模板一致（`diff` 无输出）

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

本次变更仅修改 SKILL.md 文本指令，不涉及可执行代码。复选框同步设计为单向（仅 `[ ]` → `[x]`），确保不会覆盖用户在 GitHub 上的手动勾选。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 sync-issue 新步骤 8 的文本匹配策略是否清晰
- 确认 implement-task 和 refine-task 的勾选条件（"有测试通过支撑"）是否足够严格

Generated with AI assistance