### PR TITLE
fix(sandbox): 支持跨所有状态目录查找任务

### DIFF
--- a/lib/sandbox/task-resolver.js
+++ b/lib/sandbox/task-resolver.js
@@ -2,17 +2,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+const WORKSPACE_DIRS = ['active', 'completed', 'blocked', 'archive'];
 
 function stripQuotes(value) {
   return value.replace(/^(["'])(.*)\1$/, '$2');
 }
 
 function readTaskContent(repoRoot, taskId) {
-  const taskPath = path.join(repoRoot, '.agents', 'workspace', 'active', taskId, 'task.md');
-  if (!fs.existsSync(taskPath)) {
-    throw new Error(`Task not found: ${taskId}`);
+  for (const dir of WORKSPACE_DIRS) {
+    const taskPath = path.join(repoRoot, '.agents', 'workspace', dir, taskId, 'task.md');
+    if (fs.existsSync(taskPath)) {
+      return fs.readFileSync(taskPath, 'utf8');
+    }
   }
-  return fs.readFileSync(taskPath, 'utf8');
+  throw new Error(`Task not found: ${taskId}`);
 }
 
 function resolveBranchFromTaskContent(content, taskId) {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -2344,6 +2344,65 @@ test("resolveTaskBranch strips matching quotes from legacy context branch metada
   }
 });
 
+for (const workspaceDir of ["completed", "blocked", "archive"]) {
+  test(`resolveTaskBranch resolves tasks in ${workspaceDir} directory`, async () => {
+    const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `agent-infra-sandbox-task-${workspaceDir}-`));
+    const taskDir = path.join(tmpDir, ".agents", "workspace", workspaceDir, "TASK-20260401-180003");
+
+    try {
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(path.join(taskDir, "task.md"), [
+        "---",
+        "id: TASK-20260401-180003",
+        "type: bugfix",
+        "branch: agent-infra-bugfix-some-fix",
+        "---",
+        "",
+        "# task"
+      ].join("\n"));
+
+      assert.equal(
+        taskResolver.resolveTaskBranch("TASK-20260401-180003", tmpDir),
+        "agent-infra-bugfix-some-fix"
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("resolveTaskBranch prefers active over completed when both exist", async () => {
+  const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-task-priority-"));
+  const activeDir = path.join(tmpDir, ".agents", "workspace", "active", "TASK-20260401-180004");
+  const completedDir = path.join(tmpDir, ".agents", "workspace", "completed", "TASK-20260401-180004");
+
+  try {
+    fs.mkdirSync(activeDir, { recursive: true });
+    fs.mkdirSync(completedDir, { recursive: true });
+    fs.writeFileSync(path.join(activeDir, "task.md"), [
+      "---",
+      "id: TASK-20260401-180004",
+      "branch: agent-infra-bugfix-active-wins",
+      "---"
+    ].join("\n"));
+    fs.writeFileSync(path.join(completedDir, "task.md"), [
+      "---",
+      "id: TASK-20260401-180004",
+      "branch: agent-infra-bugfix-should-be-ignored",
+      "---"
+    ].join("\n"));
+
+    assert.equal(
+      taskResolver.resolveTaskBranch("TASK-20260401-180004", tmpDir),
+      "agent-infra-bugfix-active-wins"
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("resolveTaskBranch rejects missing task files and missing branch metadata", async () => {
   const taskResolver = await loadFreshEsm("lib/sandbox/task-resolver.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-task-errors-"));


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #233

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

`lib/sandbox/task-resolver.js` 的 `readTaskContent` 函数此前硬编码了 `.agents/workspace/active/` 作为唯一查找路径。任务一旦被移出 `active/`（进入 `completed/`、`blocked/` 或 `archive/`），`ai sandbox rm`、`ai sandbox create`、`ai sandbox exec` 三个命令就无法再通过任务 ID 定位到对应的 `task.md`，导致报错 `Task not found: TASK-xxx`，而此时容器可能仍然残留。

本 PR 让 `readTaskContent` 依次搜索 `active → completed → blocked → archive`，`active` 保持首位以完全保留已有行为，从而让已完成/归档任务也能正常执行 sandbox 清理等操作。

Closes #233

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/task-resolver.js` 提取 `WORKSPACE_DIRS` 常量，`readTaskContent` 循环遍历四个工作区目录，首个命中即返回，全部未命中时抛出原有的 `Task not found: {taskId}` 错误
- `tests/cli/sandbox.test.js` 以参数化风格新增 `completed` / `blocked` / `archive` 三个目录的 `resolveTaskBranch` 覆盖测试，并新增 `resolveTaskBranch prefers active over completed when both exist` 断言优先级语义

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
2. 观察 10 个 `resolveTaskBranch` 测试全部 `ok`，全量 260/260 通过

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 代码检查通过
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性（`active` 保持首位搜索目录，active 任务行为完全不变）

## 📋 附加信息 / Additional Notes

本次改动完全封闭在 `readTaskContent` 内部，调用方（`resolveBranchFromTaskContent`、`resolveTaskBranch` 及 `sandbox rm / create / exec` 三个命令）无需任何修改；错误信息 `Task not found: {taskId}` 原样保留，相关测试断言自然兼容。

---

Generated with AI assistance