### PR TITLE
feat(sandbox): sandbox exec 自动进入 tmux session (#172)

### DIFF
--- a/lib/sandbox/commands/enter.js
+++ b/lib/sandbox/commands/enter.js
@@ -4,12 +4,28 @@ import { runInteractive, runSafe } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
 
 const USAGE = `Usage: ai sandbox exec <branch> [cmd...]`;
-export const TMUX_INTERACTIVE_TIP =
-  "tip: for long-running TUI sessions, run 'tmux new -s work' to survive disconnects (reattach with 'tmux a -t work')\n";
+export const TMUX_ENTRY_SCRIPT = `
+SESSION=work
 
-export function printInteractiveEntryTip(stream = process.stderr) {
-  stream.write(TMUX_INTERACTIVE_TIP);
-}
+if ! command -v tmux >/dev/null 2>&1; then
+  exec bash
+fi
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+  exec tmux new-session -s "$SESSION"
+fi
+
+tmux list-sessions -F '#{session_name} #{session_attached}' 2>/dev/null | \\
+  while read -r name attached; do
+    [ "$name" = "$SESSION" ] && continue
+    case "$name" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    [ "$attached" = "0" ] && tmux kill-session -t "$name" 2>/dev/null || true
+  done
+
+exec tmux new-session -t "$SESSION"
+`.trim();
 
 // Terminal-detection variables that interactive TUIs (e.g. claude-code)
 // inspect to enable progressive enhancements such as the kitty keyboard
@@ -56,8 +72,7 @@ export function enter(args) {
 
   const envFlags = terminalEnvFlags();
   if (cmd.length === 0) {
-    printInteractiveEntryTip();
-    return runInteractive('docker', ['exec', '-it', ...envFlags, container, 'bash']);
+    return runInteractive('docker', ['exec', '-it', ...envFlags, container, 'bash', '-c', TMUX_ENTRY_SCRIPT]);
   }
 
   return runInteractive('docker', ['exec', '-it', ...envFlags, container, ...cmd]);

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -256,6 +256,86 @@ test("terminalEnvFlags omits unset variables instead of forwarding empty values"
   assert.deepEqual(flags, ["-e", "TERM_PROGRAM=iTerm.app"]);
 });
 
+test("TMUX_ENTRY_SCRIPT includes fallback, primary session bootstrap, linked sessions, and cleanup", async () => {
+  const sandboxEnter = await loadFreshEsm("lib/sandbox/commands/enter.js");
+
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /command -v tmux/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /tmux has-session -t "\$SESSION"/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /tmux new-session -s "\$SESSION"/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /tmux list-sessions -F '#\{session_name\} #\{session_attached\}'/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /case "\$name" in/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /''\|\*\[!0-9\]\*\) continue ;;/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /tmux kill-session -t "\$name"/);
+  assert.match(sandboxEnter.TMUX_ENTRY_SCRIPT, /tmux new-session -t "\$SESSION"/);
+});
+
+test("sandbox exec enters tmux automatically for interactive shells", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-"));
+  const repoDir = path.join(tmpDir, "repo");
+  const binDir = path.join(tmpDir, "bin");
+  const logPath = path.join(tmpDir, "docker-log.jsonl");
+  const dockerPath = path.join(binDir, "docker");
+
+  try {
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.mkdirSync(path.join(repoDir, ".agents"), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    execSync("git init", { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(repoDir, ".agents", ".airc.json"),
+      JSON.stringify({ project: "demo", org: "fitlab-ai" }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.writeFileSync(
+      dockerPath,
+      `#!/bin/sh
+set -eu
+if [ "$1" = "ps" ]; then
+  printf '%s\\n' demo-dev-agent-infra-feature-cli-generic-sandbox
+  exit 0
+fi
+node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)) + "\\n")' "$DOCKER_LOG_PATH" "$@"
+`,
+      "utf8"
+    );
+    fs.chmodSync(dockerPath, 0o755);
+
+    execFileSync(
+      process.execPath,
+      [filePath("bin/cli.js"), "sandbox", "exec", "agent-infra-feature-cli-generic-sandbox"],
+      {
+        cwd: repoDir,
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+          DOCKER_LOG_PATH: logPath,
+          TERM_PROGRAM: "",
+          TERM_PROGRAM_VERSION: "",
+          LC_TERMINAL: "",
+          LC_TERMINAL_VERSION: ""
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"]
+      }
+    );
+
+    const dockerCalls = fs.readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(dockerCalls.length, 1);
+    assert.deepEqual(dockerCalls[0].slice(0, 5), [
+      "exec",
+      "-it",
+      "demo-dev-agent-infra-feature-cli-generic-sandbox",
+      "bash",
+      "-c"
+    ]);
+    assert.match(dockerCalls[0][5], /tmux has-session/);
+    assert.match(dockerCalls[0][5], /tmux new-session -t "\$SESSION"/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("claude-code tool pins CLAUDE_CONFIG_DIR so $HOME/.claude.json preseed reaches Claude Code", async () => {
   // Regression guard for the onboarding loop bug: without this env var Claude
   // Code reads .claude.json from $HOME/.claude.json (outside the bind mount),
@@ -442,22 +522,6 @@ test("ensureClaudeOnboarding populates workspace trust when only hasCompletedOnb
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
-});
-
-test("printInteractiveEntryTip writes a tmux-related hint to the given stream", async () => {
-  const sandboxEnter = await loadFreshEsm("lib/sandbox/commands/enter.js");
-
-  let written = "";
-  const fakeStream = {
-    write(chunk) {
-      written += chunk;
-    }
-  };
-
-  sandboxEnter.printInteractiveEntryTip(fakeStream);
-
-  assert.match(written, /tmux/);
-  assert.ok(written.endsWith("\n"), "tip should end with newline");
 });
 
 test("ensureClaudeOnboarding skips write when flag already set", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #172

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

用户通过 `ai sandbox exec` 进入容器后需要手动执行 `tmux new -s work` 创建 session，体验不佳且容易因连接断开丢失正在运行的 TUI 程序。本 PR 将交互式入口自动包裹在 tmux session 中，实现断连保护和多工作区支持：首次进入自动创建主 session `work`，后续进入创建 linked session 共享窗口但独立视图，同时自动清理已断连的关联 session。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/commands/enter.js`：新增 `TMUX_ENTRY_SCRIPT` 常量，替换原有的 `TMUX_INTERACTIVE_TIP` 和 `printInteractiveEntryTip`；交互式入口改为通过 `bash -c` 执行 tmux 入口脚本
- `tests/cli/sandbox.test.js`：新增 tmux 入口脚本内容校验测试和交互式 `docker exec` 集成测试（使用伪造 docker 可执行文件验证完整调用链）；移除旧的 tip 测试

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 全部 200 个测试通过
2. `ai sandbox exec <branch>` → 自动进入 tmux session `work`
3. 再开一个终端 `ai sandbox exec <branch>` → 进入 linked session，可独立切换 window
4. 断开第二个终端 → 再次进入 → 断连的 linked session 被自动清理
5. `ai sandbox exec <branch> ls` → 不触发 tmux，直接执行命令
6. 容器内 tmux 被删除 → fallback 到普通 bash

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（200/200）
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- tmux 不可用时自动 fallback 到普通 bash，完全向后兼容
- 清理逻辑仅针对纯数字命名的 detached session（tmux linked session 自动编号），不影响用户手动创建的命名 session
- 非交互式路径（`ai sandbox exec <branch> <cmd>`）行为完全不变

Closes #172

Generated with AI assistance