### PR TITLE
fix(sandbox): 升级 tmux 到 3.6a 源码编译并启用鼠标滚动 (#181)

### DIFF
--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -11,8 +11,10 @@ RUN (groupadd -g ${HOST_GID} devuser || true) && \
     useradd -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser
 
 RUN apt-get update && apt-get install -y \
-    curl wget git vim tmux file \
+    curl wget git vim file \
     build-essential ca-certificates gnupg lsb-release \
+    libevent-core-2.1-7 libncursesw6 libtinfo6 \
+    pkg-config bison libevent-dev libncurses-dev \
     locales \
     && locale-gen en_US.UTF-8 \
     && (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -20,6 +22,19 @@ RUN apt-get update && apt-get install -y \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y gh \
+    && TMUX_VERSION=3.6a \
+    && wget -qO /tmp/tmux.tar.gz \
+        "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
+    && tar xzf /tmp/tmux.tar.gz -C /tmp \
+    && cd /tmp/tmux-${TMUX_VERSION} \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/tmux.tar.gz /tmp/tmux-${TMUX_VERSION} \
+    && apt-get purge -y pkg-config bison libevent-dev libncurses-dev \
+    && apt-get autoremove -y \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable extended keys in CSI u format so Shift+Enter and other modified
@@ -30,6 +45,7 @@ RUN printf '%s\n' \
       'set -g extended-keys-format csi-u' \
       "set -as terminal-features 'xterm*:extkeys'" \
       "set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'" \
+      'set -g mouse on' \
     > /etc/tmux.conf
 
 ENV LANG=en_US.UTF-8

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -168,7 +168,8 @@ test("composeDockerfile includes gh CLI and bash_aliases sourcing", async () => 
     const content = fs.readFileSync(dockerfilePath, "utf8");
 
     assert.match(content, /cli\.github\.com\/packages/);
-    assert.match(content, /curl wget git vim tmux file/);
+    assert.match(content, /build-essential ca-certificates gnupg lsb-release/);
+    assert.match(content, /curl wget git vim file/);
     assert.match(content, /apt-get install -y gh/);
     assert.match(content, /export GPG_TTY=\$\(tty\)/);
     assert.match(content, /\[ -f ~\/\.bash_aliases \] && \. ~\/\.bash_aliases/);
@@ -191,6 +192,8 @@ test("composeDockerfile installs tmux for in-container session recovery", async 
     const content = fs.readFileSync(dockerfilePath, "utf8");
 
     assert.match(content, /\btmux\b/);
+    assert.match(content, /TMUX_VERSION=3\.6a/);
+    assert.match(content, /apt-get purge -y pkg-config bison libevent-dev libncurses-dev/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -216,6 +219,7 @@ test("composeDockerfile configures tmux extended keys and terminal env forwardin
       content,
       /set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'/
     );
+    assert.match(content, /set -g mouse on/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #181

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

Closes #181

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

sandbox 容器中通过 apt 安装的 tmux 版本为 3.2a（Ubuntu 22.04 默认），不支持 `extended-keys-format` 选项（tmux 3.3a 引入），导致每次进入容器时报错 `/etc/tmux.conf:2: invalid option: extended-keys-format`。本 PR 将 tmux 改为源码编译安装 3.6a，彻底解决兼容性问题，同时启用鼠标滚轮浏览终端历史。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/runtimes/base.dockerfile`：将 tmux 从 apt 安装改为源码编译 3.6a，显式安装运行时依赖（`libevent-core-2.1-7`、`libncursesw6`、`libtinfo6`），编译后仅 purge tmux 专有编译依赖（`pkg-config`、`bison`、`libevent-dev`、`libncurses-dev`），保留 `build-essential`；tmux.conf 追加 `set -g mouse on`
- `tests/cli/sandbox.test.js`：更新 apt 列表断言、新增 `build-essential` 存在性断言、`TMUX_VERSION=3.6a` 版本锁定断言、purge 范围断言、`set -g mouse on` 配置断言

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 全部 203 个测试通过
2. 重建 sandbox 镜像 → 进入容器 → `tmux -V` 输出 `tmux 3.6a`
3. 进入 tmux 后无 `invalid option` 报错
4. 鼠标滚轮可滚动终端历史

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（203/203）
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue #181
- [x] 你的 Pull Request 只解决一个 Issue / Only addresses #181
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Conventional Commits format

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass（203/203）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- Docker 构建时间增加约 10-20 秒（tmux 编译），可接受
- 源码编译对 amd64/arm64 均适用，无架构兼容性风险
- `build-essential` 作为 sandbox 永久工具保留，不受 purge 影响
- 已创建的 sandbox 容器不受影响（需 rebuild 才生效）

---

Generated with AI assistance