### PR TITLE
refactor(timestamps): 任务时间记录添加时区信息

### DIFF
--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -29,8 +29,8 @@ const DEFAULT_REQUIRED_FIELDS = [
 
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 const DEFAULT_FRESHNESS_MINUTES = 30;
-const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
-const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
+const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
+const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
 const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -1351,7 +1351,7 @@ function sleep(delayMs) {
 // === Utilities ===
 
 function minutesSinceTimestamp(timestamp) {
-  const normalized = timestamp.replace(" ", "T");
+  const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");
   const parsed = Date.parse(normalized);
   if (Number.isNaN(parsed)) {
     return Number.POSITIVE_INFINITY;

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -103,7 +103,7 @@ description: "分析任务并输出需求分析文档"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -115,7 +115,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/archive-tasks/scripts/archive-tasks.sh
+++ b/.agents/skills/archive-tasks/scripts/archive-tasks.sh
@@ -210,7 +210,7 @@ rebuild_manifest() {
   entries_file="$tmpdir/manifest.tsv"
   month_keys_file="$tmpdir/manifest-months.tsv"
   year_keys_file="$tmpdir/manifest-years.tsv"
-  generated_at=$(date "+%Y-%m-%d %H:%M:%S")
+  generated_at=$(date "+%Y-%m-%d %H:%M:%S%:z")
 
   mkdir -p "$ARCHIVE_DIR"
   : > "$entries_file"

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -40,7 +40,7 @@ description: "标记任务为阻塞状态并记录原因"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -49,7 +49,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `updated_at`：{当前时间戳}
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Blocked** by {agent} — {一行原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}
   ```
 
 在 task.md 中添加阻塞信息部分。

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -40,7 +40,7 @@ description: "取消不再需要的任务并归档"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新任务目录中的 `task.md`：
@@ -50,7 +50,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `updated_at`：{当前时间戳}
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Cancelled** by {agent} — {一行取消原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}
   ```
 
 ### 4. 转移任务

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -72,13 +72,13 @@ Code Scanning 告警 #{alert-number}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -80,13 +80,13 @@ CVE：{cve-id}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -39,7 +39,7 @@ git diff
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 > 完整的 4 种状态分支、前置条件检查和多 TUI 下一步命令见 `reference/task-status-update.md`。更新任务状态前，先读取 `reference/task-status-update.md`。

--- a/.agents/skills/commit/reference/task-status-update.md
+++ b/.agents/skills/commit/reference/task-status-update.md
@@ -7,13 +7,13 @@
 先获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 对于每一次与任务相关的提交，都要在 `task.md` 中追加以下 Activity Log：
 
 ```text
-- {yyyy-MM-dd HH:mm:ss} — **Commit** by {agent} — {commit hash short} {commit subject}
+- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
 在决定下一步之前，先确认：

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -53,7 +53,7 @@ Please complete the missing steps first, or use --force to override.
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -64,7 +64,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
   ```
 
 ### 4. 转移任务

--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -46,7 +46,7 @@ description: "从任务文件创建 GitHub Issue"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 回写 `issue_number`，更新 `updated_at`，并追加 Create Issue 的 Activity Log。

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -69,7 +69,7 @@ description: "创建 Pull Request 到目标分支"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -71,8 +71,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -85,7 +85,7 @@ assigned_to: {当前 AI 代理}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -95,7 +95,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
   ```
 
 ### 4. 完成校验

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -81,7 +81,7 @@ description: "根据技术方案实施任务并输出报告"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -91,7 +91,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：
-  `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`）：
 - 设置 `status: in-progress`，并按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -47,13 +47,13 @@ tool: <tool-name>
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -48,13 +48,13 @@ ghsa_id: <GHSA-ID>
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -45,8 +45,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -57,7 +57,7 @@ assigned_to: {当前 AI 代理}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -67,7 +67,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Issue** by {agent} — Issue #{number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
 
 ### 5. 分配 Issue Assignee

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -81,7 +81,7 @@ description: "为任务设计技术方案和实施计划"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -93,7 +93,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -51,13 +51,13 @@ description: "处理代码审查反馈并修复问题"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：
 - 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 追加：
-  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -81,7 +81,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新恢复出的 `task.md`：
@@ -91,7 +91,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 保留原 `current_step`
 - 在 `## 活动日志` 追加：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
   ```
 
 ### 7. 完成校验

--- a/.agents/skills/review-task/SKILL.md
+++ b/.agents/skills/review-task/SKILL.md
@@ -47,11 +47,11 @@ description: "审查任务实现并输出代码审查报告"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md，并追加：
-`- {yyyy-MM-dd HH:mm:ss} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -4,8 +4,8 @@ type: feature                  # feature | bugfix | refactor | docs | review
 branch: ""                     # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
-created_at: YYYY-MM-DD
-updated_at: YYYY-MM-DD
+created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to: ""                # claude | codex | gemini | opencode | human
 ---
@@ -50,7 +50,7 @@ assigned_to: ""                # claude | codex | gemini | opencode | human
 ## 活动日志
 
 <!-- 每个工作流步骤追加一条新记录，不要覆盖之前的记录。 -->
-<!-- 格式：- {yyyy-MM-dd HH:mm} — **{步骤}** by {执行者} — {简要说明} -->
+<!-- 格式：- {YYYY-MM-DD HH:mm:ss±HH:MM} — **{步骤}** by {执行者} — {简要说明} -->
 
 ## 完成检查清单
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -404,15 +404,22 @@ function removeManifestFiles(rootDir) {
 }
 
 function formatTimestamp(date) {
+  const pad = (value) => String(value).padStart(2, '0');
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = Math.floor(absoluteOffsetMinutes / 60);
+  const offsetRemainderMinutes = absoluteOffsetMinutes % 60;
+
   return [
     date.getFullYear(),
-    String(date.getMonth() + 1).padStart(2, '0'),
-    String(date.getDate()).padStart(2, '0')
+    pad(date.getMonth() + 1),
+    pad(date.getDate())
   ].join('-') + ' ' + [
-    String(date.getHours()).padStart(2, '0'),
-    String(date.getMinutes()).padStart(2, '0'),
-    String(date.getSeconds()).padStart(2, '0')
-  ].join(':');
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+  ].join(':') + `${sign}${pad(offsetHours)}:${pad(offsetRemainderMinutes)}`;
 }
 
 function formatBackupTimestamp(date) {
@@ -485,7 +492,15 @@ function getTaskTimestamp(taskDir) {
 }
 
 function compareTimestamps(left, right) {
-  return left.value.localeCompare(right.value);
+  const normalizeTimestamp = (timestamp) => (timestamp.includes('T') ? timestamp : timestamp.replace(' ', 'T'));
+  const leftMs = Date.parse(normalizeTimestamp(left.value));
+  const rightMs = Date.parse(normalizeTimestamp(right.value));
+
+  if (Number.isNaN(leftMs) || Number.isNaN(rightMs)) {
+    return left.value.localeCompare(right.value);
+  }
+
+  return leftMs - rightMs;
 }
 
 function scanWorkspaceSection(rootDir, sectionName) {

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -29,8 +29,8 @@ const DEFAULT_REQUIRED_FIELDS = [
 
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 const DEFAULT_FRESHNESS_MINUTES = 30;
-const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
-const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
+const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
+const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
 const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -1351,7 +1351,7 @@ function sleep(delayMs) {
 // === Utilities ===
 
 function minutesSinceTimestamp(timestamp) {
-  const normalized = timestamp.replace(" ", "T");
+  const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");
   const parsed = Date.parse(normalized);
   if (Number.isNaN(parsed)) {
     return Number.POSITIVE_INFINITY;

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -103,7 +103,7 @@ Create `.agents/workspace/active/{task-id}/{analysis-artifact}`.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -115,7 +115,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark requirement-analysis as complete in workflow progress and include the actual round when the task template supports it
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -103,7 +103,7 @@ description: "分析任务并输出需求分析文档"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -115,7 +115,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/archive-tasks/scripts/archive-tasks.sh
+++ b/templates/.agents/skills/archive-tasks/scripts/archive-tasks.sh
@@ -210,7 +210,7 @@ rebuild_manifest() {
   entries_file="$tmpdir/manifest.tsv"
   month_keys_file="$tmpdir/manifest-months.tsv"
   year_keys_file="$tmpdir/manifest-years.tsv"
-  generated_at=$(date "+%Y-%m-%d %H:%M:%S")
+  generated_at=$(date "+%Y-%m-%d %H:%M:%S%:z")
 
   mkdir -p "$ARCHIVE_DIR"
   : > "$entries_file"

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -40,7 +40,7 @@ Before blocking, thoroughly analyze:
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -49,7 +49,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `updated_at`: {current timestamp}
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Blocked** by {agent} — {one-line reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {one-line reason}
   ```
 
 Add a blocking information section to task.md.

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -40,7 +40,7 @@ description: "标记任务为阻塞状态并记录原因"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -49,7 +49,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `updated_at`：{当前时间戳}
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Blocked** by {agent} — {一行原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}
   ```
 
 在 task.md 中添加阻塞信息部分。

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -40,7 +40,7 @@ When syncing to the Issue, replace any existing `status:` labels with the inferr
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `task.md` in the task directory:
@@ -50,7 +50,7 @@ Update `task.md` in the task directory:
 - `updated_at`: {current timestamp}
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Cancelled** by {agent} — {one-line cancellation reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {one-line cancellation reason}
   ```
 
 ### 4. Move the Task

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -40,7 +40,7 @@ description: "取消不再需要的任务并归档"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新任务目录中的 `task.md`：
@@ -50,7 +50,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `updated_at`：{当前时间戳}
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Cancelled** by {agent} — {一行取消原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}
   ```
 
 ### 4. 转移任务

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -72,13 +72,13 @@ If a related task exists (search for `codescan_alert_number: <alert-number>`):
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - Add the dismissal record to task.md
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
 

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -72,13 +72,13 @@ Code Scanning 告警 #{alert-number}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -80,13 +80,13 @@ If a related task exists (search for `security_alert_number: <alert-number>`):
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - Add the dismissal record to task.md
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
 

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -80,13 +80,13 @@ CVE：{cve-id}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -39,7 +39,7 @@ Stage specific files only and run `git commit` with the prepared message.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 > The full four-case status matrix, prerequisite checks, and multi-TUI next-step commands live in `reference/task-status-update.md`. Read `reference/task-status-update.md` before updating task state.

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -39,7 +39,7 @@ git diff
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 > 完整的 4 种状态分支、前置条件检查和多 TUI 下一步命令见 `reference/task-status-update.md`。更新任务状态前，先读取 `reference/task-status-update.md`。

--- a/templates/.agents/skills/commit/reference/task-status-update.en.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.en.md
@@ -7,13 +7,13 @@ Read this file before choosing the post-commit task-state branch.
 Get the current time first:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 For every task-related commit, append this Activity Log entry in `task.md`:
 
 ```text
-- {yyyy-MM-dd HH:mm:ss} — **Commit** by {agent} — {commit hash short} {commit subject}
+- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
 Before selecting the next step, verify:

--- a/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
@@ -7,13 +7,13 @@
 先获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 对于每一次与任务相关的提交，都要在 `task.md` 中追加以下 Activity Log：
 
 ```text
-- {yyyy-MM-dd HH:mm:ss} — **Commit** by {agent} — {commit hash short} {commit subject}
+- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
 在决定下一步之前，先确认：

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -53,7 +53,7 @@ If prerequisites are not met and the user did not explicitly provide `--force`, 
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -64,7 +64,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Verify and check off all items in `## Completion Checklist` (change `- [ ]` to `- [x]`)
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
   ```
 
 ### 4. Move Task

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -53,7 +53,7 @@ Please complete the missing steps first, or use --force to override.
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -64,7 +64,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
   ```
 
 ### 4. 转移任务

--- a/templates/.agents/skills/create-issue/SKILL.en.md
+++ b/templates/.agents/skills/create-issue/SKILL.en.md
@@ -46,7 +46,7 @@ Create and enrich the Issue by following the "Create Issue" and "Set the Issue T
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Write back `issue_number`, update `updated_at`, and append the Create Issue Activity Log entry.

--- a/templates/.agents/skills/create-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-issue/SKILL.zh-CN.md
@@ -46,7 +46,7 @@ description: "从任务文件创建 GitHub Issue"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 回写 `issue_number`，更新 `updated_at`，并追加 Create Issue 的 Activity Log。

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -69,7 +69,7 @@ Aggregate a reviewer-facing summary from those artifacts and maintain a single i
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, and append the PR Created Activity Log entry including metadata-sync and summary results.

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -69,7 +69,7 @@ description: "创建 Pull Request 到目标分支"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -71,8 +71,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {current AI agent}
@@ -85,7 +85,7 @@ Note: `created_by` is `human` because the task comes from the user's description
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -95,7 +95,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `## Context` -> `- **Branch**:`: update it to the generated branch name
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
   ```
 
 ### 4. Verification Gate

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -71,8 +71,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -85,7 +85,7 @@ assigned_to: {当前 AI 代理}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -95,7 +95,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
   ```
 
 ### 4. 完成校验

--- a/templates/.agents/skills/implement-task/SKILL.en.md
+++ b/templates/.agents/skills/implement-task/SKILL.en.md
@@ -81,7 +81,7 @@ Create `.agents/workspace/active/{task-id}/{implementation-artifact}`.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -91,7 +91,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are clearly satisfied by this round's implemented code and passing tests
 - record `{implementation-artifact}` for Round `{implementation-round}`
 - append:
-  `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure; read `.agents/rules/issue-sync.md` first):
 - Set `status: in-progress` and refine `in:` labels from the branch diff by following `.agents/rules/issue-sync.md` (add/remove when a mapping exists, add-only when it does not)

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -81,7 +81,7 @@ description: "根据技术方案实施任务并输出报告"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -91,7 +91,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：
-  `- {yyyy-MM-dd HH:mm:ss} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`）：
 - 设置 `status: in-progress`，并按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -47,13 +47,13 @@ tool: <tool-name>
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update task.md: `current_step` -> `requirement-analysis`.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. Verification Gate

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -47,13 +47,13 @@ tool: <tool-name>
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -48,13 +48,13 @@ ghsa_id: <GHSA-ID>
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update task.md: `current_step` -> `requirement-analysis`.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. Verification Gate

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -48,13 +48,13 @@ ghsa_id: <GHSA-ID>
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -45,8 +45,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {current AI agent}
@@ -57,7 +57,7 @@ assigned_to: {current AI agent}
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -67,7 +67,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `## Context` -> `- **Branch**:`: update it to the generated branch name
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Issue** by {agent} — Issue #{number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
 
 ### 5. Assign the Issue Assignee

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -45,8 +45,8 @@ type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
 workflow: feature-development|bug-fix|refactoring
 status: active
-created_at: {yyyy-MM-dd HH:mm:ss}
-updated_at: {yyyy-MM-dd HH:mm:ss}
+created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -57,7 +57,7 @@ assigned_to: {当前 AI 代理}
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -67,7 +67,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Import Issue** by {agent} — Issue #{number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
 
 ### 5. 分配 Issue Assignee

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -81,7 +81,7 @@ Create `.agents/workspace/active/{task-id}/{plan-artifact}`.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update `.agents/workspace/active/{task-id}/task.md`:
@@ -93,7 +93,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark technical-design as complete in workflow progress and include the actual round when the task template supports it
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -81,7 +81,7 @@ description: "为任务设计技术方案和实施计划"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
@@ -93,7 +93,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -51,13 +51,13 @@ Create `.agents/workspace/active/{task-id}/{refinement-artifact}`.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update task.md:
 - review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are newly satisfied by this round's fixes and passing tests
 - append:
-  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -51,13 +51,13 @@ description: "处理代码审查反馈并修复问题"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md：
 - 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 追加：
-  `- {yyyy-MM-dd HH:mm:ss} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues → {refinement-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -81,7 +81,7 @@ Write only files that were actually recovered from Issue comments. Do not invent
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update the restored `task.md`:
@@ -91,7 +91,7 @@ Update the restored `task.md`:
 - keep the original `current_step`
 - append this entry to `## Activity Log`:
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
   ```
 
 ### 7. Verification Gate

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -81,7 +81,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新恢复出的 `task.md`：
@@ -91,7 +91,7 @@ date "+%Y-%m-%d %H:%M:%S"
 - 保留原 `current_step`
 - 在 `## 活动日志` 追加：
   ```
-  - {yyyy-MM-dd HH:mm:ss} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
   ```
 
 ### 7. 完成校验

--- a/templates/.agents/skills/review-task/SKILL.en.md
+++ b/templates/.agents/skills/review-task/SKILL.en.md
@@ -47,11 +47,11 @@ Create `.agents/workspace/active/{task-id}/{review-artifact}`.
 Get the current time:
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update task.md and append:
-`- {yyyy-MM-dd HH:mm:ss} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing

--- a/templates/.agents/skills/review-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-task/SKILL.zh-CN.md
@@ -47,11 +47,11 @@ description: "审查任务实现并输出代码审查报告"
 获取当前时间：
 
 ```bash
-date "+%Y-%m-%d %H:%M:%S"
+date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 更新 task.md，并追加：
-`- {yyyy-MM-dd HH:mm:ss} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n} → {artifact-filename}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -4,8 +4,8 @@ type: feature                  # feature | bugfix | refactor | docs | review
 branch: ""                     # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
-created_at: YYYY-MM-DD
-updated_at: YYYY-MM-DD
+created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to: ""                # claude | codex | gemini | opencode | human
 ---
@@ -50,7 +50,7 @@ assigned_to: ""                # claude | codex | gemini | opencode | human
 ## Activity Log
 
 <!-- Append a new entry for each workflow step. Do NOT overwrite previous entries. -->
-<!-- Format: - {yyyy-MM-dd HH:mm} — **{step}** by {agent} — {brief summary} -->
+<!-- Format: - {YYYY-MM-DD HH:mm:ss±HH:MM} — **{step}** by {agent} — {brief summary} -->
 
 ## Completion Checklist
 

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -4,8 +4,8 @@ type: feature                  # feature | bugfix | refactor | docs | review
 branch: ""                     # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
-created_at: YYYY-MM-DD
-updated_at: YYYY-MM-DD
+created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to: ""                # claude | codex | gemini | opencode | human
 ---
@@ -50,7 +50,7 @@ assigned_to: ""                # claude | codex | gemini | opencode | human
 ## 活动日志
 
 <!-- 每个工作流步骤追加一条新记录，不要覆盖之前的记录。 -->
-<!-- 格式：- {yyyy-MM-dd HH:mm} — **{步骤}** by {执行者} — {简要说明} -->
+<!-- 格式：- {YYYY-MM-DD HH:mm:ss±HH:MM} — **{步骤}** by {执行者} — {简要说明} -->
 
 ## 完成检查清单
 

--- a/tests/cli/merge.test.js
+++ b/tests/cli/merge.test.js
@@ -92,15 +92,20 @@ function setTimestamp(targetPath, isoString) {
 }
 
 function formatLocalTimestamp(date) {
+  const pad = (value) => String(value).padStart(2, '0');
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+
   return [
     date.getFullYear(),
-    String(date.getMonth() + 1).padStart(2, '0'),
-    String(date.getDate()).padStart(2, '0')
+    pad(date.getMonth() + 1),
+    pad(date.getDate())
   ].join('-') + ' ' + [
-    String(date.getHours()).padStart(2, '0'),
-    String(date.getMinutes()).padStart(2, '0'),
-    String(date.getSeconds()).padStart(2, '0')
-  ].join(':');
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+  ].join(':') + `${sign}${pad(Math.floor(absoluteOffsetMinutes / 60))}:${pad(absoluteOffsetMinutes % 60)}`;
 }
 
 function read(relativePath) {
@@ -346,14 +351,14 @@ test('getTaskTimestamp prefers frontmatter updated_at over file mtime', () => {
   try {
     const taskDir = writeFlatTask(workspaceDir, 'active', 'TASK-20260409-020202', {
       title: 'frontmatter wins',
-      updatedAt: '2026-04-09 02:02:02'
+      updatedAt: '2026-04-09T02:02:02+08:00'
     });
 
     setTimestamp(path.join(taskDir, 'task.md'), '2026-04-09T10:00:00Z');
 
     const timestamp = getTaskTimestamp(taskDir);
     assert.deepEqual(timestamp, {
-      value: '2026-04-09 02:02:02',
+      value: '2026-04-09T02:02:02+08:00',
       source: 'frontmatter'
     });
   } finally {

--- a/tests/core/validate-artifact.test.js
+++ b/tests/core/validate-artifact.test.js
@@ -12,6 +12,12 @@ const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 
 function formatTimestamp(date) {
   const pad = (value) => String(value).padStart(2, "0");
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = Math.floor(absoluteOffsetMinutes / 60);
+  const offsetRemainderMinutes = absoluteOffsetMinutes % 60;
+
   return [
     date.getFullYear(),
     pad(date.getMonth() + 1),
@@ -20,7 +26,7 @@ function formatTimestamp(date) {
     pad(date.getHours()),
     pad(date.getMinutes()),
     pad(date.getSeconds())
-  ].join(":");
+  ].join(":") + `${sign}${pad(offsetHours)}:${pad(offsetRemainderMinutes)}`;
 }
 
 function formatTimestampInTimeZone(date, timeZone) {
@@ -41,7 +47,13 @@ function formatTimestampInTimeZone(date, timeZone) {
       .map(({ type, value }) => [type, value])
   );
 
-  return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute}:${values.second}`;
+  const offsetPart = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "longOffset"
+  }).formatToParts(date).find(({ type }) => type === "timeZoneName")?.value;
+  const normalizedOffset = offsetPart === "GMT" ? "+00:00" : offsetPart?.replace("GMT", "") || "+00:00";
+
+  return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute}:${values.second}${normalizedOffset}`;
 }
 
 function write(filePathname, content) {

--- a/tests/templates/skills.test.js
+++ b/tests/templates/skills.test.js
@@ -193,7 +193,7 @@ test("skills that write timestamps require date command guidance", () => {
 
       assert.match(
         content,
-        /date "\+%Y-%m-%d %H:%M:%S"/,
+        /date "\+%Y-%m-%d %H:%M:%S%:z"/,
         `${relativePath} should require the date command for timestamp writes`
       );
     });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #151

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

任务工作区中所有记录的关键时间（created_at、updated_at、completed_at 等）都缺少时区信息，仅记录了本地时间。当用户在不同时区出差时，时间记录会产生歧义。本 PR 统一追加本地时区偏移（如 `+08:00`），格式为 `YYYY-MM-DD HH:mm:ss±HH:MM`，人工阅读时直观显示本地时间，极端场景可用时区偏移做准确比较。

## 📋 主要变更 / Brief Changelog

- `validate-artifact.js`：扩展 DATE_TIME_PATTERN 和 ACTIVITY_LOG_PATTERN 正则兼容新旧格式，minutesSinceTimestamp 兼容新格式解析
- `lib/merge.js`：formatTimestamp 输出带时区偏移，compareTimestamps 改为 Date.parse 语义比较
- 19 个技能 SKILL.md + 32 个模板文件：date 命令从 `date "+%Y-%m-%d %H:%M:%S"` 改为 `date "+%Y-%m-%d %H:%M:%S%:z"`，Activity Log 占位符同步更新
- 3 个任务模板：frontmatter 占位符和 Activity Log 格式注释同步更新
- 2 个 Shell 脚本（archive-tasks.sh）：generated_at 格式同步更新
- 3 个测试文件：辅助函数和断言更新以覆盖新格式

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 201 tests pass
2. 确认旧格式 task.md（不含时区）仍能通过 validate-artifact 校验
3. 确认 merge 操作对新旧格式混合的时间戳正确比较

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（201/201）
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue #151
- [x] 你的 Pull Request 只解决一个 Issue / Only addresses #151
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 单元测试通过 / 201/201

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / 验证和比较逻辑同时接受新旧格式，旧任务文件无需迁移

Closes #151

Generated with AI assistance.