### PR TITLE
refactor(skills): 元数据同步时机重构 (#206)

### DIFF
--- a/.agents/rules/issue-sync.md
+++ b/.agents/rules/issue-sync.md
@@ -106,6 +106,8 @@ fi
 
 ## `in:` label 同步
 
+> **触发时机**：`in:` label 同步应在代码提交后（commit 技能）执行，不在 implement-task 或 refine-task 阶段执行。create-pr 阶段仅从 Issue 复制到 PR，不重新计算。
+
 读取 `.agents/.airc.json` 的 `labels.in` 映射。
 
 ```bash

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -81,6 +81,7 @@ export function check({ taskDir, config, artifactFile }, shared) {
     checkPrCommentLastCommit,
     checkCommentContent,
     checkTaskCommentContent,
+    checkInLabelsComputed,
     checkInLabelsMatchPr,
     checkPrAssignee,
     checkSyncedRequirements,
@@ -502,6 +503,37 @@ function checkInLabelsMatchPr(context, remoteData) {
   );
 }
 
+function checkInLabelsComputed(context, remoteData) {
+  if (!context.config.verify_in_labels_computed || !context.hasTriage) {
+    return null;
+  }
+
+  const expectedInLabels = computeExpectedInLabels(context.taskDir);
+  if (!expectedInLabels.ok) {
+    return expectedInLabels.type === "check_failed"
+      ? failResult(CHECK_TYPE, expectedInLabels.message, expectedInLabels.type)
+      : blockedResult(CHECK_TYPE, expectedInLabels.message, expectedInLabels.type);
+  }
+
+  if (expectedInLabels.mode === "skipped") {
+    return null;
+  }
+
+  const actualInLabels = extractLabelNames(remoteData.issue.labels)
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+
+  if (arraysEqual(expectedInLabels.labels, actualInLabels)) {
+    return null;
+  }
+
+  return failResult(
+    CHECK_TYPE,
+    `Issue #${context.issueNumber} in: labels do not match committed changes: expected [${formatLabelList(expectedInLabels.labels)}], got [${formatLabelList(actualInLabels)}]`,
+    "check_failed"
+  );
+}
+
 function checkSyncedRequirements(context, remoteData) {
   if (!context.config.sync_checked_requirements || !context.hasTriage) {
     return null;
@@ -746,6 +778,106 @@ function arraysEqual(left, right) {
 
 function formatLabelList(labels) {
   return labels.length > 0 ? labels.join(", ") : "none";
+}
+
+function computeExpectedInLabels(taskDir) {
+  const changedFilesResult = gitText(["diff", "main...HEAD", "--name-only"], taskDir);
+  if (!changedFilesResult.ok) {
+    return changedFilesResult;
+  }
+
+  const changedFiles = String(changedFilesResult.value || "")
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const mapping = loadInLabelMapping();
+  if (!mapping.ok) {
+    return mapping;
+  }
+
+  if (Object.keys(mapping.value).length > 0) {
+    const labels = new Set();
+
+    for (const file of changedFiles) {
+      for (const [label, prefixes] of Object.entries(mapping.value)) {
+        if (prefixes.some((prefix) => file.startsWith(prefix))) {
+          labels.add(`in: ${label}`);
+        }
+      }
+    }
+
+    return { ok: true, labels: Array.from(labels).sort(), mode: "mapped" };
+  }
+
+  const repoLabelsResult = ghJson([
+    "label",
+    "list",
+    "--limit",
+    "200",
+    "--json",
+    "name"
+  ], taskDir);
+  if (!repoLabelsResult.ok) {
+    return repoLabelsResult;
+  }
+
+  const repoInLabels = new Set(
+    extractLabelNames(repoLabelsResult.value)
+      .filter((label) => label.startsWith("in:"))
+  );
+
+  if (repoInLabels.size === 0) {
+    return { ok: true, labels: [], mode: "fallback" };
+  }
+
+  const labels = new Set();
+  for (const file of changedFiles) {
+    const topLevel = file.split("/")[0];
+    if (!topLevel) {
+      continue;
+    }
+
+    const candidate = `in: ${topLevel}`;
+    if (repoInLabels.has(candidate)) {
+      labels.add(candidate);
+    }
+  }
+
+  return { ok: true, labels: Array.from(labels).sort(), mode: "fallback" };
+}
+
+function loadInLabelMapping() {
+  const configPath = path.join(repoRoot, ".agents", ".airc.json");
+  if (!fs.existsSync(configPath)) {
+    return { ok: true, value: {} };
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const mapping = config?.labels?.in;
+    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
+      return { ok: true, value: {} };
+    }
+
+    const normalized = {};
+    for (const [label, prefixes] of Object.entries(mapping)) {
+      if (!Array.isArray(prefixes)) {
+        continue;
+      }
+
+      const cleaned = prefixes
+        .map((value) => String(value || "").trim())
+        .filter(Boolean);
+      if (cleaned.length > 0) {
+        normalized[label] = cleaned;
+      }
+    }
+
+    return { ok: true, value: normalized };
+  } catch (error) {
+    return { ok: false, type: "check_failed", message: `Unable to parse .agents/.airc.json: ${error.message}` };
+  }
 }
 
 // === GitHub API ===

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -52,7 +52,17 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 准备审查 -> `review-task {task-id}`
 - 准备创建 PR -> `create-pr`
 
-## 6. 同步 PR 摘要（按需）
+## 6. 同步 Issue 元数据（按需）
+
+当 `{task-id}` 存在且 task.md 包含有效 `issue_number` 时，同步 `in:` label 和需求复选框到关联 Issue；否则跳过。
+
+> 触发条件、`in:` label 计算规则和复选框同步流程见 `reference/issue-metadata-sync.md`。执行前先读取该文件。
+>
+> 如果本步骤会访问代码托管平台，则先按 `.agents/rules/issue-pr-commands.md` 完成前置检测。
+
+失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
+
+## 7. 同步 PR 摘要（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上的 `<!-- sync-pr:{task-id}:summary -->` 摘要评论；否则跳过。
 
@@ -62,7 +72,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 7. 完成校验
+## 8. 完成校验
 
 如果本次操作关联了 `{task-id}`，运行完成校验，确认任务元数据和同步状态符合规范；如果没有任务上下文，跳过本步骤。
 

--- a/.agents/skills/commit/config/verify.json
+++ b/.agents/skills/commit/config/verify.json
@@ -20,6 +20,7 @@
     "platform-sync": {
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
+      "verify_in_labels_computed": true,
       "verify_pr_comment_last_commit_matches_head": true
     }
   }

--- a/.agents/skills/commit/reference/issue-metadata-sync.md
+++ b/.agents/skills/commit/reference/issue-metadata-sync.md
@@ -1,0 +1,23 @@
+# Commit 阶段 Issue 元数据同步
+
+## 触发条件
+
+仅当以下条件同时满足时执行：
+- `{task-id}` 有效
+- `task.md` frontmatter 中存在有效 `issue_number`
+
+任一条件不满足时，跳过本步骤。
+
+执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测。
+
+## `in:` label 同步
+
+按 issue-sync.md 的 `in:` label 同步步骤，基于已提交分支的改动文件（`git diff {base-branch}...HEAD --name-only`）精修 Issue 的 `in:` label。
+
+## 需求复选框同步
+
+按 issue-sync.md 的需求复选框同步步骤，将 task.md `## 需求` 中已勾选的条目同步到 Issue body。
+
+## 错误处理
+
+同步失败只记为警告，不阻塞已完成的 `git commit`。

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -46,8 +46,8 @@ description: "创建 Pull Request 到目标分支"
 
 对获取到 `{task-id}` 的 PR，立即同步这些核心元数据：
 - 按 `.agents/rules/issue-pr-commands.md` 查询标准 label / Issue / PR 元数据
-- 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理 type label 与相关 `in:` labels
-- 按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则，同步更新关联 Issue 的 `in:` label 保持一致
+- 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理 type label
+- 将 Issue 当前的 `in:` labels 复制到 PR（不重新计算，不反向更新 Issue）
 - 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」及其权限规则复用 Issue milestone
 - 通过 `Closes #{issue-number}` 保持 Development 关联
 

--- a/.agents/skills/create-pr/reference/pr-body-template.md
+++ b/.agents/skills/create-pr/reference/pr-body-template.md
@@ -54,7 +54,7 @@ Type label 映射：
 1. 按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询关联 Issue 的 labels 和 milestone
 2. 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理映射后的 type label
 3. 按同一规则的 PR 更新命令和权限降级规则处理非 `type:`、非 `status:` 的 Issue labels 继承
-4. 按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则与权限降级规则精修 PR 的 `in:` label，同时同步更新关联 Issue 的 `in:` label 保持一致
+4. 将 Issue 当前的 `in:` labels 复制到 PR（commit 阶段已完成计算，此处不重新计算也不反向更新 Issue）
 5. 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」及其权限规则处理 milestone，直接复用 Issue milestone
 6. 确保 PR 正文包含 `Closes #{issue-number}` 或等价的 closing keyword
 

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -94,8 +94,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
-- 按 issue-sync.md 设置 `status: in-progress`；按 issue-sync.md 的 `in:` label 同步步骤，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）
-- 按 issue-sync.md 的需求复选框同步步骤，同步 `## 需求` 中已勾选项到 Issue body；发布 `{implementation-artifact}` 评论
+- 按 issue-sync.md 设置 `status: in-progress`
+- 发布 `{implementation-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 10. 完成校验

--- a/.agents/skills/implement-task/config/verify.json
+++ b/.agents/skills/implement-task/config/verify.json
@@ -35,7 +35,6 @@
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",
       "verify_comment_content": true,
       "verify_task_comment_content": true,
-      "sync_checked_requirements": true,
       "verify_issue_type": true,
       "verify_milestone": true
     }

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -62,8 +62,6 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 按 issue-sync.md 的 `in:` label 同步步骤，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）
-- 按 issue-sync.md 的需求复选框同步步骤，同步 `## 需求` 中已勾选项到 Issue body
 - 发布 `{refinement-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
 

--- a/.agents/skills/refine-task/config/verify.json
+++ b/.agents/skills/refine-task/config/verify.json
@@ -31,7 +31,6 @@
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",
       "verify_comment_content": true,
       "verify_task_comment_content": true,
-      "sync_checked_requirements": true,
       "verify_issue_type": true,
       "verify_milestone": true
     }

--- a/templates/.agents/rules/issue-sync.github.en.md
+++ b/templates/.agents/rules/issue-sync.github.en.md
@@ -106,6 +106,8 @@ When a skill creates or imports an Issue, automatically add the current executor
 
 ## `in:` Label Sync
 
+> **Trigger timing**: run `in:` label sync only after code is committed (the `commit` skill). Do not run it during `implement-task` or `refine-task`. During `create-pr`, only copy the labels from the Issue to the PR without recomputing them.
+
 Read the `labels.in` mapping from `.agents/.airc.json`.
 
 ```bash

--- a/templates/.agents/rules/issue-sync.github.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.github.zh-CN.md
@@ -106,6 +106,8 @@ fi
 
 ## `in:` label 同步
 
+> **触发时机**：`in:` label 同步应在代码提交后（commit 技能）执行，不在 implement-task 或 refine-task 阶段执行。create-pr 阶段仅从 Issue 复制到 PR，不重新计算。
+
 读取 `.agents/.airc.json` 的 `labels.in` 映射。
 
 ```bash

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -81,6 +81,7 @@ export function check({ taskDir, config, artifactFile }, shared) {
     checkPrCommentLastCommit,
     checkCommentContent,
     checkTaskCommentContent,
+    checkInLabelsComputed,
     checkInLabelsMatchPr,
     checkPrAssignee,
     checkSyncedRequirements,
@@ -502,6 +503,37 @@ function checkInLabelsMatchPr(context, remoteData) {
   );
 }
 
+function checkInLabelsComputed(context, remoteData) {
+  if (!context.config.verify_in_labels_computed || !context.hasTriage) {
+    return null;
+  }
+
+  const expectedInLabels = computeExpectedInLabels(context.taskDir);
+  if (!expectedInLabels.ok) {
+    return expectedInLabels.type === "check_failed"
+      ? failResult(CHECK_TYPE, expectedInLabels.message, expectedInLabels.type)
+      : blockedResult(CHECK_TYPE, expectedInLabels.message, expectedInLabels.type);
+  }
+
+  if (expectedInLabels.mode === "skipped") {
+    return null;
+  }
+
+  const actualInLabels = extractLabelNames(remoteData.issue.labels)
+    .filter((label) => label.startsWith("in:"))
+    .sort();
+
+  if (arraysEqual(expectedInLabels.labels, actualInLabels)) {
+    return null;
+  }
+
+  return failResult(
+    CHECK_TYPE,
+    `Issue #${context.issueNumber} in: labels do not match committed changes: expected [${formatLabelList(expectedInLabels.labels)}], got [${formatLabelList(actualInLabels)}]`,
+    "check_failed"
+  );
+}
+
 function checkSyncedRequirements(context, remoteData) {
   if (!context.config.sync_checked_requirements || !context.hasTriage) {
     return null;
@@ -746,6 +778,106 @@ function arraysEqual(left, right) {
 
 function formatLabelList(labels) {
   return labels.length > 0 ? labels.join(", ") : "none";
+}
+
+function computeExpectedInLabels(taskDir) {
+  const changedFilesResult = gitText(["diff", "main...HEAD", "--name-only"], taskDir);
+  if (!changedFilesResult.ok) {
+    return changedFilesResult;
+  }
+
+  const changedFiles = String(changedFilesResult.value || "")
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const mapping = loadInLabelMapping();
+  if (!mapping.ok) {
+    return mapping;
+  }
+
+  if (Object.keys(mapping.value).length > 0) {
+    const labels = new Set();
+
+    for (const file of changedFiles) {
+      for (const [label, prefixes] of Object.entries(mapping.value)) {
+        if (prefixes.some((prefix) => file.startsWith(prefix))) {
+          labels.add(`in: ${label}`);
+        }
+      }
+    }
+
+    return { ok: true, labels: Array.from(labels).sort(), mode: "mapped" };
+  }
+
+  const repoLabelsResult = ghJson([
+    "label",
+    "list",
+    "--limit",
+    "200",
+    "--json",
+    "name"
+  ], taskDir);
+  if (!repoLabelsResult.ok) {
+    return repoLabelsResult;
+  }
+
+  const repoInLabels = new Set(
+    extractLabelNames(repoLabelsResult.value)
+      .filter((label) => label.startsWith("in:"))
+  );
+
+  if (repoInLabels.size === 0) {
+    return { ok: true, labels: [], mode: "fallback" };
+  }
+
+  const labels = new Set();
+  for (const file of changedFiles) {
+    const topLevel = file.split("/")[0];
+    if (!topLevel) {
+      continue;
+    }
+
+    const candidate = `in: ${topLevel}`;
+    if (repoInLabels.has(candidate)) {
+      labels.add(candidate);
+    }
+  }
+
+  return { ok: true, labels: Array.from(labels).sort(), mode: "fallback" };
+}
+
+function loadInLabelMapping() {
+  const configPath = path.join(repoRoot, ".agents", ".airc.json");
+  if (!fs.existsSync(configPath)) {
+    return { ok: true, value: {} };
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const mapping = config?.labels?.in;
+    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
+      return { ok: true, value: {} };
+    }
+
+    const normalized = {};
+    for (const [label, prefixes] of Object.entries(mapping)) {
+      if (!Array.isArray(prefixes)) {
+        continue;
+      }
+
+      const cleaned = prefixes
+        .map((value) => String(value || "").trim())
+        .filter(Boolean);
+      if (cleaned.length > 0) {
+        normalized[label] = cleaned;
+      }
+    }
+
+    return { ok: true, value: normalized };
+  } catch (error) {
+    return { ok: false, type: "check_failed", message: `Unable to parse .agents/.airc.json: ${error.message}` };
+  }
 }
 
 // === GitHub API ===

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -52,7 +52,17 @@ Append the Commit Activity Log entry and choose exactly one next-step case:
 - ready for review -> `review-task {task-id}`
 - ready for PR -> `create-pr`
 
-## 6. Sync PR Summary When Applicable
+## 6. Sync Issue Metadata When Applicable
+
+When `{task-id}` exists and task.md contains a valid `issue_number`, sync the linked Issue `in:` labels and requirement checkboxes. Otherwise, skip this step.
+
+> Trigger conditions, `in:` label computation rules, and requirement-checkbox sync flow live in `reference/issue-metadata-sync.md`. Read that file before running this step.
+>
+> If this step touches the code-hosting platform, complete the prerequisite checks in `.agents/rules/issue-pr-commands.md` first.
+
+Failure handling matches "Update Task Status When Applicable": warn, but do **not** block an already completed `git commit`.
+
+## 7. Sync PR Summary When Applicable
 
 When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR summary comment `<!-- sync-pr:{task-id}:summary -->` on the PR. Otherwise, skip this step.
 
@@ -62,7 +72,7 @@ When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR
 
 Failure handling matches "Update Task Status When Applicable": warn, but do **not** block an already completed `git commit`.
 
-## 7. Verification Gate
+## 8. Verification Gate
 
 If this operation is associated with `{task-id}`, run the verification gate to confirm task metadata and sync state. If there is no task context, skip this step.
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -52,7 +52,17 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 准备审查 -> `review-task {task-id}`
 - 准备创建 PR -> `create-pr`
 
-## 6. 同步 PR 摘要（按需）
+## 6. 同步 Issue 元数据（按需）
+
+当 `{task-id}` 存在且 task.md 包含有效 `issue_number` 时，同步 `in:` label 和需求复选框到关联 Issue；否则跳过。
+
+> 触发条件、`in:` label 计算规则和复选框同步流程见 `reference/issue-metadata-sync.md`。执行前先读取该文件。
+>
+> 如果本步骤会访问代码托管平台，则先按 `.agents/rules/issue-pr-commands.md` 完成前置检测。
+
+失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
+
+## 7. 同步 PR 摘要（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上的 `<!-- sync-pr:{task-id}:summary -->` 摘要评论；否则跳过。
 
@@ -62,7 +72,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 7. 完成校验
+## 8. 完成校验
 
 如果本次操作关联了 `{task-id}`，运行完成校验，确认任务元数据和同步状态符合规范；如果没有任务上下文，跳过本步骤。
 

--- a/templates/.agents/skills/commit/config/verify.json
+++ b/templates/.agents/skills/commit/config/verify.json
@@ -20,6 +20,7 @@
     "platform-sync": {
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
+      "verify_in_labels_computed": true,
       "verify_pr_comment_last_commit_matches_head": true
     }
   }

--- a/templates/.agents/skills/commit/reference/issue-metadata-sync.en.md
+++ b/templates/.agents/skills/commit/reference/issue-metadata-sync.en.md
@@ -1,0 +1,23 @@
+# Commit-Stage Issue Metadata Sync
+
+## Trigger Conditions
+
+Run this step only when all of the following are true:
+- `{task-id}` is valid
+- `task.md` frontmatter contains a valid `issue_number`
+
+If either condition is missing, skip this step.
+
+Read `.agents/rules/issue-sync.md` first so upstream repository detection and permission detection are complete before any sync work.
+
+## `in:` Label Sync
+
+Follow the `in:` label sync steps in issue-sync.md and refine the Issue `in:` labels from the committed branch diff (`git diff {base-branch}...HEAD --name-only`).
+
+## Requirement Checkbox Sync
+
+Follow the requirement-checkbox sync steps in issue-sync.md and sync checked items from task.md `## Requirements` into the Issue body.
+
+## Error Handling
+
+Treat sync failures as warnings only. Do not block an already completed `git commit`.

--- a/templates/.agents/skills/commit/reference/issue-metadata-sync.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/issue-metadata-sync.zh-CN.md
@@ -1,0 +1,23 @@
+# Commit 阶段 Issue 元数据同步
+
+## 触发条件
+
+仅当以下条件同时满足时执行：
+- `{task-id}` 有效
+- `task.md` frontmatter 中存在有效 `issue_number`
+
+任一条件不满足时，跳过本步骤。
+
+执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测。
+
+## `in:` label 同步
+
+按 issue-sync.md 的 `in:` label 同步步骤，基于已提交分支的改动文件（`git diff {base-branch}...HEAD --name-only`）精修 Issue 的 `in:` label。
+
+## 需求复选框同步
+
+按 issue-sync.md 的需求复选框同步步骤，将 task.md `## 需求` 中已勾选的条目同步到 Issue body。
+
+## 错误处理
+
+同步失败只记为警告，不阻塞已完成的 `git commit`。

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -46,8 +46,8 @@ If `{task-id}` is available and the related task provides `issue_number`, keep `
 
 For PRs where `{task-id}` is available, sync the core metadata immediately:
 - query standard labels, Issue metadata, and PR metadata via `.agents/rules/issue-pr-commands.md`
-- apply the mapped type label and related `in:` labels by following the PR update commands and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
-- sync the linked Issue `in:` labels to match by following the `in:` label sync rule in `.agents/rules/issue-sync.md`
+- apply the mapped type label by following the PR update commands and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
+- copy the current Issue `in:` labels to the PR without recomputing them and without writing back to the Issue
 - reuse the Issue milestone by following "Phase 3: `create-pr`" and its permission rules in `.agents/rules/milestone-inference.md`
 - keep Development linking in the PR body with `Closes #{issue-number}` when applicable
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -46,8 +46,8 @@ description: "创建 Pull Request 到目标分支"
 
 对获取到 `{task-id}` 的 PR，立即同步这些核心元数据：
 - 按 `.agents/rules/issue-pr-commands.md` 查询标准 label / Issue / PR 元数据
-- 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理 type label 与相关 `in:` labels
-- 按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则，同步更新关联 Issue 的 `in:` label 保持一致
+- 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理 type label
+- 将 Issue 当前的 `in:` labels 复制到 PR（不重新计算，不反向更新 Issue）
 - 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」及其权限规则复用 Issue milestone
 - 通过 `Closes #{issue-number}` 保持 Development 关联
 

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
@@ -54,7 +54,7 @@ Metadata sync order:
 1. query Issue labels and milestone via the Issue read command in `.agents/rules/issue-pr-commands.md`
 2. handle the mapped type label via the PR update command and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
 3. handle inheritance of non-`type:` and non-`status:` Issue labels via repeated PR update commands and the same permission-degradation rules
-4. refine the PR `in:` labels by following `.agents/rules/issue-sync.md`, including its permission-degradation rules, and keep the linked Issue `in:` labels in sync with the same result
+4. copy the current Issue `in:` labels to the PR (commit already computed them, so do not recompute them here and do not write back to the Issue)
 5. handle the milestone by following "Phase 3: `create-pr`" in `.agents/rules/milestone-inference.md`, including its permission rules, and reuse the Issue milestone directly
 6. ensure the PR body contains `Closes #{issue-number}` or an equivalent closing keyword
 

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
@@ -54,7 +54,7 @@ Type label 映射：
 1. 按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询关联 Issue 的 labels 和 milestone
 2. 按 `.agents/rules/issue-pr-commands.md` 的 PR 更新命令和权限降级规则处理映射后的 type label
 3. 按同一规则的 PR 更新命令和权限降级规则处理非 `type:`、非 `status:` 的 Issue labels 继承
-4. 按 `.agents/rules/issue-sync.md` 的 `in:` label 同步规则与权限降级规则精修 PR 的 `in:` label，同时同步更新关联 Issue 的 `in:` label 保持一致
+4. 将 Issue 当前的 `in:` labels 复制到 PR（commit 阶段已完成计算，此处不重新计算也不反向更新 Issue）
 5. 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」及其权限规则处理 milestone，直接复用 Issue milestone
 6. 确保 PR 正文包含 `Closes #{issue-number}` 或等价的 closing keyword
 

--- a/templates/.agents/skills/implement-task/SKILL.en.md
+++ b/templates/.agents/skills/implement-task/SKILL.en.md
@@ -94,8 +94,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure; read `.agents/rules/issue-sync.md` first and complete upstream repository detection plus permission detection):
-- Set `status: in-progress` by following issue-sync.md; refine `in:` labels from the branch diff by following the `in:` label sync steps in issue-sync.md (add/remove when a mapping exists, add-only when it does not)
-- Sync checked `## Requirements` items to the Issue body by following the requirements-checkbox sync steps in issue-sync.md; publish the `{implementation-artifact}` comment
+- Set `status: in-progress` by following issue-sync.md
+- Publish the `{implementation-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
 
 ### 10. Verification Gate

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -94,8 +94,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Implementation (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {implementation-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
-- 按 issue-sync.md 设置 `status: in-progress`；按 issue-sync.md 的 `in:` label 同步步骤，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）
-- 按 issue-sync.md 的需求复选框同步步骤，同步 `## 需求` 中已勾选项到 Issue body；发布 `{implementation-artifact}` 评论
+- 按 issue-sync.md 设置 `status: in-progress`
+- 发布 `{implementation-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 10. 完成校验

--- a/templates/.agents/skills/implement-task/config/verify.json
+++ b/templates/.agents/skills/implement-task/config/verify.json
@@ -35,7 +35,6 @@
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",
       "verify_comment_content": true,
       "verify_task_comment_content": true,
-      "sync_checked_requirements": true,
       "verify_issue_type": true,
       "verify_milestone": true
     }

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -62,8 +62,6 @@ Update task.md:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: in-progress` by following issue-sync.md
-- Refine `in:` labels from the branch diff by following the `in:` label sync steps in issue-sync.md (add/remove when a mapping exists, add-only when it does not)
-- Sync checked `## Requirements` items to the Issue body by following the requirements-checkbox sync steps in issue-sync.md
 - Publish the `{refinement-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
 

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -62,8 +62,6 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 按 issue-sync.md 的 `in:` label 同步步骤，基于分支改动精修 `in:` label（有映射时可增可删，无映射时仅补充）
-- 按 issue-sync.md 的需求复选框同步步骤，同步 `## 需求` 中已勾选项到 Issue body
 - 发布 `{refinement-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
 

--- a/templates/.agents/skills/refine-task/config/verify.json
+++ b/templates/.agents/skills/refine-task/config/verify.json
@@ -31,7 +31,6 @@
       "expected_comment_marker": "<!-- sync-issue:{task-id}:{artifact-stem} -->",
       "verify_comment_content": true,
       "verify_task_comment_content": true,
-      "sync_checked_requirements": true,
       "verify_issue_type": true,
       "verify_milestone": true
     }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #206

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

将 `in:` label 同步和需求复选框同步从 implement-task/refine-task 迁移到 commit 技能，使 GitHub 元数据仅在代码提交后才同步，避免用未提交的本地状态更新公开元数据。

## 📋 主要变更 / Brief Changelog

- implement-task 和 refine-task 移除 `in:` label 同步和复选框同步指令
- commit 新增步骤 6（同步 Issue 元数据），含 reference/issue-metadata-sync.md
- create-pr 简化 `in:` label 为从 Issue 复制到 PR，不再重新计算
- platform-sync.js 新增 `checkInLabelsComputed` 校验
- issue-sync.md 补充 `in:` label 触发时机说明
- 同步更新所有语言模板

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
2. 确认 implement-task/refine-task SKILL.md 不再包含 `in:` label 和复选框同步指令
3. 确认 commit SKILL.md 步骤 6 正确引用 issue-metadata-sync.md

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass (211/211)
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation

Closes #206

---

Generated with AI assistance

*内部追踪：TASK-20260415-110436*