### PR TITLE
feat(skills): add auto branch detection to implement-task (#85)

### DIFF
--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -24,7 +24,20 @@ description: "根据技术方案实施任务并输出报告"
 
 如果缺少任一文件，立即停止并提示用户先完成前置步骤。
 
-### 2. 确定输入方案与实现轮次
+### 2. 确保任务分支
+
+先读取 `task.md` 中 `## 上下文` 的分支字段，并检查当前 Git 分支是否匹配。
+
+- 已记录任务分支：当前分支不匹配时切换到该分支
+- 未记录任务分支：判断当前分支是否符合命名规范且属于当前任务
+  - 符合：记录当前分支并继续
+  - 不符合：按规范创建并切换到新的任务分支
+
+完成后，把最终使用的分支名回写到 `task.md`。
+
+> 分支命名规则、Git 命令和边界处理见 `reference/branch-management.md`。执行此步骤前，先读取 `reference/branch-management.md`。
+
+### 3. 确定输入方案与实现轮次
 
 扫描 `.agents/workspace/active/{task-id}/` 并记录：
 - 最高轮次的方案文件为 `{plan-artifact}`
@@ -33,7 +46,7 @@ description: "根据技术方案实施任务并输出报告"
 
 如果存在 `plan-r{N}.md`，读取最高轮次的方案文件；否则读取 `plan.md`。
 
-### 3. 阅读技术方案
+### 4. 阅读技术方案
 
 仔细阅读 `{plan-artifact}`，提取：
 - 实施步骤
@@ -41,25 +54,25 @@ description: "根据技术方案实施任务并输出报告"
 - 测试策略
 - 约束、风险与已批准的取舍
 
-### 4. 执行代码实现
+### 5. 执行代码实现
 
 按照 `.agents/workflows/feature-development.yaml` 和方案顺序实施。
 
 > 详细实现规则、测试纪律和偏离处理见 `reference/implementation-rules.md`。执行此步骤前，先读取 `reference/implementation-rules.md`。
 
-### 5. 运行测试验证
+### 6. 运行测试验证
 
 使用 `test` 技能中的项目测试命令，直到所有必需测试通过。
 
 如果测试失败，先尝试修复并重新运行测试。只有在确认存在外部阻塞、环境缺失或需求不明确且超出任务范围时，才可以停止。
 
-### 6. 编写实现报告
+### 7. 编写实现报告
 
 创建 `.agents/workspace/active/{task-id}/{implementation-artifact}`。
 
 > 报告结构、必填章节和完整模板见 `reference/report-template.md`。写报告前先读取 `reference/report-template.md`。
 
-### 7. 更新任务状态
+### 8. 更新任务状态
 
 获取当前时间：
 
@@ -76,7 +89,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 追加：
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
-### 8. 告知用户
+### 9. 告知用户
 
 输出实现摘要，并完整展示下一步代码审查的所有 TUI 命令格式。
 

--- a/.agents/skills/implement-task/reference/branch-management.md
+++ b/.agents/skills/implement-task/reference/branch-management.md
@@ -1,0 +1,49 @@
+# 分支管理
+
+在确保任务分支之前先读取本文件。
+
+## 分支名规则
+
+- 格式：`agent-infra-{type}-{slug}`
+- 项目前缀：读取 `.agents/.airc.json` 中的 `project`
+- `{type}`：读取 `task.md` frontmatter 中的 `type`
+- `{slug}`：根据任务标题提取 3-6 个英文关键词，转为 kebab-case
+
+## 分支检测流程
+
+先读取：
+- `task.md` 中 `## 上下文` 下的 `- **分支**：`
+- 当前分支：`git branch --show-current`
+
+有效已记录分支：
+- 有值，且不是 `待定`、`待创建`、`N/A` 或空字符串
+
+场景 A：`task.md` 已记录任务分支
+- 当前分支与记录值一致：直接继续
+- 当前分支不一致：按下方”创建与切换命令”章节切换到已记录分支
+
+场景 B：`task.md` 未记录任务分支
+- 判断当前分支是否符合项目分支命名规范（`agent-infra-{type}-{slug}`）且语义上属于当前任务
+- 符合：将当前分支名回写到 `task.md`，继续
+- 不符合：生成新的任务分支名，按下方”创建与切换命令”章节创建并切换，回写到 `task.md`
+
+## 创建与切换命令
+
+按以下顺序处理：
+
+```bash
+git branch --list {branch-name}
+git ls-remote --heads origin {branch-name}
+```
+
+- 本地分支已存在：`git switch {branch-name}`
+- 仅远程分支存在：`git switch --track origin/{branch-name}`
+- 本地和远程都不存在：`git switch -c {branch-name}`
+
+如果切换失败，立即停止并提示用户先处理工作区冲突或未解决的分支问题。
+
+## task.md 回写要求
+
+- 更新 `## 上下文` 中的 `- **分支**：{branch-name}`
+- 不修改其他上下文字段
+- 若本步骤已回写 `task.md`，后续更新任务状态时保留该分支值

--- a/templates/.agents/skills/implement-task/SKILL.md
+++ b/templates/.agents/skills/implement-task/SKILL.md
@@ -24,7 +24,20 @@ Check these files first:
 
 If either file is missing, stop and ask the user to complete the prerequisite step.
 
-### 2. Determine the Input Plan and Implementation Round
+### 2. Ensure the Task Branch
+
+Read the branch field in `## Context` from `task.md` and check whether the current Git branch matches it.
+
+- if a task branch is already recorded, switch to it when the current branch does not match
+- if no branch is recorded, check whether the current branch follows the naming convention and belongs to this task
+  - if yes: record the current branch and continue
+  - if no: create and switch to a new task branch that follows the naming rule
+
+After this step, write the final branch name back to `task.md`.
+
+> Branch naming rules, Git commands, and edge-case handling live in `reference/branch-management.md`. Read `reference/branch-management.md` before executing this step.
+
+### 3. Determine the Input Plan and Implementation Round
 
 Scan `.agents/workspace/active/{task-id}/` and record:
 - the highest-round plan file as `{plan-artifact}`
@@ -33,7 +46,7 @@ Scan `.agents/workspace/active/{task-id}/` and record:
 
 If any `plan-r{N}.md` exists, read the highest-round plan file. Otherwise read `plan.md`.
 
-### 3. Read the Technical Plan
+### 4. Read the Technical Plan
 
 Read `{plan-artifact}` carefully and extract:
 - implementation steps
@@ -41,25 +54,25 @@ Read `{plan-artifact}` carefully and extract:
 - test strategy
 - constraints, risks, and any approved tradeoffs
 
-### 4. Implement the Code
+### 5. Implement the Code
 
 Follow `.agents/workflows/feature-development.yaml` and the plan in order.
 
 > Detailed implementation rules, testing discipline, and deviation handling live in `reference/implementation-rules.md`. Read `reference/implementation-rules.md` before executing this step.
 
-### 5. Run Test Verification
+### 6. Run Test Verification
 
 Use the project test command from the `test` skill and keep iterating until all required tests pass.
 
 If tests fail, Attempt to fix the issue and re-run tests first. Only stop when you confirm an external blocker, missing environment, or unclear requirement that is out of scope for the task.
 
-### 6. Write the Implementation Report
+### 7. Write the Implementation Report
 
 Create `.agents/workspace/active/{task-id}/{implementation-artifact}`.
 
 > Report structure, required sections, and the full template live in `reference/report-template.md`. Read `reference/report-template.md` before writing the report.
 
-### 7. Update Task Status
+### 8. Update Task Status
 
 Get the current time:
 
@@ -76,7 +89,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - append:
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
-### 8. Inform the User
+### 9. Inform the User
 
 Output the implementation summary and include all TUI command variants for the next review step.
 

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -24,7 +24,20 @@ description: "根据技术方案实施任务并输出报告"
 
 如果缺少任一文件，立即停止并提示用户先完成前置步骤。
 
-### 2. 确定输入方案与实现轮次
+### 2. 确保任务分支
+
+先读取 `task.md` 中 `## 上下文` 的分支字段，并检查当前 Git 分支是否匹配。
+
+- 已记录任务分支：当前分支不匹配时切换到该分支
+- 未记录任务分支：判断当前分支是否符合命名规范且属于当前任务
+  - 符合：记录当前分支并继续
+  - 不符合：按规范创建并切换到新的任务分支
+
+完成后，把最终使用的分支名回写到 `task.md`。
+
+> 分支命名规则、Git 命令和边界处理见 `reference/branch-management.md`。执行此步骤前，先读取 `reference/branch-management.md`。
+
+### 3. 确定输入方案与实现轮次
 
 扫描 `.agents/workspace/active/{task-id}/` 并记录：
 - 最高轮次的方案文件为 `{plan-artifact}`
@@ -33,7 +46,7 @@ description: "根据技术方案实施任务并输出报告"
 
 如果存在 `plan-r{N}.md`，读取最高轮次的方案文件；否则读取 `plan.md`。
 
-### 3. 阅读技术方案
+### 4. 阅读技术方案
 
 仔细阅读 `{plan-artifact}`，提取：
 - 实施步骤
@@ -41,25 +54,25 @@ description: "根据技术方案实施任务并输出报告"
 - 测试策略
 - 约束、风险与已批准的取舍
 
-### 4. 执行代码实现
+### 5. 执行代码实现
 
 按照 `.agents/workflows/feature-development.yaml` 和方案顺序实施。
 
 > 详细实现规则、测试纪律和偏离处理见 `reference/implementation-rules.md`。执行此步骤前，先读取 `reference/implementation-rules.md`。
 
-### 5. 运行测试验证
+### 6. 运行测试验证
 
 使用 `test` 技能中的项目测试命令，直到所有必需测试通过。
 
 如果测试失败，先尝试修复并重新运行测试。只有在确认存在外部阻塞、环境缺失或需求不明确且超出任务范围时，才可以停止。
 
-### 6. 编写实现报告
+### 7. 编写实现报告
 
 创建 `.agents/workspace/active/{task-id}/{implementation-artifact}`。
 
 > 报告结构、必填章节和完整模板见 `reference/report-template.md`。写报告前先读取 `reference/report-template.md`。
 
-### 7. 更新任务状态
+### 8. 更新任务状态
 
 获取当前时间：
 
@@ -76,7 +89,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 追加：
   `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
-### 8. 告知用户
+### 9. 告知用户
 
 输出实现摘要，并完整展示下一步代码审查的所有 TUI 命令格式。
 

--- a/templates/.agents/skills/implement-task/reference/branch-management.md
+++ b/templates/.agents/skills/implement-task/reference/branch-management.md
@@ -1,0 +1,48 @@
+# Branch Management
+
+Read this file before ensuring the task branch.
+
+## Branch Naming Rule
+
+- Format: `{{project}}-{type}-{slug}`
+- project prefix: read the `project` field from `.agents/.airc.json`
+- `{type}`: read the `type` field from the task frontmatter
+- `{slug}`: derive a 3-6 word English kebab-case phrase from the task title
+
+## Branch Detection Flow
+
+Read these inputs first:
+- the `- **Branch**:` field under `## Context` in `task.md`
+- the current branch from `git branch --show-current`
+
+A recorded branch is valid when it has a non-empty value other than `TBD`, `to be created`, or `N/A`.
+
+Scenario A: `task.md` already records the task branch
+- if the current branch matches, continue
+- if it does not match, follow the "Create and Switch Commands" section below to switch to the recorded branch
+
+Scenario B: `task.md` has no task branch recorded
+- check whether the current branch follows the project naming convention (`{{project}}-{type}-{slug}`) and semantically belongs to this task
+- if yes: write the current branch name back to `task.md` and continue
+- if no: generate a new task branch name, create and switch using the "Create and Switch Commands" section below, then write it back to `task.md`
+
+## Create and Switch Commands
+
+Check branches in this order:
+
+```bash
+git branch --list {branch-name}
+git ls-remote --heads origin {branch-name}
+```
+
+- local branch exists: `git switch {branch-name}`
+- only remote branch exists: `git switch --track origin/{branch-name}`
+- neither exists: `git switch -c {branch-name}`
+
+If switching fails, stop and ask the user to resolve the branch or working tree conflict first.
+
+## task.md Write-back
+
+- update `- **Branch**: {branch-name}` under `## Context`
+- do not modify the other context fields
+- preserve the recorded branch value when updating task status later

--- a/templates/.agents/skills/implement-task/reference/branch-management.zh-CN.md
+++ b/templates/.agents/skills/implement-task/reference/branch-management.zh-CN.md
@@ -1,0 +1,49 @@
+# 分支管理
+
+在确保任务分支之前先读取本文件。
+
+## 分支名规则
+
+- 格式：`{{project}}-{type}-{slug}`
+- 项目前缀：读取 `.agents/.airc.json` 中的 `project`
+- `{type}`：读取 `task.md` frontmatter 中的 `type`
+- `{slug}`：根据任务标题提取 3-6 个英文关键词，转为 kebab-case
+
+## 分支检测流程
+
+先读取：
+- `task.md` 中 `## 上下文` 下的 `- **分支**：`
+- 当前分支：`git branch --show-current`
+
+有效已记录分支：
+- 有值，且不是 `待定`、`待创建`、`N/A` 或空字符串
+
+场景 A：`task.md` 已记录任务分支
+- 当前分支与记录值一致：直接继续
+- 当前分支不一致：按下方”创建与切换命令”章节切换到已记录分支
+
+场景 B：`task.md` 未记录任务分支
+- 判断当前分支是否符合项目分支命名规范（`{{project}}-{type}-{slug}`）且语义上属于当前任务
+- 符合：将当前分支名回写到 `task.md`，继续
+- 不符合：生成新的任务分支名，按下方”创建与切换命令”章节创建并切换，回写到 `task.md`
+
+## 创建与切换命令
+
+按以下顺序处理：
+
+```bash
+git branch --list {branch-name}
+git ls-remote --heads origin {branch-name}
+```
+
+- 本地分支已存在：`git switch {branch-name}`
+- 仅远程分支存在：`git switch --track origin/{branch-name}`
+- 本地和远程都不存在：`git switch -c {branch-name}`
+
+如果切换失败，立即停止并提示用户先处理工作区冲突或未解决的分支问题。
+
+## task.md 回写要求
+
+- 更新 `## 上下文` 中的 `- **分支**：{branch-name}`
+- 不修改其他上下文字段
+- 若本步骤已回写 `task.md`，后续更新任务状态时保留该分支值


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #85

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

当前 implement-task 技能不包含分支管理逻辑，用户执行 `/implement-task` 时可能在错误的分支（如 `main` 或版本主干）上直接修改代码。本 PR 在实现步骤之前新增"确保任务分支"步骤，自动检测当前分支是否属于当前任务，不符合则创建并切换到任务对应的分支。

The implement-task skill currently lacks branch management logic. Users running `/implement-task` may end up modifying code on the wrong branch (e.g. `main` or a version trunk). This PR adds an "Ensure Task Branch" step before implementation begins, which automatically checks whether the current branch belongs to the current task and creates/switches to a task branch if not.

## 📋 主要变更 / Brief Changelog

- 在 implement-task SKILL.md 步骤 1 和步骤 2 之间插入新步骤 2「确保任务分支」，原步骤 2-8 顺延为 3-9
- 新增 `reference/branch-management.md`，定义分支命名规则（`{project}-{type}-{slug}`）、检测流程（2 个场景）和 Git 命令序列
- 判断逻辑基于命名规范匹配而非枚举主干分支，兼容版本主干（如 `1.1.x`）
- 同步更新三版文件：本地 zh-CN、模板 EN、模板 zh-CN

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 执行 `node --test tests/*.test.js`，确认全部 39 个测试通过
2. 检查 SKILL.md 步骤编号连续（1-9），reference 路径引用正确
3. 确认模板文件使用 `{{project}}` 双花括号占位符，本地文件使用渲染后的 `agent-infra`

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass (39/39)
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

Closes #85

Generated with AI assistance