### PR TITLE
fix(sandbox): 修复分支名包含引号导致沙箱创建失败

### DIFF
--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -1,13 +1,13 @@
 ---
 id: task-XXX
 type: feature                  # feature | bugfix | refactor | docs | review
-branch: ""                     # <project>-<type>-<slug>
+branch:                        # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
-assigned_to: ""                # claude | codex | gemini | opencode | human
+assigned_to:                   # claude | codex | gemini | opencode | human
 ---
 
 # 任务：[标题]

--- a/lib/sandbox/task-resolver.js
+++ b/lib/sandbox/task-resolver.js
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
 
+function stripQuotes(value) {
+  return value.replace(/^(["'])(.*)\1$/, '$2');
+}
+
 function readTaskContent(repoRoot, taskId) {
   const taskPath = path.join(repoRoot, '.agents', 'workspace', 'active', taskId, 'task.md');
   if (!fs.existsSync(taskPath)) {
@@ -14,12 +18,12 @@ function readTaskContent(repoRoot, taskId) {
 function resolveBranchFromTaskContent(content, taskId) {
   const frontmatterBranch = content.match(/^branch:\s*(.+)$/m);
   if (frontmatterBranch && frontmatterBranch[1].trim()) {
-    return frontmatterBranch[1].trim();
+    return stripQuotes(frontmatterBranch[1].trim());
   }
 
   const contextBranch = content.match(/^- \*\*(?:分支|Branch)\*\*：[ \t]*`?([^`\n]+)`?$/m);
   if (contextBranch && contextBranch[1].trim()) {
-    return contextBranch[1].trim();
+    return stripQuotes(contextBranch[1].trim());
   }
 
   throw new Error(`Task ${taskId} has no branch field in task.md`);

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -1,13 +1,13 @@
 ---
 id: task-XXX
 type: feature                  # feature | bugfix | refactor | docs | review
-branch: ""                     # <project>-<type>-<slug>
+branch:                        # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
-assigned_to: ""                # claude | codex | gemini | opencode | human
+assigned_to:                   # claude | codex | gemini | opencode | human
 ---
 
 # Task: [Title]

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -1,13 +1,13 @@
 ---
 id: task-XXX
 type: feature                  # feature | bugfix | refactor | docs | review
-branch: ""                     # <project>-<type>-<slug>
+branch:                        # <project>-<type>-<slug>
 workflow: feature-development  # feature-development | bug-fix | code-review | refactoring
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 current_step: analysis         # analysis | design | implementation | review | fix | commit
-assigned_to: ""                # claude | codex | gemini | opencode | human
+assigned_to:                   # claude | codex | gemini | opencode | human
 ---
 
 # 任务：[标题]

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -2258,6 +2258,38 @@ test("resolveTaskBranch reads branch from task frontmatter", async () => {
   }
 });
 
+test("resolveTaskBranch strips matching quotes from task branch metadata", async () => {
+  const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-task-quotes-"));
+  const cases = [
+    ["TASK-20260401-180010", "branch: \"agent-infra-feature-cli-generic-sandbox\""],
+    ["TASK-20260401-180011", "branch: 'agent-infra-feature-cli-generic-sandbox'"]
+  ];
+
+  try {
+    for (const [taskId, branchLine] of cases) {
+      const taskDir = path.join(tmpDir, ".agents", "workspace", "active", taskId);
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(path.join(taskDir, "task.md"), [
+        "---",
+        `id: ${taskId}`,
+        "type: feature",
+        branchLine,
+        "---",
+        "",
+        "# task"
+      ].join("\n"));
+
+      assert.equal(
+        taskResolver.resolveTaskBranch(taskId, tmpDir),
+        "agent-infra-feature-cli-generic-sandbox"
+      );
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("resolveTaskBranch falls back to the context branch for legacy tasks", async () => {
   const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-task-context-"));
@@ -2279,6 +2311,33 @@ test("resolveTaskBranch falls back to the context branch for legacy tasks", asyn
     assert.equal(
       taskResolver.resolveTaskBranch("TASK-20260401-180001", tmpDir),
       "agent-infra-feature-cli-generic-sandbox"
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveTaskBranch strips matching quotes from legacy context branch metadata", async () => {
+  const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-task-context-quotes-"));
+  const taskDir = path.join(tmpDir, ".agents", "workspace", "active", "TASK-20260401-180012");
+
+  try {
+    fs.mkdirSync(taskDir, { recursive: true });
+    fs.writeFileSync(path.join(taskDir, "task.md"), [
+      "---",
+      "id: TASK-20260401-180012",
+      "type: feature",
+      "---",
+      "",
+      "## Context",
+      "",
+      "- **Branch**：\"feature/quoted-context\""
+    ].join("\n"));
+
+    assert.equal(
+      taskResolver.resolveTaskBranch("TASK-20260401-180012", tmpDir),
+      "feature/quoted-context"
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #231

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

当任务 `task.md` 的 frontmatter 中 `branch` 字段值被单/双引号包围时（例如 `branch: "agent-infra-feature-foo"`），`ai sandbox create` 会因 `assertValidBranchName` 拒绝引号字符而报错 `Invalid branch name`。该值来自 `resolveBranchFromTaskContent`，它仅对捕获结果做 `.trim()`，保留了引号字符。本 PR 从解析层与模板源头两层修复该问题。

When a task's `task.md` frontmatter stores the `branch` field wrapped in single or double quotes (e.g. `branch: "agent-infra-feature-foo"`), `ai sandbox create` fails with `Invalid branch name` because `assertValidBranchName` rejects the quote characters that `resolveBranchFromTaskContent` passes through unchanged. This PR fixes the problem both at the parser layer and at the template source.

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/task-resolver.js`：新增 `stripQuotes`，在 frontmatter 分支与 legacy 上下文分支两个返回点剥离**匹配**的单/双引号（使用反向引用 `\1`），不匹配引号保持原样
- `.agents/templates/task.md` 与 `templates/.agents/templates/task.{en,zh-CN}.md`：将 `branch` 与 `assigned_to` 的默认值从引号空字符串改为 YAML 裸空值，减少新任务继承引号风格
- `tests/cli/sandbox.test.js`：新增回归测试，覆盖 frontmatter 双/单引号以及 legacy context-branch `- **Branch**："…"` 场景

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 切到本分支后执行 `node --test tests/cli/sandbox.test.js`，确认 `resolveTaskBranch strips matching quotes …` 两条新增测试通过
2. 运行完整测试套件 `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`，确认 248/248 通过
3. 手动验证：在 `task.md` 中将分支写为 `branch: "agent-infra-bugfix-xxx"`，执行 `ai sandbox create TASK-...`，应成功创建沙箱

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（不含引号的分支名行为不变）

---

Generated with AI assistance.
