### PR TITLE
fix(import-issue): 复用 Issue sync 标记中的原任务 ID

### DIFF
--- a/.agents/scripts/platform-adapters/find-existing-task.js
+++ b/.agents/scripts/platform-adapters/find-existing-task.js
@@ -1,0 +1,272 @@
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const markerPattern = /^<!-- sync-issue:(TASK-\d{8}-\d{6}):([a-z][a-z0-9-]*) -->$/;
+
+function parseArgs(argv) {
+  const args = {
+    format: "json"
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--issue") {
+      args.issue = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      args.repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--format") {
+      args.format = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node .agents/scripts/platform-adapters/find-existing-task.js --issue <number> [--repo <owner/name>] [--format json]"
+  ].join("\n");
+}
+
+function runGh(args) {
+  const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
+  const result = spawnSync(ghBin, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024
+  });
+
+  if (result.error) {
+    const error = new Error(`gh command failed: ${result.error.message}`);
+    error.stderr = result.error.message;
+    throw error;
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim() || `gh exited with status ${result.status}`;
+    const error = new Error(stderr);
+    error.stderr = stderr;
+    throw error;
+  }
+
+  return result.stdout;
+}
+
+function resolveRepo(explicitRepo) {
+  if (explicitRepo) {
+    return explicitRepo;
+  }
+
+  const currentRepo = runGh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).trim();
+  if (!currentRepo) {
+    throw new Error("Cannot detect current GitHub repository");
+  }
+
+  const upstreamRepo = runGh([
+    "api",
+    `repos/${currentRepo}`,
+    "--jq",
+    "if .fork then .parent.full_name else .full_name end"
+  ]).trim();
+
+  return upstreamRepo || currentRepo;
+}
+
+function parseComments(output) {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return trimmed
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  }
+}
+
+function fetchComments(repo, issueNumber) {
+  const output = runGh([
+    "api",
+    `repos/${repo}/issues/${issueNumber}/comments`,
+    "--paginate",
+    "--jq",
+    ".[] | @json"
+  ]);
+
+  return parseComments(output);
+}
+
+function firstLine(value) {
+  return String(value || "").split(/\r?\n/, 1)[0].trim();
+}
+
+function normalizeScalar(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseFrontmatterBlock(block) {
+  const match = block.match(/^---\r?\n([\s\S]*?)\r?\n---\s*$/);
+  if (!match) {
+    return null;
+  }
+
+  const metadata = {};
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    metadata[key] = normalizeScalar(value);
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+function recoverTaskFrontmatter(body) {
+  const detailsStart = body.search(/<details><summary>[^<]*frontmatter[^<]*<\/summary>/i);
+  if (detailsStart < 0) {
+    return null;
+  }
+
+  const detailsBody = body.slice(detailsStart);
+  const yamlMatch = detailsBody.match(/```yaml\s*([\s\S]*?)\s*```/i);
+  if (!yamlMatch) {
+    return null;
+  }
+
+  return parseFrontmatterBlock(yamlMatch[1].trim());
+}
+
+function collectCandidates(comments) {
+  const byTaskId = new Map();
+
+  for (const comment of comments) {
+    const match = firstLine(comment.body).match(markerPattern);
+    if (!match) {
+      continue;
+    }
+
+    const [, taskId, fileStem] = match;
+    const existing = byTaskId.get(taskId) || {
+      task_id: taskId,
+      first_seen_at: comment.created_at || "",
+      has_task_comment: false,
+      task_comment_body: ""
+    };
+
+    if (!existing.first_seen_at || (comment.created_at && comment.created_at < existing.first_seen_at)) {
+      existing.first_seen_at = comment.created_at;
+    }
+
+    if (fileStem === "task") {
+      existing.has_task_comment = true;
+      existing.task_comment_body = comment.body || "";
+    }
+
+    byTaskId.set(taskId, existing);
+  }
+
+  return [...byTaskId.values()].sort((left, right) => {
+    const createdComparison = String(left.first_seen_at || "").localeCompare(String(right.first_seen_at || ""));
+    if (createdComparison !== 0) {
+      return createdComparison;
+    }
+    return left.task_id.localeCompare(right.task_id);
+  });
+}
+
+function buildResult(comments) {
+  const candidates = collectCandidates(comments);
+  if (candidates.length === 0) {
+    return { found: false };
+  }
+
+  const selectedCandidate = candidates[0];
+  const frontmatter = selectedCandidate.has_task_comment
+    ? recoverTaskFrontmatter(selectedCandidate.task_comment_body)
+    : null;
+
+  const result = {
+    found: true,
+    task_id: selectedCandidate.task_id
+  };
+
+  if (frontmatter) {
+    result.frontmatter = frontmatter;
+  }
+
+  return result;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  if (!args.issue) {
+    console.error("Missing required argument: --issue");
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (args.format !== "json") {
+    console.error(`Unsupported format: ${args.format}`);
+    process.exit(1);
+  }
+
+  try {
+    const repo = resolveRepo(args.repo);
+    const comments = fetchComments(repo, args.issue);
+    console.log(JSON.stringify(buildResult(comments), null, 2));
+  } catch (error) {
+    console.error(`Cannot scan issue comments: ${error.stderr || error.message}`);
+    process.exit(2);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -24,22 +24,46 @@ description: "从 GitHub Issue 导入并创建任务"
 
 ### 2. 检查已有任务
 
-搜索 `.agents/workspace/active/` 中是否已有链接到此 Issue 的任务。
+2.1 搜索 `.agents/workspace/active/` 中是否已有链接到此 Issue 的任务。
 - 如果找到，询问用户是重新导入还是继续使用现有任务
-- 如果未找到，创建新任务
+- 如果未找到，继续执行 2.2
+
+2.2 扫描 Issue 评论中的同步标记，查找可恢复的历史任务 ID：
+
+如未在步骤 1 中已设置 `$upstream_repo`，可省略 `--repo`，脚本会自动按 issue-sync.md 的检测规则推断。
+
+```bash
+node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-number> --repo "$upstream_repo" --format json
+```
+
+- 脚本输出 `found=false`：按新 Issue 导入流程创建新任务
+- 脚本输出 `found=true`：复用 `task_id`
+- 脚本退出码 2：视为网络、认证或 GitHub API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
 
 ### 3. 创建任务目录和文件
+
+3.1 决定 task ID 和 `created_at`。
+
+| 场景 | 触发条件 | task ID 来源 | created_at 来源 | 用户确认 |
+|---|---|---|---|---|
+| 场景 A | 2.1 命中本地任务 | 复用本地 ID | 本地保留 | 必须询问"重新导入还是继续使用现有任务" |
+| 场景 B | 2.1 无命中 + 2.2 无候选 | `date +%Y%m%d-%H%M%S` 新建 | 当前时间 | 不需要 |
+| 场景 C | 2.1 无命中 + 2.2 有候选 | 自动复用最早候选 ID | 优先用远端 frontmatter 的 `created_at`，缺失时用当前时间 | 告知即可 |
 
 ```bash
 date +%Y%m%d-%H%M%S
 ```
 
-- 创建目录：`.agents/workspace/active/TASK-{yyyyMMdd-HHmmss}/`
+3.2 写入任务目录和 `task.md`。
+
+- 创建目录：`.agents/workspace/active/{task-id}/`
 - 使用 `.agents/templates/task.md` 模板创建 `task.md`
+- 场景 C 优先沿用远端 frontmatter 中的 `type`、`workflow`、`branch`、`created_by`、`milestone`；缺失或损坏字段按 Issue 标签和当前规则重新推断
+- `current_step` 始终写入 `requirement-analysis`，不要恢复为远端原 `current_step`
 
 任务元数据：
 ```yaml
-id: TASK-{yyyyMMdd-HHmmss}
+id: {task-id}
 issue_number: <issue-number>
 type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
@@ -51,6 +75,11 @@ created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
+
+3.3 追加 Activity Log。
+
+- 场景 B：追加 `Import Issue`
+- 场景 C：追加 `Import Issue (Recovered)`，注明恢复的 task ID、可恢复的原 `current_step`、原 `assigned_to`，并说明 `current_step` 已重置为 `requirement-analysis`；如果部分 frontmatter 字段缺失或损坏，在同一条记录中注明 fallback
 
 ### 4. 更新任务状态
 
@@ -69,6 +98,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
+  如果步骤 3.3 已经按恢复场景追加了 Activity Log，不要重复追加同义记录。
 
 ### 5. 分配 Issue Assignee
 
@@ -79,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 检查 Issue 当前 milestone；如果未设置，先读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 1：`create-issue`」规则推断并设置 milestone；如果 `has_triage=false` 或推断不确定，跳过并继续
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 7. 完成校验
 
@@ -126,7 +156,7 @@ Issue #{number} 已导入。
 - [ ] 更新了 `current_step` 为 requirement-analysis
 - [ ] 更新了 `updated_at` 为当前时间
 - [ ] 追加了 Activity Log 条目到 task.md
-- [ ] 同步了 task 评论到 Issue
+- [ ] 同步了 task 评论到 Issue，且远端内容与本地 task.md 一致
 - [ ] 告知了用户下一步（必须展示所有 TUI 的命令格式，含自定义 TUI，不要筛选）
 - [ ] **没有修改任何业务代码**
 

--- a/.agents/skills/test-integration/SKILL.md
+++ b/.agents/skills/test-integration/SKILL.md
@@ -24,7 +24,7 @@ node --version
 本项目的集成测试包含在统一测试套件中（如在临时目录中运行 `ai init` 并验证结果）。
 
 ```bash
-node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
+node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js
 ```
 
 ## 3. 输出结果

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -16,7 +16,7 @@ description: >
 ## 2. 运行所有单元测试
 
 ```bash
-node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
+node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js
 ```
 
 ## 3. 输出结果

--- a/.agents/skills/upgrade-dependency/SKILL.md
+++ b/.agents/skills/upgrade-dependency/SKILL.md
@@ -41,7 +41,7 @@ npm install
 
 本项目无构建步骤。运行测试验证：
 ```bash
-node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
+node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js
 ```
 
 ### 6. 运行测试

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ npm install
 # 构建项目：无需构建，项目由 Node.js CLI 和模板文件组成
 
 # 运行测试
-node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
+node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js
 
 # 代码检查：暂未配置 lint 工具
 ```
@@ -51,7 +51,7 @@ node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
 ## 测试要求
 
 - 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 18）
-- 运行命令：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
+- 运行命令：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 
 ### 测试编写规约

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ npm install
 # 构建项目：无需构建，项目由 Node.js CLI 和模板文件组成
 
 # 运行测试
-node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
+node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js
 
 # 代码检查：暂未配置 lint 工具
 ```
@@ -51,7 +51,7 @@ node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js
 ## 测试要求
 
 - 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 18）
-- 运行命令：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js`
+- 运行命令：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 
 ### 测试编写规约

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "node scripts/build-inline.js",
     "demo:regen": "sh scripts/demo-regen.sh",
     "prepare": "git config core.hooksPath .github/hooks || true",
-    "test": "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js",
-    "prepublishOnly": "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js"
+    "test": "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js",
+    "prepublishOnly": "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js"
   }
 }

--- a/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
+++ b/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
@@ -1,0 +1,272 @@
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const markerPattern = /^<!-- sync-issue:(TASK-\d{8}-\d{6}):([a-z][a-z0-9-]*) -->$/;
+
+function parseArgs(argv) {
+  const args = {
+    format: "json"
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--issue") {
+      args.issue = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      args.repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "--format") {
+      args.format = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node .agents/scripts/platform-adapters/find-existing-task.js --issue <number> [--repo <owner/name>] [--format json]"
+  ].join("\n");
+}
+
+function runGh(args) {
+  const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
+  const result = spawnSync(ghBin, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024
+  });
+
+  if (result.error) {
+    const error = new Error(`gh command failed: ${result.error.message}`);
+    error.stderr = result.error.message;
+    throw error;
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim() || `gh exited with status ${result.status}`;
+    const error = new Error(stderr);
+    error.stderr = stderr;
+    throw error;
+  }
+
+  return result.stdout;
+}
+
+function resolveRepo(explicitRepo) {
+  if (explicitRepo) {
+    return explicitRepo;
+  }
+
+  const currentRepo = runGh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).trim();
+  if (!currentRepo) {
+    throw new Error("Cannot detect current GitHub repository");
+  }
+
+  const upstreamRepo = runGh([
+    "api",
+    `repos/${currentRepo}`,
+    "--jq",
+    "if .fork then .parent.full_name else .full_name end"
+  ]).trim();
+
+  return upstreamRepo || currentRepo;
+}
+
+function parseComments(output) {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return trimmed
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  }
+}
+
+function fetchComments(repo, issueNumber) {
+  const output = runGh([
+    "api",
+    `repos/${repo}/issues/${issueNumber}/comments`,
+    "--paginate",
+    "--jq",
+    ".[] | @json"
+  ]);
+
+  return parseComments(output);
+}
+
+function firstLine(value) {
+  return String(value || "").split(/\r?\n/, 1)[0].trim();
+}
+
+function normalizeScalar(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseFrontmatterBlock(block) {
+  const match = block.match(/^---\r?\n([\s\S]*?)\r?\n---\s*$/);
+  if (!match) {
+    return null;
+  }
+
+  const metadata = {};
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    metadata[key] = normalizeScalar(value);
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+function recoverTaskFrontmatter(body) {
+  const detailsStart = body.search(/<details><summary>[^<]*frontmatter[^<]*<\/summary>/i);
+  if (detailsStart < 0) {
+    return null;
+  }
+
+  const detailsBody = body.slice(detailsStart);
+  const yamlMatch = detailsBody.match(/```yaml\s*([\s\S]*?)\s*```/i);
+  if (!yamlMatch) {
+    return null;
+  }
+
+  return parseFrontmatterBlock(yamlMatch[1].trim());
+}
+
+function collectCandidates(comments) {
+  const byTaskId = new Map();
+
+  for (const comment of comments) {
+    const match = firstLine(comment.body).match(markerPattern);
+    if (!match) {
+      continue;
+    }
+
+    const [, taskId, fileStem] = match;
+    const existing = byTaskId.get(taskId) || {
+      task_id: taskId,
+      first_seen_at: comment.created_at || "",
+      has_task_comment: false,
+      task_comment_body: ""
+    };
+
+    if (!existing.first_seen_at || (comment.created_at && comment.created_at < existing.first_seen_at)) {
+      existing.first_seen_at = comment.created_at;
+    }
+
+    if (fileStem === "task") {
+      existing.has_task_comment = true;
+      existing.task_comment_body = comment.body || "";
+    }
+
+    byTaskId.set(taskId, existing);
+  }
+
+  return [...byTaskId.values()].sort((left, right) => {
+    const createdComparison = String(left.first_seen_at || "").localeCompare(String(right.first_seen_at || ""));
+    if (createdComparison !== 0) {
+      return createdComparison;
+    }
+    return left.task_id.localeCompare(right.task_id);
+  });
+}
+
+function buildResult(comments) {
+  const candidates = collectCandidates(comments);
+  if (candidates.length === 0) {
+    return { found: false };
+  }
+
+  const selectedCandidate = candidates[0];
+  const frontmatter = selectedCandidate.has_task_comment
+    ? recoverTaskFrontmatter(selectedCandidate.task_comment_body)
+    : null;
+
+  const result = {
+    found: true,
+    task_id: selectedCandidate.task_id
+  };
+
+  if (frontmatter) {
+    result.frontmatter = frontmatter;
+  }
+
+  return result;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  if (!args.issue) {
+    console.error("Missing required argument: --issue");
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (args.format !== "json") {
+    console.error(`Unsupported format: ${args.format}`);
+    process.exit(1);
+  }
+
+  try {
+    const repo = resolveRepo(args.repo);
+    const comments = fetchComments(repo, args.issue);
+    console.log(JSON.stringify(buildResult(comments), null, 2));
+  } catch (error) {
+    console.error(`Cannot scan issue comments: ${error.stderr || error.message}`);
+    process.exit(2);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/templates/.agents/scripts/platform-adapters/find-existing-task.js
+++ b/templates/.agents/scripts/platform-adapters/find-existing-task.js
@@ -1,0 +1,5 @@
+import { pathToFileURL } from "node:url";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(JSON.stringify({ found: false }, null, 2));
+}

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -24,22 +24,46 @@ Use the Issue title as-is for the task title (preserve the Issue's original lang
 
 ### 2. Check for an Existing Task
 
-Search `.agents/workspace/active/` for an existing task linked to this Issue.
+2.1 Search `.agents/workspace/active/` for an existing task linked to this Issue.
 - If found, ask the user whether to re-import or continue with the existing task
-- If not found, create a new task
+- If not found, continue to 2.2
+
+2.2 Scan Issue comments for sync markers and look for a recoverable historical task ID:
+
+If `$upstream_repo` was not set in step 1, omit `--repo`; the script will infer it using the issue-sync.md detection rule.
+
+```bash
+node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-number> --repo "$upstream_repo" --format json
+```
+
+- Script outputs `found=false`: create a new task through the normal import flow
+- Script outputs `found=true`: reuse `task_id`
+- Script exits 2: treat it as network, authentication, or GitHub API degradation; show the failure reason from script stderr to the user, then continue with the new-task import flow without blocking
 
 ### 3. Create the Task Directory and File
+
+3.1 Decide the task ID and `created_at`.
+
+| Scenario | Trigger | task ID source | created_at source | User confirmation |
+|---|---|---|---|---|
+| Scenario A | 2.1 finds a local task | Reuse local ID | Preserve local value | Must ask whether to re-import or continue using the existing task |
+| Scenario B | 2.1 no match + 2.2 no candidate | Create with `date +%Y%m%d-%H%M%S` | Current time | Not required |
+| Scenario C | 2.1 no match + 2.2 any candidate | Automatically reuse the earliest candidate ID | Prefer remote frontmatter `created_at`; use current time if missing | Inform only |
 
 ```bash
 date +%Y%m%d-%H%M%S
 ```
 
-- Create the directory: `.agents/workspace/active/TASK-{yyyyMMdd-HHmmss}/`
+3.2 Write the task directory and `task.md`.
+
+- Create the directory: `.agents/workspace/active/{task-id}/`
 - Use the `.agents/templates/task.md` template to create `task.md`
+- For Scenario C, prefer `type`, `workflow`, `branch`, `created_by`, and `milestone` from the remote frontmatter; infer missing or damaged fields from Issue labels and current rules
+- Always write `current_step` as `requirement-analysis`; do not restore the remote original `current_step`
 
 Task metadata:
 ```yaml
-id: TASK-{yyyyMMdd-HHmmss}
+id: {task-id}
 issue_number: <issue-number>
 type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
@@ -51,6 +75,11 @@ created_by: human
 current_step: requirement-analysis
 assigned_to: {current AI agent}
 ```
+
+3.3 Append Activity Log entries.
+
+- Scenario B: append `Import Issue`
+- Scenario C: append `Import Issue (Recovered)` and include the recovered task ID, any recoverable original `current_step`, original `assigned_to`, and that `current_step` was reset to `requirement-analysis`; if some frontmatter fields are missing or damaged, mention the fallback in the same entry
 
 ### 4. Update Task Status
 
@@ -69,6 +98,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
+  If step 3.3 already appended recovery Activity Log entries, do not append a duplicate equivalent entry.
 
 ### 5. Assign the Issue Assignee
 
@@ -79,7 +109,7 @@ If task.md contains a valid `issue_number`, use the Issue update command from `.
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Check the Issue's current milestone; if it is unset, read `.agents/rules/milestone-inference.md` and infer plus set the milestone using "Stage 1: `create-issue`". If `has_triage=false` or the inference is uncertain, skip and continue
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- After every scenario, task comment sync is mandatory: create or update the `<!-- sync-issue:{task-id}:task -->` comment so the remote `:task` comment exists and matches the local `task.md` content (follow the task.md comment sync rule in issue-sync.md)
 
 ### 7. Verification Gate
 
@@ -126,7 +156,7 @@ Next step - run requirements analysis:
 - [ ] Updated `current_step` to requirement-analysis
 - [ ] Updated `updated_at` to the current time
 - [ ] Appended an Activity Log entry to task.md
-- [ ] Synced the task comment to the Issue
+- [ ] Synced the task comment to the Issue, with remote content matching local task.md
 - [ ] Informed the user of the next step (must include all TUI command formats, including any custom TUIs; do not filter)
 - [ ] **Did not modify any business code**
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -24,22 +24,46 @@ description: "从 GitHub Issue 导入并创建任务"
 
 ### 2. 检查已有任务
 
-搜索 `.agents/workspace/active/` 中是否已有链接到此 Issue 的任务。
+2.1 搜索 `.agents/workspace/active/` 中是否已有链接到此 Issue 的任务。
 - 如果找到，询问用户是重新导入还是继续使用现有任务
-- 如果未找到，创建新任务
+- 如果未找到，继续执行 2.2
+
+2.2 扫描 Issue 评论中的同步标记，查找可恢复的历史任务 ID：
+
+如未在步骤 1 中已设置 `$upstream_repo`，可省略 `--repo`，脚本会自动按 issue-sync.md 的检测规则推断。
+
+```bash
+node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-number> --repo "$upstream_repo" --format json
+```
+
+- 脚本输出 `found=false`：按新 Issue 导入流程创建新任务
+- 脚本输出 `found=true`：复用 `task_id`
+- 脚本退出码 2：视为网络、认证或 GitHub API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
 
 ### 3. 创建任务目录和文件
+
+3.1 决定 task ID 和 `created_at`。
+
+| 场景 | 触发条件 | task ID 来源 | created_at 来源 | 用户确认 |
+|---|---|---|---|---|
+| 场景 A | 2.1 命中本地任务 | 复用本地 ID | 本地保留 | 必须询问"重新导入还是继续使用现有任务" |
+| 场景 B | 2.1 无命中 + 2.2 无候选 | `date +%Y%m%d-%H%M%S` 新建 | 当前时间 | 不需要 |
+| 场景 C | 2.1 无命中 + 2.2 有候选 | 自动复用最早候选 ID | 优先用远端 frontmatter 的 `created_at`，缺失时用当前时间 | 告知即可 |
 
 ```bash
 date +%Y%m%d-%H%M%S
 ```
 
-- 创建目录：`.agents/workspace/active/TASK-{yyyyMMdd-HHmmss}/`
+3.2 写入任务目录和 `task.md`。
+
+- 创建目录：`.agents/workspace/active/{task-id}/`
 - 使用 `.agents/templates/task.md` 模板创建 `task.md`
+- 场景 C 优先沿用远端 frontmatter 中的 `type`、`workflow`、`branch`、`created_by`、`milestone`；缺失或损坏字段按 Issue 标签和当前规则重新推断
+- `current_step` 始终写入 `requirement-analysis`，不要恢复为远端原 `current_step`
 
 任务元数据：
 ```yaml
-id: TASK-{yyyyMMdd-HHmmss}
+id: {task-id}
 issue_number: <issue-number>
 type: feature|bugfix|refactor|docs|chore
 branch: <project>-<type>-<slug>
@@ -51,6 +75,11 @@ created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
+
+3.3 追加 Activity Log。
+
+- 场景 B：追加 `Import Issue`
+- 场景 C：追加 `Import Issue (Recovered)`，注明恢复的 task ID、可恢复的原 `current_step`、原 `assigned_to`，并说明 `current_step` 已重置为 `requirement-analysis`；如果部分 frontmatter 字段缺失或损坏，在同一条记录中注明 fallback
 
 ### 4. 更新任务状态
 
@@ -69,6 +98,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Issue** by {agent} — Issue #{number} imported
   ```
+  如果步骤 3.3 已经按恢复场景追加了 Activity Log，不要重复追加同义记录。
 
 ### 5. 分配 Issue Assignee
 
@@ -79,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 检查 Issue 当前 milestone；如果未设置，先读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 1：`create-issue`」规则推断并设置 milestone；如果 `has_triage=false` 或推断不确定，跳过并继续
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 7. 完成校验
 
@@ -126,7 +156,7 @@ Issue #{number} 已导入。
 - [ ] 更新了 `current_step` 为 requirement-analysis
 - [ ] 更新了 `updated_at` 为当前时间
 - [ ] 追加了 Activity Log 条目到 task.md
-- [ ] 同步了 task 评论到 Issue
+- [ ] 同步了 task 评论到 Issue，且远端内容与本地 task.md 一致
 - [ ] 告知了用户下一步（必须展示所有 TUI 的命令格式，含自定义 TUI，不要筛选）
 - [ ] **没有修改任何业务代码**
 

--- a/tests/core/release.test.js
+++ b/tests/core/release.test.js
@@ -23,7 +23,7 @@ test("package metadata supports scoped npm publishing", () => {
   });
   assert.equal(
     pkg.scripts.prepublishOnly,
-    "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js"
+    "node scripts/build-inline.js --check && node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js"
   );
 });
 

--- a/tests/scripts/find-existing-task.test.js
+++ b/tests/scripts/find-existing-task.test.js
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { filePath, writeNodeCommandShim } from "../helpers.js";
+
+const scriptPath = filePath(".agents/scripts/platform-adapters/find-existing-task.js");
+
+function writeFile(filePathname, content) {
+  fs.mkdirSync(path.dirname(filePathname), { recursive: true });
+  fs.writeFileSync(filePathname, content, "utf8");
+}
+
+function writeFakeGh(tmpDir, comments, options = {}) {
+  const dataPath = path.join(tmpDir, "comments.json");
+  writeFile(dataPath, JSON.stringify(comments));
+
+  const fakeGhPath = path.join(tmpDir, "fake-gh.js");
+  writeFile(fakeGhPath, [
+    "#!/usr/bin/env node",
+    "const fs = require('node:fs');",
+    "const args = process.argv.slice(2);",
+    "if (process.env.FAKE_GH_FAIL === '1') {",
+    "  console.error('simulated gh failure');",
+    "  process.exit(1);",
+    "}",
+    "if (args[0] === 'api' && args[1].includes('/issues/') && args[1].endsWith('/comments')) {",
+    "  const comments = JSON.parse(fs.readFileSync(process.env.FAKE_GH_COMMENTS, 'utf8'));",
+    "  for (const comment of comments) {",
+    "    console.log(JSON.stringify(comment));",
+    "  }",
+    "  process.exit(0);",
+    "}",
+    "console.error(`unexpected gh args: ${args.join(' ')}`);",
+    "process.exit(1);"
+  ].join("\n"));
+
+  const commandPath = process.platform === "win32"
+    ? writeNodeCommandShim(path.join(tmpDir, "gh"), fakeGhPath)
+    : fakeGhPath;
+  if (process.platform !== "win32") {
+    fs.chmodSync(commandPath, 0o755);
+  }
+
+  return {
+    commandPath,
+    env: {
+      ...process.env,
+      FAKE_GH_COMMENTS: dataPath,
+      FAKE_GH_FAIL: options.fail ? "1" : "0",
+      IMPORT_ISSUE_GH_BIN: commandPath
+    }
+  };
+}
+
+function runScript(comments, options = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-import-issue-"));
+  const { env } = writeFakeGh(tmpDir, comments, options);
+
+  return spawnSync(process.execPath, [
+    scriptPath,
+    "--issue",
+    "184",
+    "--repo",
+    "fitlab-ai/agent-infra"
+  ], {
+    cwd: filePath("."),
+    encoding: "utf8",
+    env
+  });
+}
+
+function parseStdout(result) {
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+function comment(body, createdAt = "2026-04-12T03:51:33Z") {
+  return {
+    created_at: createdAt,
+    body
+  };
+}
+
+function taskComment(taskId, frontmatterLines = []) {
+  return [
+    `<!-- sync-issue:${taskId}:task -->`,
+    "## 任务文件",
+    "",
+    "> **codex** · TASK-20260412-114725",
+    "",
+    "<details><summary>元数据 (frontmatter)</summary>",
+    "",
+    "```yaml",
+    "---",
+    ...frontmatterLines,
+    "---",
+    "```",
+    "",
+    "</details>",
+    "",
+    "# 任务：示例"
+  ].join("\n");
+}
+
+test("find-existing-task reports no match when comments have no sync marker", () => {
+  const result = parseStdout(runScript([
+    comment("plain comment")
+  ]));
+
+  assert.deepEqual(result, { found: false });
+});
+
+test("find-existing-task recovers frontmatter from a single task candidate", () => {
+  const result = parseStdout(runScript([
+    comment("<!-- sync-issue:TASK-20260412-114725:analysis -->\n# 分析", "2026-04-12T03:55:00Z"),
+    comment(taskComment("TASK-20260412-114725", [
+      "id: TASK-20260412-114725",
+      "type: bugfix",
+      "workflow: bug-fix",
+      "created_at: 2026-04-12 11:47:25+08:00",
+      "current_step: review",
+      "assigned_to: codex"
+    ]), "2026-04-12T03:51:33Z")
+  ]));
+
+  assert.equal(result.found, true);
+  assert.equal(result.task_id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter.id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter.current_step, "review");
+});
+
+test("find-existing-task selects the earliest candidate deterministically", () => {
+  const result = parseStdout(runScript([
+    comment(taskComment("TASK-20260426-120458", ["id: TASK-20260426-120458"]), "2026-04-26T04:04:58Z"),
+    comment(taskComment("TASK-20260412-114725", ["id: TASK-20260412-114725"]), "2026-04-12T03:51:33Z")
+  ]));
+
+  assert.equal(result.task_id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter.id, "TASK-20260412-114725");
+  assert.equal(result.candidates, undefined);
+});
+
+test("find-existing-task keeps the task id when no task comment exists", () => {
+  const result = parseStdout(runScript([
+    comment("<!-- sync-issue:TASK-20260412-114725:analysis -->\n# 分析")
+  ]));
+
+  assert.equal(result.found, true);
+  assert.equal(result.task_id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter, undefined);
+});
+
+test("find-existing-task keeps the task id when frontmatter is damaged", () => {
+  const result = parseStdout(runScript([
+    comment([
+      "<!-- sync-issue:TASK-20260412-114725:task -->",
+      "## 任务文件",
+      "",
+      "<details><summary>元数据 (frontmatter)</summary>",
+      "",
+      "not a yaml fence",
+      "",
+      "</details>"
+    ].join("\n"))
+  ]));
+
+  assert.equal(result.found, true);
+  assert.equal(result.task_id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter, undefined);
+});
+
+test("find-existing-task skips damaged frontmatter lines when useful fields remain", () => {
+  const result = parseStdout(runScript([
+    comment(taskComment("TASK-20260412-114725", [
+      "id: TASK-20260412-114725",
+      "damaged yaml line",
+      "created_at: 2026-04-12 11:47:25+08:00"
+    ]))
+  ]));
+
+  assert.equal(result.found, true);
+  assert.equal(result.task_id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter.id, "TASK-20260412-114725");
+  assert.equal(result.frontmatter.created_at, "2026-04-12 11:47:25+08:00");
+});
+
+test("find-existing-task exits 2 when gh fails", () => {
+  const result = runScript([], { fail: true });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /simulated gh failure/);
+});

--- a/tests/templates/templates.test.js
+++ b/tests/templates/templates.test.js
@@ -157,6 +157,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/skills/create-task/config/verify.json", "templates/.agents/skills/create-task/config/verify.json"],
     [".agents/skills/import-issue/SKILL.md", "templates/.agents/skills/import-issue/SKILL.en.md"],
     [".agents/skills/import-issue/config/verify.json", "templates/.agents/skills/import-issue/config/verify.json"],
+    [".agents/scripts/platform-adapters/find-existing-task.js", "templates/.agents/scripts/platform-adapters/find-existing-task.github.js"],
     [".agents/skills/init-labels/SKILL.md", "templates/.agents/skills/init-labels/SKILL.en.md"],
     [".agents/skills/update-agent-infra/SKILL.md", "templates/.agents/skills/update-agent-infra/SKILL.en.md"],
     [".agents/skills/update-agent-infra/scripts/package.json", "templates/.agents/skills/update-agent-infra/scripts/package.json"],
@@ -174,6 +175,18 @@ test("update-agent-infra template copies stay in sync with working files", () =>
 
     assert.equal(rendered, read(source), `${templatePath} is out of sync with ${source}`);
   });
+
+  assert.equal(
+    read("templates/.agents/scripts/platform-adapters/find-existing-task.js").trim(),
+    [
+      'import { pathToFileURL } from "node:url";',
+      "",
+      "if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {",
+      "  console.log(JSON.stringify({ found: false }, null, 2));",
+      "}"
+    ].join("\n"),
+    "find-existing-task should keep a no-op platform fallback script"
+  );
 });
 
 test("Claude command disable-model-invocation settings match command frequency", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #247

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`/import-issue` 在重新导入同一个 GitHub Issue 时，每次都用 `date +%Y%m%d-%H%M%S` 生成新的 task ID，与 Issue 评论里 `<!-- sync-issue:TASK-*:* -->` 标记中已存在的原 ID 不一致。同一 Issue 在不同时间 / 不同 AI / 不同 worktree 下重新导入会得到多个互不相通的本地任务，GitHub 上的 task / analysis / plan / implementation / review / refinement 等产物 sync 评论无法关联到本地，「恢复」语义彻底缺失（实际案例：Issue #184 上同时存在 `TASK-20260412-114725` 与 `TASK-20260426-120458`）。

`/import-issue` re-imports of the same GitHub Issue would always mint a brand-new timestamp-based task ID, ignoring any `<!-- sync-issue:TASK-*:* -->` markers already on the Issue. The same Issue re-imported across different machines / worktrees / AIs ended up with many disconnected local tasks while remote sync comments stayed pinned to the original ID. This PR makes import-issue prefer recovering the original task ID instead of always creating a new one.

## 📋 主要变更 / Brief Changelog

- 新增 `.agents/scripts/platform-adapters/find-existing-task.{js, github.js}` + 模板 no-op 兜底，遵循项目「workflow skill 不挂平台脚本，平台逻辑收敛到 `platform-adapters/`」的双文件变体惯例（与 `platform-sync.{github.js,js}` 同处）。
- 重写 `import-issue` SKILL 步骤 2/3：本地无命中时调用上述适配器扫描 Issue 评论；用 A/B/C 三场景表分流（本地命中 / 远端无候选新建 / 远端有候选自动取最早）。`current_step` 强制写回 `requirement-analysis`，把恢复来源记入 Activity Log。
- 步骤 6 显式声明"所有场景结束后必须执行 task 留言同步"，确保远端 `:task` 评论永远与本地 `task.md` 一致；完成检查清单同步加强。
- `tests/scripts/find-existing-task.test.js` 覆盖 7 个分支（无 marker / 单候选完整 / 多候选取最早 / 无 task / frontmatter 损坏 / 局部损坏 / gh 失败），并把 `tests/scripts/*.test.js` 接入 `npm test` / `prepublishOnly` / 各处文档命令。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全套 291 个用例通过
2. `node --test tests/scripts/*.test.js` —— 新增 7 个适配器单测通过
3. 真实仓库只读验证：`node .agents/scripts/platform-adapters/find-existing-task.js --issue 247 --repo fitlab-ai/agent-infra --format json` 输出 `TASK-20260426-124425` 并恢复 frontmatter；对 Issue #184 同样命令输出 `TASK-20260412-114725`（多候选自动取最早）
4. **合并前 smoke test（建议 reviewer 执行）**：在新 worktree 上运行 `/import-issue 184`，验证场景 C ——本地新建任务的 ID 应直接复用 `TASK-20260412-114725`，`created_at` 来自远端 frontmatter，远端 `:task` 留言 PATCH 为本地新内容（不再产生孤儿 sync 评论）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass (no lint configured for this repo)
- [x] 单元测试通过 / Unit tests pass (291/291)

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（CLAUDE.md / AGENTS.md / 三份测试相关 SKILL 已同步加上 `tests/scripts/*.test.js`）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（无 sync 标记的 Issue 走原行为，回归路径零变化）

## 📋 附加信息 / Additional Notes

- 显式排除（留作后续任务）：把 Issue 上历史的 analysis / plan / implementation / review / refinement 等 sync 评论拉回本地对应文件；搜索 `.agents/workspace/archive/` 中已归档的同 Issue 任务。
- 平台无关：本次新增的适配器在非 GitHub 平台部署时退化为 no-op，输出 `{"found": false}` 让 SKILL 直接走"新建"路径，不阻塞导入。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `.agents/scripts/platform-adapters/find-existing-task.js` 的入口保护（`pathToFileURL(process.argv[1]).href`）—— 该脚本会被 `validate-artifact.js` 动态 import 做适配器注册，guard 防止 import 时触发 CLI 副作用
- `.agents/skills/import-issue/SKILL.md` 的场景表（A/B/C）和步骤 6 的"task 留言一致性"显式声明是恢复语义的契约核心
- `templates/.agents/scripts/platform-adapters/find-existing-task.js`（no-op 兜底）的内容已被 `tests/templates/templates.test.js` inline 钉死，未来修改需同步更新断言

Generated with AI assistance.
