### PR TITLE
refactor(scripts): 门禁校验平台同步适配器化重构

### DIFF
--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -1,0 +1,948 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const CHECK_TYPE = "platform-sync";
+const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+
+let activeShared = null;
+let repoRoot = "";
+
+function getShared() {
+  if (!activeShared) {
+    throw new Error("platform-sync adapter shared utilities are unavailable");
+  }
+
+  return activeShared;
+}
+
+function loadTask(...args) {
+  return getShared().loadTask(...args);
+}
+
+function getCheckedRequirements(...args) {
+  return getShared().getCheckedRequirements(...args);
+}
+
+function normalizeContent(...args) {
+  return getShared().normalizeContent(...args);
+}
+
+function isBlank(...args) {
+  return getShared().isBlank(...args);
+}
+
+function escapeRegExp(...args) {
+  return getShared().escapeRegExp(...args);
+}
+
+function passResult(...args) {
+  return getShared().passResult(...args);
+}
+
+function failResult(...args) {
+  return getShared().failResult(...args);
+}
+
+function blockedResult(...args) {
+  return getShared().blockedResult(...args);
+}
+
+function safeStat(...args) {
+  return getShared().safeStat(...args);
+}
+
+function parseIssueNumber(...args) {
+  return getShared().parseIssueNumber(...args);
+}
+
+function parsePrNumber(...args) {
+  return getShared().parsePrNumber(...args);
+}
+
+export function check({ taskDir, config, artifactFile }, shared) {
+  activeShared = shared;
+  repoRoot = shared.repoRoot;
+  const context = buildSyncContext({ taskDir, config, artifactFile });
+  if (context.earlyReturn) {
+    return context.earlyReturn;
+  }
+
+  const remoteData = fetchRemoteData(context);
+  if (remoteData.earlyReturn) {
+    return remoteData.earlyReturn;
+  }
+
+  const subChecks = [
+    checkStatusLabel,
+    checkCommentMarker,
+    checkPrCommentMarker,
+    checkPrCommentLastCommit,
+    checkCommentContent,
+    checkTaskCommentContent,
+    checkInLabelsMatchPr,
+    checkPrAssignee,
+    checkSyncedRequirements,
+    checkIssueType,
+    checkMilestone
+  ];
+
+  for (const subCheck of subChecks) {
+    const result = subCheck(context, remoteData);
+    if (result) {
+      return result;
+    }
+  }
+
+  return passResult(CHECK_TYPE, `GitHub sync checks passed for Issue #${context.issueNumber}`);
+}
+
+function buildSyncContext({ taskDir, config, artifactFile }) {
+  const task = loadTask(taskDir);
+  if (!task.ok) {
+    return { earlyReturn: failResult(CHECK_TYPE, task.message) };
+  }
+
+  const issueNumber = parseIssueNumber(task.metadata.issue_number);
+  const prNumber = parsePrNumber(task.metadata.pr_number);
+  if (config.when === "issue_number_exists" && !issueNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: task has no issue_number") };
+  }
+  if (config.when === "pr_number_exists" && !prNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: task has no pr_number") };
+  }
+
+  if (!issueNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: platform-sync not required for this task") };
+  }
+
+  const upstreamRepo = resolveUpstreamRepo(taskDir);
+  if (!upstreamRepo.ok) {
+    return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
+  }
+  const permissions = detectPermissions(upstreamRepo.value, taskDir);
+
+  const marker = config.expected_comment_marker
+    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
+    : null;
+  const prMarker = config.expected_pr_comment_marker
+    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
+    : null;
+  const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
+
+  return {
+    task,
+    taskDir,
+    config,
+    artifactFile,
+    artifactPath,
+    issueNumber,
+    prNumber,
+    upstreamRepo: upstreamRepo.value,
+    hasTriage: permissions.hasTriage,
+    hasPush: permissions.hasPush,
+    marker,
+    prMarker
+  };
+}
+
+function fetchRemoteData(context) {
+  let issueResult = withRetry(() => ghJson([
+    "issue",
+    "view",
+    String(context.issueNumber),
+    "-R",
+    context.upstreamRepo,
+    "--json",
+    "state,labels,body,milestone"
+  ], context.taskDir));
+  if (!issueResult.ok && issueResult.type !== "check_failed") {
+    const fallbackIssueResult = withRetry(() => ghJson([
+      "api",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`
+    ], context.taskDir));
+    if (fallbackIssueResult.ok) {
+      issueResult = {
+        ok: true,
+        value: normalizeIssuePayload(fallbackIssueResult.value)
+      };
+    } else {
+      issueResult = fallbackIssueResult;
+    }
+  }
+  if (!issueResult.ok) {
+    return {
+      earlyReturn: issueResult.type === "check_failed"
+        ? failResult(CHECK_TYPE, issueResult.message, issueResult.type)
+        : blockedResult(CHECK_TYPE, issueResult.message, issueResult.type)
+    };
+  }
+
+  const issue = issueResult.value;
+  if (context.config.issue_must_exist !== false && !issue) {
+    return {
+      earlyReturn: failResult(CHECK_TYPE, `Issue #${context.issueNumber} not found`, "check_failed")
+    };
+  }
+
+  let comments = null;
+  if (shouldFetchComments(context.config)) {
+    const commentsResult = withRetry(() => ghPaginatedJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}/comments?per_page=100`
+    ], context.taskDir));
+
+    if (!commentsResult.ok) {
+      return {
+        earlyReturn: commentsResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, commentsResult.message, commentsResult.type)
+          : blockedResult(CHECK_TYPE, commentsResult.message, commentsResult.type)
+      };
+    }
+
+    comments = flattenComments(commentsResult.value);
+  }
+
+  let prComments = null;
+  if (context.config.expected_pr_comment_marker) {
+    if (!context.prNumber) {
+      return {
+        earlyReturn: failResult(CHECK_TYPE, "Expected a valid pr_number for PR comment verification", "check_failed")
+      };
+    }
+
+    const prCommentsResult = withRetry(() => ghPaginatedJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${context.upstreamRepo}/issues/${context.prNumber}/comments?per_page=100`
+    ], context.taskDir));
+
+    if (!prCommentsResult.ok) {
+      return {
+        earlyReturn: prCommentsResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, prCommentsResult.message, prCommentsResult.type)
+          : blockedResult(CHECK_TYPE, prCommentsResult.message, prCommentsResult.type)
+      };
+    }
+
+    prComments = flattenComments(prCommentsResult.value);
+  }
+
+  let issueType;
+  if (context.config.verify_issue_type && context.hasPush) {
+    const issueTypeResult = withRetry(() => ghText([
+      "api",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`,
+      "--jq",
+      ".type.name // empty"
+    ], context.taskDir));
+
+    if (issueTypeResult.ok) {
+      issueType = issueTypeResult.value || null;
+    }
+  }
+
+  let prLabels = null;
+  let prMilestone;
+  let prAssignees;
+  if (((context.config.verify_in_labels_match_pr && context.hasTriage)
+    || (context.config.verify_milestone && context.hasTriage)
+    || (context.config.verify_pr_assignee && context.hasPush)) && context.prNumber) {
+    const prFields = [];
+    if (context.config.verify_in_labels_match_pr) {
+      prFields.push("labels");
+    }
+    if (context.config.verify_milestone) {
+      prFields.push("milestone");
+    }
+    if (context.config.verify_pr_assignee) {
+      prFields.push("assignees");
+    }
+
+    const prResult = withRetry(() => ghJson([
+      "pr",
+      "view",
+      String(context.prNumber),
+      "--json",
+      prFields.join(",")
+    ], context.taskDir));
+
+    if (!prResult.ok) {
+      return {
+        earlyReturn: prResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, prResult.message, prResult.type)
+          : blockedResult(CHECK_TYPE, prResult.message, prResult.type)
+      };
+    }
+
+    prLabels = context.config.verify_in_labels_match_pr
+      ? extractLabelNames(prResult.value?.labels)
+      : null;
+    prMilestone = context.config.verify_milestone
+      ? prResult.value?.milestone ?? null
+      : undefined;
+    prAssignees = context.config.verify_pr_assignee
+      ? (prResult.value?.assignees || []).map((a) => a.login).filter(Boolean)
+      : undefined;
+  }
+
+  return {
+    issue,
+    comments,
+    prComments,
+    prLabels,
+    issueType,
+    prMilestone,
+    prAssignees
+  };
+}
+
+function shouldFetchComments(config) {
+  return Boolean(
+    config.expected_comment_marker
+    || config.expected_pr_comment_marker
+    || config.verify_pr_comment_last_commit_matches_head
+    || config.verify_comment_content
+    || config.verify_task_comment_content
+  );
+}
+
+function flattenComments(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((page) => Array.isArray(page) ? page : []);
+}
+
+function checkStatusLabel(context, remoteData) {
+  if (!context.config.expected_status_label || !context.hasTriage) {
+    return null;
+  }
+
+  if (String(remoteData.issue.state || "").toUpperCase() !== "OPEN") {
+    return null;
+  }
+
+  const labels = extractLabelNames(remoteData.issue.labels);
+  if (labels.includes(context.config.expected_status_label)) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
+    "check_failed"
+  );
+}
+
+function checkCommentMarker(context, remoteData) {
+  if (!context.marker) {
+    return null;
+  }
+
+  const comment = findCommentByMarker(remoteData.comments, context.marker);
+  if (comment) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected comment marker '${context.marker}' not found on Issue #${context.issueNumber}`,
+    "check_failed"
+  );
+}
+
+function checkPrCommentMarker(context, remoteData) {
+  if (!context.prMarker) {
+    return null;
+  }
+
+  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
+  if (comment) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
+    "check_failed"
+  );
+}
+
+function checkPrCommentLastCommit(context, remoteData) {
+  if (!context.config.verify_pr_comment_last_commit_matches_head) {
+    return null;
+  }
+
+  if (!context.prMarker) {
+    return failResult(CHECK_TYPE,
+      "verify_pr_comment_last_commit_matches_head requires expected_pr_comment_marker",
+      "check_failed"
+    );
+  }
+
+  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
+  if (!comment) {
+    return failResult(CHECK_TYPE,
+      `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
+      "check_failed"
+    );
+  }
+
+  const match = String(comment.body || "").match(/<!--\s*last-commit:\s*([0-9a-f]{7,40})\s*-->/i);
+  if (!match) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} summary comment is missing '<!-- last-commit: <sha> -->' metadata`,
+      "check_failed"
+    );
+  }
+
+  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  if (!headResult.ok) {
+    return headResult.type === "check_failed"
+      ? failResult(CHECK_TYPE, headResult.message, headResult.type)
+      : blockedResult(CHECK_TYPE, headResult.message, headResult.type);
+  }
+
+  const expectedHead = String(headResult.value || "").trim();
+  const actualHead = match[1].trim();
+  if (expectedHead === actualHead) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `PR #${context.prNumber} summary comment last-commit metadata mismatch: expected ${expectedHead}, got ${actualHead}`,
+    "check_failed"
+  );
+}
+
+function checkCommentContent(context, remoteData) {
+  if (!context.config.verify_comment_content) {
+    return null;
+  }
+
+  if (!context.marker) {
+    return failResult(CHECK_TYPE, "verify_comment_content requires expected_comment_marker", "check_failed");
+  }
+
+  if (!context.artifactPath || !safeStat(context.artifactPath)) {
+    return failResult(CHECK_TYPE,
+      `Artifact not found for comment verification: ${context.artifactFile || "(missing artifactFile)"}`,
+      "check_failed"
+    );
+  }
+
+  const comment = findCommentByMarker(remoteData.comments, context.marker);
+  const localContent = normalizeContent(fs.readFileSync(context.artifactPath, "utf8"));
+  const commentContent = normalizeContent(extractCommentBody(comment?.body || ""));
+
+  if (localContent === commentContent) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    buildCommentContentMismatchMessage(
+      path.basename(context.artifactPath, path.extname(context.artifactPath)),
+      context.issueNumber,
+      localContent,
+      commentContent
+    ),
+    "check_failed"
+  );
+}
+
+function checkTaskCommentContent(context, remoteData) {
+  if (!context.config.verify_task_comment_content) {
+    return null;
+  }
+
+  const taskMarker = `<!-- sync-issue:${context.task.metadata.id}:task -->`;
+  const comment = findCommentByMarker(remoteData.comments, taskMarker);
+  if (!comment) {
+    return failResult(CHECK_TYPE,
+      `Expected comment marker '${taskMarker}' not found on Issue #${context.issueNumber}`,
+      "check_failed"
+    );
+  }
+
+  const expectedBody = normalizeContent(buildExpectedTaskBody(context.task.content));
+  const commentBody = normalizeContent(extractCommentBody(comment.body || ""));
+
+  if (expectedBody === commentBody) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    buildCommentContentMismatchMessage("task", context.issueNumber, expectedBody, commentBody),
+    "check_failed"
+  );
+}
+
+function checkInLabelsMatchPr(context, remoteData) {
+  if (!context.config.verify_in_labels_match_pr || !context.hasTriage || !context.prNumber || !remoteData.prLabels) {
+    return null;
+  }
+
+  const issueInLabels = extractLabelNames(remoteData.issue.labels)
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+  const prInLabels = remoteData.prLabels
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+
+  if (arraysEqual(issueInLabels, prInLabels)) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `in: labels mismatch — PR #${context.prNumber} has [${formatLabelList(prInLabels)}], Issue #${context.issueNumber} has [${formatLabelList(issueInLabels)}]`,
+    "check_failed"
+  );
+}
+
+function checkSyncedRequirements(context, remoteData) {
+  if (!context.config.sync_checked_requirements || !context.hasTriage) {
+    return null;
+  }
+
+  const checkedRequirements = getCheckedRequirements(context.task.content);
+  if (checkedRequirements.length === 0) {
+    return null;
+  }
+
+  const issueBody = remoteData.issue.body || "";
+  const missingRequirements = checkedRequirements.filter(
+    (item) => !new RegExp(`^- \\[x\\] ${escapeRegExp(item)}$`, "m").test(issueBody)
+  );
+  if (missingRequirements.length === 0) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Issue body is missing checked requirements: ${missingRequirements.join(", ")}`,
+    "check_failed"
+  );
+}
+
+function checkIssueType(context, remoteData) {
+  if (!context.config.verify_issue_type || !context.hasPush) {
+    return null;
+  }
+
+  if (remoteData.issueType === undefined) {
+    return null;
+  }
+
+  if (!remoteData.issueType) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has no Issue Type set`,
+      "check_failed"
+    );
+  }
+
+  const expectedType = mapTaskTypeToIssueType(context.task.metadata.type);
+  if (expectedType && remoteData.issueType !== expectedType) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has type '${remoteData.issueType}', expected '${expectedType}' (from task type '${context.task.metadata.type}')`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function checkPrAssignee(context, remoteData) {
+  if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
+    return null;
+  }
+
+  if (!remoteData.prAssignees || remoteData.prAssignees.length === 0) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} has no assignee`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function checkMilestone(context, remoteData) {
+  if (!context.config.verify_milestone || !context.hasTriage) {
+    return null;
+  }
+
+  if (!remoteData.issue?.milestone?.title) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has no milestone set`,
+      "check_failed"
+    );
+  }
+
+  if (context.prNumber && remoteData.prMilestone !== undefined && !remoteData.prMilestone?.title) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} has no milestone set`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function findCommentByMarker(comments, marker) {
+  return (comments || []).find((comment) => typeof comment.body === "string" && comment.body.includes(marker)) || null;
+}
+
+function extractCommentBody(commentBody) {
+  const lines = String(commentBody || "").split(/\r?\n/);
+
+  let start = 0;
+  while (start < lines.length && (lines[start].trim() === "" || /^<!--.*-->$/.test(lines[start].trim()))) {
+    start += 1;
+  }
+
+  if (start < lines.length && lines[start].startsWith("## ")) {
+    start += 1;
+  }
+
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  if (start < lines.length && /^> \*\*.+\*\* · .+$/.test(lines[start].trim())) {
+    start += 1;
+  }
+
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  let end = lines.length;
+  for (let index = lines.length - 1; index >= start; index -= 1) {
+    const trimmed = lines[index].trim();
+    if (trimmed === "") {
+      continue;
+    }
+
+    if (/^\*.*\*$/.test(trimmed)) {
+      end = index;
+      if (end > start && lines[end - 1].trim() === "---") {
+        end -= 1;
+      }
+    }
+    break;
+  }
+
+  return lines.slice(start, end).join("\n");
+}
+
+function buildExpectedTaskBody(taskContent) {
+  const frontmatterMatch = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatterMatch) {
+    return taskContent.trim();
+  }
+
+  const body = taskContent.slice(frontmatterMatch[0].length).trim();
+  return [
+    buildTaskFrontmatterSummary(),
+    "",
+    "```yaml",
+    frontmatterMatch[0].trim(),
+    "```",
+    "",
+    "</details>",
+    "",
+    body
+  ].join("\n").trim();
+}
+
+function buildTaskFrontmatterSummary() {
+  const language = loadProjectLanguage();
+  if (language === "en" || language === "en-US") {
+    return "<details><summary>Metadata (frontmatter)</summary>";
+  }
+
+  return "<details><summary>元数据 (frontmatter)</summary>";
+}
+
+function loadProjectLanguage() {
+  const override = process.env.VALIDATE_ARTIFACT_LANGUAGE;
+  if (!isBlank(override)) {
+    return String(override).trim();
+  }
+
+  const configPath = path.join(repoRoot, ".agents", ".airc.json");
+  if (!fs.existsSync(configPath)) {
+    return "";
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    return String(config.language || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+function buildCommentContentMismatchMessage(fileStem, issueNumber, localContent, commentContent) {
+  const diffIndex = firstDifferenceIndex(localContent, commentContent);
+  const position = indexToLineColumn(localContent, diffIndex);
+
+  return `Comment content mismatch for '${fileStem}' on Issue #${issueNumber}: local file has ${localContent.length} chars, comment body has ${commentContent.length} chars (first difference near char ${diffIndex + 1}, line ${position.line}, column ${position.column})`;
+}
+
+function firstDifferenceIndex(left, right) {
+  const limit = Math.max(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    if (left[index] !== right[index]) {
+      return index;
+    }
+  }
+
+  return limit;
+}
+
+function indexToLineColumn(text, index) {
+  const prefix = text.slice(0, Math.min(index, text.length));
+  const lines = prefix.split("\n");
+  return {
+    line: lines.length,
+    column: (lines.at(-1) || "").length + 1
+  };
+}
+
+function extractLabelNames(labels) {
+  return (labels || [])
+    .map((label) => typeof label === "string" ? label : label?.name)
+    .filter((label) => typeof label === "string" && label.length > 0);
+}
+
+function mapTaskTypeToIssueType(taskType) {
+  const mapping = {
+    bug: "Bug",
+    bugfix: "Bug",
+    enhancement: "Feature",
+    feature: "Feature",
+    task: "Task",
+    documentation: "Task",
+    "dependency-upgrade": "Task",
+    chore: "Task",
+    docs: "Task",
+    refactor: "Task",
+    refactoring: "Task"
+  };
+
+  return mapping[taskType] || "Task";
+}
+
+function arraysEqual(left, right) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function formatLabelList(labels) {
+  return labels.length > 0 ? labels.join(", ") : "none";
+}
+
+// === GitHub API ===
+
+function normalizeIssuePayload(payload) {
+  return {
+    state: String(payload?.state || "").toUpperCase(),
+    labels: Array.isArray(payload?.labels) ? payload.labels : [],
+    body: typeof payload?.body === "string" ? payload.body : "",
+    milestone: payload?.milestone ?? null
+  };
+}
+
+function resolveUpstreamRepo(taskDir) {
+  const ownerRepo = resolveOwnerRepo(taskDir);
+  if (!ownerRepo.ok) {
+    return ownerRepo;
+  }
+
+  const upstreamResult = ghText([
+    "api",
+    `repos/${ownerRepo.value}`,
+    "--jq",
+    "if .fork then .parent.full_name else .full_name end"
+  ], taskDir);
+
+  if (!upstreamResult.ok) {
+    return upstreamResult;
+  }
+
+  if (isBlank(upstreamResult.value)) {
+    return { ok: false, message: "Unable to resolve upstream repository" };
+  }
+
+  return { ok: true, value: upstreamResult.value };
+}
+
+function resolveOwnerRepo(taskDir) {
+  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: taskDir,
+    encoding: "utf8"
+  });
+
+  if (gitResult.status !== 0) {
+    return { ok: false, message: `Unable to resolve git remote: ${gitResult.stderr.trim() || gitResult.stdout.trim()}` };
+  }
+
+  const remote = gitResult.stdout.trim();
+  const sshMatch = remote.match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (!sshMatch) {
+    return { ok: false, message: `Unable to parse owner/repo from remote '${remote}'` };
+  }
+
+  return { ok: true, value: sshMatch[1] };
+}
+
+function detectPermissions(upstreamRepo, taskDir) {
+  const permissionsResult = ghJson([
+    "api",
+    `repos/${upstreamRepo}`,
+    "--jq",
+    ".permissions"
+  ], taskDir);
+
+  if (!permissionsResult.ok) {
+    return { hasTriage: false, hasPush: false };
+  }
+
+  const permissions = permissionsResult.value && typeof permissionsResult.value === "object"
+    ? permissionsResult.value
+    : {};
+
+  return {
+    hasTriage: permissions.triage === true,
+    hasPush: permissions.push === true
+  };
+}
+
+function ghJson(args, cwd) {
+  const result = ghCommand(args, cwd);
+  if (!result.ok) {
+    return result;
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(result.value || "null") };
+  } catch (error) {
+    return { ok: false, type: "network_error", message: `Invalid JSON from gh: ${error.message}` };
+  }
+}
+
+function ghText(args, cwd) {
+  const result = ghCommand(args, cwd);
+  if (!result.ok) {
+    return result;
+  }
+
+  return { ok: true, value: String(result.value || "").trim() };
+}
+
+function ghCommand(args, cwd) {
+  const result = spawnSync("gh", args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env
+  });
+
+  if (result.status !== 0) {
+    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
+    const classified = classifyGhFailure(stderr, args);
+    return { ok: false, type: classified.type, message: classified.message };
+  }
+
+  return { ok: true, value: result.stdout };
+}
+
+function ghPaginatedJson(args, cwd) {
+  return ghJson(args, cwd);
+}
+
+function gitText(args, cwd) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env
+  });
+
+  if (result.status !== 0) {
+    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
+    return {
+      ok: false,
+      type: "check_failed",
+      message: stderr || `git ${args.join(" ")} failed`
+    };
+  }
+
+  return { ok: true, value: String(result.stdout || "").trim() };
+}
+
+function withRetry(operation) {
+  const delays = getRetryDelays();
+  let lastFailure = null;
+
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    const result = operation();
+    if (result.ok) {
+      return result;
+    }
+
+    lastFailure = result;
+    if (result.type === "check_failed") {
+      return result;
+    }
+
+    if (attempt < delays.length) {
+      sleep(delays[attempt]);
+    }
+  }
+
+  return lastFailure || { ok: false, type: "network_error", message: "Unknown GitHub sync failure" };
+}
+
+function classifyGhFailure(stderr, args) {
+  const message = stderr || `gh ${args.join(" ")} failed`;
+
+  if (/not found|could not resolve to an issue|http 404/i.test(message)) {
+    return { type: "check_failed", message };
+  }
+
+  return { type: "network_error", message };
+}
+
+function getRetryDelays() {
+  const override = process.env.VALIDATE_ARTIFACT_RETRY_DELAYS_MS;
+  if (!override) {
+    return DEFAULT_RETRY_DELAYS_MS;
+  }
+
+  const parsed = override
+    .split(",")
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isFinite(value) && value >= 0);
+
+  return parsed.length > 0 ? parsed : DEFAULT_RETRY_DELAYS_MS;
+}
+
+function sleep(delayMs) {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+function interpolate(template, taskDir, artifactFile) {
+  const artifactStem = artifactFile ? path.basename(artifactFile, path.extname(artifactFile)) : "";
+  return template
+    .replace(/\{task-id\}/g, path.basename(taskDir))
+    .replace(/\{artifact-stem\}/g, artifactStem);
+}

--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const EXIT_CODE = {
@@ -27,7 +26,6 @@ const DEFAULT_REQUIRED_FIELDS = [
   "assigned_to"
 ];
 
-const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
@@ -35,6 +33,39 @@ const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
+
+const PLATFORM_ADAPTERS = {};
+const OPTIONAL_PLATFORM_CHECKS = new Set(["platform-sync"]);
+const adaptersDir = path.join(path.dirname(scriptPath), "platform-adapters");
+
+if (fs.existsSync(adaptersDir)) {
+  for (const file of fs.readdirSync(adaptersDir)) {
+    if (!file.endsWith(".js")) {
+      continue;
+    }
+
+    const adapterName = path.basename(file, ".js");
+    const mod = await import(new URL(`./platform-adapters/${file}`, import.meta.url));
+    if (typeof mod.check === "function") {
+      PLATFORM_ADAPTERS[adapterName] = mod.check;
+    }
+  }
+}
+
+const sharedUtils = {
+  loadTask,
+  getCheckedRequirements,
+  normalizeContent,
+  isBlank,
+  escapeRegExp,
+  passResult,
+  failResult,
+  blockedResult,
+  safeStat,
+  parseIssueNumber,
+  parsePrNumber,
+  repoRoot
+};
 
 // === CLI Entry ===
 
@@ -155,10 +186,18 @@ function runCheck(type, context) {
       return checkActivityLog(context);
     case "completion-checklist":
       return checkCompletionChecklist(context);
-    case "github-sync":
-      return checkGithubSync(context);
-    default:
-      return failResult(type, `Unsupported check type '${type}'.`);
+    default: {
+      const adapter = PLATFORM_ADAPTERS[type];
+      if (!adapter) {
+        if (OPTIONAL_PLATFORM_CHECKS.has(type)) {
+          return passResult(type, `Skipped: no platform adapter registered for '${type}'`);
+        }
+
+        return failResult(type, `Unsupported check type '${type}'.`);
+      }
+
+      return adapter(context, sharedUtils);
+    }
   }
 }
 
@@ -419,41 +458,6 @@ function checkCompletionChecklist({ taskDir, config }) {
   return passResult("completion-checklist", `Completion Checklist valid (${items.length} items checked)`);
 }
 
-function checkGithubSync({ taskDir, config, artifactFile }) {
-  const context = buildSyncContext({ taskDir, config, artifactFile });
-  if (context.earlyReturn) {
-    return context.earlyReturn;
-  }
-
-  const remoteData = fetchRemoteData(context);
-  if (remoteData.earlyReturn) {
-    return remoteData.earlyReturn;
-  }
-
-  const subChecks = [
-    checkStatusLabel,
-    checkCommentMarker,
-    checkPrCommentMarker,
-    checkPrCommentLastCommit,
-    checkCommentContent,
-    checkTaskCommentContent,
-    checkInLabelsMatchPr,
-    checkPrAssignee,
-    checkSyncedRequirements,
-    checkIssueType,
-    checkMilestone
-  ];
-
-  for (const subCheck of subChecks) {
-    const result = subCheck(context, remoteData);
-    if (result) {
-      return result;
-    }
-  }
-
-  return passResult("github-sync", `GitHub sync checks passed for Issue #${context.issueNumber}`);
-}
-
 // === File & Config Loaders ===
 
 function loadVerifyConfig(skillName) {
@@ -573,692 +577,6 @@ function getCheckedRequirements(content) {
     .map((match) => match[1].trim());
 }
 
-function buildSyncContext({ taskDir, config, artifactFile }) {
-  const task = loadTask(taskDir);
-  if (!task.ok) {
-    return { earlyReturn: failResult("github-sync", task.message) };
-  }
-
-  const issueNumber = parseIssueNumber(task.metadata.issue_number);
-  const prNumber = parsePrNumber(task.metadata.pr_number);
-  if (config.when === "issue_number_exists" && !issueNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: task has no issue_number") };
-  }
-  if (config.when === "pr_number_exists" && !prNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: task has no pr_number") };
-  }
-
-  if (!issueNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: github-sync not required for this task") };
-  }
-
-  const upstreamRepo = resolveUpstreamRepo(taskDir);
-  if (!upstreamRepo.ok) {
-    return { earlyReturn: blockedResult("github-sync", upstreamRepo.message, "network_error") };
-  }
-  const permissions = detectPermissions(upstreamRepo.value, taskDir);
-
-  const marker = config.expected_comment_marker
-    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
-    : null;
-  const prMarker = config.expected_pr_comment_marker
-    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
-    : null;
-  const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
-
-  return {
-    task,
-    taskDir,
-    config,
-    artifactFile,
-    artifactPath,
-    issueNumber,
-    prNumber,
-    upstreamRepo: upstreamRepo.value,
-    hasTriage: permissions.hasTriage,
-    hasPush: permissions.hasPush,
-    marker,
-    prMarker
-  };
-}
-
-function fetchRemoteData(context) {
-  let issueResult = withRetry(() => ghJson([
-    "issue",
-    "view",
-    String(context.issueNumber),
-    "-R",
-    context.upstreamRepo,
-    "--json",
-    "state,labels,body,milestone"
-  ], context.taskDir));
-  if (!issueResult.ok && issueResult.type !== "check_failed") {
-    const fallbackIssueResult = withRetry(() => ghJson([
-      "api",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`
-    ], context.taskDir));
-    if (fallbackIssueResult.ok) {
-      issueResult = {
-        ok: true,
-        value: normalizeIssuePayload(fallbackIssueResult.value)
-      };
-    } else {
-      issueResult = fallbackIssueResult;
-    }
-  }
-  if (!issueResult.ok) {
-    return {
-      earlyReturn: issueResult.type === "check_failed"
-        ? failResult("github-sync", issueResult.message, issueResult.type)
-        : blockedResult("github-sync", issueResult.message, issueResult.type)
-    };
-  }
-
-  const issue = issueResult.value;
-  if (context.config.issue_must_exist !== false && !issue) {
-    return {
-      earlyReturn: failResult("github-sync", `Issue #${context.issueNumber} not found`, "check_failed")
-    };
-  }
-
-  let comments = null;
-  if (shouldFetchComments(context.config)) {
-    const commentsResult = withRetry(() => ghPaginatedJson([
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}/comments?per_page=100`
-    ], context.taskDir));
-
-    if (!commentsResult.ok) {
-      return {
-        earlyReturn: commentsResult.type === "check_failed"
-          ? failResult("github-sync", commentsResult.message, commentsResult.type)
-          : blockedResult("github-sync", commentsResult.message, commentsResult.type)
-      };
-    }
-
-    comments = flattenComments(commentsResult.value);
-  }
-
-  let prComments = null;
-  if (context.config.expected_pr_comment_marker) {
-    if (!context.prNumber) {
-      return {
-        earlyReturn: failResult("github-sync", "Expected a valid pr_number for PR comment verification", "check_failed")
-      };
-    }
-
-    const prCommentsResult = withRetry(() => ghPaginatedJson([
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${context.upstreamRepo}/issues/${context.prNumber}/comments?per_page=100`
-    ], context.taskDir));
-
-    if (!prCommentsResult.ok) {
-      return {
-        earlyReturn: prCommentsResult.type === "check_failed"
-          ? failResult("github-sync", prCommentsResult.message, prCommentsResult.type)
-          : blockedResult("github-sync", prCommentsResult.message, prCommentsResult.type)
-      };
-    }
-
-    prComments = flattenComments(prCommentsResult.value);
-  }
-
-  let issueType;
-  if (context.config.verify_issue_type && context.hasPush) {
-    const issueTypeResult = withRetry(() => ghText([
-      "api",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`,
-      "--jq",
-      ".type.name // empty"
-    ], context.taskDir));
-
-    if (issueTypeResult.ok) {
-      issueType = issueTypeResult.value || null;
-    }
-  }
-
-  let prLabels = null;
-  let prMilestone;
-  let prAssignees;
-  if (((context.config.verify_in_labels_match_pr && context.hasTriage)
-    || (context.config.verify_milestone && context.hasTriage)
-    || (context.config.verify_pr_assignee && context.hasPush)) && context.prNumber) {
-    const prFields = [];
-    if (context.config.verify_in_labels_match_pr) {
-      prFields.push("labels");
-    }
-    if (context.config.verify_milestone) {
-      prFields.push("milestone");
-    }
-    if (context.config.verify_pr_assignee) {
-      prFields.push("assignees");
-    }
-
-    const prResult = withRetry(() => ghJson([
-      "pr",
-      "view",
-      String(context.prNumber),
-      "--json",
-      prFields.join(",")
-    ], context.taskDir));
-
-    if (!prResult.ok) {
-      return {
-        earlyReturn: prResult.type === "check_failed"
-          ? failResult("github-sync", prResult.message, prResult.type)
-          : blockedResult("github-sync", prResult.message, prResult.type)
-      };
-    }
-
-    prLabels = context.config.verify_in_labels_match_pr
-      ? extractLabelNames(prResult.value?.labels)
-      : null;
-    prMilestone = context.config.verify_milestone
-      ? prResult.value?.milestone ?? null
-      : undefined;
-    prAssignees = context.config.verify_pr_assignee
-      ? (prResult.value?.assignees || []).map((a) => a.login).filter(Boolean)
-      : undefined;
-  }
-
-  return {
-    issue,
-    comments,
-    prComments,
-    prLabels,
-    issueType,
-    prMilestone,
-    prAssignees
-  };
-}
-
-function shouldFetchComments(config) {
-  return Boolean(
-    config.expected_comment_marker
-    || config.expected_pr_comment_marker
-    || config.verify_pr_comment_last_commit_matches_head
-    || config.verify_comment_content
-    || config.verify_task_comment_content
-  );
-}
-
-function flattenComments(value) {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((page) => Array.isArray(page) ? page : []);
-}
-
-function checkStatusLabel(context, remoteData) {
-  if (!context.config.expected_status_label || !context.hasTriage) {
-    return null;
-  }
-
-  if (String(remoteData.issue.state || "").toUpperCase() !== "OPEN") {
-    return null;
-  }
-
-  const labels = extractLabelNames(remoteData.issue.labels);
-  if (labels.includes(context.config.expected_status_label)) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
-    "check_failed"
-  );
-}
-
-function checkCommentMarker(context, remoteData) {
-  if (!context.marker) {
-    return null;
-  }
-
-  const comment = findCommentByMarker(remoteData.comments, context.marker);
-  if (comment) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected comment marker '${context.marker}' not found on Issue #${context.issueNumber}`,
-    "check_failed"
-  );
-}
-
-function checkPrCommentMarker(context, remoteData) {
-  if (!context.prMarker) {
-    return null;
-  }
-
-  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
-  if (comment) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
-    "check_failed"
-  );
-}
-
-function checkPrCommentLastCommit(context, remoteData) {
-  if (!context.config.verify_pr_comment_last_commit_matches_head) {
-    return null;
-  }
-
-  if (!context.prMarker) {
-    return failResult(
-      "github-sync",
-      "verify_pr_comment_last_commit_matches_head requires expected_pr_comment_marker",
-      "check_failed"
-    );
-  }
-
-  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
-  if (!comment) {
-    return failResult(
-      "github-sync",
-      `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
-      "check_failed"
-    );
-  }
-
-  const match = String(comment.body || "").match(/<!--\s*last-commit:\s*([0-9a-f]{7,40})\s*-->/i);
-  if (!match) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} summary comment is missing '<!-- last-commit: <sha> -->' metadata`,
-      "check_failed"
-    );
-  }
-
-  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
-  if (!headResult.ok) {
-    return headResult.type === "check_failed"
-      ? failResult("github-sync", headResult.message, headResult.type)
-      : blockedResult("github-sync", headResult.message, headResult.type);
-  }
-
-  const expectedHead = String(headResult.value || "").trim();
-  const actualHead = match[1].trim();
-  if (expectedHead === actualHead) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `PR #${context.prNumber} summary comment last-commit metadata mismatch: expected ${expectedHead}, got ${actualHead}`,
-    "check_failed"
-  );
-}
-
-function checkCommentContent(context, remoteData) {
-  if (!context.config.verify_comment_content) {
-    return null;
-  }
-
-  if (!context.marker) {
-    return failResult("github-sync", "verify_comment_content requires expected_comment_marker", "check_failed");
-  }
-
-  if (!context.artifactPath || !safeStat(context.artifactPath)) {
-    return failResult(
-      "github-sync",
-      `Artifact not found for comment verification: ${context.artifactFile || "(missing artifactFile)"}`,
-      "check_failed"
-    );
-  }
-
-  const comment = findCommentByMarker(remoteData.comments, context.marker);
-  const localContent = normalizeContent(fs.readFileSync(context.artifactPath, "utf8"));
-  const commentContent = normalizeContent(extractCommentBody(comment?.body || ""));
-
-  if (localContent === commentContent) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    buildCommentContentMismatchMessage(
-      path.basename(context.artifactPath, path.extname(context.artifactPath)),
-      context.issueNumber,
-      localContent,
-      commentContent
-    ),
-    "check_failed"
-  );
-}
-
-function checkTaskCommentContent(context, remoteData) {
-  if (!context.config.verify_task_comment_content) {
-    return null;
-  }
-
-  const taskMarker = `<!-- sync-issue:${context.task.metadata.id}:task -->`;
-  const comment = findCommentByMarker(remoteData.comments, taskMarker);
-  if (!comment) {
-    return failResult(
-      "github-sync",
-      `Expected comment marker '${taskMarker}' not found on Issue #${context.issueNumber}`,
-      "check_failed"
-    );
-  }
-
-  const expectedBody = normalizeContent(buildExpectedTaskBody(context.task.content));
-  const commentBody = normalizeContent(extractCommentBody(comment.body || ""));
-
-  if (expectedBody === commentBody) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    buildCommentContentMismatchMessage("task", context.issueNumber, expectedBody, commentBody),
-    "check_failed"
-  );
-}
-
-function checkInLabelsMatchPr(context, remoteData) {
-  if (!context.config.verify_in_labels_match_pr || !context.hasTriage || !context.prNumber || !remoteData.prLabels) {
-    return null;
-  }
-
-  const issueInLabels = extractLabelNames(remoteData.issue.labels)
-    .filter((label) => label.startsWith("in:"))
-    .sort();
-  const prInLabels = remoteData.prLabels
-    .filter((label) => label.startsWith("in:"))
-    .sort();
-
-  if (arraysEqual(issueInLabels, prInLabels)) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `in: labels mismatch — PR #${context.prNumber} has [${formatLabelList(prInLabels)}], Issue #${context.issueNumber} has [${formatLabelList(issueInLabels)}]`,
-    "check_failed"
-  );
-}
-
-function checkSyncedRequirements(context, remoteData) {
-  if (!context.config.sync_checked_requirements || !context.hasTriage) {
-    return null;
-  }
-
-  const checkedRequirements = getCheckedRequirements(context.task.content);
-  if (checkedRequirements.length === 0) {
-    return null;
-  }
-
-  const issueBody = remoteData.issue.body || "";
-  const missingRequirements = checkedRequirements.filter(
-    (item) => !new RegExp(`^- \\[x\\] ${escapeRegExp(item)}$`, "m").test(issueBody)
-  );
-  if (missingRequirements.length === 0) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Issue body is missing checked requirements: ${missingRequirements.join(", ")}`,
-    "check_failed"
-  );
-}
-
-function checkIssueType(context, remoteData) {
-  if (!context.config.verify_issue_type || !context.hasPush) {
-    return null;
-  }
-
-  if (remoteData.issueType === undefined) {
-    return null;
-  }
-
-  if (!remoteData.issueType) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has no Issue Type set`,
-      "check_failed"
-    );
-  }
-
-  const expectedType = mapTaskTypeToIssueType(context.task.metadata.type);
-  if (expectedType && remoteData.issueType !== expectedType) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has type '${remoteData.issueType}', expected '${expectedType}' (from task type '${context.task.metadata.type}')`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function checkPrAssignee(context, remoteData) {
-  if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
-    return null;
-  }
-
-  if (!remoteData.prAssignees || remoteData.prAssignees.length === 0) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} has no assignee`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function checkMilestone(context, remoteData) {
-  if (!context.config.verify_milestone || !context.hasTriage) {
-    return null;
-  }
-
-  if (!remoteData.issue?.milestone?.title) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has no milestone set`,
-      "check_failed"
-    );
-  }
-
-  if (context.prNumber && remoteData.prMilestone !== undefined && !remoteData.prMilestone?.title) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} has no milestone set`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function findCommentByMarker(comments, marker) {
-  return (comments || []).find((comment) => typeof comment.body === "string" && comment.body.includes(marker)) || null;
-}
-
-function extractCommentBody(commentBody) {
-  const lines = String(commentBody || "").split(/\r?\n/);
-
-  let start = 0;
-  while (start < lines.length && (lines[start].trim() === "" || /^<!--.*-->$/.test(lines[start].trim()))) {
-    start += 1;
-  }
-
-  if (start < lines.length && lines[start].startsWith("## ")) {
-    start += 1;
-  }
-
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  if (start < lines.length && /^> \*\*.+\*\* · .+$/.test(lines[start].trim())) {
-    start += 1;
-  }
-
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  let end = lines.length;
-  for (let index = lines.length - 1; index >= start; index -= 1) {
-    const trimmed = lines[index].trim();
-    if (trimmed === "") {
-      continue;
-    }
-
-    if (/^\*.*\*$/.test(trimmed)) {
-      end = index;
-      if (end > start && lines[end - 1].trim() === "---") {
-        end -= 1;
-      }
-    }
-    break;
-  }
-
-  return lines.slice(start, end).join("\n");
-}
-
-function buildExpectedTaskBody(taskContent) {
-  const frontmatterMatch = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
-  if (!frontmatterMatch) {
-    return taskContent.trim();
-  }
-
-  const body = taskContent.slice(frontmatterMatch[0].length).trim();
-  return [
-    buildTaskFrontmatterSummary(),
-    "",
-    "```yaml",
-    frontmatterMatch[0].trim(),
-    "```",
-    "",
-    "</details>",
-    "",
-    body
-  ].join("\n").trim();
-}
-
-function buildTaskFrontmatterSummary() {
-  const language = loadProjectLanguage();
-  if (language === "en" || language === "en-US") {
-    return "<details><summary>Metadata (frontmatter)</summary>";
-  }
-
-  return "<details><summary>元数据 (frontmatter)</summary>";
-}
-
-function loadProjectLanguage() {
-  const override = process.env.VALIDATE_ARTIFACT_LANGUAGE;
-  if (!isBlank(override)) {
-    return String(override).trim();
-  }
-
-  const configPath = path.join(repoRoot, ".agents", ".airc.json");
-  if (!fs.existsSync(configPath)) {
-    return "";
-  }
-
-  try {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    return String(config.language || "").trim();
-  } catch {
-    return "";
-  }
-}
-
-function normalizeContent(text) {
-  return String(text || "")
-    .replace(/\r\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-function buildCommentContentMismatchMessage(fileStem, issueNumber, localContent, commentContent) {
-  const diffIndex = firstDifferenceIndex(localContent, commentContent);
-  const position = indexToLineColumn(localContent, diffIndex);
-
-  return `Comment content mismatch for '${fileStem}' on Issue #${issueNumber}: local file has ${localContent.length} chars, comment body has ${commentContent.length} chars (first difference near char ${diffIndex + 1}, line ${position.line}, column ${position.column})`;
-}
-
-function firstDifferenceIndex(left, right) {
-  const limit = Math.max(left.length, right.length);
-  for (let index = 0; index < limit; index += 1) {
-    if (left[index] !== right[index]) {
-      return index;
-    }
-  }
-
-  return limit;
-}
-
-function indexToLineColumn(text, index) {
-  const prefix = text.slice(0, Math.min(index, text.length));
-  const lines = prefix.split("\n");
-  return {
-    line: lines.length,
-    column: (lines.at(-1) || "").length + 1
-  };
-}
-
-function extractLabelNames(labels) {
-  return (labels || [])
-    .map((label) => typeof label === "string" ? label : label?.name)
-    .filter((label) => typeof label === "string" && label.length > 0);
-}
-
-function mapTaskTypeToIssueType(taskType) {
-  const mapping = {
-    bug: "Bug",
-    bugfix: "Bug",
-    enhancement: "Feature",
-    feature: "Feature",
-    task: "Task",
-    documentation: "Task",
-    "dependency-upgrade": "Task",
-    chore: "Task",
-    docs: "Task",
-    refactor: "Task",
-    refactoring: "Task"
-  };
-
-  return mapping[taskType] || "Task";
-}
-
-function arraysEqual(left, right) {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  return left.every((value, index) => value === right[index]);
-}
-
-function formatLabelList(labels) {
-  return labels.length > 0 ? labels.join(", ") : "none";
-}
-
-// === GitHub API ===
-
-function normalizeIssuePayload(payload) {
-  return {
-    state: String(payload?.state || "").toUpperCase(),
-    labels: Array.isArray(payload?.labels) ? payload.labels : [],
-    body: typeof payload?.body === "string" ? payload.body : "",
-    milestone: payload?.milestone ?? null
-  };
-}
-
 function parseIssueNumber(value) {
   if (isBlank(value) || value === "N/A") {
     return null;
@@ -1272,188 +590,14 @@ function parsePrNumber(value) {
   return parseIssueNumber(value);
 }
 
-function resolveUpstreamRepo(taskDir) {
-  const ownerRepo = resolveOwnerRepo(taskDir);
-  if (!ownerRepo.ok) {
-    return ownerRepo;
-  }
-
-  const upstreamResult = ghText([
-    "api",
-    `repos/${ownerRepo.value}`,
-    "--jq",
-    "if .fork then .parent.full_name else .full_name end"
-  ], taskDir);
-
-  if (!upstreamResult.ok) {
-    return upstreamResult;
-  }
-
-  if (isBlank(upstreamResult.value)) {
-    return { ok: false, message: "Unable to resolve upstream repository" };
-  }
-
-  return { ok: true, value: upstreamResult.value };
-}
-
-function resolveOwnerRepo(taskDir) {
-  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
-    cwd: taskDir,
-    encoding: "utf8"
-  });
-
-  if (gitResult.status !== 0) {
-    return { ok: false, message: `Unable to resolve git remote: ${gitResult.stderr.trim() || gitResult.stdout.trim()}` };
-  }
-
-  const remote = gitResult.stdout.trim();
-  const sshMatch = remote.match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
-  if (!sshMatch) {
-    return { ok: false, message: `Unable to parse owner/repo from remote '${remote}'` };
-  }
-
-  return { ok: true, value: sshMatch[1] };
-}
-
-function detectPermissions(upstreamRepo, taskDir) {
-  const permissionsResult = ghJson([
-    "api",
-    `repos/${upstreamRepo}`,
-    "--jq",
-    ".permissions"
-  ], taskDir);
-
-  if (!permissionsResult.ok) {
-    return { hasTriage: false, hasPush: false };
-  }
-
-  const permissions = permissionsResult.value && typeof permissionsResult.value === "object"
-    ? permissionsResult.value
-    : {};
-
-  return {
-    hasTriage: permissions.triage === true,
-    hasPush: permissions.push === true
-  };
-}
-
-function ghJson(args, cwd) {
-  const result = ghCommand(args, cwd);
-  if (!result.ok) {
-    return result;
-  }
-
-  try {
-    return { ok: true, value: JSON.parse(result.value || "null") };
-  } catch (error) {
-    return { ok: false, type: "network_error", message: `Invalid JSON from gh: ${error.message}` };
-  }
-}
-
-function ghText(args, cwd) {
-  const result = ghCommand(args, cwd);
-  if (!result.ok) {
-    return result;
-  }
-
-  return { ok: true, value: String(result.value || "").trim() };
-}
-
-function ghCommand(args, cwd) {
-  const result = spawnSync("gh", args, {
-    cwd,
-    encoding: "utf8",
-    env: process.env
-  });
-
-  if (result.status !== 0) {
-    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
-    const classified = classifyGhFailure(stderr, args);
-    return { ok: false, type: classified.type, message: classified.message };
-  }
-
-  return { ok: true, value: result.stdout };
-}
-
-function ghPaginatedJson(args, cwd) {
-  return ghJson(args, cwd);
-}
-
-function gitText(args, cwd) {
-  const result = spawnSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    env: process.env
-  });
-
-  if (result.status !== 0) {
-    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
-    return {
-      ok: false,
-      type: "check_failed",
-      message: stderr || `git ${args.join(" ")} failed`
-    };
-  }
-
-  return { ok: true, value: String(result.stdout || "").trim() };
-}
-
-function withRetry(operation) {
-  const delays = getRetryDelays();
-  let lastFailure = null;
-
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    const result = operation();
-    if (result.ok) {
-      return result;
-    }
-
-    lastFailure = result;
-    if (result.type === "check_failed") {
-      return result;
-    }
-
-    if (attempt < delays.length) {
-      sleep(delays[attempt]);
-    }
-  }
-
-  return lastFailure || { ok: false, type: "network_error", message: "Unknown GitHub sync failure" };
-}
-
-function classifyGhFailure(stderr, args) {
-  const message = stderr || `gh ${args.join(" ")} failed`;
-
-  if (/not found|could not resolve to an issue|http 404/i.test(message)) {
-    return { type: "check_failed", message };
-  }
-
-  return { type: "network_error", message };
-}
-
-function getRetryDelays() {
-  const override = process.env.VALIDATE_ARTIFACT_RETRY_DELAYS_MS;
-  if (!override) {
-    return DEFAULT_RETRY_DELAYS_MS;
-  }
-
-  const parsed = override
-    .split(",")
-    .map((value) => Number(value.trim()))
-    .filter((value) => Number.isFinite(value) && value >= 0);
-
-  return parsed.length > 0 ? parsed : DEFAULT_RETRY_DELAYS_MS;
-}
-
-function sleep(delayMs) {
-  if (delayMs <= 0) {
-    return;
-  }
-
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
-}
-
 // === Utilities ===
