### PR TITLE
fix(skills): Issue 评论同步顺序错误，task 留言应始终在产物评论之前

### DIFF
--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -121,8 +121,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 发布 `{analysis-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{analysis-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -95,8 +95,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{implementation-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{implementation-artifact}` 评论
 
 ### 10. 完成校验
 

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -74,7 +74,13 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，按 `.agents/rules/issue-pr-commands.md` 的 Issue 更新命令为当前执行者添加 assignee；Assignee 同步的边界仍遵循 `.agents/rules/issue-sync.md`。
 
-### 6. 完成校验
+### 6. 同步到 Issue
+
+如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
+- 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
+- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+
+### 7. 完成校验
 
 运行完成校验，确认任务产物和同步状态符合规范：
 
@@ -89,7 +95,7 @@ node .agents/scripts/validate-artifact.js gate import-issue .agents/workspace/ac
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-### 7. 告知用户
+### 8. 告知用户
 
 > 仅在校验通过后执行本步骤。
 
@@ -119,6 +125,7 @@ Issue #{number} 已导入。
 - [ ] 更新了 `current_step` 为 requirement-analysis
 - [ ] 更新了 `updated_at` 为当前时间
 - [ ] 追加了 Activity Log 条目到 task.md
+- [ ] 同步了 task 评论到 Issue
 - [ ] 告知了用户下一步（必须展示所有 TUI 的命令格式，不要筛选）
 - [ ] **没有修改任何业务代码**
 

