### PR TITLE
refactor(cli): 沙箱删除时默认确认删除本地分支

### DIFF
--- a/lib/sandbox/commands/rm.js
+++ b/lib/sandbox/commands/rm.js
@@ -87,7 +87,7 @@ async function rmOne(config, tools, branch) {
 
       const shouldDeleteBranch = await p.confirm({
         message: `Also delete local branch '${effectiveBranch}'?`,
-        initialValue: false
+        initialValue: true
       });
 
       if (!p.isCancel(shouldDeleteBranch) && shouldDeleteBranch) {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -32,6 +32,15 @@ test("sandbox create help documents the host aliases file", () => {
   assert.match(output, /\/home\/devuser\/\.bash_aliases/);
 });
 
+test("sandbox rm defaults local branch deletion confirmation to yes", () => {
+  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
+
+  assert.match(
+    commandSource,
+    /const shouldDeleteBranch = await p\.confirm\(\{[\s\S]*?message: `Also delete local branch '\$\{effectiveBranch\}'\?`,[\s\S]*?initialValue: true[\s\S]*?\}\);/
+  );
+});
+
 test("sandbox create fails before preparing a temporary Dockerfile when Claude credentials are missing", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-create-no-credentials-"));
   const repoDir = path.join(tmpDir, "repo");


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #153

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

执行 `node bin/cli.js sandbox rm <name>` 删除沙箱时，"Also delete local branch '<name>'?" 确认提示的默认值为 No，用户每次删除沙箱都需要额外手动选择 Yes，体验不顺畅。本 PR 将该确认提示的默认值改为 Yes，与同函数中 worktree 删除确认的默认行为保持一致。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/commands/rm.js`：将 `rmOne` 函数中 `shouldDeleteBranch` 的 `initialValue` 从 `false` 改为 `true`
- `tests/cli/sandbox.test.js`：新增断言，通过正则匹配锁定 `initialValue: true` 配置，防止回归

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 全部 202 个测试通过
2. 确认 `lib/sandbox/commands/rm.js` 中仅修改了 `initialValue` 参数值，控制流不变

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（202/202）
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue #153
- [x] 你的 Pull Request 只解决一个 Issue / Only addresses #153
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 单元测试通过 / 202/202

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / 用户仍可手动选择 No 拒绝删除分支

Closes #153

Generated with AI assistance.