### PR TITLE
fix(sandbox): tmux 会话中 Shift+Enter 换行失效 (#173)

### DIFF
--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -22,6 +22,16 @@ RUN apt-get update && apt-get install -y \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Enable extended keys in CSI u format so Shift+Enter and other modified
+# keys are forwarded through tmux. Preserve terminal-detection variables
+# injected at `docker exec` time when new tmux sessions are created.
+RUN printf '%s\n' \
+      'set -g extended-keys always' \
+      'set -g extended-keys-format csi-u' \
+      "set -as terminal-features 'xterm*:extkeys'" \
+      "set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'" \
+    > /etc/tmux.conf
+
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV TERM=xterm-256color

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -196,6 +196,31 @@ test("composeDockerfile installs tmux for in-container session recovery", async 
   }
 });
 
+test("composeDockerfile configures tmux extended keys and terminal env forwarding", async () => {
+  const sandboxDockerfile = await loadFreshEsm("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmux-config-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /set -g extended-keys always/);
+    assert.match(content, /set -g extended-keys-format csi-u/);
+    assert.match(content, /set -as terminal-features 'xterm\*:extkeys'/);
+    assert.match(
+      content,
+      /set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'/
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("buildContainerEnvArgs injects GH_TOKEN when available", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #173

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

容器内启动 tmux 后，claude TUI 的 Shift+Enter 换行失效。#165（PR #167）通过 `docker exec -e` 转发终端检测环境变量修复了直接 bash 下的问题，但 tmux 会话中这些变量未传递且 tmux 默认未启用 extended-keys，导致 Shift+Enter 再次退化为普通 Enter。

本 PR 在镜像构建阶段写入系统级 `/etc/tmux.conf`，启用 CSI u 格式的 extended-keys 并转发终端检测环境变量，确保 tmux 会话内 Shift+Enter 正常工作。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/runtimes/base.dockerfile`：新增 `RUN` 指令写入 `/etc/tmux.conf`，配置 `extended-keys always`、`csi-u` 格式、`xterm*:extkeys` 终端特性声明，以及 `TERM_PROGRAM`/`LC_TERMINAL` 等 4 个环境变量的 `update-environment` 转发
- `tests/cli/sandbox.test.js`：新增回归测试，验证生成的 Dockerfile 包含全部 4 条 tmux 配置

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 全部 201 个测试通过
2. 重建沙箱镜像 → 进入容器 → `tmux new` → 运行 `claude` → 测试 Shift+Enter 换行
3. 确认用户 `~/.tmux.conf` 不受影响（tmux 加载顺序：`/etc/tmux.conf` → `~/.tmux.conf`）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（201/201）
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 使用 `/etc/tmux.conf`（系统级）确保不覆盖用户自定义 `~/.tmux.conf`
- `extended-keys always` 不等待应用主动请求，直接发送扩展键序列
- `csi-u` 格式与 claude-code 的解析逻辑匹配
- Ubuntu 22.04 默认 tmux 3.2a 已支持 `extended-keys`（tmux 3.2+ 引入）

Closes #173

Generated with AI assistance