### PR TITLE
feat(sandbox): 沙箱开发体验优化（aliases 同步 + gh CLI）(#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Open the project in any AI TUI and run `update-agent-infra`:
 
 This detects the packaged template version and renders all managed files. The same command is used both for first-time setup and for future template upgrades.
 
+### Sandbox aliases and GitHub CLI
+
+`ai sandbox create` now bootstraps the host-side aliases file at `~/.ai-sandbox-aliases` on first run. The generated file includes ready-to-edit yolo shortcuts for Claude, Codex, Gemini CLI, and OpenCode, and every sandbox syncs that file into `/home/devuser/.bash_aliases`.
+
+The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the host, `ai sandbox create` injects the token into the container as `GH_TOKEN`, so `gh` commands work inside the sandbox without extra setup.
+
 <a id="architecture-overview"></a>
 
 ## Architecture Overview

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,6 +171,12 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 该命令会检测当前打包模板版本并渲染所有受管理文件。首次安装和后续升级都使用同一条命令。
 
+### 沙箱 aliases 与 GitHub CLI
+
+`ai sandbox create` 在首次运行时会自动生成宿主机侧的 `~/.ai-sandbox-aliases`。该文件内置了 Claude、Codex、Gemini CLI 和 OpenCode 的 yolo 快捷命令模板，你可以直接修改；每次创建沙箱时，这个文件都会同步到容器内的 `/home/devuser/.bash_aliases`。
+
+沙箱镜像也会预装 `gh`。如果宿主机上的 `gh auth token` 能成功返回 token，`ai sandbox create` 会把它以 `GH_TOKEN` 环境变量注入容器，让你在沙箱里直接使用 `gh`，无需额外登录配置。
+
 <a id="architecture-overview"></a>
 
 ## 架构概览

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -22,7 +22,22 @@ import { run, runOk, runSafe } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
 import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../tools.js';
 
-const USAGE = `Usage: ai sandbox create <branch> [base] [--cpu <n>] [--memory <n>]`;
+const DEFAULT_SANDBOX_ALIASES = `alias claude-yolo='claude --dangerously-skip-permissions'
+alias opencode-yolo='opencode --dangerously-skip-permissions'
+alias codex-yolo='codex --yolo'
+alias gemini-yolo='gemini --yolo'
+
+alias cy='claude --dangerously-skip-permissions'
+alias oy='opencode --dangerously-skip-permissions'
+alias xy='codex --yolo'
+alias gy='gemini --yolo'
+`;
+const CONTAINER_HOME = '/home/devuser';
+const USAGE = `Usage: ai sandbox create <branch> [base] [--cpu <n>] [--memory <n>]
+
+Host aliases:
+  ${'~'}/.ai-sandbox-aliases is auto-created on first run and synced to
+  ${CONTAINER_HOME}/.bash_aliases inside the sandbox container.`;
 
 function buildSignature(preparedDockerfile, tools) {
   return createHash('sha256')
@@ -60,19 +75,17 @@ function runtimeChecks(runtimes) {
 }
 
 function syncGitConfig(container, repoRoot, home) {
-  const containerHome = '/home/devuser';
-
   const gitconfigPath = path.join(home, '.gitconfig');
   if (!fs.existsSync(gitconfigPath)) {
     return;
   }
 
   let gitconfig = fs.readFileSync(gitconfigPath, 'utf8');
-  gitconfig = gitconfig.replaceAll(home, containerHome);
+  gitconfig = gitconfig.replaceAll(home, CONTAINER_HOME);
   gitconfig = gitconfig.replace(/\[difftool "sourcetree"\][^\[]*/gs, '');
   gitconfig = gitconfig.replace(/\[mergetool "sourcetree"\][^\[]*/gs, '');
 
-  execFileSync('docker', ['exec', '-i', container, 'sh', '-c', `cat > ${containerHome}/.gitconfig`], {
+  execFileSync('docker', ['exec', '-i', container, 'sh', '-c', `cat > ${CONTAINER_HOME}/.gitconfig`], {
     input: gitconfig,
     stdio: ['pipe', 'pipe', 'pipe']
   });
@@ -83,9 +96,48 @@ function syncGitConfig(container, repoRoot, home) {
   for (const file of ['.gitignore_global', '.stCommitMsg']) {
     const hostFile = path.join(home, file);
     if (fs.existsSync(hostFile)) {
-      runSafe('docker', ['cp', hostFile, `${container}:${containerHome}/${file}`]);
+      runSafe('docker', ['cp', hostFile, `${container}:${CONTAINER_HOME}/${file}`]);
     }
   }
+}
+
+export function syncShellAliases(container, home, execDocker = execFileSync) {
+  const aliasesPath = sandboxAliasesPath(home);
+  if (!fs.existsSync(aliasesPath)) {
+    return false;
+  }
+
+  const aliases = fs.readFileSync(aliasesPath, 'utf8');
+  execDocker('docker', ['exec', '-i', container, 'sh', '-c', `cat > ${CONTAINER_HOME}/.bash_aliases`], {
+    input: aliases,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+  return true;
+}
+
+export function buildContainerEnvArgs(resolvedTools, runSafeCommand = runSafe) {
+  const envArgs = resolvedTools.flatMap(({ tool }) =>
+    Object.entries(tool.envVars ?? {}).flatMap(([key, value]) => ['-e', `${key}=${value}`])
+  );
+  const ghToken = runSafeCommand('gh', ['auth', 'token']);
+  if (ghToken) {
+    envArgs.push('-e', `GH_TOKEN=${ghToken}`);
+  }
+  return envArgs;
+}
+
+export function sandboxAliasesPath(home) {
+  return path.join(home, '.ai-sandbox-aliases');
+}
+
+export function ensureSandboxAliasesFile(home) {
+  const aliasesPath = sandboxAliasesPath(home);
+  if (fs.existsSync(aliasesPath)) {
+    return { created: false, path: aliasesPath };
+  }
+
+  fs.writeFileSync(aliasesPath, DEFAULT_SANDBOX_ALIASES, 'utf8');
+  return { created: true, path: aliasesPath };
 }
 
 function buildImage(config, tools, dockerfilePath, imageSignature) {
@@ -277,9 +329,12 @@ export async function create(args) {
             }
           }
 
-          const envArgs = resolvedTools.flatMap(({ tool }) =>
-            Object.entries(tool.envVars ?? {}).flatMap(([key, value]) => ['-e', `${key}=${value}`])
-          );
+          const aliasesFile = ensureSandboxAliasesFile(effectiveConfig.home);
+          if (aliasesFile.created) {
+            message(`Created default sandbox aliases at ${aliasesFile.path}`);
+          }
+
+          const envArgs = buildContainerEnvArgs(resolvedTools);
           const toolVolumes = resolvedTools.flatMap(({ tool, dir }) => ['-v', `${dir}:${tool.containerMount}`]);
           const workspaceDir = path.join(effectiveConfig.repoRoot, '.agents', 'workspace');
           const liveMountVolumes = resolvedTools.flatMap(({ tool }) =>
@@ -322,6 +377,7 @@ export async function create(args) {
 
           message('Syncing git config...');
           syncGitConfig(container, effectiveConfig.repoRoot, effectiveConfig.home);
+          syncShellAliases(container, effectiveConfig.home);
 
           for (const { tool } of resolvedTools) {
             for (const command of tool.postSetupCmds ?? []) {
@@ -344,7 +400,8 @@ export async function create(args) {
     ...runtimeChecks(effectiveConfig.runtimes).map((check) => ({
       name: check.name,
       ok: runOk('docker', ['exec', container, ...check.cmd])
-    }))
+    })),
+    { name: 'GitHub CLI', ok: runOk('docker', ['exec', container, 'gh', '--version']) }
   ];
   const toolChecks = tools.map((tool) => ({
     name: tool.name,
@@ -376,11 +433,15 @@ export async function create(args) {
 Container: ${container}
 Image: ${effectiveConfig.imageName}
 Worktree: ${worktree}
+Host aliases: ${sandboxAliasesPath(effectiveConfig.home)}
 
 Management:
   ai sandbox ls
   ai sandbox exec ${branch}
   ai sandbox rm ${branch}
+
+Sandbox aliases:
+  Edit the host aliases file to customize shortcuts synced to ${CONTAINER_HOME}/.bash_aliases.
 
 Tool notes:
 ${toolHints}

--- a/lib/sandbox/runtimes/ai-tools.dockerfile
+++ b/lib/sandbox/runtimes/ai-tools.dockerfile
@@ -17,7 +17,8 @@ RUN git config --global --add safe.directory /workspace
 
 RUN echo 'export NPM_CONFIG_PREFIX=/home/devuser/.npm-global' >> /home/devuser/.bashrc && \
     echo 'export PATH="/home/devuser/.npm-global/bin:${PATH}"' >> /home/devuser/.bashrc && \
-    echo 'export GIT_CONFIG_GLOBAL=/home/devuser/.gitconfig' >> /home/devuser/.bashrc
+    echo 'export GIT_CONFIG_GLOBAL=/home/devuser/.gitconfig' >> /home/devuser/.bashrc && \
+    echo '[ -f ~/.bash_aliases ] && . ~/.bash_aliases' >> /home/devuser/.bashrc
 
 WORKDIR /workspace
 

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -15,6 +15,11 @@ RUN apt-get update && apt-get install -y \
     build-essential ca-certificates gnupg lsb-release \
     locales \
     && locale-gen en_US.UTF-8 \
+    && (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg) \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.UTF-8

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -17,6 +17,16 @@ test("agent-infra sandbox help is wired into the main CLI", () => {
   assert.match(output, /rebuild \[--quiet\]/);
 });
 
+test("sandbox create help documents the host aliases file", () => {
+  const output = execFileSync(process.execPath, [filePath("bin/cli.js"), "sandbox", "create", "--help"], {
+    encoding: "utf8"
+  });
+
+  assert.match(output, /Usage: ai sandbox create <branch> \[base\] \[--cpu <n>\] \[--memory <n>\]/);
+  assert.match(output, /~\/\.ai-sandbox-aliases/);
+  assert.match(output, /\/home\/devuser\/\.bash_aliases/);
+});
+
 test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => {
   const sandboxConfig = await loadFreshEsm("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-config-"));
@@ -80,6 +90,111 @@ test("composeDockerfile joins runtime fragments in order", async () => {
     assert.match(content, /setup_20\.x/);
     assert.match(content, /python3 python3-pip python3-venv/);
     assert.match(content, /AI_TOOL_PACKAGES build arg is required/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("composeDockerfile includes gh CLI and bash_aliases sourcing", async () => {
+  const sandboxDockerfile = await loadFreshEsm("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-gh-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /cli\.github\.com\/packages/);
+    assert.match(content, /apt-get install -y gh/);
+    assert.match(content, /\[ -f ~\/\.bash_aliases \] && \. ~\/\.bash_aliases/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvArgs injects GH_TOKEN when available", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  const envArgs = sandboxCreate.buildContainerEnvArgs([
+    { tool: { envVars: { FOO: "bar" } } },
+    { tool: { envVars: { BAZ: "qux" } } }
+  ], (cmd, args) => {
+    assert.equal(cmd, "gh");
+    assert.deepEqual(args, ["auth", "token"]);
+    return "token-123";
+  });
+
+  assert.deepEqual(envArgs, [
+    "-e", "FOO=bar",
+    "-e", "BAZ=qux",
+    "-e", "GH_TOKEN=token-123"
+  ]);
+});
+
+test("buildContainerEnvArgs skips GH_TOKEN when auth token is unavailable", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  const envArgs = sandboxCreate.buildContainerEnvArgs([
+    { tool: { envVars: { FOO: "bar" } } }
+  ], () => "");
+
+  assert.deepEqual(envArgs, ["-e", "FOO=bar"]);
+});
+
+test("ensureSandboxAliasesFile creates the default aliases once", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-aliases-defaults-"));
+
+  try {
+    const created = sandboxCreate.ensureSandboxAliasesFile(tmpDir);
+    assert.equal(created.created, true);
+    assert.equal(created.path, path.join(tmpDir, ".ai-sandbox-aliases"));
+
+    const content = fs.readFileSync(created.path, "utf8");
+    assert.match(content, /alias claude-yolo='claude --dangerously-skip-permissions'/);
+    assert.match(content, /alias gy='gemini --yolo'/);
+
+    const second = sandboxCreate.ensureSandboxAliasesFile(tmpDir);
+    assert.equal(second.created, false);
+    assert.equal(fs.readFileSync(created.path, "utf8"), content);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncShellAliases skips missing alias files and copies existing aliases", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-aliases-"));
+
+  try {
+    const calls = [];
+    const missing = sandboxCreate.syncShellAliases("demo-container", tmpDir, (...args) => calls.push(args));
+    assert.equal(missing, false);
+    assert.deepEqual(calls, []);
+
+    const aliasesPath = path.join(tmpDir, ".ai-sandbox-aliases");
+    fs.writeFileSync(aliasesPath, "alias cy='claude --dangerously-skip-permissions'\n", "utf8");
+
+    const copied = sandboxCreate.syncShellAliases("demo-container", tmpDir, (...args) => calls.push(args));
+    assert.equal(copied, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], "docker");
+    assert.deepEqual(calls[0][1], [
+      "exec",
+      "-i",
+      "demo-container",
+      "sh",
+      "-c",
+      "cat > /home/devuser/.bash_aliases"
+    ]);
+    assert.deepEqual(calls[0][2], {
+      input: "alias cy='claude --dangerously-skip-permissions'\n",
+      stdio: ["pipe", "pipe", "pipe"]
+    });
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #139

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

优化沙箱开发体验，解决两个痛点：

1. 宿主机的 shell aliases 不会同步到沙箱容器，用户每次进入都要手动配置
2. 容器内没有 `gh` CLI，且 macOS 二进制无法在 Linux 容器中运行

## 📋 主要变更 / Brief Changelog

- 在 `base.dockerfile` 中预装 GitHub CLI (`gh`)
- 在 `ai-tools.dockerfile` 的 `.bashrc` 中追加 `~/.bash_aliases` 自动加载
- `ai sandbox create` 首次运行时自动生成 `~/.ai-sandbox-aliases` 默认文件（含 yolo 快捷命令）
- 容器启动时通过 `docker exec` 将宿主机 aliases 注入容器
- 容器启动时从宿主机 `gh auth token` 获取 OAuth token 并通过 `GH_TOKEN` 环境变量注入
- `--help` 输出和创建完成提示中补充 aliases 使用说明
- 双语 README 补充沙箱 aliases 和 gh CLI 文档

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `ai sandbox create test-branch` 创建沙箱
2. 确认 `~/.ai-sandbox-aliases` 已自动生成
3. `ai sandbox exec test-branch` 进入沙箱，验证 `cy`、`gh --version`、`gh auth status` 可用

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] PR 只解决一个 Issue / Your PR addresses just this issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 代码遵循项目规范 / My code follows the project's coding standards
- [x] 已进行自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 已编写单元测试 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass (16/16 sandbox, 87/87 full suite)

**文档和兼容性 / Documentation and Compatibility:**

- [x] 已更新文档 / I have made corresponding changes to the documentation
- [x] 已考虑向后兼容性 / I have considered backward compatibility

Closes #139

Generated with AI assistance