### PR TITLE
fix(skills): unify Issue/PR title format chain and reduce CLAUDE.md context noise (#96)

### DIFF
--- a/.agents/rules/commit-and-pr.md
+++ b/.agents/rules/commit-and-pr.md
@@ -4,6 +4,7 @@
 
 - 使用 Conventional Commits：`<type>(<scope>): <subject>`
 - `type` 仅限：`feat`、`fix`、`docs`、`refactor`、`test`、`chore`
+- `scope`：模块名（可省略）
 - `subject` 使用英文祈使语气，保持简洁
 
 ## 禁止自动提交

--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -10,6 +10,7 @@ description: "从任务文件创建 GitHub Issue"
 ## 行为边界 / 关键规则
 
 - Issue 标题和正文只能来自 `task.md`
+- Issue 标题格式为 `type(scope): 描述`——type 从 task.md 的 `type` 字段映射（feature→feat, bugfix→fix, refactor→refactor, docs→docs, chore→chore），scope 从受影响模块推断（无法确定时省略），描述使用 task.md 中的任务标题原文（不要翻译或改写）
 - 不要读取 `analysis.md`、`plan.md`、`implementation.md` 或审查产物
 - 持久产物只有 GitHub Issue 本身，以及 task.md 中的 `issue_number` 更新
 - 执行本技能后，你**必须**立即更新 task.md
@@ -26,7 +27,7 @@ description: "从任务文件创建 GitHub Issue"
 
 ### 2. 提取任务信息
 
-从 task.md 提取标题、`## Description`、`## Requirements`、`type` 和 `milestone`。
+从 task.md 提取标题、`## Description`、`## Requirements`、`type` 和 `milestone`。构造 Issue 标题：将 task.md 的 `type` 映射为 Conventional Commits type，推断 scope，拼接为 `cc_type(scope): task_title` 或 `cc_type: task_title`（scope 不确定时省略）。
 
 ### 3. 构建 Issue 内容
 

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -24,7 +24,7 @@ description: "根据自然语言描述创建任务"
 ### 1. 解析用户描述
 
 从自然语言描述中提取：
-- **任务标题**：简洁标题（最多 50 个字符），使用与用户描述相同的语言
+- **任务标题**：简洁标题（最多 50 个字符），使用中文——不要翻译为英文，不要套用 Conventional Commits 格式
 - **任务类型**：`feature` | `bugfix` | `refactor` | `docs` | `chore`（从描述推断）
 - **工作流**：`feature-development` | `bug-fix` | `refactoring`（从类型推断）
 - **详细描述**：整理后的用户原始描述

--- a/.agents/skills/refine-title/SKILL.md
+++ b/.agents/skills/refine-title/SKILL.md
@@ -37,7 +37,7 @@ gh pr view <id> --json number,title,body,labels,state,files
 
 **生成 Subject**：
 - **忽略原始标题**（避免偏见）- 从 body 中提取核心意图
-- 保持简洁（不超过 50 字符），英文祈使语气，末尾无句号
+- 保持简洁（不超过 50 字符），使用内容原始语言（中文内容用中文，英文内容用英文），末尾无句号
 
 ### 3. 展示建议
 
@@ -86,7 +86,7 @@ gh pr edit <id> --title "<new-title>"
 ## 优势
 
 本技能的优势：
-1. **修复误导性标题**：即使原始标题是"Help me"，也能读取 body 并生成合适的标题，如 `fix(core): resolve startup error`
+1. **修复误导性标题**：即使原始标题是"Help me"，也能读取 body 并生成合适的标题，如 `fix(core): 修复启动错误` 或 `fix(core): resolve startup error`
 2. **精确 scope**：通过分析 PR 文件变更，可以自动推断正确的 scope，无需手动指定
 
 ## 注意事项

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,28 +60,7 @@ node --test tests/*.test.js
 
 ## 提交与 PR 规范
 
-### 提交信息格式（Conventional Commits）
-```
-<type>(<scope>): <subject>
-
-示例：
-feat(module): add new feature
-fix(module): fix critical bug
-docs(module): update documentation
-refactor(module): refactor internal logic
-```
-
-- **type**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
-- **scope**: 模块名（可省略）
-- **subject**: 英文，简洁祈使语气，不超过 50 字符
-
-### PR 检查清单
-提交 PR 前必须确保：
-- [ ] 所有测试通过
-- [ ] 代码检查通过
-- [ ] 构建成功
-- [ ] 公共 API 有文档
-- [ ] 版权头年份已更新（如适用）
+详见 `.agents/rules/commit-and-pr.md`（提交代码或创建 PR 时按需加载）。
 
 ## 安全注意事项
 
@@ -110,7 +89,8 @@ refactor(module): refactor internal logic
 | 代码标识符、JSDoc/TSDoc | 英文 | 代码即文档 |
 | CLI 帮助文本、错误信息 | 英文 | 面向所有用户 |
 | Git commit message | 英文 | Conventional Commits 祈使语气 |
-| 任务标题与 GitHub Issue 标题 | 跟随用户输入语言 | 通过 `/create-task` 或 `/import-issue` 创建 |
+| 任务标题 | 跟随用户输入语言 | task.md 标题保持用户原文，不套用 Conventional Commits 格式 |
+| GitHub Issue/PR 标题 | 英文前缀 + 跟随用户输入语言 | 格式：`type(scope): 中文描述`；type/scope 英文，描述保持原文 |
 | 任务工作区产物 | 跟随已部署的技能语言 | `.agents/workspace/` 文件使用 `.airc.json` 选定的 SKILL.md 语言 |
 | Activity Log 步骤名 | 英文 | 工具链使用的结构化标识符（如 `**Commit** by`） |
 | 项目文档 | 英文（主） + 中文翻译 | 如 `README.md` + `README.zh-CN.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,28 +60,7 @@ node --test tests/*.test.js
 
 ## 提交与 PR 规范
 
-### 提交信息格式（Conventional Commits）
-```
-<type>(<scope>): <subject>
-
-示例：
-feat(module): add new feature
-fix(module): fix critical bug
-docs(module): update documentation
-refactor(module): refactor internal logic
-```
-
-- **type**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
-- **scope**: 模块名（可省略）
-- **subject**: 英文，简洁祈使语气，不超过 50 字符
-
-### PR 检查清单
-提交 PR 前必须确保：
-- [ ] 所有测试通过
-- [ ] 代码检查通过
-- [ ] 构建成功
-- [ ] 公共 API 有文档
-- [ ] 版权头年份已更新（如适用）
+详见 `.agents/rules/commit-and-pr.md`（提交代码或创建 PR 时按需加载）。
 
 ## 安全注意事项
 
@@ -110,7 +89,8 @@ refactor(module): refactor internal logic
 | 代码标识符、JSDoc/TSDoc | 英文 | 代码即文档 |
 | CLI 帮助文本、错误信息 | 英文 | 面向所有用户 |
 | Git commit message | 英文 | Conventional Commits 祈使语气 |
-| 任务标题与 GitHub Issue 标题 | 跟随用户输入语言 | 通过 `/create-task` 或 `/import-issue` 创建 |
+| 任务标题 | 跟随用户输入语言 | task.md 标题保持用户原文，不套用 Conventional Commits 格式 |
+| GitHub Issue/PR 标题 | 英文前缀 + 跟随用户输入语言 | 格式：`type(scope): 中文描述`；type/scope 英文，描述保持原文 |
 | 任务工作区产物 | 跟随已部署的技能语言 | `.agents/workspace/` 文件使用 `.airc.json` 选定的 SKILL.md 语言 |
 | Activity Log 步骤名 | 英文 | 工具链使用的结构化标识符（如 `**Commit** by`） |
 | 项目文档 | 英文（主） + 中文翻译 | 如 `README.md` + `README.zh-CN.md` |

--- a/templates/.agents/skills/create-issue/SKILL.md
+++ b/templates/.agents/skills/create-issue/SKILL.md
@@ -10,6 +10,7 @@ Create the base GitHub Issue from `task.md` and write `issue_number` back to the
 ## Boundary / Critical Rules
 
 - Build the Issue title and body from `task.md` only
+- Issue title format: `type(scope): description` - map `type` from task.md (`feature` -> `feat`, `bugfix` -> `fix`, `refactor` -> `refactor`, `docs` -> `docs`, `chore` -> `chore`), infer scope from the affected module (omit it if unclear), and use the task title from task.md verbatim for the description (do not translate or rewrite)
 - Do not read `analysis.md`, `plan.md`, `implementation.md`, or review artifacts
 - The only durable outputs are the GitHub Issue and the `issue_number` update in task.md
 - After executing this skill, you **must** immediately update task.md
@@ -26,7 +27,7 @@ If `issue_number` already exists and is not empty or `N/A`, confirm with the use
 
 ### 2. Extract Task Information
 
-Extract the title, `## Description`, `## Requirements`, `type`, and `milestone` from task.md.
+Extract the title, `## Description`, `## Requirements`, `type`, and `milestone` from task.md. Build the Issue title by mapping task.md `type` to a Conventional Commits type, inferring scope, and formatting it as `cc_type(scope): task_title` or `cc_type: task_title` when scope is unclear.
 
 ### 3. Build Issue Content
 

--- a/templates/.agents/skills/create-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-issue/SKILL.zh-CN.md
@@ -10,6 +10,7 @@ description: "从任务文件创建 GitHub Issue"
 ## 行为边界 / 关键规则
 
 - Issue 标题和正文只能来自 `task.md`
+- Issue 标题格式为 `type(scope): 描述`——type 从 task.md 的 `type` 字段映射（feature→feat, bugfix→fix, refactor→refactor, docs→docs, chore→chore），scope 从受影响模块推断（无法确定时省略），描述使用 task.md 中的任务标题原文（不要翻译或改写）
 - 不要读取 `analysis.md`、`plan.md`、`implementation.md` 或审查产物
 - 持久产物只有 GitHub Issue 本身，以及 task.md 中的 `issue_number` 更新
 - 执行本技能后，你**必须**立即更新 task.md
@@ -26,7 +27,7 @@ description: "从任务文件创建 GitHub Issue"
 
 ### 2. 提取任务信息
 
-从 task.md 提取标题、`## Description`、`## Requirements`、`type` 和 `milestone`。
+从 task.md 提取标题、`## Description`、`## Requirements`、`type` 和 `milestone`。构造 Issue 标题：将 task.md 的 `type` 映射为 Conventional Commits type，推断 scope，拼接为 `cc_type(scope): task_title` 或 `cc_type: task_title`（scope 不确定时省略）。
 
 ### 3. 构建 Issue 内容
 

--- a/templates/.agents/skills/create-task/SKILL.md
+++ b/templates/.agents/skills/create-task/SKILL.md
@@ -24,7 +24,7 @@ After executing this skill, you **must** immediately update task status in task.
 ### 1. Parse the User Description
 
 Extract from the natural-language description:
-- **Task title**: a concise title (maximum 50 characters), in the same language as the user's description
+- **Task title**: a concise title (maximum 50 characters), in the same language as the user's description - do not translate it to English or apply Conventional Commits formatting
 - **Task type**: `feature` | `bugfix` | `refactor` | `docs` | `chore` (infer from the description)
 - **Workflow**: `feature-development` | `bug-fix` | `refactoring` (infer from the type)
 - **Detailed description**: the cleaned-up original user request

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -24,7 +24,7 @@ description: "根据自然语言描述创建任务"
 ### 1. 解析用户描述
 
 从自然语言描述中提取：
-- **任务标题**：简洁标题（最多 50 个字符），使用与用户描述相同的语言
+- **任务标题**：简洁标题（最多 50 个字符），使用中文——不要翻译为英文，不要套用 Conventional Commits 格式
 - **任务类型**：`feature` | `bugfix` | `refactor` | `docs` | `chore`（从描述推断）
 - **工作流**：`feature-development` | `bug-fix` | `refactoring`（从类型推断）
 - **详细描述**：整理后的用户原始描述

--- a/templates/.agents/skills/refine-title/SKILL.md
+++ b/templates/.agents/skills/refine-title/SKILL.md
@@ -37,7 +37,7 @@ Based on the fetched data:
 
 **Generate Subject**:
 - **Ignore the original title** (avoid bias) - extract core intent from body
-- Keep concise (under 50 characters), English imperative mood, no trailing period
+- Keep concise (under 50 characters), use the content's original language (Chinese content stays Chinese, English content stays English), no trailing period
 
 ### 3. Present Suggestion
 
@@ -86,7 +86,7 @@ Next step - sync task progress to the PR:
 ## Advantages
 
 This skill:
-1. **Fixes misleading titles**: Even if the original title is "Help me", it reads the body and generates a proper title like `fix(core): resolve startup error`
+1. **Fixes misleading titles**: Even if the original title is "Help me", it reads the body and generates a proper title like `fix(core): resolve startup error` while keeping the subject in the content's original language
 2. **Accurate scope**: By analyzing PR file changes, it can automatically infer the correct scope without manual specification
 
 ## Notes

--- a/templates/.agents/skills/refine-title/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-title/SKILL.zh-CN.md
@@ -37,7 +37,7 @@ gh pr view <id> --json number,title,body,labels,state,files
 
 **生成 Subject**：
 - **忽略原始标题**（避免偏见）- 从 body 中提取核心意图
-- 保持简洁（不超过 50 字符），英文祈使语气，末尾无句号
+- 保持简洁（不超过 50 字符），使用内容原始语言（中文内容用中文，英文内容用英文），末尾无句号
 
 ### 3. 展示建议
 
@@ -86,7 +86,7 @@ gh pr edit <id> --title "<new-title>"
 ## 优势
 
 本技能的优势：
-1. **修复误导性标题**：即使原始标题是"Help me"，也能读取 body 并生成合适的标题，如 `fix(core): resolve startup error`
+1. **修复误导性标题**：即使原始标题是"Help me"，也能读取 body 并生成合适的标题，如 `fix(core): 修复启动错误` 或 `fix(core): resolve startup error`
 2. **精确 scope**：通过分析 PR 文件变更，可以自动推断正确的 scope，无需手动指定
 
 ## 注意事项


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #96

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

Issue/PR 标题格式在整条链路（create-task → create-issue → refine-title）上缺失或矛盾，导致 AI 在创建 Issue 时将中文标题翻译为英文 Conventional Commits 格式。同时 CLAUDE.md 中的提交规范详情每次对话都加载，污染了非提交场景的上下文。

本 PR 从根源上理顺标题格式链路：统一为 `type(scope): 中文描述`（type/scope 英文，描述跟随用户语言），并将 CLAUDE.md 中的提交规范详情移至按需加载的规则文件。

## 📋 主要变更 / Brief Changelog

- 将 CLAUDE.md/AGENTS.md 中的 `### 提交信息格式（Conventional Commits）` 段落和 PR 检查清单移至 `.agents/rules/commit-and-pr.md`，仅保留一行索引
- 拆分语言规范表中的"任务标题与 GitHub Issue 标题"为两行，分别明确 task.md 标题（保持原文）和 Issue/PR 标题（`type(scope): 描述` 格式）
- 在 create-task SKILL.md 中明确标题使用中文，不翻译、不套用 Conventional Commits 格式
- 在 create-issue SKILL.md 行为边界中新增标题构造规则，含完整 type 映射表（feature→feat, bugfix→fix 等）
- 将 refine-title SKILL.md 的 subject 语言要求从"英文祈使语气"改为"跟随内容原始语言"
- 同步更新 6 个模板文件（英文 + 中文）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/*.test.js` — 38 个测试全部通过
2. `diff .claude/CLAUDE.md AGENTS.md` — 确认两文件完全一致
3. 对比部署版与 zh-CN 模板（create-task, create-issue, refine-title）— 全部一致
4. `rg '[一-龥]' templates/.agents/skills/refine-title/SKILL.md` — 确认英文模板无中文字符

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass (38/38)
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass
- [x] 代码检查通过 / Lint checks pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / Documentation updated
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered

## 📋 附加信息 / Additional Notes

- task.md 中的标题保持纯中文（不加前缀），`type(scope):` 前缀由 create-issue 在构造 Issue 标题时拼接
- 已有的 Issue 标题不会被自动修改，可后续使用 `/refine-title` 手动重格式化

Closes #96

Generated with AI assistance