--- a/.agents/skills/import-issue/config/verify.json
+++ b/.agents/skills/import-issue/config/verify.json
@@ -22,7 +22,8 @@
     },
     "platform-sync": {
       "when": "issue_number_exists",
-      "issue_must_exist": true
+      "issue_must_exist": true,
+      "verify_task_comment_content": true
     }
   }
 }

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -99,8 +99,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 发布 `{plan-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{plan-artifact}` 评论
 
 ### 8. 完成校验
 

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -62,8 +62,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{refinement-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{refinement-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/.agents/skills/review-task/SKILL.md
+++ b/.agents/skills/review-task/SKILL.md
@@ -56,8 +56,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{review-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{review-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -121,8 +121,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: pending-design-work` by following issue-sync.md
-- Publish the `{analysis-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Publish the `{analysis-artifact}` comment
 
 ### 7. Verification Gate
 

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -121,8 +121,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 发布 `{analysis-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{analysis-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/templates/.agents/skills/implement-task/SKILL.en.md
+++ b/templates/.agents/skills/implement-task/SKILL.en.md
@@ -95,8 +95,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure; read `.agents/rules/issue-sync.md` first and complete upstream repository detection plus permission detection):
 - Set `status: in-progress` by following issue-sync.md
-- Publish the `{implementation-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Publish the `{implementation-artifact}` comment
 
 ### 10. Verification Gate
 

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -95,8 +95,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{implementation-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{implementation-artifact}` 评论
 
 ### 10. 完成校验
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -74,7 +74,13 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 
 If task.md contains a valid `issue_number`, use the Issue update command from `.agents/rules/issue-pr-commands.md` to add the current executor as an assignee. The behavioral boundary still follows `.agents/rules/issue-sync.md`.
 
-### 6. Verification Gate
+### 6. Sync to the Issue
+
+If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
+- Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
+- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+
+### 7. Verification Gate
 
 Run the verification gate to confirm the task artifact and sync state are valid:
 
@@ -89,7 +95,7 @@ Handle the result as follows:
 
 Keep the gate output in your reply as fresh evidence. Do not claim completion without output from this run.
 
-### 7. Inform User
+### 8. Inform User
 
 > Execute this step only after the verification gate passes.
 
@@ -119,6 +125,7 @@ Next step - run requirements analysis:
 - [ ] Updated `current_step` to requirement-analysis
 - [ ] Updated `updated_at` to the current time
 - [ ] Appended an Activity Log entry to task.md
+- [ ] Synced the task comment to the Issue
 - [ ] Informed the user of the next step (must include all TUI command formats; do not filter)
 - [ ] **Did not modify any business code**
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -74,7 +74,13 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，按 `.agents/rules/issue-pr-commands.md` 的 Issue 更新命令为当前执行者添加 assignee；Assignee 同步的边界仍遵循 `.agents/rules/issue-sync.md`。
 
-### 6. 完成校验
+### 6. 同步到 Issue
+
+如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
+- 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
+- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+
+### 7. 完成校验
 
 运行完成校验，确认任务产物和同步状态符合规范：
 
@@ -89,7 +95,7 @@ node .agents/scripts/validate-artifact.js gate import-issue .agents/workspace/ac
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-### 7. 告知用户
+### 8. 告知用户
 
 > 仅在校验通过后执行本步骤。
 
@@ -119,6 +125,7 @@ Issue #{number} 已导入。
 - [ ] 更新了 `current_step` 为 requirement-analysis
 - [ ] 更新了 `updated_at` 为当前时间
 - [ ] 追加了 Activity Log 条目到 task.md
+- [ ] 同步了 task 评论到 Issue
 - [ ] 告知了用户下一步（必须展示所有 TUI 的命令格式，不要筛选）
 - [ ] **没有修改任何业务代码**
 

--- a/templates/.agents/skills/import-issue/config/verify.json
+++ b/templates/.agents/skills/import-issue/config/verify.json
@@ -22,7 +22,8 @@
     },
     "platform-sync": {
       "when": "issue_number_exists",
-      "issue_must_exist": true
+      "issue_must_exist": true,
+      "verify_task_comment_content": true
     }
   }
 }

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -99,8 +99,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: pending-design-work` by following issue-sync.md
-- Publish the `{plan-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Publish the `{plan-artifact}` comment
 
 ### 8. Verification Gate
 

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -99,8 +99,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 发布 `{plan-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{plan-artifact}` 评论
 
 ### 8. 完成校验
 

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -62,8 +62,8 @@ Update task.md:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: in-progress` by following issue-sync.md
-- Publish the `{refinement-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Publish the `{refinement-artifact}` comment
 
 ### 7. Verification Gate
 

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -62,8 +62,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{refinement-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{refinement-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/templates/.agents/skills/review-task/SKILL.en.md
+++ b/templates/.agents/skills/review-task/SKILL.en.md
@@ -56,8 +56,8 @@ Update task.md and append:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: in-progress` by following issue-sync.md
-- Publish the `{review-artifact}` comment
 - Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Publish the `{review-artifact}` comment
 
 ### 7. Verification Gate
 

--- a/templates/.agents/skills/review-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-task/SKILL.zh-CN.md
@@ -56,8 +56,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 发布 `{review-artifact}` 评论
 - 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 发布 `{review-artifact}` 评论
 
 ### 7. 完成校验
 

--- a/tests/templates/skills.test.js
+++ b/tests/templates/skills.test.js
@@ -199,3 +199,60 @@ test("skills that write timestamps require date command guidance", () => {
     });
   });
 });
+
+test("workflow skill docs update task comments before publishing artifact comments", () => {
+  const orderedCommentSkills = [
+    ["analyze-task", "{analysis-artifact}"],
+    ["plan-task", "{plan-artifact}"],
+    ["implement-task", "{implementation-artifact}"],
+    ["review-task", "{review-artifact}"],
+    ["refine-task", "{refinement-artifact}"]
+  ];
+
+  orderedCommentSkills.forEach(([skill, artifact]) => {
+    skillDocPaths(skill).forEach((relativePath) => {
+      const content = read(relativePath);
+      const taskCommentIndex = content.indexOf("<!-- sync-issue:{task-id}:task -->");
+      const artifactCommentIndex = relativePath.includes(".en.")
+        ? content.indexOf(`Publish the \`${artifact}\` comment`)
+        : content.indexOf(`发布 \`${artifact}\` 评论`);
+
+      assert.notEqual(taskCommentIndex, -1, `${relativePath} should include the task comment sync marker`);
+      assert.notEqual(artifactCommentIndex, -1, `${relativePath} should include the artifact comment publish step`);
+      assert.ok(
+        taskCommentIndex < artifactCommentIndex,
+        `${relativePath} should sync the task comment before publishing the artifact comment`
+      );
+    });
+  });
+});
+
+test("import-issue requires task comment sync in local and template configs", () => {
+  [
+    ".agents/skills/import-issue/config/verify.json",
+    "templates/.agents/skills/import-issue/config/verify.json"
+  ].forEach((relativePath) => {
+    const config = JSON.parse(read(relativePath));
+
+    assert.equal(
+      config.checks["platform-sync"]?.verify_task_comment_content,
+      true,
+      `${relativePath} should require task comment verification`
+    );
+  });
+});
+
+test("import-issue checklists include the task comment sync step", () => {
+  skillDocPaths("import-issue").forEach((relativePath) => {
+    const content = read(relativePath);
+    const expectedChecklistItem = relativePath.includes(".en.")
+      ? "- [ ] Synced the task comment to the Issue"
+      : "- [ ] 同步了 task 评论到 Issue";
+
+    assert.match(
+      content,
+      new RegExp(escapeRegExp(expectedChecklistItem)),
+      `${relativePath} should include the task comment sync checklist item`
+    );
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #220

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

修复 Issue 评论同步顺序错误：import-issue 导入时不创建 task 评论，后续技能先发布产物评论再创建 task 评论，导致 Issue 时间线上 task 留言排在产物评论之后。

Fix incorrect comment sync order on Issues: import-issue did not create a task comment at import time, and subsequent skills published artifact comments before creating/updating the task comment, causing the task comment to appear after artifact comments on the Issue timeline.

## 📋 主要变更 / Brief Changelog

- 在 import-issue 技能中新增「同步到 Issue」步骤，导入时立即创建 task 评论
- 将 analyze-task、plan-task、implement-task、review-task、refine-task 的评论发布顺序统一改为先更新 task 评论再发布产物评论
- 在 import-issue 的 verify.json 中启用 `verify_task_comment_content` 校验
- 在 import-issue 的完成检查清单中新增 task 评论同步检查项
- 同步所有英文和中文模板文件，确保新项目初始化后采用相同顺序
- 新增 3 个回归测试用例

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
2. 确认 240/240 测试全部通过
3. 在新 Issue 上执行 `/import-issue` → `/analyze-task`，确认 task 评论在产物评论之前

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

---

Closes #220

Generated with AI assistance