### PR TITLE
refactor(skills): refine-task 下一步始终推荐重新审查 (#122)

### DIFF
--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -88,21 +88,15 @@ node .agents/scripts/validate-artifact.js gate refine-task .agents/workspace/act
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。
 
-输出修复摘要后，根据修复的问题严重程度选择下一步：
-
-如果修复了 Blocker 或 Major（推荐重新审查）：
+输出修复摘要后，展示下一步：
 
 ```
-下一步 - 代码审查：
+下一步 - 重新审查或提交：
+- 重新审查（始终推荐）：
   - Claude Code / OpenCode：/review-task {task-id}
   - Gemini CLI：/agent-infra:review-task {task-id}
   - Codex CLI：$review-task {task-id}
-```
-
-如果仅修复 Minor（可直接提交）：
-
-```
-下一步 - 提交代码：
+- 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit
   - Codex CLI：$commit

--- a/.agents/skills/refine-task/reference/fix-workflow.md
+++ b/.agents/skills/refine-task/reference/fix-workflow.md
@@ -35,12 +35,12 @@
 ## 选择下一步分支
 
 判断规则：
-1. 如果本轮修复了任何 `Blocker` 或 `Major`，默认推荐重新审查
-2. 只有当本轮只修复了 Minor，且改动明显低风险时，才可以把直接提交作为一个可选项
-3. 如果仍有任何 `Blocker` 或 `Major` 未解决，就不要建议直接提交
+1. 始终将重新审查作为默认推荐的下一步，无论本轮修复了哪个级别的问题
+2. 直接提交仅可作为附加选项，且仅在所有问题均已解决且改动明显低风险时
+3. 如果仍有任何 `Blocker` 或 `Major` 未解决，不要提供直接提交选项
 
 禁止规则：
-- 只要还存在高风险问题，绝对不要把直接提交写成唯一下一步
+- 绝对不要把直接提交写成唯一下一步——重新审查必须始终作为首要推荐
 
 必用输出模板：
 
@@ -56,11 +56,11 @@
 - 修复产物：{refinement-artifact}
 
 下一步 - 重新审查或提交：
-- 重新审查（默认推荐；修复了 Blocker/Major 时优先）：
+- 重新审查（始终推荐）：
   - Claude Code / OpenCode：/review-task {task-id}
   - Gemini CLI：/agent-infra:review-task {task-id}
   - Codex CLI：$review-task {task-id}
-- 直接提交（仅限只修复 Minor 且风险可控）：
+- 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit
   - Codex CLI：$commit
@@ -72,5 +72,5 @@
 2. **禁止自动提交**：不要执行 `git commit`
 3. **范围约束**：只修复审查中列出的问题
 4. **分歧处理**：如果不同意审查意见，要在报告里明确记录
-5. **重新审查**：修复了 Blocker 或 Major 后，推荐执行 `review-task`
+5. **重新审查**：修复后始终推荐执行 `review-task`
 6. **一致性**：最新审查产物、Activity Log 记录和修复报告必须引用同一轮次

--- a/templates/.agents/skills/refine-task/SKILL.md
+++ b/templates/.agents/skills/refine-task/SKILL.md
@@ -88,21 +88,15 @@ Keep the gate output in your reply as fresh evidence. Do not claim completion wi
 
 > **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent.
 
-After summarizing the fixes, choose the next step based on severity:
-
-If the round fixed any Blocker or Major issues (recommended):
+After summarizing the fixes, present the next step:
 
 ```
-Next step - code review:
+Next step - re-review or commit:
+- Re-review (always recommended):
   - Claude Code / OpenCode: /review-task {task-id}
   - Gemini CLI: /{{project}}:review-task {task-id}
   - Codex CLI: $review-task {task-id}
-```
-
-If the round fixed Minor issues only (low risk):
-
-```
-Next step - commit changes:
+- Commit directly (optional; only when all issues are resolved and changes are low risk):
   - Claude Code / OpenCode: /commit
   - Gemini CLI: /{{project}}:commit
   - Codex CLI: $commit

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -88,21 +88,15 @@ node .agents/scripts/validate-artifact.js gate refine-task .agents/workspace/act
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。
 
-输出修复摘要后，根据修复的问题严重程度选择下一步：
-
-如果修复了 Blocker 或 Major（推荐重新审查）：
+输出修复摘要后，展示下一步：
 
 ```
-下一步 - 代码审查：
+下一步 - 重新审查或提交：
+- 重新审查（始终推荐）：
   - Claude Code / OpenCode：/review-task {task-id}
   - Gemini CLI：/agent-infra:review-task {task-id}
   - Codex CLI：$review-task {task-id}
-```
-
-如果仅修复 Minor（可直接提交）：
-
-```
-下一步 - 提交代码：
+- 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit
   - Codex CLI：$commit

--- a/templates/.agents/skills/refine-task/reference/fix-workflow.md
+++ b/templates/.agents/skills/refine-task/reference/fix-workflow.md
@@ -35,12 +35,12 @@ Run the project test command from the `test` skill and confirm that all required
 ## Choose the Next-Step Branch
 
 Decision rules:
-1. if this round fixed any `Blocker` or `Major`, recommend re-review by default
-2. only when this round fixed Minor issues only and the change is clearly low risk may direct commit be offered as an option
-3. if any `Blocker` or `Major` remains unresolved, do not suggest direct commit
+1. always recommend re-review as the default next step, regardless of the severity of fixed issues
+2. direct commit may be offered as an additional option only when all issues are resolved and changes are clearly low risk
+3. if any `Blocker` or `Major` remains unresolved, do not offer direct commit as an option
 
 Prohibition:
-- never present direct commit as the only next step unless no high-risk issue remains
+- never present direct commit as the only next step — re-review must always be the primary recommendation
 
 Required output template:
 
@@ -56,11 +56,11 @@ Refinement status:
 - Refinement artifact: {refinement-artifact}
 
 Next step - re-review or commit:
-- Re-review (recommended by default when Blocker/Major issues were fixed):
+- Re-review (always recommended):
   - Claude Code / OpenCode: /review-task {task-id}
   - Gemini CLI: /agent-infra:review-task {task-id}
   - Codex CLI: $review-task {task-id}
-- Commit directly (Minor-only, low-risk changes only):
+- Commit directly (optional; only when all issues are resolved and changes are low risk):
   - Claude Code / OpenCode: /commit
   - Gemini CLI: /agent-infra:commit
   - Codex CLI: $commit
@@ -72,5 +72,5 @@ Next step - re-review or commit:
 2. **No auto-commit**: do not run `git commit`
 3. **Scope discipline**: only fix reviewed issues
 4. **Disagreement handling**: record any disagreement in the report
-5. **Re-review**: after fixing Blockers or Major issues, recommend `review-task`
+5. **Re-review**: always recommend `review-task` as the default next step after refinement
 6. **Consistency**: the latest review artifact, Activity Log entry, and refinement report must reference the same round

--- a/templates/.agents/skills/refine-task/reference/fix-workflow.zh-CN.md
+++ b/templates/.agents/skills/refine-task/reference/fix-workflow.zh-CN.md
@@ -35,12 +35,12 @@
 ## 选择下一步分支
 
 判断规则：
-1. 如果本轮修复了任何 `Blocker` 或 `Major`，默认推荐重新审查
-2. 只有当本轮只修复了 Minor，且改动明显低风险时，才可以把直接提交作为一个可选项
-3. 如果仍有任何 `Blocker` 或 `Major` 未解决，就不要建议直接提交
+1. 始终将重新审查作为默认推荐的下一步，无论本轮修复了哪个级别的问题
+2. 直接提交仅可作为附加选项，且仅在所有问题均已解决且改动明显低风险时
+3. 如果仍有任何 `Blocker` 或 `Major` 未解决，不要提供直接提交选项
 
 禁止规则：
-- 只要还存在高风险问题，绝对不要把直接提交写成唯一下一步
+- 绝对不要把直接提交写成唯一下一步——重新审查必须始终作为首要推荐
 
 必用输出模板：
 
@@ -56,11 +56,11 @@
 - 修复产物：{refinement-artifact}
 
 下一步 - 重新审查或提交：
-- 重新审查（默认推荐；修复了 Blocker/Major 时优先）：
+- 重新审查（始终推荐）：
   - Claude Code / OpenCode：/review-task {task-id}
   - Gemini CLI：/agent-infra:review-task {task-id}
   - Codex CLI：$review-task {task-id}
-- 直接提交（仅限只修复 Minor 且风险可控）：
+- 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit
   - Codex CLI：$commit
@@ -72,5 +72,5 @@
 2. **禁止自动提交**：不要执行 `git commit`
 3. **范围约束**：只修复审查中列出的问题
 4. **分歧处理**：如果不同意审查意见，要在报告里明确记录
-5. **重新审查**：修复了 Blocker 或 Major 后，推荐执行 `review-task`
+5. **重新审查**：修复后始终推荐执行 `review-task`
 6. **一致性**：最新审查产物、Activity Log 记录和修复报告必须引用同一轮次


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #122

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

refine-task 技能的"下一步"判断规则存在缺口：重新审查应始终作为默认推荐的下一步，而非仅在修复了 Blocker/Major 时才推荐。当前规则允许执行者在只修复 Minor 时跳过审查环节，直接推荐提交，导致审查门禁被执行者的自我评估绕过。

本 PR 将判断规则改为无条件推荐重新审查，同时保留直接提交作为可选项（仅在所有问题已解决且风险可控时）。

## 📋 主要变更 / Brief Changelog

- 修改 fix-workflow.md 判断规则：始终推荐重新审查作为默认下一步
- 修改 SKILL.md 步骤 8：将两个条件分支合并为统一输出（始终展示重新审查 + 可选提交）
- 同步英文模板源、中文模板源和 `.agents/skills/` 部署副本（共 6 个文件）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
2. 确认 65 项测试全部通过
3. 对照英文版和中文版，确认判断规则和输出模板语义一致

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation

Closes #122

Generated with AI assistance