### PR TITLE
fix(skills): 补齐 create-release-note 贡献者搜集的 Co-authored-by 来源 (#178)

### DIFF
--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -54,7 +54,7 @@ git rev-parse v<prev-version>
 - 后续步骤 7 生成发布说明时，**必须**同时参考步骤 3 的历史格式风格和完整分类清单，保持版本间的一致性
 - 如果没有历史发布说明，则使用步骤 7 中定义的默认格式
 
-### 4. 收集已合并的 PR
+### 4. 收集已合并的 PR 与贡献者
 
 获取标签之间的日期范围，然后查询已合并的 PR：
 
@@ -70,6 +70,17 @@ git log v<version> --format=%aI -1
 ```bash
 git log v<prev-version>..v<version> --format="%H %s" --no-merges
 ```
+
+从 commit `Co-authored-by` trailer 中收集协作贡献者：
+
+```bash
+git log v<prev-version>..v<version> \
+  --no-merges \
+  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
+  | grep -v '^$' | sort | uniq -c | sort -rn
+```
+
+输出每行一个 `Name <email>`（`uniq -c` 给出该身份在范围内作为 co-author 的 commit 数）。
 
 ### 5. 收集关联 Issue
 
@@ -115,7 +126,21 @@ git log v<prev-version>..v<version> --format="%H %s" --no-merges
 1. 条目格式：`- [scope] Description by @author in [#N](url)`
 2. Issue + PR：`in [#Issue](url) and [#PR](url)`
 3. 描述：使用 PR 标题，移除 `type(scope):` 前缀，首字母大写
-4. 贡献者：去重，按贡献数量降序排列
+4. **贡献者搜集**：
+   - **数据源**：
+     - PR author：来自步骤 4 的 `gh pr list --json author`
+     - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
+   - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
+   - **Name → `@login` 映射**：
+     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 GitHub `@login`
+     - 优先从 email 提取：匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com` 时，取第二个捕获组并转为小写；该正则同时覆盖 `{id}+{login}@users.noreply.github.com` 与 `{login}@users.noreply.github.com`
+     - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
+     - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
+     - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
+     - Bot 身份保留原样（如 `dependabot[bot]`）
+     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 GitHub login -->`
+   - **排序**：按贡献数降序；贡献数相同时按 login 字典序
+   - **去重**：以最终映射后的 `@login` 为键
 5. 空部分：省略没有条目的部分
 
 ### 8. 展示并确认

--- a/templates/.agents/skills/create-release-note/SKILL.en.md
+++ b/templates/.agents/skills/create-release-note/SKILL.en.md
@@ -54,7 +54,7 @@ Read `.agents/rules/release-commands.md` before this step.
 - When generating release notes in Step 7, **must** follow both the historical format style and the full category list gathered in Step 3
 - If no historical release notes exist, use the default format defined in Step 7
 
-### 4. Collect Merged PRs
+### 4. Collect Merged PRs and Contributors
 
 Get the date range between tags, then query merged PRs:
 
@@ -70,6 +70,17 @@ Also collect direct commits without PRs:
 ```bash
 git log v<prev-version>..v<version> --format="%H %s" --no-merges
 ```
+
+Collect collaborative contributors from commit `Co-authored-by` trailers:
+
+```bash
+git log v<prev-version>..v<version> \
+  --no-merges \
+  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
+  | grep -v '^$' | sort | uniq -c | sort -rn
+```
+
+Each output line is `Name <email>` and `uniq -c` provides the number of commits where that identity appeared as a co-author within the range.
 
 ### 5. Collect Related Issues
 
@@ -115,7 +126,21 @@ If no historical release notes exist, use the following default Markdown format:
 1. Item format: `- [scope] Description by @author in [#N](url)`
 2. Issue + PR: `in [#Issue](url) and [#PR](url)`
 3. Description: Use PR title, remove `type(scope):` prefix, capitalize first letter
-4. Contributors: Deduplicated, sorted by contribution count (descending)
+4. **Contributor collection**:
+   - **Data sources**:
+     - PR authors from Step 4 `gh pr list --json author`
+     - Commit co-authors from Step 4 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
+   - **Contribution count**: `PR count + co-authored commit count` for the same identity, merged across both sources
+   - **Name -> `@login` mapping**:
+     - Raw `Co-authored-by` values are `Name <email>` and must be mapped to a GitHub `@login`
+     - Prefer email extraction: if it matches `(\d+\+)?(\S+?)@users\.noreply\.github\.com`, use the second capture group lowercased; this regex covers both `{id}+{login}@users.noreply.github.com` and `{login}@users.noreply.github.com`
+     - Otherwise use a Name heuristic: take the first token before a space and lowercase it, for example `Claude Opus 4.6 (1M context)` -> `@claude`, `Codex` -> `@codex`, `Gemini` -> `@gemini`
+     - If the login already appears in the PR author list, merge counts into that login so `Claude` and `@claude` do not become separate entries
+     - Merge all Name variants that map to the same login before counting and sorting; for example, `Claude` and `Claude Opus 4.6 (1M context)` should both collapse into `@claude`
+     - Preserve bot identities as-is, for example `dependabot[bot]`
+     - If the login still cannot be determined reliably, output `@{lowercased first Name token}` and append `<!-- TODO(reviewer): confirm GitHub login for {original Name <email>} -->` below the `Contributors` section
+   - **Sorting**: descending by contribution count, then lexicographically by login for ties
+   - **Deduplication**: use the final mapped `@login` as the key
 5. Empty sections: Omit sections with no entries
 
 ### 8. Present and Confirm

--- a/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
@@ -54,7 +54,7 @@ git rev-parse v<prev-version>
 - 后续步骤 7 生成发布说明时，**必须**同时参考步骤 3 的历史格式风格和完整分类清单，保持版本间的一致性
 - 如果没有历史发布说明，则使用步骤 7 中定义的默认格式
 
-### 4. 收集已合并的 PR
+### 4. 收集已合并的 PR 与贡献者
 
 获取标签之间的日期范围，然后查询已合并的 PR：
 
@@ -70,6 +70,17 @@ git log v<version> --format=%aI -1
 ```bash
 git log v<prev-version>..v<version> --format="%H %s" --no-merges
 ```
+
+从 commit `Co-authored-by` trailer 中收集协作贡献者：
+
+```bash
+git log v<prev-version>..v<version> \
+  --no-merges \
+  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
+  | grep -v '^$' | sort | uniq -c | sort -rn
+```
+
+输出每行一个 `Name <email>`（`uniq -c` 给出该身份在范围内作为 co-author 的 commit 数）。
 
 ### 5. 收集关联 Issue
 
@@ -115,7 +126,21 @@ git log v<prev-version>..v<version> --format="%H %s" --no-merges
 1. 条目格式：`- [scope] Description by @author in [#N](url)`
 2. Issue + PR：`in [#Issue](url) and [#PR](url)`
 3. 描述：使用 PR 标题，移除 `type(scope):` 前缀，首字母大写
-4. 贡献者：去重，按贡献数量降序排列
+4. **贡献者搜集**：
+   - **数据源**：
+     - PR author：来自步骤 4 的 `gh pr list --json author`
+     - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
+   - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
+   - **Name → `@login` 映射**：
+     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 GitHub `@login`
+     - 优先从 email 提取：匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com` 时，取第二个捕获组并转为小写；该正则同时覆盖 `{id}+{login}@users.noreply.github.com` 与 `{login}@users.noreply.github.com`
+     - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
+     - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
+     - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
+     - Bot 身份保留原样（如 `dependabot[bot]`）
+     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 GitHub login -->`
+   - **排序**：按贡献数降序；贡献数相同时按 login 字典序
+   - **去重**：以最终映射后的 `@login` 为键
 5. 空部分：省略没有条目的部分
 
 ### 8. 展示并确认


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #178

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

修复 `create-release-note` 技能的贡献者搜集遗漏 —— 在 v0.5.2 发布说明生成时，贡献者列表只包含 PR author，遗漏了以 `Co-authored-by` trailer 参与多个提交的 AI 协作者（@claude、@codex）。根因：技能仅从 `gh pr list --json author` 取 PR 作者，未解析 commit message body 中的 trailer。

本 PR 通过纯文档调整把贡献者搜集从"单一来源（PR author）"扩展为"双来源合并（PR author + commit Co-authored-by trailer）"，并明确贡献数定义、Name → `@login` 映射的启发式规则、排序和去重口径，未来 release note 会自动覆盖 AI 协作者。

## 📋 主要变更 / Brief Changelog

- `.agents/skills/create-release-note/SKILL.md` 步骤 4 追加 `git log --format='%(trailers:key=Co-authored-by,valueonly,unfold)'` 的 co-author 提取命令（使用 git 原生 trailer 解析，避免对 `%b` 做正则 grep 的误匹配）
- 步骤 7 规则 4「Contributors」从"去重、按贡献数量降序"扩写为 5 段：**数据源 / 贡献数定义 / Name → `@login` 映射（含 noreply 正则 + Name 启发式 + 变体归并 + Bot 身份保留 + reviewer TODO 兜底）/ 排序 / 去重**
- 步骤 4 标题同步扩展为「收集已合并的 PR 与贡献者」/ `Collect Merged PRs and Contributors`
- `templates/.agents/skills/create-release-note/SKILL.zh-CN.md` 与 `templates/.agents/skills/create-release-note/SKILL.en.md` 同步以上所有改动，三份文件逐字等价

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` — 234 tests / 0 fail
2. 冒烟：对历史范围 `v0.5.1..v0.5.2` 跑新加的命令：
   ```bash
   git log v0.5.1..v0.5.2 --no-merges \
     --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
     | grep -v '^$' | sort | uniq -c | sort -rn
   ```
   输出：`6 Codex`、`5 Claude`、`1 Claude Opus 4.6 (1M context)` —— 覆盖 Issue #178 描述的遗漏场景，按规则 4 的变体归并后合并为 `@codex` (6) + `@claude` (6)

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

不新增单元测试断言 —— 本次改动仅涉及 SKILL.md 自然语言文案；项目 CLAUDE.md 明确禁止对 SKILL.md 文案做关键词语义断言（测试会随文案调整而脆弱失效）。`tests/templates/templates.test.js:36-47` 已覆盖模板存在性与基础结构。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（Round 1 review + Round 2 review，均 Approved）

**测试要求 / Testing Requirements:**

- [x] 单元测试通过 / Unit tests pass（234/234）
- [x] 代码检查通过 / Lint checks pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（主 SKILL + 中英模板全部同步）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（历史 release note 不变；仅对下一次生成生效）

## 📋 附加信息 / Additional Notes

- 本次修复**不回补**已发布的 v0.5.2 release body —— 属数据修正范畴，不在本 PR 范围
- Name → `@login` 映射采用 AI 启发式（符合 `create-release-note` 技能"自然语言步骤驱动"的设计哲学），最终展示仍需通过步骤 8 的人工确认；无法确定 login 时会输出 `<!-- TODO(reviewer) -->` 注释显式提醒
- 刻意**不**引入 `.airc.json` 配置或独立脚本 —— 详见 `plan.md` 方案对比章节

---

**审查者注意事项 / Reviewer Notes:**

- 建议重点核对 `.agents/skills/create-release-note/SKILL.md` 与两个 `templates/` 模板的三处改动是否逐字等价
- 可选验证：在本地跑 `git log <tag-range> --no-merges --format='%(trailers:key=Co-authored-by,valueonly,unfold)' | sort | uniq -c | sort -rn` 观察提取结果是否符合预期

Closes #178

Generated with AI assistance
