### PR TITLE
refactor(cli): 消除 INSTALLER_VERSION 硬编码导致的版本冲突

### DIFF
--- a/.agents/skills/post-release/SKILL.md
+++ b/.agents/skills/post-release/SKILL.md
@@ -34,8 +34,7 @@ npm install --package-lock-only
 ```
 
 - 读取新的 prerelease 版本号
-- 使用编辑工具更新 `.agents/.airc.json` 中的 `templateVersion` 为 `v{new-version}`
-- 确保 `package.json`、`package-lock.json` 和 `.agents/.airc.json` 中的版本保持一致
+- 确保 `package.json` 与 `package-lock.json` 的版本保持一致
 
 ### 4. 重新生成内联产物
 

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -62,10 +62,12 @@ const DEFAULTS = {
       ".opencode/commands/"
     ],
     "merged": [
+      "**/post-release.*",
       "**/release.*",
       "**/test-integration.*",
       "**/test.*",
       "**/upgrade-dependency.*",
+      ".agents/skills/post-release/SKILL.*",
       ".agents/skills/release/SKILL.*",
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",
@@ -79,7 +81,6 @@ const DEFAULTS = {
   }
 };
 
-const INSTALLER_VERSION = "v0.5.8-alpha.0";
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
@@ -139,6 +140,12 @@ function removeEmptyDirs(dir) {
   if (fs.readdirSync(dir).length === 0) {
     fs.rmdirSync(dir);
   }
+}
+
+function resolveVersionFromTemplateRoot(tplRoot) {
+  const pkgPath = path.join(path.dirname(tplRoot), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return 'v' + pkg.version;
 }
 
 function parseSkillFrontmatter(filePath) {
@@ -945,7 +952,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
       };
     }
   }
-  const version = INSTALLER_VERSION;
+  const version = resolveVersionFromTemplateRoot(templateRoot);
   const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,7 +114,6 @@ git push origin vX.Y.Z
 
 - 检测最新已发布标签并解析版本
 - bump 到下一个开发版本
-- 同步更新 `.agents/.airc.json` 中的 `templateVersion`
 - 重建内联产物
 - 可选录制最新执行动图
 - 创建发布后处理提交

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -41,10 +41,12 @@
       ".opencode/commands/"
     ],
     "merged": [
+      "**/post-release.*",
       "**/release.*",
       "**/test-integration.*",
       "**/test.*",
       "**/upgrade-dependency.*",
+      ".agents/skills/post-release/SKILL.*",
       ".agents/skills/release/SKILL.*",
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",

--- a/scripts/build-inline.js
+++ b/scripts/build-inline.js
@@ -26,23 +26,17 @@ const targetPaths = [
 ];
 
 const DEFAULTS_EXPR = /const DEFAULTS = JSON\.parse\(\s*fs\.readFileSync\(new URL\('..\/lib\/defaults\.json', import\.meta\.url\), 'utf8'\)\s*\);/m;
-const VERSION_EXPR = /const INSTALLER_VERSION = 'v' \+ JSON\.parse\(\s*fs\.readFileSync\(new URL\('..\/package\.json', import\.meta\.url\), 'utf8'\)\s*\)\.version;/m;
 
 function buildInlineContent() {
   const source = fs.readFileSync(sourcePath, 'utf8');
   const defaults = JSON.parse(fs.readFileSync(path.join(rootDir, 'lib', 'defaults.json'), 'utf8'));
-  const version = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')).version;
 
   if (!DEFAULTS_EXPR.test(source)) {
     throw new Error('Could not find DEFAULTS expression in src/sync-templates.js');
   }
-  if (!VERSION_EXPR.test(source)) {
-    throw new Error('Could not find INSTALLER_VERSION expression in src/sync-templates.js');
-  }
 
   return source
-    .replace(DEFAULTS_EXPR, `const DEFAULTS = ${JSON.stringify(defaults, null, 2)};`)
-    .replace(VERSION_EXPR, `const INSTALLER_VERSION = ${JSON.stringify(`v${version}`)};`);
+    .replace(DEFAULTS_EXPR, `const DEFAULTS = ${JSON.stringify(defaults, null, 2)};`);
 }
 
 function main() {

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -23,9 +23,6 @@ const DEFAULTS = JSON.parse(
   fs.readFileSync(new URL('../lib/defaults.json', import.meta.url), 'utf8')
 );
 
-const INSTALLER_VERSION = 'v' + JSON.parse(
-  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
-).version;
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
@@ -85,6 +82,12 @@ function removeEmptyDirs(dir) {
   if (fs.readdirSync(dir).length === 0) {
     fs.rmdirSync(dir);
   }
+}
+
+function resolveVersionFromTemplateRoot(tplRoot) {
+  const pkgPath = path.join(path.dirname(tplRoot), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return 'v' + pkg.version;
 }
 
 function parseSkillFrontmatter(filePath) {
@@ -891,7 +894,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
       };
     }
   }
-  const version = INSTALLER_VERSION;
+  const version = resolveVersionFromTemplateRoot(templateRoot);
   const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -62,10 +62,12 @@ const DEFAULTS = {
       ".opencode/commands/"
     ],
     "merged": [
+      "**/post-release.*",
       "**/release.*",
       "**/test-integration.*",
       "**/test.*",
       "**/upgrade-dependency.*",
+      ".agents/skills/post-release/SKILL.*",
       ".agents/skills/release/SKILL.*",
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",
@@ -79,7 +81,6 @@ const DEFAULTS = {
   }
 };
 
-const INSTALLER_VERSION = "v0.5.8-alpha.0";
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
@@ -139,6 +140,12 @@ function removeEmptyDirs(dir) {
   if (fs.readdirSync(dir).length === 0) {
     fs.rmdirSync(dir);
   }
+}
+
+function resolveVersionFromTemplateRoot(tplRoot) {
+  const pkgPath = path.join(path.dirname(tplRoot), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return 'v' + pkg.version;
 }
 
 function parseSkillFrontmatter(filePath) {
@@ -945,7 +952,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
       };
     }
   }
-  const version = INSTALLER_VERSION;
+  const version = resolveVersionFromTemplateRoot(templateRoot);
   const hadTemplateSource = Object.prototype.hasOwnProperty.call(cfg, 'templateSource');
 
   const { project, org, language: lang = 'en' } = cfg;

--- a/tests/cli/sync-templates.test.js
+++ b/tests/cli/sync-templates.test.js
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { loadFreshEsm, read, supportsPosixModeBits } from "../helpers.js";
+import { loadFreshEsm, supportsPosixModeBits } from "../helpers.js";
 
 function writeFile(root, relativePath, content) {
   const fullPath = path.join(root, relativePath);
@@ -19,6 +19,19 @@ function writeJson(root, relativePath, value) {
 
 function normalize(targetPath) {
   return targetPath.replace(/\\/g, "/");
+}
+
+function createTemplateInstall(tmpDir, version = "0.0.0-test") {
+  const installRoot = path.join(tmpDir, "install");
+  const templateRoot = path.join(installRoot, "templates");
+
+  fs.mkdirSync(templateRoot, { recursive: true });
+  writeJson(installRoot, "package.json", {
+    name: "@fitlab-ai/agent-infra",
+    version
+  });
+
+  return { installRoot, templateRoot };
 }
 
 test("syncTemplates resolves template roots via PATH lookup and removes legacy templateSource", async () => {
@@ -199,10 +212,9 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, "README.md", "Hello {{project}}\n");
     writeJson(projectRoot, ".agents/.airc.json", {
@@ -227,10 +239,7 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
     const { syncTemplates } = await loadFreshEsm(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
-    assert.equal(
-      report.templateVersion,
-      `v${JSON.parse(read("package.json")).version}`
-    );
+    assert.equal(report.templateVersion, "v0.0.0-test");
   } finally {
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -243,10 +252,9 @@ test("syncTemplates prefers platform-specific variants and composes with zh-CN l
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/rule.md", "base\n");
     writeFile(templateRoot, "docs/rule.github.md", "github-en\n");
@@ -288,11 +296,10 @@ test("syncTemplates includes external-only files for managed directories", async
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
     const externalRoot = path.join(tmpDir, "external-root");
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
     fs.mkdirSync(externalRoot, { recursive: true });
 
     writeFile(externalRoot, ".agents/rules/custom.md", "Custom {{project}}\n");
@@ -346,12 +353,11 @@ test("syncTemplates keeps built-ins authoritative and lets later external templa
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
     const externalRootOne = path.join(tmpDir, "external-root-one");
     const externalRootTwo = path.join(tmpDir, "external-root-two");
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
     fs.mkdirSync(externalRootOne, { recursive: true });
     fs.mkdirSync(externalRootTwo, { recursive: true });
 
@@ -424,11 +430,10 @@ test("syncTemplates ignores external platform variants when a built-in variant a
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
     const externalRoot = path.join(tmpDir, "external-root");
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
     fs.mkdirSync(externalRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/rule.md", "builtin-base\n");
@@ -480,11 +485,10 @@ test("syncTemplates selects platform and language variants from external templat
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
     const externalRoot = path.join(tmpDir, "external-root");
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
     fs.mkdirSync(externalRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/rule.md", "builtin\n");
@@ -529,11 +533,10 @@ test("syncTemplates reports invalid external template sources and keeps built-in
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
     const missingRoot = path.join(tmpDir, "missing-root");
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, "README.md", "Hello {{project}}\n");
 
@@ -586,10 +589,9 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/guide.md", "Guide\n");
     writeFile(templateRoot, ".agents/keep.md", "AI enabled\n");
@@ -651,10 +653,9 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, "docs/guide.md", "Guide\n");
     writeJson(projectRoot, ".agents/.airc.json", {
@@ -698,10 +699,9 @@ test("syncTemplates syncs the managed github hook as a single file", async () =>
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(
       templateRoot,
@@ -765,10 +765,9 @@ test("syncTemplates reports github pre-commit as a merged pending file", async (
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const templateRoot = path.join(tmpDir, "template-root");
+    const { templateRoot } = createTemplateInstall(tmpDir);
 
     fs.mkdirSync(projectRoot, { recursive: true });
-    fs.mkdirSync(templateRoot, { recursive: true });
 
     writeFile(templateRoot, ".github/hooks/pre-commit", "#!/bin/sh\n");
 

--- a/tests/core/custom-skills.test.js
+++ b/tests/core/custom-skills.test.js
@@ -18,6 +18,10 @@ function writeJson(root, relativePath, value) {
 
 function makeTemplateRoot(tmpDir) {
   const templateRoot = path.join(tmpDir, "template-root");
+  writeJson(tmpDir, "package.json", {
+    name: "@fitlab-ai/agent-infra",
+    version: "0.0.0-test"
+  });
   fs.mkdirSync(path.join(templateRoot, ".agents/skills"), { recursive: true });
   fs.mkdirSync(path.join(templateRoot, ".claude/commands"), { recursive: true });
   fs.mkdirSync(path.join(templateRoot, ".gemini/commands/_project_"), { recursive: true });

--- a/tests/core/custom-tuis.test.js
+++ b/tests/core/custom-tuis.test.js
@@ -18,6 +18,10 @@ function writeJson(root, relativePath, value) {
 
 function makeTemplateRoot(tmpDir) {
   const templateRoot = path.join(tmpDir, "template-root");
+  writeJson(tmpDir, "package.json", {
+    name: "@fitlab-ai/agent-infra",
+    version: "0.0.0-test"
+  });
   writeFile(
     templateRoot,
     ".agents/skills/analyze-task/SKILL.md",


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #244

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`sync-templates.js` 中的 `INSTALLER_VERSION` 是 `build-inline.js` 从 `package.json` 烘焙的硬编码常量。`/post-release` 升版后，该常量领先于全局安装版本，导致两个具体问题：

- `ai update` 覆盖时产生版本回退 diff（`v0.5.8-alpha.0` → `v0.5.7`）
- `/update-agent-infra` 执行时版本戳（来自脚本硬编码）与模板源（来自安装包）不一致

根因是「版本戳来自脚本自身的硬编码」，而不是「模板的实际来源」。

本 PR 把 `templateVersion` 的产生方式收敛为：**`sync-templates` 在运行时从 `templateRoot` 父目录的 `package.json` 动态读取，作为 `.airc.json.templateVersion` 的唯一权威来源**。`post-release` 不再手动写 `.airc.json`。

## 📋 主要变更 / Brief Changelog

- **核心**：`src/sync-templates.js` 移除模块级 `INSTALLER_VERSION` 硬编码常量；新增 `resolveVersionFromTemplateRoot()`，从 `templateRoot` 父目录的 `package.json` 动态解析版本号。
- **构建**：`scripts/build-inline.js` 删除 `VERSION_EXPR` 替换逻辑，仅保留 `DEFAULTS` 烘焙；两份内联副本 `(.agents|templates/.agents)/skills/update-agent-infra/scripts/sync-templates.js` 已通过 `node scripts/build-inline.js` 重新生成。
- **配置**：`lib/defaults.json` 的 `merged` 列表新增 `**/post-release.*` 与 `.agents/skills/post-release/SKILL.*`（按字典序就位），让项目特化的 post-release SKILL 不会被 `ai update` 覆盖。
- **行为**：`.agents/skills/post-release/SKILL.md` 步骤 3 删除手动写 `.agents/.airc.json.templateVersion` 的步骤；该字段由 sync 独占同步。
- **文档**：`RELEASING.md` 同步更新 post-release 责任描述，与新行为对齐。
- **测试**：`tests/cli/sync-templates.test.js` / `tests/core/custom-skills.test.js` / `tests/core/custom-tuis.test.js` 调整 override 测试夹具，提供与新动态版本解析路径匹配的父目录 `package.json`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js` —— 282/282 通过。
2. `node scripts/build-inline.js --check` —— `Inline build output is up to date.`，确认源码与两份内联副本一致。
3. 手动核对：在 agent-infra 仓库 dev 分支（`package.json` 为 `0.5.8-alpha.0`）执行 `node .agents/skills/update-agent-infra/scripts/sync-templates.js .`，`.agents/.airc.json.templateVersion` 解析为 `v0.5.8-alpha.0`，与 package.json 一致；不再出现回退 diff。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- `syncTemplates(projectRoot, templateRootOverride)` 函数签名保持不变；生产路径下 `verifyPackageDir()` 已经验证了父目录 `package.json` 的存在与合法性，故 `resolveVersionFromTemplateRoot()` 不需要额外的兜底分支。
- 测试夹具中 override 路径需要显式提供父目录 `package.json`，已通过统一的 `createTemplateInstall()` 帮手在 9 个用例中复用，避免重复模板。
- `.airc.json.templateVersion` 字段由 sync 同步；`/post-release` 与 `/release` 等技能不再写该字段。

---

**审查者注意事项 / Reviewer Notes:**

重点请关注：

1. `src/sync-templates.js:87-91` 的 `resolveVersionFromTemplateRoot()` 是否在所有调用路径下都成立（`templateRootOverride` 路径已在测试中覆盖；生产路径由 `resolveTemplateRoot()` → `verifyPackageDir()` 提供不变量）。
2. `lib/defaults.json` 的 `merged` 列表 post-release 入口位置（已按字典序放在 release 之前）。
3. `.agents/skills/post-release/SKILL.md:37` 步骤 3 措辞是否足够中性（已删除手动 templateVersion 写入步骤，仅描述 package.json 与 lockfile 的版本一致性要求）。

Generated with AI assistance