+
+function normalizeContent(text) {
+  return String(text || "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 function minutesSinceTimestamp(timestamp) {
   const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -30,7 +30,7 @@
       "expected_action_pattern": "Requirement Analysis \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: pending-design-work",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/.agents/skills/block-task/config/verify.json
+++ b/.agents/skills/block-task/config/verify.json
@@ -20,7 +20,7 @@
       "expected_action_pattern": "Blocked",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: blocked"
     }

--- a/.agents/skills/cancel-task/config/verify.json
+++ b/.agents/skills/cancel-task/config/verify.json
@@ -21,7 +21,7 @@
       "expected_action_pattern": "Cancelled",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:cancel -->",
       "verify_task_comment_content": true

--- a/.agents/skills/commit/config/verify.json
+++ b/.agents/skills/commit/config/verify.json
@@ -17,7 +17,7 @@
       "expected_action_pattern": "Commit",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_pr_comment_last_commit_matches_head": true

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -23,7 +23,7 @@
     "completion-checklist": {
       "require_all_checked": true
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:summary -->",
       "verify_task_comment_content": true,

--- a/.agents/skills/create-issue/config/verify.json
+++ b/.agents/skills/create-issue/config/verify.json
@@ -18,7 +18,7 @@
       "expected_action_pattern": "Create Issue",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "issue_must_exist": true,
       "verify_task_comment_content": true,

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -17,7 +17,7 @@
       "expected_action_pattern": "PR Created",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_match_pr": true,

--- a/.agents/skills/create-task/config/verify.json
+++ b/.agents/skills/create-task/config/verify.json
@@ -20,6 +20,6 @@
       "expected_action_pattern": "Task Created",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/.agents/skills/implement-task/config/verify.json
+++ b/.agents/skills/implement-task/config/verify.json
@@ -29,7 +29,7 @@
       "expected_action_pattern": "Implementation \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/.agents/skills/import-codescan/config/verify.json
+++ b/.agents/skills/import-codescan/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Import Code Scanning Alert",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/.agents/skills/import-dependabot/config/verify.json
+++ b/.agents/skills/import-dependabot/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Import Dependabot Alert",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/.agents/skills/import-issue/config/verify.json
+++ b/.agents/skills/import-issue/config/verify.json
@@ -20,7 +20,7 @@
       "expected_action_pattern": "Import Issue",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "issue_must_exist": true
     }

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -31,7 +31,7 @@
       "expected_action_pattern": "Technical Design \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: pending-design-work",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/.agents/skills/refine-task/config/verify.json
+++ b/.agents/skills/refine-task/config/verify.json
@@ -25,7 +25,7 @@
       "expected_action_pattern": "Refinement \\(Round \\d+, for .+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/.agents/skills/restore-task/config/verify.json
+++ b/.agents/skills/restore-task/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Restore Task",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/.agents/skills/review-task/config/verify.json
+++ b/.agents/skills/review-task/config/verify.json
@@ -29,7 +29,7 @@
       "expected_action_pattern": "Code Review \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -1,0 +1,948 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const CHECK_TYPE = "platform-sync";
+const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+
+let activeShared = null;
+let repoRoot = "";
+
+function getShared() {
+  if (!activeShared) {
+    throw new Error("platform-sync adapter shared utilities are unavailable");
+  }
+
+  return activeShared;
+}
+
+function loadTask(...args) {
+  return getShared().loadTask(...args);
+}
+
+function getCheckedRequirements(...args) {
+  return getShared().getCheckedRequirements(...args);
+}
+
+function normalizeContent(...args) {
+  return getShared().normalizeContent(...args);
+}
+
+function isBlank(...args) {
+  return getShared().isBlank(...args);
+}
+
+function escapeRegExp(...args) {
+  return getShared().escapeRegExp(...args);
+}
+
+function passResult(...args) {
+  return getShared().passResult(...args);
+}
+
+function failResult(...args) {
+  return getShared().failResult(...args);
+}
+
+function blockedResult(...args) {
+  return getShared().blockedResult(...args);
+}
+
+function safeStat(...args) {
+  return getShared().safeStat(...args);
+}
+
+function parseIssueNumber(...args) {
+  return getShared().parseIssueNumber(...args);
+}
+
+function parsePrNumber(...args) {
+  return getShared().parsePrNumber(...args);
+}
+
+export function check({ taskDir, config, artifactFile }, shared) {
+  activeShared = shared;
+  repoRoot = shared.repoRoot;
+  const context = buildSyncContext({ taskDir, config, artifactFile });
+  if (context.earlyReturn) {
+    return context.earlyReturn;
+  }
+
+  const remoteData = fetchRemoteData(context);
+  if (remoteData.earlyReturn) {
+    return remoteData.earlyReturn;
+  }
+
+  const subChecks = [
+    checkStatusLabel,
+    checkCommentMarker,
+    checkPrCommentMarker,
+    checkPrCommentLastCommit,
+    checkCommentContent,
+    checkTaskCommentContent,
+    checkInLabelsMatchPr,
+    checkPrAssignee,
+    checkSyncedRequirements,
+    checkIssueType,
+    checkMilestone
+  ];
+
+  for (const subCheck of subChecks) {
+    const result = subCheck(context, remoteData);
+    if (result) {
+      return result;
+    }
+  }
+
+  return passResult(CHECK_TYPE, `GitHub sync checks passed for Issue #${context.issueNumber}`);
+}
+
+function buildSyncContext({ taskDir, config, artifactFile }) {
+  const task = loadTask(taskDir);
+  if (!task.ok) {
+    return { earlyReturn: failResult(CHECK_TYPE, task.message) };
+  }
+
+  const issueNumber = parseIssueNumber(task.metadata.issue_number);
+  const prNumber = parsePrNumber(task.metadata.pr_number);
+  if (config.when === "issue_number_exists" && !issueNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: task has no issue_number") };
+  }
+  if (config.when === "pr_number_exists" && !prNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: task has no pr_number") };
+  }
+
+  if (!issueNumber) {
+    return { earlyReturn: passResult(CHECK_TYPE, "Skipped: platform-sync not required for this task") };
+  }
+
+  const upstreamRepo = resolveUpstreamRepo(taskDir);
+  if (!upstreamRepo.ok) {
+    return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
+  }
+  const permissions = detectPermissions(upstreamRepo.value, taskDir);
+
+  const marker = config.expected_comment_marker
+    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
+    : null;
+  const prMarker = config.expected_pr_comment_marker
+    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
+    : null;
+  const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
+
+  return {
+    task,
+    taskDir,
+    config,
+    artifactFile,
+    artifactPath,
+    issueNumber,
+    prNumber,
+    upstreamRepo: upstreamRepo.value,
+    hasTriage: permissions.hasTriage,
+    hasPush: permissions.hasPush,
+    marker,
+    prMarker
+  };
+}
+
+function fetchRemoteData(context) {
+  let issueResult = withRetry(() => ghJson([
+    "issue",
+    "view",
+    String(context.issueNumber),
+    "-R",
+    context.upstreamRepo,
+    "--json",
+    "state,labels,body,milestone"
+  ], context.taskDir));
+  if (!issueResult.ok && issueResult.type !== "check_failed") {
+    const fallbackIssueResult = withRetry(() => ghJson([
+      "api",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`
+    ], context.taskDir));
+    if (fallbackIssueResult.ok) {
+      issueResult = {
+        ok: true,
+        value: normalizeIssuePayload(fallbackIssueResult.value)
+      };
+    } else {
+      issueResult = fallbackIssueResult;
+    }
+  }
+  if (!issueResult.ok) {
+    return {
+      earlyReturn: issueResult.type === "check_failed"
+        ? failResult(CHECK_TYPE, issueResult.message, issueResult.type)
+        : blockedResult(CHECK_TYPE, issueResult.message, issueResult.type)
+    };
+  }
+
+  const issue = issueResult.value;
+  if (context.config.issue_must_exist !== false && !issue) {
+    return {
+      earlyReturn: failResult(CHECK_TYPE, `Issue #${context.issueNumber} not found`, "check_failed")
+    };
+  }
+
+  let comments = null;
+  if (shouldFetchComments(context.config)) {
+    const commentsResult = withRetry(() => ghPaginatedJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}/comments?per_page=100`
+    ], context.taskDir));
+
+    if (!commentsResult.ok) {
+      return {
+        earlyReturn: commentsResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, commentsResult.message, commentsResult.type)
+          : blockedResult(CHECK_TYPE, commentsResult.message, commentsResult.type)
+      };
+    }
+
+    comments = flattenComments(commentsResult.value);
+  }
+
+  let prComments = null;
+  if (context.config.expected_pr_comment_marker) {
+    if (!context.prNumber) {
+      return {
+        earlyReturn: failResult(CHECK_TYPE, "Expected a valid pr_number for PR comment verification", "check_failed")
+      };
+    }
+
+    const prCommentsResult = withRetry(() => ghPaginatedJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${context.upstreamRepo}/issues/${context.prNumber}/comments?per_page=100`
+    ], context.taskDir));
+
+    if (!prCommentsResult.ok) {
+      return {
+        earlyReturn: prCommentsResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, prCommentsResult.message, prCommentsResult.type)
+          : blockedResult(CHECK_TYPE, prCommentsResult.message, prCommentsResult.type)
+      };
+    }
+
+    prComments = flattenComments(prCommentsResult.value);
+  }
+
+  let issueType;
+  if (context.config.verify_issue_type && context.hasPush) {
+    const issueTypeResult = withRetry(() => ghText([
+      "api",
+      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`,
+      "--jq",
+      ".type.name // empty"
+    ], context.taskDir));
+
+    if (issueTypeResult.ok) {
+      issueType = issueTypeResult.value || null;
+    }
+  }
+
+  let prLabels = null;
+  let prMilestone;
+  let prAssignees;
+  if (((context.config.verify_in_labels_match_pr && context.hasTriage)
+    || (context.config.verify_milestone && context.hasTriage)
+    || (context.config.verify_pr_assignee && context.hasPush)) && context.prNumber) {
+    const prFields = [];
+    if (context.config.verify_in_labels_match_pr) {
+      prFields.push("labels");
+    }
+    if (context.config.verify_milestone) {
+      prFields.push("milestone");
+    }
+    if (context.config.verify_pr_assignee) {
+      prFields.push("assignees");
+    }
+
+    const prResult = withRetry(() => ghJson([
+      "pr",
+      "view",
+      String(context.prNumber),
+      "--json",
+      prFields.join(",")
+    ], context.taskDir));
+
+    if (!prResult.ok) {
+      return {
+        earlyReturn: prResult.type === "check_failed"
+          ? failResult(CHECK_TYPE, prResult.message, prResult.type)
+          : blockedResult(CHECK_TYPE, prResult.message, prResult.type)
+      };
+    }
+
+    prLabels = context.config.verify_in_labels_match_pr
+      ? extractLabelNames(prResult.value?.labels)
+      : null;
+    prMilestone = context.config.verify_milestone
+      ? prResult.value?.milestone ?? null
+      : undefined;
+    prAssignees = context.config.verify_pr_assignee
+      ? (prResult.value?.assignees || []).map((a) => a.login).filter(Boolean)
+      : undefined;
+  }
+
+  return {
+    issue,
+    comments,
+    prComments,
+    prLabels,
+    issueType,
+    prMilestone,
+    prAssignees
+  };
+}
+
+function shouldFetchComments(config) {
+  return Boolean(
+    config.expected_comment_marker
+    || config.expected_pr_comment_marker
+    || config.verify_pr_comment_last_commit_matches_head
+    || config.verify_comment_content
+    || config.verify_task_comment_content
+  );
+}
+
+function flattenComments(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((page) => Array.isArray(page) ? page : []);
+}
+
+function checkStatusLabel(context, remoteData) {
+  if (!context.config.expected_status_label || !context.hasTriage) {
+    return null;
+  }
+
+  if (String(remoteData.issue.state || "").toUpperCase() !== "OPEN") {
+    return null;
+  }
+
+  const labels = extractLabelNames(remoteData.issue.labels);
+  if (labels.includes(context.config.expected_status_label)) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
+    "check_failed"
+  );
+}
+
+function checkCommentMarker(context, remoteData) {
+  if (!context.marker) {
+    return null;
+  }
+
+  const comment = findCommentByMarker(remoteData.comments, context.marker);
+  if (comment) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected comment marker '${context.marker}' not found on Issue #${context.issueNumber}`,
+    "check_failed"
+  );
+}
+
+function checkPrCommentMarker(context, remoteData) {
+  if (!context.prMarker) {
+    return null;
+  }
+
+  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
+  if (comment) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
+    "check_failed"
+  );
+}
+
+function checkPrCommentLastCommit(context, remoteData) {
+  if (!context.config.verify_pr_comment_last_commit_matches_head) {
+    return null;
+  }
+
+  if (!context.prMarker) {
+    return failResult(CHECK_TYPE,
+      "verify_pr_comment_last_commit_matches_head requires expected_pr_comment_marker",
+      "check_failed"
+    );
+  }
+
+  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
+  if (!comment) {
+    return failResult(CHECK_TYPE,
+      `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
+      "check_failed"
+    );
+  }
+
+  const match = String(comment.body || "").match(/<!--\s*last-commit:\s*([0-9a-f]{7,40})\s*-->/i);
+  if (!match) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} summary comment is missing '<!-- last-commit: <sha> -->' metadata`,
+      "check_failed"
+    );
+  }
+
+  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  if (!headResult.ok) {
+    return headResult.type === "check_failed"
+      ? failResult(CHECK_TYPE, headResult.message, headResult.type)
+      : blockedResult(CHECK_TYPE, headResult.message, headResult.type);
+  }
+
+  const expectedHead = String(headResult.value || "").trim();
+  const actualHead = match[1].trim();
+  if (expectedHead === actualHead) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `PR #${context.prNumber} summary comment last-commit metadata mismatch: expected ${expectedHead}, got ${actualHead}`,
+    "check_failed"
+  );
+}
+
+function checkCommentContent(context, remoteData) {
+  if (!context.config.verify_comment_content) {
+    return null;
+  }
+
+  if (!context.marker) {
+    return failResult(CHECK_TYPE, "verify_comment_content requires expected_comment_marker", "check_failed");
+  }
+
+  if (!context.artifactPath || !safeStat(context.artifactPath)) {
+    return failResult(CHECK_TYPE,
+      `Artifact not found for comment verification: ${context.artifactFile || "(missing artifactFile)"}`,
+      "check_failed"
+    );
+  }
+
+  const comment = findCommentByMarker(remoteData.comments, context.marker);
+  const localContent = normalizeContent(fs.readFileSync(context.artifactPath, "utf8"));
+  const commentContent = normalizeContent(extractCommentBody(comment?.body || ""));
+
+  if (localContent === commentContent) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    buildCommentContentMismatchMessage(
+      path.basename(context.artifactPath, path.extname(context.artifactPath)),
+      context.issueNumber,
+      localContent,
+      commentContent
+    ),
+    "check_failed"
+  );
+}
+
+function checkTaskCommentContent(context, remoteData) {
+  if (!context.config.verify_task_comment_content) {
+    return null;
+  }
+
+  const taskMarker = `<!-- sync-issue:${context.task.metadata.id}:task -->`;
+  const comment = findCommentByMarker(remoteData.comments, taskMarker);
+  if (!comment) {
+    return failResult(CHECK_TYPE,
+      `Expected comment marker '${taskMarker}' not found on Issue #${context.issueNumber}`,
+      "check_failed"
+    );
+  }
+
+  const expectedBody = normalizeContent(buildExpectedTaskBody(context.task.content));
+  const commentBody = normalizeContent(extractCommentBody(comment.body || ""));
+
+  if (expectedBody === commentBody) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    buildCommentContentMismatchMessage("task", context.issueNumber, expectedBody, commentBody),
+    "check_failed"
+  );
+}
+
+function checkInLabelsMatchPr(context, remoteData) {
+  if (!context.config.verify_in_labels_match_pr || !context.hasTriage || !context.prNumber || !remoteData.prLabels) {
+    return null;
+  }
+
+  const issueInLabels = extractLabelNames(remoteData.issue.labels)
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+  const prInLabels = remoteData.prLabels
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+
+  if (arraysEqual(issueInLabels, prInLabels)) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `in: labels mismatch — PR #${context.prNumber} has [${formatLabelList(prInLabels)}], Issue #${context.issueNumber} has [${formatLabelList(issueInLabels)}]`,
+    "check_failed"
+  );
+}
+
+function checkSyncedRequirements(context, remoteData) {
+  if (!context.config.sync_checked_requirements || !context.hasTriage) {
+    return null;
+  }
+
+  const checkedRequirements = getCheckedRequirements(context.task.content);
+  if (checkedRequirements.length === 0) {
+    return null;
+  }
+
+  const issueBody = remoteData.issue.body || "";
+  const missingRequirements = checkedRequirements.filter(
+    (item) => !new RegExp(`^- \\[x\\] ${escapeRegExp(item)}$`, "m").test(issueBody)
+  );
+  if (missingRequirements.length === 0) {
+    return null;
+  }
+
+  return failResult(CHECK_TYPE,
+    `Issue body is missing checked requirements: ${missingRequirements.join(", ")}`,
+    "check_failed"
+  );
+}
+
+function checkIssueType(context, remoteData) {
+  if (!context.config.verify_issue_type || !context.hasPush) {
+    return null;
+  }
+
+  if (remoteData.issueType === undefined) {
+    return null;
+  }
+
+  if (!remoteData.issueType) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has no Issue Type set`,
+      "check_failed"
+    );
+  }
+
+  const expectedType = mapTaskTypeToIssueType(context.task.metadata.type);
+  if (expectedType && remoteData.issueType !== expectedType) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has type '${remoteData.issueType}', expected '${expectedType}' (from task type '${context.task.metadata.type}')`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function checkPrAssignee(context, remoteData) {
+  if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
+    return null;
+  }
+
+  if (!remoteData.prAssignees || remoteData.prAssignees.length === 0) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} has no assignee`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function checkMilestone(context, remoteData) {
+  if (!context.config.verify_milestone || !context.hasTriage) {
+    return null;
+  }
+
+  if (!remoteData.issue?.milestone?.title) {
+    return failResult(CHECK_TYPE,
+      `Issue #${context.issueNumber} has no milestone set`,
+      "check_failed"
+    );
+  }
+
+  if (context.prNumber && remoteData.prMilestone !== undefined && !remoteData.prMilestone?.title) {
+    return failResult(CHECK_TYPE,
+      `PR #${context.prNumber} has no milestone set`,
+      "check_failed"
+    );
+  }
+
+  return null;
+}
+
+function findCommentByMarker(comments, marker) {
+  return (comments || []).find((comment) => typeof comment.body === "string" && comment.body.includes(marker)) || null;
+}
+
+function extractCommentBody(commentBody) {
+  const lines = String(commentBody || "").split(/\r?\n/);
+
+  let start = 0;
+  while (start < lines.length && (lines[start].trim() === "" || /^<!--.*-->$/.test(lines[start].trim()))) {
+    start += 1;
+  }
+
+  if (start < lines.length && lines[start].startsWith("## ")) {
+    start += 1;
+  }
+
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  if (start < lines.length && /^> \*\*.+\*\* · .+$/.test(lines[start].trim())) {
+    start += 1;
+  }
+
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  let end = lines.length;
+  for (let index = lines.length - 1; index >= start; index -= 1) {
+    const trimmed = lines[index].trim();
+    if (trimmed === "") {
+      continue;
+    }
+
+    if (/^\*.*\*$/.test(trimmed)) {
+      end = index;
+      if (end > start && lines[end - 1].trim() === "---") {
+        end -= 1;
+      }
+    }
+    break;
+  }
+
+  return lines.slice(start, end).join("\n");
+}
+
+function buildExpectedTaskBody(taskContent) {
+  const frontmatterMatch = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatterMatch) {
+    return taskContent.trim();
+  }
+
+  const body = taskContent.slice(frontmatterMatch[0].length).trim();
+  return [
+    buildTaskFrontmatterSummary(),
+    "",
+    "```yaml",
+    frontmatterMatch[0].trim(),
+    "```",
+    "",
+    "</details>",
+    "",
+    body
+  ].join("\n").trim();
+}
+
+function buildTaskFrontmatterSummary() {
+  const language = loadProjectLanguage();
+  if (language === "en" || language === "en-US") {
+    return "<details><summary>Metadata (frontmatter)</summary>";
+  }
+
+  return "<details><summary>元数据 (frontmatter)</summary>";
+}
+
+function loadProjectLanguage() {
+  const override = process.env.VALIDATE_ARTIFACT_LANGUAGE;
+  if (!isBlank(override)) {
+    return String(override).trim();
+  }
+
+  const configPath = path.join(repoRoot, ".agents", ".airc.json");
+  if (!fs.existsSync(configPath)) {
+    return "";
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    return String(config.language || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+function buildCommentContentMismatchMessage(fileStem, issueNumber, localContent, commentContent) {
+  const diffIndex = firstDifferenceIndex(localContent, commentContent);
+  const position = indexToLineColumn(localContent, diffIndex);
+
+  return `Comment content mismatch for '${fileStem}' on Issue #${issueNumber}: local file has ${localContent.length} chars, comment body has ${commentContent.length} chars (first difference near char ${diffIndex + 1}, line ${position.line}, column ${position.column})`;
+}
+
+function firstDifferenceIndex(left, right) {
+  const limit = Math.max(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    if (left[index] !== right[index]) {
+      return index;
+    }
+  }
+
+  return limit;
+}
+
+function indexToLineColumn(text, index) {
+  const prefix = text.slice(0, Math.min(index, text.length));
+  const lines = prefix.split("\n");
+  return {
+    line: lines.length,
+    column: (lines.at(-1) || "").length + 1
+  };
+}
+
+function extractLabelNames(labels) {
+  return (labels || [])
+    .map((label) => typeof label === "string" ? label : label?.name)
+    .filter((label) => typeof label === "string" && label.length > 0);
+}
+
+function mapTaskTypeToIssueType(taskType) {
+  const mapping = {
+    bug: "Bug",
+    bugfix: "Bug",
+    enhancement: "Feature",
+    feature: "Feature",
+    task: "Task",
+    documentation: "Task",
+    "dependency-upgrade": "Task",
+    chore: "Task",
+    docs: "Task",
+    refactor: "Task",
+    refactoring: "Task"
+  };
+
+  return mapping[taskType] || "Task";
+}
+
+function arraysEqual(left, right) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function formatLabelList(labels) {
+  return labels.length > 0 ? labels.join(", ") : "none";
+}
+
+// === GitHub API ===
+
+function normalizeIssuePayload(payload) {
+  return {
+    state: String(payload?.state || "").toUpperCase(),
+    labels: Array.isArray(payload?.labels) ? payload.labels : [],
+    body: typeof payload?.body === "string" ? payload.body : "",
+    milestone: payload?.milestone ?? null
+  };
+}
+
+function resolveUpstreamRepo(taskDir) {
+  const ownerRepo = resolveOwnerRepo(taskDir);
+  if (!ownerRepo.ok) {
+    return ownerRepo;
+  }
+
+  const upstreamResult = ghText([
+    "api",
+    `repos/${ownerRepo.value}`,
+    "--jq",
+    "if .fork then .parent.full_name else .full_name end"
+  ], taskDir);
+
+  if (!upstreamResult.ok) {
+    return upstreamResult;
+  }
+
+  if (isBlank(upstreamResult.value)) {
+    return { ok: false, message: "Unable to resolve upstream repository" };
+  }
+
+  return { ok: true, value: upstreamResult.value };
+}
+
+function resolveOwnerRepo(taskDir) {
+  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: taskDir,
+    encoding: "utf8"
+  });
+
+  if (gitResult.status !== 0) {
+    return { ok: false, message: `Unable to resolve git remote: ${gitResult.stderr.trim() || gitResult.stdout.trim()}` };
+  }
+
+  const remote = gitResult.stdout.trim();
+  const sshMatch = remote.match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (!sshMatch) {
+    return { ok: false, message: `Unable to parse owner/repo from remote '${remote}'` };
+  }
+
+  return { ok: true, value: sshMatch[1] };
+}
+
+function detectPermissions(upstreamRepo, taskDir) {
+  const permissionsResult = ghJson([
+    "api",
+    `repos/${upstreamRepo}`,
+    "--jq",
+    ".permissions"
+  ], taskDir);
+
+  if (!permissionsResult.ok) {
+    return { hasTriage: false, hasPush: false };
+  }
+
+  const permissions = permissionsResult.value && typeof permissionsResult.value === "object"
+    ? permissionsResult.value
+    : {};
+
+  return {
+    hasTriage: permissions.triage === true,
+    hasPush: permissions.push === true
+  };
+}
+
+function ghJson(args, cwd) {
+  const result = ghCommand(args, cwd);
+  if (!result.ok) {
+    return result;
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(result.value || "null") };
+  } catch (error) {
+    return { ok: false, type: "network_error", message: `Invalid JSON from gh: ${error.message}` };
+  }
+}
+
+function ghText(args, cwd) {
+  const result = ghCommand(args, cwd);
+  if (!result.ok) {
+    return result;
+  }
+
+  return { ok: true, value: String(result.value || "").trim() };
+}
+
+function ghCommand(args, cwd) {
+  const result = spawnSync("gh", args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env
+  });
+
+  if (result.status !== 0) {
+    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
+    const classified = classifyGhFailure(stderr, args);
+    return { ok: false, type: classified.type, message: classified.message };
+  }
+
+  return { ok: true, value: result.stdout };
+}
+
+function ghPaginatedJson(args, cwd) {
+  return ghJson(args, cwd);
+}
+
+function gitText(args, cwd) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env
+  });
+
+  if (result.status !== 0) {
+    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
+    return {
+      ok: false,
+      type: "check_failed",
+      message: stderr || `git ${args.join(" ")} failed`
+    };
+  }
+
+  return { ok: true, value: String(result.stdout || "").trim() };
+}
+
+function withRetry(operation) {
+  const delays = getRetryDelays();
+  let lastFailure = null;
+
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    const result = operation();
+    if (result.ok) {
+      return result;
+    }
+
+    lastFailure = result;
+    if (result.type === "check_failed") {
+      return result;
+    }
+
+    if (attempt < delays.length) {
+      sleep(delays[attempt]);
+    }
+  }
+
+  return lastFailure || { ok: false, type: "network_error", message: "Unknown GitHub sync failure" };
+}
+
+function classifyGhFailure(stderr, args) {
+  const message = stderr || `gh ${args.join(" ")} failed`;
+
+  if (/not found|could not resolve to an issue|http 404/i.test(message)) {
+    return { type: "check_failed", message };
+  }
+
+  return { type: "network_error", message };
+}
+
+function getRetryDelays() {
+  const override = process.env.VALIDATE_ARTIFACT_RETRY_DELAYS_MS;
+  if (!override) {
+    return DEFAULT_RETRY_DELAYS_MS;
+  }
+
+  const parsed = override
+    .split(",")
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isFinite(value) && value >= 0);
+
+  return parsed.length > 0 ? parsed : DEFAULT_RETRY_DELAYS_MS;
+}
+
+function sleep(delayMs) {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+function interpolate(template, taskDir, artifactFile) {
+  const artifactStem = artifactFile ? path.basename(artifactFile, path.extname(artifactFile)) : "";
+  return template
+    .replace(/\{task-id\}/g, path.basename(taskDir))
+    .replace(/\{artifact-stem\}/g, artifactStem);
+}

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const EXIT_CODE = {
@@ -27,7 +26,6 @@ const DEFAULT_REQUIRED_FIELDS = [
   "assigned_to"
 ];
 
-const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
@@ -35,6 +33,39 @@ const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
+
+const PLATFORM_ADAPTERS = {};
+const OPTIONAL_PLATFORM_CHECKS = new Set(["platform-sync"]);
+const adaptersDir = path.join(path.dirname(scriptPath), "platform-adapters");
+
+if (fs.existsSync(adaptersDir)) {
+  for (const file of fs.readdirSync(adaptersDir)) {
+    if (!file.endsWith(".js")) {
+      continue;
+    }
+
+    const adapterName = path.basename(file, ".js");
+    const mod = await import(new URL(`./platform-adapters/${file}`, import.meta.url));
+    if (typeof mod.check === "function") {
+      PLATFORM_ADAPTERS[adapterName] = mod.check;
+    }
+  }
+}
+
+const sharedUtils = {
+  loadTask,
+  getCheckedRequirements,
+  normalizeContent,
+  isBlank,
+  escapeRegExp,
+  passResult,
+  failResult,
+  blockedResult,
+  safeStat,
+  parseIssueNumber,
+  parsePrNumber,
+  repoRoot
+};
 
 // === CLI Entry ===
 
@@ -155,10 +186,18 @@ function runCheck(type, context) {
       return checkActivityLog(context);
     case "completion-checklist":
       return checkCompletionChecklist(context);
-    case "github-sync":
-      return checkGithubSync(context);
-    default:
-      return failResult(type, `Unsupported check type '${type}'.`);
+    default: {
+      const adapter = PLATFORM_ADAPTERS[type];
+      if (!adapter) {
+        if (OPTIONAL_PLATFORM_CHECKS.has(type)) {
+          return passResult(type, `Skipped: no platform adapter registered for '${type}'`);
+        }
+
+        return failResult(type, `Unsupported check type '${type}'.`);
+      }
+
+      return adapter(context, sharedUtils);
+    }
   }
 }
 
@@ -419,41 +458,6 @@ function checkCompletionChecklist({ taskDir, config }) {
   return passResult("completion-checklist", `Completion Checklist valid (${items.length} items checked)`);
 }
 
-function checkGithubSync({ taskDir, config, artifactFile }) {
-  const context = buildSyncContext({ taskDir, config, artifactFile });
-  if (context.earlyReturn) {
-    return context.earlyReturn;
-  }
-
-  const remoteData = fetchRemoteData(context);
-  if (remoteData.earlyReturn) {
-    return remoteData.earlyReturn;
-  }
-
-  const subChecks = [
-    checkStatusLabel,
-    checkCommentMarker,
-    checkPrCommentMarker,
-    checkPrCommentLastCommit,
-    checkCommentContent,
-    checkTaskCommentContent,
-    checkInLabelsMatchPr,
-    checkPrAssignee,
-    checkSyncedRequirements,
-    checkIssueType,
-    checkMilestone
-  ];
-
-  for (const subCheck of subChecks) {
-    const result = subCheck(context, remoteData);
-    if (result) {
-      return result;
-    }
-  }
-
-  return passResult("github-sync", `GitHub sync checks passed for Issue #${context.issueNumber}`);
-}
-
 // === File & Config Loaders ===
 
 function loadVerifyConfig(skillName) {
@@ -573,692 +577,6 @@ function getCheckedRequirements(content) {
     .map((match) => match[1].trim());
 }
 
-function buildSyncContext({ taskDir, config, artifactFile }) {
-  const task = loadTask(taskDir);
-  if (!task.ok) {
-    return { earlyReturn: failResult("github-sync", task.message) };
-  }
-
-  const issueNumber = parseIssueNumber(task.metadata.issue_number);
-  const prNumber = parsePrNumber(task.metadata.pr_number);
-  if (config.when === "issue_number_exists" && !issueNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: task has no issue_number") };
-  }
-  if (config.when === "pr_number_exists" && !prNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: task has no pr_number") };
-  }
-
-  if (!issueNumber) {
-    return { earlyReturn: passResult("github-sync", "Skipped: github-sync not required for this task") };
-  }
-
-  const upstreamRepo = resolveUpstreamRepo(taskDir);
-  if (!upstreamRepo.ok) {
-    return { earlyReturn: blockedResult("github-sync", upstreamRepo.message, "network_error") };
-  }
-  const permissions = detectPermissions(upstreamRepo.value, taskDir);
-
-  const marker = config.expected_comment_marker
-    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
-    : null;
-  const prMarker = config.expected_pr_comment_marker
-    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
-    : null;
-  const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
-
-  return {
-    task,
-    taskDir,
-    config,
-    artifactFile,
-    artifactPath,
-    issueNumber,
-    prNumber,
-    upstreamRepo: upstreamRepo.value,
-    hasTriage: permissions.hasTriage,
-    hasPush: permissions.hasPush,
-    marker,
-    prMarker
-  };
-}
-
-function fetchRemoteData(context) {
-  let issueResult = withRetry(() => ghJson([
-    "issue",
-    "view",
-    String(context.issueNumber),
-    "-R",
-    context.upstreamRepo,
-    "--json",
-    "state,labels,body,milestone"
-  ], context.taskDir));
-  if (!issueResult.ok && issueResult.type !== "check_failed") {
-    const fallbackIssueResult = withRetry(() => ghJson([
-      "api",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`
-    ], context.taskDir));
-    if (fallbackIssueResult.ok) {
-      issueResult = {
-        ok: true,
-        value: normalizeIssuePayload(fallbackIssueResult.value)
-      };
-    } else {
-      issueResult = fallbackIssueResult;
-    }
-  }
-  if (!issueResult.ok) {
-    return {
-      earlyReturn: issueResult.type === "check_failed"
-        ? failResult("github-sync", issueResult.message, issueResult.type)
-        : blockedResult("github-sync", issueResult.message, issueResult.type)
-    };
-  }
-
-  const issue = issueResult.value;
-  if (context.config.issue_must_exist !== false && !issue) {
-    return {
-      earlyReturn: failResult("github-sync", `Issue #${context.issueNumber} not found`, "check_failed")
-    };
-  }
-
-  let comments = null;
-  if (shouldFetchComments(context.config)) {
-    const commentsResult = withRetry(() => ghPaginatedJson([
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}/comments?per_page=100`
-    ], context.taskDir));
-
-    if (!commentsResult.ok) {
-      return {
-        earlyReturn: commentsResult.type === "check_failed"
-          ? failResult("github-sync", commentsResult.message, commentsResult.type)
-          : blockedResult("github-sync", commentsResult.message, commentsResult.type)
-      };
-    }
-
-    comments = flattenComments(commentsResult.value);
-  }
-
-  let prComments = null;
-  if (context.config.expected_pr_comment_marker) {
-    if (!context.prNumber) {
-      return {
-        earlyReturn: failResult("github-sync", "Expected a valid pr_number for PR comment verification", "check_failed")
-      };
-    }
-
-    const prCommentsResult = withRetry(() => ghPaginatedJson([
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${context.upstreamRepo}/issues/${context.prNumber}/comments?per_page=100`
-    ], context.taskDir));
-
-    if (!prCommentsResult.ok) {
-      return {
-        earlyReturn: prCommentsResult.type === "check_failed"
-          ? failResult("github-sync", prCommentsResult.message, prCommentsResult.type)
-          : blockedResult("github-sync", prCommentsResult.message, prCommentsResult.type)
-      };
-    }
-
-    prComments = flattenComments(prCommentsResult.value);
-  }
-
-  let issueType;
-  if (context.config.verify_issue_type && context.hasPush) {
-    const issueTypeResult = withRetry(() => ghText([
-      "api",
-      `repos/${context.upstreamRepo}/issues/${context.issueNumber}`,
-      "--jq",
-      ".type.name // empty"
-    ], context.taskDir));
-
-    if (issueTypeResult.ok) {
-      issueType = issueTypeResult.value || null;
-    }
-  }
-
-  let prLabels = null;
-  let prMilestone;
-  let prAssignees;
-  if (((context.config.verify_in_labels_match_pr && context.hasTriage)
-    || (context.config.verify_milestone && context.hasTriage)
-    || (context.config.verify_pr_assignee && context.hasPush)) && context.prNumber) {
-    const prFields = [];
-    if (context.config.verify_in_labels_match_pr) {
-      prFields.push("labels");
-    }
-    if (context.config.verify_milestone) {
-      prFields.push("milestone");
-    }
-    if (context.config.verify_pr_assignee) {
-      prFields.push("assignees");
-    }
-
-    const prResult = withRetry(() => ghJson([
-      "pr",
-      "view",
-      String(context.prNumber),
-      "--json",
-      prFields.join(",")
-    ], context.taskDir));
-
-    if (!prResult.ok) {
-      return {
-        earlyReturn: prResult.type === "check_failed"
-          ? failResult("github-sync", prResult.message, prResult.type)
-          : blockedResult("github-sync", prResult.message, prResult.type)
-      };
-    }
-
-    prLabels = context.config.verify_in_labels_match_pr
-      ? extractLabelNames(prResult.value?.labels)
-      : null;
-    prMilestone = context.config.verify_milestone
-      ? prResult.value?.milestone ?? null
-      : undefined;
-    prAssignees = context.config.verify_pr_assignee
-      ? (prResult.value?.assignees || []).map((a) => a.login).filter(Boolean)
-      : undefined;
-  }
-
-  return {
-    issue,
-    comments,
-    prComments,
-    prLabels,
-    issueType,
-    prMilestone,
-    prAssignees
-  };
-}
-
-function shouldFetchComments(config) {
-  return Boolean(
-    config.expected_comment_marker
-    || config.expected_pr_comment_marker
-    || config.verify_pr_comment_last_commit_matches_head
-    || config.verify_comment_content
-    || config.verify_task_comment_content
-  );
-}
-
-function flattenComments(value) {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((page) => Array.isArray(page) ? page : []);
-}
-
-function checkStatusLabel(context, remoteData) {
-  if (!context.config.expected_status_label || !context.hasTriage) {
-    return null;
-  }
-
-  if (String(remoteData.issue.state || "").toUpperCase() !== "OPEN") {
-    return null;
-  }
-
-  const labels = extractLabelNames(remoteData.issue.labels);
-  if (labels.includes(context.config.expected_status_label)) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
-    "check_failed"
-  );
-}
-
-function checkCommentMarker(context, remoteData) {
-  if (!context.marker) {
-    return null;
-  }
-
-  const comment = findCommentByMarker(remoteData.comments, context.marker);
-  if (comment) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected comment marker '${context.marker}' not found on Issue #${context.issueNumber}`,
-    "check_failed"
-  );
-}
-
-function checkPrCommentMarker(context, remoteData) {
-  if (!context.prMarker) {
-    return null;
-  }
-
-  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
-  if (comment) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
-    "check_failed"
-  );
-}
-
-function checkPrCommentLastCommit(context, remoteData) {
-  if (!context.config.verify_pr_comment_last_commit_matches_head) {
-    return null;
-  }
-
-  if (!context.prMarker) {
-    return failResult(
-      "github-sync",
-      "verify_pr_comment_last_commit_matches_head requires expected_pr_comment_marker",
-      "check_failed"
-    );
-  }
-
-  const comment = findCommentByMarker(remoteData.prComments, context.prMarker);
-  if (!comment) {
-    return failResult(
-      "github-sync",
-      `Expected PR comment marker '${context.prMarker}' not found on PR #${context.prNumber}`,
-      "check_failed"
-    );
-  }
-
-  const match = String(comment.body || "").match(/<!--\s*last-commit:\s*([0-9a-f]{7,40})\s*-->/i);
-  if (!match) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} summary comment is missing '<!-- last-commit: <sha> -->' metadata`,
-      "check_failed"
-    );
-  }
-
-  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
-  if (!headResult.ok) {
-    return headResult.type === "check_failed"
-      ? failResult("github-sync", headResult.message, headResult.type)
-      : blockedResult("github-sync", headResult.message, headResult.type);
-  }
-
-  const expectedHead = String(headResult.value || "").trim();
-  const actualHead = match[1].trim();
-  if (expectedHead === actualHead) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `PR #${context.prNumber} summary comment last-commit metadata mismatch: expected ${expectedHead}, got ${actualHead}`,
-    "check_failed"
-  );
-}
-
-function checkCommentContent(context, remoteData) {
-  if (!context.config.verify_comment_content) {
-    return null;
-  }
-
-  if (!context.marker) {
-    return failResult("github-sync", "verify_comment_content requires expected_comment_marker", "check_failed");
-  }
-
-  if (!context.artifactPath || !safeStat(context.artifactPath)) {
-    return failResult(
-      "github-sync",
-      `Artifact not found for comment verification: ${context.artifactFile || "(missing artifactFile)"}`,
-      "check_failed"
-    );
-  }
-
-  const comment = findCommentByMarker(remoteData.comments, context.marker);
-  const localContent = normalizeContent(fs.readFileSync(context.artifactPath, "utf8"));
-  const commentContent = normalizeContent(extractCommentBody(comment?.body || ""));
-
-  if (localContent === commentContent) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    buildCommentContentMismatchMessage(
-      path.basename(context.artifactPath, path.extname(context.artifactPath)),
-      context.issueNumber,
-      localContent,
-      commentContent
-    ),
-    "check_failed"
-  );
-}
-
-function checkTaskCommentContent(context, remoteData) {
-  if (!context.config.verify_task_comment_content) {
-    return null;
-  }
-
-  const taskMarker = `<!-- sync-issue:${context.task.metadata.id}:task -->`;
-  const comment = findCommentByMarker(remoteData.comments, taskMarker);
-  if (!comment) {
-    return failResult(
-      "github-sync",
-      `Expected comment marker '${taskMarker}' not found on Issue #${context.issueNumber}`,
-      "check_failed"
-    );
-  }
-
-  const expectedBody = normalizeContent(buildExpectedTaskBody(context.task.content));
-  const commentBody = normalizeContent(extractCommentBody(comment.body || ""));
-
-  if (expectedBody === commentBody) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    buildCommentContentMismatchMessage("task", context.issueNumber, expectedBody, commentBody),
-    "check_failed"
-  );
-}
-
-function checkInLabelsMatchPr(context, remoteData) {
-  if (!context.config.verify_in_labels_match_pr || !context.hasTriage || !context.prNumber || !remoteData.prLabels) {
-    return null;
-  }
-
-  const issueInLabels = extractLabelNames(remoteData.issue.labels)
-    .filter((label) => label.startsWith("in:"))
-    .sort();
-  const prInLabels = remoteData.prLabels
-    .filter((label) => label.startsWith("in:"))
-    .sort();
-
-  if (arraysEqual(issueInLabels, prInLabels)) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `in: labels mismatch — PR #${context.prNumber} has [${formatLabelList(prInLabels)}], Issue #${context.issueNumber} has [${formatLabelList(issueInLabels)}]`,
-    "check_failed"
-  );
-}
-
-function checkSyncedRequirements(context, remoteData) {
-  if (!context.config.sync_checked_requirements || !context.hasTriage) {
-    return null;
-  }
-
-  const checkedRequirements = getCheckedRequirements(context.task.content);
-  if (checkedRequirements.length === 0) {
-    return null;
-  }
-
-  const issueBody = remoteData.issue.body || "";
-  const missingRequirements = checkedRequirements.filter(
-    (item) => !new RegExp(`^- \\[x\\] ${escapeRegExp(item)}$`, "m").test(issueBody)
-  );
-  if (missingRequirements.length === 0) {
-    return null;
-  }
-
-  return failResult(
-    "github-sync",
-    `Issue body is missing checked requirements: ${missingRequirements.join(", ")}`,
-    "check_failed"
-  );
-}
-
-function checkIssueType(context, remoteData) {
-  if (!context.config.verify_issue_type || !context.hasPush) {
-    return null;
-  }
-
-  if (remoteData.issueType === undefined) {
-    return null;
-  }
-
-  if (!remoteData.issueType) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has no Issue Type set`,
-      "check_failed"
-    );
-  }
-
-  const expectedType = mapTaskTypeToIssueType(context.task.metadata.type);
-  if (expectedType && remoteData.issueType !== expectedType) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has type '${remoteData.issueType}', expected '${expectedType}' (from task type '${context.task.metadata.type}')`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function checkPrAssignee(context, remoteData) {
-  if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
-    return null;
-  }
-
-  if (!remoteData.prAssignees || remoteData.prAssignees.length === 0) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} has no assignee`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function checkMilestone(context, remoteData) {
-  if (!context.config.verify_milestone || !context.hasTriage) {
-    return null;
-  }
-
-  if (!remoteData.issue?.milestone?.title) {
-    return failResult(
-      "github-sync",
-      `Issue #${context.issueNumber} has no milestone set`,
-      "check_failed"
-    );
-  }
-
-  if (context.prNumber && remoteData.prMilestone !== undefined && !remoteData.prMilestone?.title) {
-    return failResult(
-      "github-sync",
-      `PR #${context.prNumber} has no milestone set`,
-      "check_failed"
-    );
-  }
-
-  return null;
-}
-
-function findCommentByMarker(comments, marker) {
-  return (comments || []).find((comment) => typeof comment.body === "string" && comment.body.includes(marker)) || null;
-}
-
-function extractCommentBody(commentBody) {
-  const lines = String(commentBody || "").split(/\r?\n/);
-
-  let start = 0;
-  while (start < lines.length && (lines[start].trim() === "" || /^<!--.*-->$/.test(lines[start].trim()))) {
-    start += 1;
-  }
-
-  if (start < lines.length && lines[start].startsWith("## ")) {
-    start += 1;
-  }
-
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  if (start < lines.length && /^> \*\*.+\*\* · .+$/.test(lines[start].trim())) {
-    start += 1;
-  }
-
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  let end = lines.length;
-  for (let index = lines.length - 1; index >= start; index -= 1) {
-    const trimmed = lines[index].trim();
-    if (trimmed === "") {
-      continue;
-    }
-
-    if (/^\*.*\*$/.test(trimmed)) {
-      end = index;
-      if (end > start && lines[end - 1].trim() === "---") {
-        end -= 1;
-      }
-    }
-    break;
-  }
-
-  return lines.slice(start, end).join("\n");
-}
-
-function buildExpectedTaskBody(taskContent) {
-  const frontmatterMatch = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
-  if (!frontmatterMatch) {
-    return taskContent.trim();
-  }
-
-  const body = taskContent.slice(frontmatterMatch[0].length).trim();
-  return [
-    buildTaskFrontmatterSummary(),
-    "",
-    "```yaml",
-    frontmatterMatch[0].trim(),
-    "```",
-    "",
-    "</details>",
-    "",
-    body
-  ].join("\n").trim();
-}
-
-function buildTaskFrontmatterSummary() {
-  const language = loadProjectLanguage();
-  if (language === "en" || language === "en-US") {
-    return "<details><summary>Metadata (frontmatter)</summary>";
-  }
-
-  return "<details><summary>元数据 (frontmatter)</summary>";
-}
-
-function loadProjectLanguage() {
-  const override = process.env.VALIDATE_ARTIFACT_LANGUAGE;
-  if (!isBlank(override)) {
-    return String(override).trim();
-  }
-
-  const configPath = path.join(repoRoot, ".agents", ".airc.json");
-  if (!fs.existsSync(configPath)) {
-    return "";
-  }
-
-  try {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    return String(config.language || "").trim();
-  } catch {
-    return "";
-  }
-}
-
-function normalizeContent(text) {
-  return String(text || "")
-    .replace(/\r\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-function buildCommentContentMismatchMessage(fileStem, issueNumber, localContent, commentContent) {
-  const diffIndex = firstDifferenceIndex(localContent, commentContent);
-  const position = indexToLineColumn(localContent, diffIndex);
-
-  return `Comment content mismatch for '${fileStem}' on Issue #${issueNumber}: local file has ${localContent.length} chars, comment body has ${commentContent.length} chars (first difference near char ${diffIndex + 1}, line ${position.line}, column ${position.column})`;
-}
-
-function firstDifferenceIndex(left, right) {
-  const limit = Math.max(left.length, right.length);
-  for (let index = 0; index < limit; index += 1) {
-    if (left[index] !== right[index]) {
-      return index;
-    }
-  }
-
-  return limit;
-}
-
-function indexToLineColumn(text, index) {
-  const prefix = text.slice(0, Math.min(index, text.length));
-  const lines = prefix.split("\n");
-  return {
-    line: lines.length,
-    column: (lines.at(-1) || "").length + 1
-  };
-}
-
-function extractLabelNames(labels) {
-  return (labels || [])
-    .map((label) => typeof label === "string" ? label : label?.name)
-    .filter((label) => typeof label === "string" && label.length > 0);
-}
-
-function mapTaskTypeToIssueType(taskType) {
-  const mapping = {
-    bug: "Bug",
-    bugfix: "Bug",
-    enhancement: "Feature",
-    feature: "Feature",
-    task: "Task",
-    documentation: "Task",
-    "dependency-upgrade": "Task",
-    chore: "Task",
-    docs: "Task",
-    refactor: "Task",
-    refactoring: "Task"
-  };
-
-  return mapping[taskType] || "Task";
-}
-
-function arraysEqual(left, right) {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  return left.every((value, index) => value === right[index]);
-}
-
-function formatLabelList(labels) {
-  return labels.length > 0 ? labels.join(", ") : "none";
-}
-
-// === GitHub API ===
-
-function normalizeIssuePayload(payload) {
-  return {
-    state: String(payload?.state || "").toUpperCase(),
-    labels: Array.isArray(payload?.labels) ? payload.labels : [],
-    body: typeof payload?.body === "string" ? payload.body : "",
-    milestone: payload?.milestone ?? null
-  };
-}
-
 function parseIssueNumber(value) {
   if (isBlank(value) || value === "N/A") {
     return null;
@@ -1272,188 +590,14 @@ function parsePrNumber(value) {
   return parseIssueNumber(value);
 }
 
-function resolveUpstreamRepo(taskDir) {
-  const ownerRepo = resolveOwnerRepo(taskDir);
-  if (!ownerRepo.ok) {
-    return ownerRepo;
-  }
-
-  const upstreamResult = ghText([
-    "api",
-    `repos/${ownerRepo.value}`,
-    "--jq",
-    "if .fork then .parent.full_name else .full_name end"
-  ], taskDir);
-
-  if (!upstreamResult.ok) {
-    return upstreamResult;
-  }
-
-  if (isBlank(upstreamResult.value)) {
-    return { ok: false, message: "Unable to resolve upstream repository" };
-  }
-
-  return { ok: true, value: upstreamResult.value };
-}
-
-function resolveOwnerRepo(taskDir) {
-  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
-    cwd: taskDir,
-    encoding: "utf8"
-  });
-
-  if (gitResult.status !== 0) {
-    return { ok: false, message: `Unable to resolve git remote: ${gitResult.stderr.trim() || gitResult.stdout.trim()}` };
-  }
-
-  const remote = gitResult.stdout.trim();
-  const sshMatch = remote.match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
-  if (!sshMatch) {
-    return { ok: false, message: `Unable to parse owner/repo from remote '${remote}'` };
-  }
-
-  return { ok: true, value: sshMatch[1] };
-}
-
-function detectPermissions(upstreamRepo, taskDir) {
-  const permissionsResult = ghJson([
-    "api",
-    `repos/${upstreamRepo}`,
-    "--jq",
-    ".permissions"
-  ], taskDir);
-
-  if (!permissionsResult.ok) {
-    return { hasTriage: false, hasPush: false };
-  }
-
-  const permissions = permissionsResult.value && typeof permissionsResult.value === "object"
-    ? permissionsResult.value
-    : {};
-
-  return {
-    hasTriage: permissions.triage === true,
-    hasPush: permissions.push === true
-  };
-}
-
-function ghJson(args, cwd) {
-  const result = ghCommand(args, cwd);
-  if (!result.ok) {
-    return result;
-  }
-
-  try {
-    return { ok: true, value: JSON.parse(result.value || "null") };
-  } catch (error) {
-    return { ok: false, type: "network_error", message: `Invalid JSON from gh: ${error.message}` };
-  }
-}
-
-function ghText(args, cwd) {
-  const result = ghCommand(args, cwd);
-  if (!result.ok) {
-    return result;
-  }
-
-  return { ok: true, value: String(result.value || "").trim() };
-}
-
-function ghCommand(args, cwd) {
-  const result = spawnSync("gh", args, {
-    cwd,
-    encoding: "utf8",
-    env: process.env
-  });
-
-  if (result.status !== 0) {
-    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
-    const classified = classifyGhFailure(stderr, args);
-    return { ok: false, type: classified.type, message: classified.message };
-  }
-
-  return { ok: true, value: result.stdout };
-}
-
-function ghPaginatedJson(args, cwd) {
-  return ghJson(args, cwd);
-}
-
-function gitText(args, cwd) {
-  const result = spawnSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    env: process.env
-  });
-
-  if (result.status !== 0) {
-    const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
-    return {
-      ok: false,
-      type: "check_failed",
-      message: stderr || `git ${args.join(" ")} failed`
-    };
-  }
-
-  return { ok: true, value: String(result.stdout || "").trim() };
-}
-
-function withRetry(operation) {
-  const delays = getRetryDelays();
-  let lastFailure = null;
-
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    const result = operation();
-    if (result.ok) {
-      return result;
-    }
-
-    lastFailure = result;
-    if (result.type === "check_failed") {
-      return result;
-    }
-
-    if (attempt < delays.length) {
-      sleep(delays[attempt]);
-    }
-  }
-
-  return lastFailure || { ok: false, type: "network_error", message: "Unknown GitHub sync failure" };
-}
-
-function classifyGhFailure(stderr, args) {
-  const message = stderr || `gh ${args.join(" ")} failed`;
-
-  if (/not found|could not resolve to an issue|http 404/i.test(message)) {
-    return { type: "check_failed", message };
-  }
-
-  return { type: "network_error", message };
-}
-
-function getRetryDelays() {
-  const override = process.env.VALIDATE_ARTIFACT_RETRY_DELAYS_MS;
-  if (!override) {
-    return DEFAULT_RETRY_DELAYS_MS;
-  }
-
-  const parsed = override
-    .split(",")
-    .map((value) => Number(value.trim()))
-    .filter((value) => Number.isFinite(value) && value >= 0);
-
-  return parsed.length > 0 ? parsed : DEFAULT_RETRY_DELAYS_MS;
-}
-
-function sleep(delayMs) {
-  if (delayMs <= 0) {
-    return;
-  }
-
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
-}
-
 // === Utilities ===
