### PR TITLE
feat(sandbox): 沙箱引擎切换支持

### DIFF
--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -24,6 +24,7 @@ const DEFAULTS = {
     "type": "github"
   },
   "sandbox": {
+    "engine": null,
     "runtimes": [
       "node20"
     ],

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -3,6 +3,7 @@
     "type": "github"
   },
   "sandbox": {
+    "engine": null,
     "runtimes": [
       "node20"
     ],

--- a/lib/init.js
+++ b/lib/init.js
@@ -114,8 +114,8 @@ async function cmdInit() {
   if (platform() === 'darwin') {
     sandboxEngine = await select(
       'Sandbox engine (macOS)',
-      ['orbstack', 'colima', 'docker-desktop'],
-      'orbstack'
+      ['colima', 'orbstack', 'docker-desktop'],
+      'colima'
     );
   }
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
 import { info, ok, err } from './log.js';
 import { prompt, select, closePrompt } from './prompt.js';
 import { resolveTemplateDir } from './paths.js';
@@ -109,6 +110,15 @@ async function cmdInit() {
     return;
   }
 
+  let sandboxEngine = null;
+  if (platform() === 'darwin') {
+    sandboxEngine = await select(
+      'Sandbox engine (macOS)',
+      ['orbstack', 'colima', 'docker-desktop'],
+      'orbstack'
+    );
+  }
+
   const platformChoices = [...KNOWN_PLATFORMS, 'other'];
   let platformType = await select('Platform', platformChoices, 'github');
 
@@ -214,6 +224,10 @@ async function cmdInit() {
     labels: structuredClone(defaults.labels),
     files: structuredClone(defaults.files)
   };
+
+  if (sandboxEngine) {
+    config.sandbox.engine = sandboxEngine;
+  }
 
   if (templateSources.length > 0) {
     config.templates = {

--- a/lib/sandbox/commands/rm.js
+++ b/lib/sandbox/commands/rm.js
@@ -11,7 +11,7 @@ import {
   sandboxLabel,
   worktreeDirCandidates
 } from '../constants.js';
-import { isVmManaged } from '../engine.js';
+import { detectEngine, engineDisplayName, isManagedEngine, stopManagedVm } from '../engine.js';
 import { run, runOk, runSafe } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
 import { resolveTools, toolConfigDirCandidates, toolProjectDirCandidates } from '../tools.js';
@@ -165,13 +165,15 @@ async function rmAll(config, tools) {
     runSafe('docker', ['rmi', config.imageName]);
   }
 
-  if (isVmManaged()) {
+  const engine = detectEngine(config);
+  if (isManagedEngine(engine)) {
+    const name = engineDisplayName(engine);
     const shouldStopVm = await p.confirm({
-      message: 'Stop Colima VM?',
+      message: `Stop ${name} VM?`,
       initialValue: false
     });
     if (!p.isCancel(shouldStopVm) && shouldStopVm) {
-      runSafe('colima', ['stop']);
+      stopManagedVm(config);
     }
   }
 

--- a/lib/sandbox/commands/vm.js
+++ b/lib/sandbox/commands/vm.js
@@ -3,31 +3,49 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { loadConfig } from '../config.js';
 import { parsePositiveIntegerOption } from '../constants.js';
-import { detectEngine, ensureDocker, isVmManaged } from '../engine.js';
-import { run, runOk, runSafe } from '../shell.js';
+import {
+  ENGINES,
+  detectEngine,
+  engineDisplayName,
+  ensureDocker,
+  isManagedEngine,
+  stopManagedVm
+} from '../engine.js';
+import { runOk, runSafe } from '../shell.js';
 
 const USAGE = `Usage: ai sandbox vm <status|start|stop> [--cpu <n>] [--memory <n>]`;
 
-function ensureManagedVm() {
-  if (!isVmManaged()) {
-    throw new Error(`VM management is unavailable on ${detectEngine()}.`);
+function ensureManagedVm(engine) {
+  if (!isManagedEngine(engine)) {
+    throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
   }
 }
 
 function status() {
-  ensureManagedVm();
+  const config = loadConfig();
+  const engine = detectEngine(config);
+  const name = engineDisplayName(engine);
+  ensureManagedVm(engine);
   p.intro(pc.cyan('Sandbox VM status'));
 
-  if (runOk('colima', ['status'])) {
-    process.stdout.write(`${runSafe('colima', ['status'])}\n`);
-  } else {
-    p.log.warn('Colima VM is not running');
+  if (engine === ENGINES.COLIMA) {
+    if (runOk('colima', ['status'])) {
+      process.stdout.write(`${runSafe('colima', ['status'])}\n`);
+    } else {
+      p.log.warn('Colima VM is not running');
+    }
+    return;
   }
+
+  if (!runOk('orb', ['status'])) {
+    p.log.warn(`${name} VM is not running`);
+    return;
+  }
+
+  process.stdout.write(`${runSafe('orb', ['status'])}\n`);
 }
 
 async function start(args) {
-  ensureManagedVm();
-
   const { values } = parseArgs({
     args,
     allowPositionals: true,
@@ -45,6 +63,8 @@ async function start(args) {
   }
 
   const config = loadConfig();
+  const engine = detectEngine(config);
+  ensureManagedVm(engine);
   const effectiveConfig = {
     ...config,
     vm: {
@@ -62,15 +82,22 @@ async function start(args) {
 }
 
 function stop() {
-  ensureManagedVm();
+  const config = loadConfig();
+  const engine = detectEngine(config);
+  const name = engineDisplayName(engine);
+  ensureManagedVm(engine);
   p.intro(pc.cyan('Stopping sandbox VM'));
 
-  if (!runOk('colima', ['status'])) {
-    p.log.warn('Colima VM is not running');
+  if (engine === ENGINES.COLIMA && !runOk('colima', ['status'])) {
+    p.log.warn(`${name} VM is not running`);
+    return;
+  }
+  if (engine === ENGINES.ORBSTACK && !runOk('orb', ['status'])) {
+    p.log.warn(`${name} VM is not running`);
     return;
   }
 
-  run('colima', ['stop']);
+  stopManagedVm(config);
   p.outro(pc.green('VM stopped'));
 }
 

--- a/lib/sandbox/config.js
+++ b/lib/sandbox/config.js
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { validateSandboxEngine } from './engine.js';
 
 const DEFAULTS = Object.freeze({
+  engine: null,
   runtimes: ['node20'],
   tools: ['claude-code', 'codex', 'opencode', 'gemini-cli'],
   dockerfile: null,
@@ -26,6 +28,7 @@ function detectRepoRoot() {
 
 function cloneDefaults() {
   return {
+    engine: DEFAULTS.engine,
     runtimes: [...DEFAULTS.runtimes],
     tools: [...DEFAULTS.tools],
     dockerfile: DEFAULTS.dockerfile,
@@ -49,6 +52,7 @@ export function loadConfig() {
   const airc = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   const defaults = cloneDefaults();
   const sandbox = airc.sandbox ?? {};
+  const engine = validateSandboxEngine(sandbox.engine ?? defaults.engine);
   const project = airc.project;
 
   if (!project || typeof project !== 'string') {
@@ -64,6 +68,7 @@ export function loadConfig() {
     containerPrefix: `${project}-dev`,
     imageName: `${project}-sandbox:latest`,
     worktreeBase: path.join(home, '.agent-infra', 'worktrees', project),
+    engine,
     runtimes: Array.isArray(sandbox.runtimes) && sandbox.runtimes.length > 0
       ? [...sandbox.runtimes]
       : defaults.runtimes,

--- a/lib/sandbox/engine.js
+++ b/lib/sandbox/engine.js
@@ -2,16 +2,49 @@ import { platform } from 'node:os';
 import { detectHostResources } from './constants.js';
 import { run, runOk, runSafe, runVerbose } from './shell.js';
 
-export function detectEngine() {
-  const os = platform();
-  if (os === 'darwin') {
-    return 'colima';
+export const ENGINES = Object.freeze({
+  COLIMA: 'colima',
+  ORBSTACK: 'orbstack',
+  DOCKER_DESKTOP: 'docker-desktop'
+});
+
+const VALID_CONFIG_ENGINES = new Set(['auto', ...Object.values(ENGINES)]);
+
+export function validateSandboxEngine(engine) {
+  if (engine === null || engine === undefined) {
+    return null;
   }
+
+  if (VALID_CONFIG_ENGINES.has(engine)) {
+    return engine;
+  }
+
+  throw new Error(
+    `sandbox: invalid "sandbox.engine" value "${engine}". `
+    + 'Expected one of: null, auto, colima, orbstack, docker-desktop. '
+    + 'This setting only affects macOS sandbox engine selection.'
+  );
+}
+
+export function detectEngine(config = {}, { platformFn = platform, runOkFn = runOk } = {}) {
+  const configured = validateSandboxEngine(config.engine);
+  const os = platformFn();
   if (os === 'linux') {
     return 'native';
   }
   if (os === 'win32') {
     return 'wsl2';
+  }
+  if (os === 'darwin') {
+    if (configured && configured !== 'auto') {
+      return configured;
+    }
+
+    if (runOkFn('docker', ['info'])) {
+      return ENGINES.DOCKER_DESKTOP;
+    }
+
+    return ENGINES.COLIMA;
   }
   return 'unsupported';
 }
@@ -19,9 +52,10 @@ export function detectEngine() {
 function colimaArgs(config, runSafeFn = runSafe) {
   const arch = runSafeFn('uname', ['-m']);
   const defaults = detectHostResources();
-  const cpu = config.vm.cpu ?? defaults.cpu;
-  const memory = config.vm.memory ?? defaults.memory;
-  const disk = config.vm.disk ?? 60;
+  const vm = config.vm ?? {};
+  const cpu = vm.cpu ?? defaults.cpu;
+  const memory = vm.memory ?? defaults.memory;
+  const disk = vm.disk ?? 60;
   const args = ['start', '--cpu', String(cpu), '--memory', String(memory), '--disk', String(disk)];
 
   if (arch === 'arm64') {
@@ -53,11 +87,51 @@ export async function ensureColima(
   }
 }
 
-export async function ensureDocker(config, onMessage) {
-  const engine = detectEngine();
+export async function ensureOrbStack(
+  _config,
+  onMessage,
+  { runOkFn = runOk, runVerboseFn = runVerbose } = {}
+) {
+  if (!runOkFn('which', ['orb'])) {
+    onMessage?.('Installing OrbStack via Homebrew...');
+    runVerboseFn('brew', ['install', '--cask', 'orbstack']);
+  }
 
-  if (engine === 'colima') {
+  if (!runOkFn('docker', ['info'])) {
+    onMessage?.('Starting OrbStack...');
+    runVerboseFn('orb', ['start']);
+  }
+
+  if (!runOkFn('docker', ['info'])) {
+    throw new Error('Docker daemon is not available after starting OrbStack');
+  }
+}
+
+export async function ensureDockerDesktop(
+  _config,
+  onMessage,
+  { runOkFn = runOk } = {}
+) {
+  if (!runOkFn('docker', ['info'])) {
+    throw new Error('Docker Desktop is not running. Please start Docker Desktop manually.');
+  }
+}
+
+export async function ensureDocker(config, onMessage) {
+  const engine = detectEngine(config);
+
+  if (engine === ENGINES.COLIMA) {
     await ensureColima(config, onMessage);
+    return;
+  }
+
+  if (engine === ENGINES.ORBSTACK) {
+    await ensureOrbStack(config, onMessage);
+    return;
+  }
+
+  if (engine === ENGINES.DOCKER_DESKTOP) {
+    await ensureDockerDesktop(config, onMessage);
     return;
   }
 
@@ -75,19 +149,58 @@ export async function ensureDocker(config, onMessage) {
   throw new Error(`Unsupported sandbox engine: ${engine}`);
 }
 
-export function isVmManaged() {
-  return detectEngine() === 'colima';
+export function isVmManaged(config = {}, dependencies = {}) {
+  const engine = detectEngine(config, dependencies);
+  return isManagedEngine(engine);
 }
 
-export function startManagedVm(config) {
-  if (!isVmManaged()) {
-    throw new Error('VM management is only available on macOS with Colima.');
+export function isManagedEngine(engine) {
+  return engine === ENGINES.COLIMA || engine === ENGINES.ORBSTACK;
+}
+
+export function engineDisplayName(engine) {
+  const names = {
+    [ENGINES.COLIMA]: 'Colima',
+    [ENGINES.ORBSTACK]: 'OrbStack',
+    [ENGINES.DOCKER_DESKTOP]: 'Docker Desktop',
+    native: 'native Docker',
+    wsl2: 'WSL2'
+  };
+  return names[engine] ?? engine;
+}
+
+export function startManagedVm(
+  config,
+  { platformFn = platform, runOkFn = runOk, runVerboseFn = runVerbose } = {}
+) {
+  const engine = detectEngine(config, { platformFn, runOkFn });
+  if (!isManagedEngine(engine)) {
+    throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
   }
 
-  if (runOk('colima', ['status'])) {
+  if (engine === ENGINES.COLIMA && runOkFn('colima', ['status'])) {
+    return 'already-running';
+  }
+  if (engine === ENGINES.ORBSTACK && runOkFn('orb', ['status'])) {
     return 'already-running';
   }
 
-  runVerbose('colima', colimaArgs(config));
+  if (engine === ENGINES.COLIMA) {
+    runVerboseFn('colima', colimaArgs(config));
+  } else if (engine === ENGINES.ORBSTACK) {
+    runVerboseFn('orb', ['start']);
+  }
   return 'started';
+}
+
+export function stopManagedVm(config, { platformFn = platform, runOkFn = runOk, runFn = run } = {}) {
+  const engine = detectEngine(config, { platformFn, runOkFn });
+  if (engine === ENGINES.COLIMA) {
+    runFn('colima', ['stop']);
+    return 'stopped';
+  } else if (engine === ENGINES.ORBSTACK) {
+    runFn('orb', ['stop']);
+    return 'stopped';
+  }
+  throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
 }

--- a/lib/sandbox/engine.js
+++ b/lib/sandbox/engine.js
@@ -8,7 +8,7 @@ export const ENGINES = Object.freeze({
   DOCKER_DESKTOP: 'docker-desktop'
 });
 
-const VALID_CONFIG_ENGINES = new Set(['auto', ...Object.values(ENGINES)]);
+const VALID_CONFIG_ENGINES = new Set(Object.values(ENGINES));
 
 export function validateSandboxEngine(engine) {
   if (engine === null || engine === undefined) {
@@ -21,12 +21,12 @@ export function validateSandboxEngine(engine) {
 
   throw new Error(
     `sandbox: invalid "sandbox.engine" value "${engine}". `
-    + 'Expected one of: null, auto, colima, orbstack, docker-desktop. '
+    + 'Expected one of: null, colima, orbstack, docker-desktop. '
     + 'This setting only affects macOS sandbox engine selection.'
   );
 }
 
-export function detectEngine(config = {}, { platformFn = platform, runOkFn = runOk } = {}) {
+export function detectEngine(config = {}, { platformFn = platform } = {}) {
   const configured = validateSandboxEngine(config.engine);
   const os = platformFn();
   if (os === 'linux') {
@@ -36,12 +36,8 @@ export function detectEngine(config = {}, { platformFn = platform, runOkFn = run
     return 'wsl2';
   }
   if (os === 'darwin') {
-    if (configured && configured !== 'auto') {
+    if (configured) {
       return configured;
-    }
-
-    if (runOkFn('docker', ['info'])) {
-      return ENGINES.DOCKER_DESKTOP;
     }
 
     return ENGINES.COLIMA;
@@ -173,7 +169,7 @@ export function startManagedVm(
   config,
   { platformFn = platform, runOkFn = runOk, runVerboseFn = runVerbose } = {}
 ) {
-  const engine = detectEngine(config, { platformFn, runOkFn });
+  const engine = detectEngine(config, { platformFn });
   if (!isManagedEngine(engine)) {
     throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
   }
@@ -193,8 +189,8 @@ export function startManagedVm(
   return 'started';
 }
 
-export function stopManagedVm(config, { platformFn = platform, runOkFn = runOk, runFn = run } = {}) {
-  const engine = detectEngine(config, { platformFn, runOkFn });
+export function stopManagedVm(config, { platformFn = platform, runFn = run } = {}) {
+  const engine = detectEngine(config, { platformFn });
   if (engine === ENGINES.COLIMA) {
     runFn('colima', ['stop']);
     return 'stopped';

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -24,6 +24,7 @@ const DEFAULTS = {
     "type": "github"
   },
   "sandbox": {
+    "engine": null,
     "runtimes": [
       "node20"
     ],

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -62,6 +62,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.ok(!config.branchPrefix, "branchPrefix should not exist");
     assert.ok(!config.source, "consumer projects should not have source: self");
     assert.deepEqual(config.sandbox, {
+      engine: null,
       runtimes: ["node20"],
       tools: ["claude-code", "codex", "opencode", "gemini-cli"],
       dockerfile: null,
@@ -449,6 +450,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     );
     assert.deepEqual(updated.platform, { type: "github" }, "update should backfill default platform config");
     assert.deepEqual(updated.sandbox, {
+      engine: null,
       runtimes: ["node20"],
       tools: ["claude-code", "codex", "opencode", "gemini-cli"],
       dockerfile: null,

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -140,6 +140,15 @@ test("agent-infra init generates seed files in a temp directory", () => {
   }
 });
 
+test("agent-infra init defaults macOS sandbox engine to Colima", () => {
+  const initSource = read("lib/init.js");
+
+  assert.match(
+    initSource,
+    /select\(\s*'Sandbox engine \(macOS\)',\s*\[\s*'colima',\s*'orbstack',\s*'docker-desktop'\s*\],\s*'colima'\s*\)/s
+  );
+});
+
 test("agent-infra init accepts a custom platform selected from the menu", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-test-"));
   const cli = filePath("bin/cli.js");

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -95,6 +95,64 @@ test("sandbox create fails before preparing a temporary Dockerfile when Claude c
   }
 });
 
+test("sandbox vm stop warns instead of stopping when OrbStack is not running", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-vm-stop-orb-"));
+  const repoDir = path.join(tmpDir, "repo");
+  const binDir = path.join(tmpDir, "bin");
+  const orbPath = path.join(binDir, "orb");
+  const orbLogPath = path.join(tmpDir, "orb-log.txt");
+  const previousCwd = process.cwd();
+  const previousEnv = { ...process.env };
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+  try {
+    fs.mkdirSync(path.join(repoDir, ".agents"), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    execSync("git init", { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(repoDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        sandbox: { engine: "orbstack" }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.writeFileSync(
+      orbPath,
+      `#!/bin/sh
+set -eu
+printf '%s\\n' "$1" >> "$ORB_LOG_PATH"
+if [ "$1" = "status" ]; then
+  exit 1
+fi
+exit 0
+`,
+      "utf8"
+    );
+    fs.chmodSync(orbPath, 0o755);
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    process.chdir(repoDir);
+    process.env = {
+      ...envWithPrependedPath(process.env, binDir),
+      HOME: tmpDir,
+      ORB_LOG_PATH: orbLogPath
+    };
+
+    const sandboxVm = await loadFreshEsm("lib/sandbox/commands/vm.js");
+    await sandboxVm.vm(["stop"]);
+
+    assert.deepEqual(fs.readFileSync(orbLogPath, "utf8").trim().split("\n"), ["status"]);
+  } finally {
+    process.chdir(previousCwd);
+    process.env = previousEnv;
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => {
   const sandboxConfig = await loadFreshEsm("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-config-"));
@@ -118,8 +176,68 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.equal(config.imageName, "demo-sandbox:latest");
     assert.deepEqual(config.runtimes, ["node20"]);
     assert.deepEqual(config.tools, ["claude-code", "codex", "opencode", "gemini-cli"]);
+    assert.equal(config.engine, null);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME, ".agent-infra", "worktrees", "demo"));
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig preserves configured sandbox engine", async () => {
+  const sandboxConfig = await loadFreshEsm("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-engine-config-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        org: "fitlab-ai",
+        sandbox: { engine: "orbstack" }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    const config = sandboxConfig.loadConfig();
+
+    assert.equal(config.engine, "orbstack");
+    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects unsupported sandbox engine values", async () => {
+  const sandboxConfig = await loadFreshEsm("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-engine-invalid-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        sandbox: { engine: "podman" }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+
+    assert.throws(
+      () => sandboxConfig.loadConfig(),
+      /invalid "sandbox\.engine" value "podman".*only affects macOS/s
+    );
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -1260,6 +1378,169 @@ test("ensureColima uses verbose commands for install and startup", async () => {
     ["colima", "status"],
     ["docker", "info"]
   ]);
+});
+
+test("detectEngine honors configured macOS sandbox engines", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const dependencies = {
+    platformFn: () => "darwin",
+    runOkFn() {
+      throw new Error("docker auto-detection should be skipped for explicit engines");
+    }
+  };
+
+  assert.equal(sandboxEngine.detectEngine({ engine: "orbstack" }, dependencies), "orbstack");
+  assert.equal(sandboxEngine.detectEngine({ engine: "colima" }, dependencies), "colima");
+  assert.equal(sandboxEngine.detectEngine({ engine: "docker-desktop" }, dependencies), "docker-desktop");
+});
+
+test("detectEngine rejects unsupported configured sandbox engines early", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.throws(
+    () => sandboxEngine.detectEngine({ engine: "podman" }, { platformFn: () => "darwin" }),
+    /Expected one of: null, auto, colima, orbstack, docker-desktop.*only affects macOS/s
+  );
+});
+
+test("detectEngine auto-detects a running macOS Docker daemon before falling back to Colima", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const checks = [];
+
+  assert.equal(sandboxEngine.detectEngine(
+    { engine: null },
+    {
+      platformFn: () => "darwin",
+      runOkFn(cmd, args) {
+        checks.push([cmd, ...args]);
+        return true;
+      }
+    }
+  ), "docker-desktop");
+
+  assert.equal(sandboxEngine.detectEngine(
+    {},
+    {
+      platformFn: () => "darwin",
+      runOkFn: () => false
+    }
+  ), "colima");
+  assert.deepEqual(checks, [["docker", "info"]]);
+});
+
+test("detectEngine keeps non-macOS platform behavior independent of sandbox engine config", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.equal(
+    sandboxEngine.detectEngine({ engine: "orbstack" }, { platformFn: () => "linux" }),
+    "native"
+  );
+  assert.equal(
+    sandboxEngine.detectEngine({ engine: "orbstack" }, { platformFn: () => "win32" }),
+    "wsl2"
+  );
+});
+
+test("ensureOrbStack installs OrbStack and starts the Docker daemon", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const messages = [];
+  const verboseCalls = [];
+  const checks = [];
+  let dockerInfoChecks = 0;
+
+  await sandboxEngine.ensureOrbStack(
+    {},
+    (message) => messages.push(message),
+    {
+      runOkFn(cmd, args) {
+        checks.push([cmd, ...args]);
+        if (cmd === "which") {
+          return false;
+        }
+        if (cmd === "docker" && args[0] === "info") {
+          dockerInfoChecks += 1;
+          return dockerInfoChecks > 1;
+        }
+        throw new Error(`unexpected check: ${cmd} ${args.join(" ")}`);
+      },
+      runVerboseFn(cmd, args) {
+        verboseCalls.push([cmd, ...args]);
+      }
+    }
+  );
+
+  assert.deepEqual(messages, [
+    "Installing OrbStack via Homebrew...",
+    "Starting OrbStack..."
+  ]);
+  assert.deepEqual(verboseCalls, [
+    ["brew", "install", "--cask", "orbstack"],
+    ["orb", "start"]
+  ]);
+  assert.deepEqual(checks, [
+    ["which", "orb"],
+    ["docker", "info"],
+    ["docker", "info"]
+  ]);
+});
+
+test("ensureDockerDesktop reports when Docker Desktop is not running", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  await assert.rejects(
+    () => sandboxEngine.ensureDockerDesktop({}, null, { runOkFn: () => false }),
+    /Docker Desktop is not running/
+  );
+});
+
+test("startManagedVm uses OrbStack status instead of Docker daemon state", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const checks = [];
+  const verboseCalls = [];
+
+  const result = sandboxEngine.startManagedVm(
+    { engine: "orbstack" },
+    {
+      platformFn: () => "darwin",
+      runOkFn(cmd, args) {
+        checks.push([cmd, ...args]);
+        if (cmd === "docker") {
+          throw new Error("docker info must not decide explicit OrbStack VM state");
+        }
+        return false;
+      },
+      runVerboseFn(cmd, args) {
+        verboseCalls.push([cmd, ...args]);
+      }
+    }
+  );
+
+  assert.equal(result, "started");
+  assert.deepEqual(checks, [["orb", "status"]]);
+  assert.deepEqual(verboseCalls, [["orb", "start"]]);
+});
+
+test("stopManagedVm reports unsupported engines instead of silently returning", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.throws(
+    () => sandboxEngine.stopManagedVm(
+      { engine: "docker-desktop" },
+      { platformFn: () => "darwin", runFn: () => assert.fail("unexpected stop command") }
+    ),
+    /VM management is unavailable for engine 'Docker Desktop'/
+  );
+});
+
+test("isVmManaged and engineDisplayName describe supported engines", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const macDependencies = { platformFn: () => "darwin" };
+
+  assert.equal(sandboxEngine.isVmManaged({ engine: "colima" }, macDependencies), true);
+  assert.equal(sandboxEngine.isVmManaged({ engine: "orbstack" }, macDependencies), true);
+  assert.equal(sandboxEngine.isVmManaged({ engine: "docker-desktop" }, macDependencies), false);
+  assert.equal(sandboxEngine.engineDisplayName("orbstack"), "OrbStack");
+  assert.equal(sandboxEngine.engineDisplayName("docker-desktop"), "Docker Desktop");
 });
 
 test("hostHasGpgKeys reports whether the host keyring is available", async () => {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1399,33 +1399,21 @@ test("detectEngine rejects unsupported configured sandbox engines early", async 
 
   assert.throws(
     () => sandboxEngine.detectEngine({ engine: "podman" }, { platformFn: () => "darwin" }),
-    /Expected one of: null, auto, colima, orbstack, docker-desktop.*only affects macOS/s
+    /Expected one of: null, colima, orbstack, docker-desktop.*only affects macOS/s
   );
 });
 
-test("detectEngine auto-detects a running macOS Docker daemon before falling back to Colima", async () => {
+test("detectEngine returns Colima on macOS when no engine is configured", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
-  const checks = [];
-
-  assert.equal(sandboxEngine.detectEngine(
-    { engine: null },
-    {
-      platformFn: () => "darwin",
-      runOkFn(cmd, args) {
-        checks.push([cmd, ...args]);
-        return true;
-      }
+  const dependencies = {
+    platformFn: () => "darwin",
+    runOkFn() {
+      throw new Error("docker auto-detection should not run for missing engines");
     }
-  ), "docker-desktop");
+  };
 
-  assert.equal(sandboxEngine.detectEngine(
-    {},
-    {
-      platformFn: () => "darwin",
-      runOkFn: () => false
-    }
-  ), "colima");
-  assert.deepEqual(checks, [["docker", "info"]]);
+  assert.equal(sandboxEngine.detectEngine({ engine: null }, dependencies), "colima");
+  assert.equal(sandboxEngine.detectEngine({}, dependencies), "colima");
 });
 
 test("detectEngine keeps non-macOS platform behavior independent of sandbox engine config", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #237

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #237

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

当前 Colima 通过 SSH 隧道与 Lima VM 通信，笔记本睡眠/唤醒等场景下频繁断链，导致终端状态损坏需要 `reset`。这是 SSH 长连接的固有缺陷，无法根治。OrbStack / Docker Desktop 使用原生 Socket 通信，不存在此问题。

本 PR 为 sandbox 增加 `engine` 配置字段，允许用户在 `ai init` 时显式选择容器引擎（仅 macOS），支持 `colima` / `orbstack` / `docker-desktop` 三种选项。默认值保持 `colima`，以保留当前已验证的稳定行为；OrbStack 与 Docker Desktop 作为用户显式选择的优化路径。

Linux（native Docker）和 Windows（WSL2，当前预留）的行为保持不变。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/config.js` / `lib/defaults.json`：新增 `sandbox.engine` 字段（`null`、`colima`、`orbstack`、`docker-desktop`），`null` 语义收窄为"回落 Colima"，去除了运行时 `docker info` 探测以确保配置可预测
- `lib/sandbox/engine.js`：重构为配置驱动的多引擎分发，新增 `ensureOrbStack` / `ensureDockerDesktop`、`startManagedVm` / `stopManagedVm` / `isManagedEngine` / `engineDisplayName` / `validateSandboxEngine` 等函数；`ensureDocker(config, onMessage)` 对外签名不变
- `lib/sandbox/commands/vm.js`：`status` / `start` / `stop` 三个子命令适配多引擎，缓存 `detectEngine(config)` 结果；Colima 与 OrbStack 对"VM 未运行"输出一致的友好提示
- `lib/sandbox/commands/rm.js`：`rm --all` 在确认停止 VM 时按引擎显示正确名称（Colima / OrbStack）
- `lib/init.js`：在 macOS 上新增 `Sandbox engine` 交互选择（默认 `colima`），非 macOS 不新增交互
- `.agents/skills/update-agent-infra/scripts/sync-templates.js` 与 `templates/.agents/skills/update-agent-infra/scripts/sync-templates.js`：同步 inline DEFAULTS
- `tests/cli/sandbox.test.js`：新增多引擎检测、安装、VM 管理、错误校验等单元 / 集成测试；`tests/cli/cli.test.js`：锁定 macOS 默认引擎为 `colima`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/sandbox.test.js`（113 个引擎相关用例全部通过）
2. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`（全量 273 个用例通过）
3. 手动验证：macOS `ai init` 出现 `Sandbox engine (macOS)` 选项，默认高亮 `colima`；在 `.airc.json` 中手动设 `\"engine\": \"orbstack\"`，`ai sandbox vm status/start/stop` 使用 `orb` 命令

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（6 轮评审 → 全部收敛）
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过
- [x] 单元测试通过（273/273）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（inline DEFAULTS 同步）
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明（本 PR 无破坏性变更）
- [x] 我已经考虑了向后兼容性（旧项目 `.airc.json` 无 `engine` 字段 → 继续使用 Colima，行为与历史一致）

## 📋 附加信息 / Additional Notes

- `OrbStack` 与 `Docker Desktop` 目前仅在用户显式配置时生效；默认仍走 `Colima`，以保留现有测试矩阵已验证的稳定行为。待 OrbStack / Docker Desktop 通过更充分的实战验证后，可再考虑调整默认值。
- 本 PR 不覆盖 Windows WSL2 引擎的实现（当前仍预留错误提示）。

---

**审查者注意事项 / Reviewer Notes:**

- 关键改动集中在 `lib/sandbox/engine.js`（多引擎分发 + 校验 + VM 生命周期）和 `lib/init.js`（macOS 引擎选择）。
- 所有 VM 管理函数采用 `{ platformFn, runOkFn, runVerboseFn, runFn }` 依赖注入，测试无需真正 spawn 子进程。
- `detectEngine` 在本 PR 中被刻意设计为不 spawn 任何子进程（Round 5 / 6 审查结论），配置即事实：读 `.airc.json` 就能确定 `ai sandbox` 会走哪条分支。

---

Generated with AI assistance