### PR TITLE
fix(skills,ci): 修复 cancel-task label 清理和 status-label Action (#126)

### DIFF
--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -75,6 +75,7 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 如果存在有效的 `issue_number`：
 - 替换所有 `status:` labels，并设置步骤 2 推断出的标签
+- 移除所有 `in:` labels
 - 移除 milestone
 - 移除全部 assignees
 - 发布取消评论，隐藏标记使用 `<!-- sync-issue:{task-id}:cancel -->`
@@ -84,7 +85,6 @@ ls .agents/workspace/completed/{task-id}/task.md
 取消评论至少包含：
 - 取消原因
 - 选定的 `status:` label
-- 归档路径 `.agents/workspace/completed/{task-id}/`
 
 ### 7. 完成校验
 

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove status labels on issue close
-        if: github.event_name == 'issues' && github.event.action == 'closed'
+        if: >-
+          github.event_name == 'issues' &&
+          github.event.action == 'closed' &&
+          github.event.issue.state_reason == 'completed'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/templates/.agents/skills/cancel-task/SKILL.md
+++ b/templates/.agents/skills/cancel-task/SKILL.md
@@ -75,6 +75,7 @@ Check whether `task.md` contains a valid `issue_number`. If not, skip this step.
 
 If a valid `issue_number` exists:
 - Replace all `status:` labels with the label inferred in Step 2
+- Remove all `in:` labels
 - Remove the milestone
 - Remove all assignees
 - Publish a cancellation comment using the marker `<!-- sync-issue:{task-id}:cancel -->`
@@ -84,7 +85,6 @@ If a valid `issue_number` exists:
 The cancellation comment must include at least:
 - the cancellation reason
 - the selected `status:` label
-- the archive path `.agents/workspace/completed/{task-id}/`
 
 ### 7. Verification Gate
 

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -75,6 +75,7 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 如果存在有效的 `issue_number`：
 - 替换所有 `status:` labels，并设置步骤 2 推断出的标签
+- 移除所有 `in:` labels
 - 移除 milestone
 - 移除全部 assignees
 - 发布取消评论，隐藏标记使用 `<!-- sync-issue:{task-id}:cancel -->`
@@ -84,7 +85,6 @@ ls .agents/workspace/completed/{task-id}/task.md
 取消评论至少包含：
 - 取消原因
 - 选定的 `status:` label
-- 归档路径 `.agents/workspace/completed/{task-id}/`
 
 ### 7. 完成校验
 

--- a/templates/.github/workflows/status-label.yml
+++ b/templates/.github/workflows/status-label.yml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove status labels on issue close
-        if: github.event_name == 'issues' && github.event.action == 'closed'
+        if: >-
+          github.event_name == 'issues' &&
+          github.event.action == 'closed' &&
+          github.event.issue.state_reason == 'completed'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/tests/core/status-label-workflow.test.js
+++ b/tests/core/status-label-workflow.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { read } from "../helpers.js";
+
+const workflowTargets = [
+  ".github/workflows/status-label.yml",
+  "templates/.github/workflows/status-label.yml"
+];
+
+test("status-label workflow only removes status labels for completed issue closes", () => {
+  workflowTargets.forEach((relativePath) => {
+    const content = read(relativePath);
+
+    assert.match(
+      content,
+      /- name: Remove status labels on issue close[\s\S]*github\.event\.issue\.state_reason == 'completed'/,
+      `${relativePath} should gate issue-close cleanup on completed state_reason`
+    );
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #126

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

使用 cancel-task 取消 Issue #119 时发现三个问题：

1. **`in:` label 残留**：cancel-task 取消任务后 `in:` 系列标签未被清理
2. **GitHub Action 误删 `status:` label**：`status-label.yml` 的 Issue 关闭步骤无差别清除所有 `status:` label，包括 cancel-task 刚设置的关闭原因标签（`invalid`/`declined`/`superseded`）
3. **取消评论含本地路径**：发布到 GitHub Issue 的取消评论包含 `.agents/workspace/completed/` 本地路径

## 📋 主要变更 / Brief Changelog

- 在 `status-label.yml` 的 "Remove status labels on issue close" 步骤添加 `github.event.issue.state_reason == 'completed'` 条件，只在正常完成关闭时清除 `status:` label，cancel-task 的 `not planned` 关闭路径不触发清除
- 在 cancel-task SKILL.md 的 Issue 同步步骤中添加"移除所有 `in:` labels"指令
- 从 cancel-task SKILL.md 的取消评论模板中移除本地归档路径
- 同步更新模板目录的英文版和中文版
- 新增 `tests/core/status-label-workflow.test.js` 回归测试，校验部署版和模板版工作流一致性

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 全部 65 个测试通过
2. 确认 reopen 和 PR merge 步骤未受影响

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

Closes #126

Generated with AI assistance