+
+function normalizeContent(text) {
+  return String(text || "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 function minutesSinceTimestamp(timestamp) {
   const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");

--- a/templates/.agents/skills/analyze-task/config/verify.json
+++ b/templates/.agents/skills/analyze-task/config/verify.json
@@ -30,7 +30,7 @@
       "expected_action_pattern": "Requirement Analysis \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: pending-design-work",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/templates/.agents/skills/block-task/config/verify.json
+++ b/templates/.agents/skills/block-task/config/verify.json
@@ -20,7 +20,7 @@
       "expected_action_pattern": "Blocked",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: blocked"
     }

--- a/templates/.agents/skills/cancel-task/config/verify.json
+++ b/templates/.agents/skills/cancel-task/config/verify.json
@@ -21,7 +21,7 @@
       "expected_action_pattern": "Cancelled",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:cancel -->",
       "verify_task_comment_content": true

--- a/templates/.agents/skills/commit/config/verify.json
+++ b/templates/.agents/skills/commit/config/verify.json
@@ -17,7 +17,7 @@
       "expected_action_pattern": "Commit",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_pr_comment_last_commit_matches_head": true

--- a/templates/.agents/skills/complete-task/config/verify.json
+++ b/templates/.agents/skills/complete-task/config/verify.json
@@ -23,7 +23,7 @@
     "completion-checklist": {
       "require_all_checked": true
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:summary -->",
       "verify_task_comment_content": true,

--- a/templates/.agents/skills/create-issue/config/verify.json
+++ b/templates/.agents/skills/create-issue/config/verify.json
@@ -18,7 +18,7 @@
       "expected_action_pattern": "Create Issue",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "issue_must_exist": true,
       "verify_task_comment_content": true,

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -17,7 +17,7 @@
       "expected_action_pattern": "PR Created",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_match_pr": true,

--- a/templates/.agents/skills/create-task/config/verify.json
+++ b/templates/.agents/skills/create-task/config/verify.json
@@ -20,6 +20,6 @@
       "expected_action_pattern": "Task Created",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/templates/.agents/skills/implement-task/config/verify.json
+++ b/templates/.agents/skills/implement-task/config/verify.json
@@ -29,7 +29,7 @@
       "expected_action_pattern": "Implementation \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/templates/.agents/skills/import-codescan/config/verify.json
+++ b/templates/.agents/skills/import-codescan/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Import Code Scanning Alert",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/templates/.agents/skills/import-dependabot/config/verify.json
+++ b/templates/.agents/skills/import-dependabot/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Import Dependabot Alert",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/templates/.agents/skills/import-issue/config/verify.json
+++ b/templates/.agents/skills/import-issue/config/verify.json
@@ -20,7 +20,7 @@
       "expected_action_pattern": "Import Issue",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "issue_must_exist": true
     }

--- a/templates/.agents/skills/plan-task/config/verify.json
+++ b/templates/.agents/skills/plan-task/config/verify.json
@@ -31,7 +31,7 @@
       "expected_action_pattern": "Technical Design \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: pending-design-work",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/templates/.agents/skills/refine-task/config/verify.json
+++ b/templates/.agents/skills/refine-task/config/verify.json
@@ -25,7 +25,7 @@
       "expected_action_pattern": "Refinement \\(Round \\d+, for .+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/templates/.agents/skills/restore-task/config/verify.json
+++ b/templates/.agents/skills/restore-task/config/verify.json
@@ -19,6 +19,6 @@
       "expected_action_pattern": "Restore Task",
       "freshness_minutes": 30
     },
-    "github-sync": null
+    "platform-sync": null
   }
 }

--- a/templates/.agents/skills/review-task/config/verify.json
+++ b/templates/.agents/skills/review-task/config/verify.json
@@ -29,7 +29,7 @@
       "expected_action_pattern": "Code Review \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
-    "github-sync": {
+    "platform-sync": {
       "when": "issue_number_exists",
       "expected_status_label": "status: in-progress",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",

--- a/tests/core/validate-artifact.test.js
+++ b/tests/core/validate-artifact.test.js
@@ -475,7 +475,7 @@ test("validate-artifact gate passes for complete-task when completion checklist 
     assert.equal(payload.gate, "pass");
     assert.deepEqual(
       payload.checks.map((check) => check.type),
-      ["task-meta", "activity-log", "completion-checklist", "github-sync"]
+      ["task-meta", "activity-log", "completion-checklist", "platform-sync"]
     );
     assert.deepEqual(
       payload.checks.map((check) => check.status),
@@ -509,7 +509,7 @@ test("validate-artifact completion-checklist fails when a complete-task item is 
   }
 });
 
-test("validate-artifact github-sync blocks after retry exhaustion on gh network errors", () => {
+test("validate-artifact platform-sync blocks after retry exhaustion on gh network errors", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-blocked-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
@@ -540,7 +540,7 @@ test("validate-artifact github-sync blocks after retry exhaustion on gh network 
 
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.gate, "blocked");
-    const githubCheck = payload.checks.find((check) => check.type === "github-sync");
+    const githubCheck = payload.checks.find((check) => check.type === "platform-sync");
     assert.equal(githubCheck.status, "blocked");
     assert.equal(githubCheck.fail_type, "network_error");
   } finally {
@@ -548,8 +548,42 @@ test("validate-artifact github-sync blocks after retry exhaustion on gh network 
   }
 });
 
+test("validate-artifact platform-sync skips when no platform adapter is registered", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-skip-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+  const verifyCopy = path.join(tempRoot, ".agents/skills/implement-task/config/verify.json");
+
+  try {
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(verifyCopy, read(".agents/skills/implement-task/config/verify.json"));
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
+    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptCopy, "check", "platform-sync", taskDir, "implementation.md", "--skill", "implement-task"],
+      {
+        encoding: "utf8",
+        cwd: tempRoot,
+        env: process.env
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.type, "platform-sync");
+    assert.equal(payload.status, "pass");
+    assert.equal(payload.message, "Skipped: no platform adapter registered for 'platform-sync'");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("validate-artifact gate passes when synced artifact and task comments match local files", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pass-"));
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pass-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -592,8 +626,8 @@ test("validate-artifact gate passes when synced artifact and task comments match
   }
 });
 
-test("validate-artifact github-sync fails when artifact comment content differs from the local artifact", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-artifact-mismatch-"));
+test("validate-artifact platform-sync fails when artifact comment content differs from the local artifact", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-artifact-mismatch-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -617,7 +651,7 @@ test("validate-artifact github-sync fails when artifact comment content differs 
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "implementation.md",
       "--skill",
@@ -633,7 +667,7 @@ test("validate-artifact github-sync fails when artifact comment content differs 
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /Comment content mismatch for 'implementation'/);
     assert.match(payload.message, /first difference near char \d+/);
@@ -642,8 +676,8 @@ test("validate-artifact github-sync fails when artifact comment content differs 
   }
 });
 
-test("validate-artifact github-sync fails when the task comment does not use the rendered frontmatter details block", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-task-mismatch-"));
+test("validate-artifact platform-sync fails when the task comment does not use the rendered frontmatter details block", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-task-mismatch-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -667,7 +701,7 @@ test("validate-artifact github-sync fails when the task comment does not use the
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "implementation.md",
       "--skill",
@@ -683,7 +717,7 @@ test("validate-artifact github-sync fails when the task comment does not use the
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /Comment content mismatch for 'task'/);
     assert.match(payload.message, /line \d+, column \d+/);
@@ -692,8 +726,8 @@ test("validate-artifact github-sync fails when the task comment does not use the
   }
 });
 
-test("validate-artifact github-sync fails when the Issue Type does not match task type", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-issue-type-"));
+test("validate-artifact platform-sync fails when the Issue Type does not match task type", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-type-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -719,7 +753,7 @@ test("validate-artifact github-sync fails when the Issue Type does not match tas
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "implementation.md",
       "--skill",
@@ -735,7 +769,7 @@ test("validate-artifact github-sync fails when the Issue Type does not match tas
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /has type 'Task', expected 'Feature'/);
   } finally {
@@ -743,8 +777,8 @@ test("validate-artifact github-sync fails when the Issue Type does not match tas
   }
 });
 
-test("validate-artifact github-sync skips Issue Type verification when the REST query is unavailable", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-issue-type-skip-"));
+test("validate-artifact platform-sync skips Issue Type verification when the REST query is unavailable", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-type-skip-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -768,7 +802,7 @@ test("validate-artifact github-sync skips Issue Type verification when the REST 
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "implementation.md",
       "--skill",
@@ -786,15 +820,15 @@ test("validate-artifact github-sync skips Issue Type verification when the REST 
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test("validate-artifact github-sync accepts English task frontmatter summary when language override is en", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-task-en-"));
+test("validate-artifact platform-sync accepts English task frontmatter summary when language override is en", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-task-en-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -818,7 +852,7 @@ test("validate-artifact github-sync accepts English task frontmatter summary whe
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "implementation.md",
       "--skill",
@@ -835,15 +869,15 @@ test("validate-artifact github-sync accepts English task frontmatter summary whe
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test("validate-artifact github-sync fails when create-pr milestone is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pr-milestone-"));
+test("validate-artifact platform-sync fails when create-pr milestone is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-milestone-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -869,7 +903,7 @@ test("validate-artifact github-sync fails when create-pr milestone is missing", 
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -887,7 +921,7 @@ test("validate-artifact github-sync fails when create-pr milestone is missing", 
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /PR #77 has no milestone set/);
   } finally {
@@ -895,8 +929,8 @@ test("validate-artifact github-sync fails when create-pr milestone is missing", 
   }
 });
 
-test("validate-artifact github-sync fails when PR and Issue in: labels diverge", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-in-labels-"));
+test("validate-artifact platform-sync fails when PR and Issue in: labels diverge", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-in-labels-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -922,7 +956,7 @@ test("validate-artifact github-sync fails when PR and Issue in: labels diverge",
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -940,7 +974,7 @@ test("validate-artifact github-sync fails when PR and Issue in: labels diverge",
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /in: labels mismatch/);
     assert.match(payload.message, /PR #77/);
@@ -950,8 +984,8 @@ test("validate-artifact github-sync fails when PR and Issue in: labels diverge",
   }
 });
 
-test("validate-artifact github-sync fails when create-pr has no assignee", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pr-assignee-"));
+test("validate-artifact platform-sync fails when create-pr has no assignee", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-assignee-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -977,7 +1011,7 @@ test("validate-artifact github-sync fails when create-pr has no assignee", () =>
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -995,7 +1029,7 @@ test("validate-artifact github-sync fails when create-pr has no assignee", () =>
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /PR #77 has no assignee/);
   } finally {
@@ -1003,8 +1037,8 @@ test("validate-artifact github-sync fails when create-pr has no assignee", () =>
   }
 });
 
-test("validate-artifact github-sync skips create-pr assignee verification without push permission", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pr-assignee-skip-"));
+test("validate-artifact platform-sync skips create-pr assignee verification without push permission", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-assignee-skip-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1030,7 +1064,7 @@ test("validate-artifact github-sync skips create-pr assignee verification withou
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -1049,15 +1083,15 @@ test("validate-artifact github-sync skips create-pr assignee verification withou
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test("validate-artifact github-sync passes when create-pr summary comment exists on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pr-comment-pass-"));
+test("validate-artifact platform-sync passes when create-pr summary comment exists on the PR", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-comment-pass-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1081,7 +1115,7 @@ test("validate-artifact github-sync passes when create-pr summary comment exists
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -1099,7 +1133,7 @@ test("validate-artifact github-sync passes when create-pr summary comment exists
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -1129,8 +1163,8 @@ test("template English rule contains the canonical PR summary structure", () => 
   assertHasCanonicalPrSyncStructure("templates/.agents/rules/pr-sync.github.en.md", enHeadings);
 });
 
-test("validate-artifact github-sync skips for commit when task has no pr_number", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-commit-skip-"));
+test("validate-artifact platform-sync skips for commit when task has no pr_number", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-skip-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
 
   try {
@@ -1139,7 +1173,7 @@ test("validate-artifact github-sync skips for commit when task has no pr_number"
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "commit"
@@ -1148,7 +1182,7 @@ test("validate-artifact github-sync skips for commit when task has no pr_number"
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
     assert.equal(payload.message, "Skipped: task has no pr_number");
   } finally {
@@ -1156,8 +1190,8 @@ test("validate-artifact github-sync skips for commit when task has no pr_number"
   }
 });
 
-test("validate-artifact github-sync passes for commit when summary comment exists on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-commit-pass-"));
+test("validate-artifact platform-sync passes for commit when summary comment exists on the PR", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-pass-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1180,7 +1214,7 @@ test("validate-artifact github-sync passes for commit when summary comment exist
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "commit"
@@ -1197,15 +1231,15 @@ test("validate-artifact github-sync passes for commit when summary comment exist
     assert.equal(result.status, 0, result.stderr);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test("validate-artifact github-sync fails for commit when summary comment last-commit metadata mismatches HEAD", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-commit-head-fail-"));
+test("validate-artifact platform-sync fails for commit when summary comment last-commit metadata mismatches HEAD", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-head-fail-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1228,7 +1262,7 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "commit"
@@ -1245,7 +1279,7 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /last-commit metadata mismatch/);
   } finally {
@@ -1253,8 +1287,8 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
   }
 });
 
-test("validate-artifact github-sync fails for commit when summary comment last-commit metadata is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-commit-head-missing-"));
+test("validate-artifact platform-sync fails for commit when summary comment last-commit metadata is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-head-missing-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1277,7 +1311,7 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "commit"
@@ -1294,7 +1328,7 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /missing '<!-- last-commit: <sha> -->' metadata/);
   } finally {
@@ -1302,8 +1336,8 @@ test("validate-artifact github-sync fails for commit when summary comment last-c
   }
 });
 
-test("validate-artifact github-sync fails when create-pr summary comment is missing on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-pr-comment-fail-"));
+test("validate-artifact platform-sync fails when create-pr summary comment is missing on the PR", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-comment-fail-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1325,7 +1359,7 @@ test("validate-artifact github-sync fails when create-pr summary comment is miss
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-pr"
@@ -1343,7 +1377,7 @@ test("validate-artifact github-sync fails when create-pr summary comment is miss
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /Expected PR comment marker/);
     assert.match(payload.message, /PR #77/);
@@ -1352,8 +1386,8 @@ test("validate-artifact github-sync fails when create-pr summary comment is miss
   }
 });
 
-test("validate-artifact github-sync fails for commit when summary comment is missing on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-commit-fail-"));
+test("validate-artifact platform-sync fails for commit when summary comment is missing on the PR", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-fail-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1373,7 +1407,7 @@ test("validate-artifact github-sync fails for commit when summary comment is mis
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "commit"
@@ -1390,7 +1424,7 @@ test("validate-artifact github-sync fails for commit when summary comment is mis
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /Expected PR comment marker/);
     assert.match(payload.message, /PR #77/);
@@ -1399,8 +1433,8 @@ test("validate-artifact github-sync fails for commit when summary comment is mis
   }
 });
 
-test("validate-artifact github-sync fails for create-issue when the task comment is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-github-sync-create-issue-task-"));
+test("validate-artifact platform-sync fails for create-issue when the task comment is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-create-issue-task-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = path.join(binDir, "gh");
@@ -1420,7 +1454,7 @@ test("validate-artifact github-sync fails for create-issue when the task comment
 
     const result = runValidator([
       "check",
-      "github-sync",
+      "platform-sync",
       taskDir,
       "--skill",
       "create-issue"
@@ -1436,7 +1470,7 @@ test("validate-artifact github-sync fails for create-issue when the task comment
     assert.equal(result.status, 1);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.type, "github-sync");
+    assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "fail");
     assert.match(payload.message, /sync-issue:TASK-20260328-000001:task/);
   } finally {
@@ -1447,7 +1481,9 @@ test("validate-artifact github-sync fails for create-issue when the task comment
 test("verification assets are present in local and template trees", () => {
   [
     ".agents/scripts/validate-artifact.js",
+    ".agents/scripts/platform-adapters/platform-sync.js",
     "templates/.agents/scripts/validate-artifact.js",
+    "templates/.agents/scripts/platform-adapters/platform-sync.github.js",
     ".agents/skills/implement-task/config/verify.json",
     "templates/.agents/skills/implement-task/config/verify.json"
   ].forEach((relativePath) => {
@@ -1458,5 +1494,10 @@ test("verification assets are present in local and template trees", () => {
     read(".agents/scripts/validate-artifact.js"),
     read("templates/.agents/scripts/validate-artifact.js"),
     "template validate-artifact.js should stay in sync with the local script"
+  );
+  assert.equal(
+    read(".agents/scripts/platform-adapters/platform-sync.js"),
+    read("templates/.agents/scripts/platform-adapters/platform-sync.github.js"),
+    "template platform adapter should stay in sync with the local adapter"
   );
 });

--- a/tests/templates/restore-task-skill.test.js
+++ b/tests/templates/restore-task-skill.test.js
@@ -38,12 +38,12 @@ test("restore-task verify configs declare the expected checks", () => {
     assert.equal(verify.skill, "restore-task");
     assert.deepEqual(
       Object.keys(verify.checks),
-      ["task-meta", "activity-log", "github-sync"],
+      ["task-meta", "activity-log", "platform-sync"],
       `${relativePath} should declare the restore-task checks`
     );
     assert.equal(verify.checks["task-meta"].require_issue_number, true);
     assert.equal(verify.checks["activity-log"].expected_action_pattern, "Restore Task");
-    assert.equal(verify.checks["github-sync"], null);
+    assert.equal(verify.checks["platform-sync"], null);
   });
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #201

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

将 `validate-artifact.js` 中硬编码的 `github-sync` 平台同步检查（约 700 行）提取为独立的可插拔适配器模块，使切换代码托管平台（GitLab/Gitee/Gitea 等）时只需替换一个适配器文件，核心校验逻辑和配置零修改。

## 📋 主要变更 / Brief Changelog

- 新增 `.agents/scripts/platform-adapters/platform-sync.js`，将 GitHub 平台同步逻辑封装为独立适配器，通过 `shared` 工具集与核心脚本解耦
- 重构 `validate-artifact.js`，使用顶层 `await` 动态扫描 `platform-adapters/` 目录注册适配器，`runCheck()` 通过映射表分发平台检查
- 所有 32 个 `verify.json`（16 本地 + 16 模板）中的检查 key 从 `github-sync` 重命名为平台无关的 `platform-sync`
- 新增缺失适配器时优雅跳过的回归测试

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 211 测试全部通过
2. `node .agents/scripts/validate-artifact.js gate analyze-task .agents/workspace/active/TASK-20260414-115756 analysis.md --format text` — 验证 gate 流程
3. 删除 `platform-adapters/` 目录后脚本仍能运行（platform-sync 跳过而非崩溃）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

Closes #201

---

Generated with AI assistance