### PR TITLE
refactor(templates): 收敛模板中的平台相关内容到 rules 与 platform adapter

### DIFF
--- a/.agents/QUICKSTART.md
+++ b/.agents/QUICKSTART.md
@@ -16,7 +16,7 @@
 git config core.hooksPath .github/hooks
 ```
 
-这样 Git 才会调用同步到 `.github/hooks/` 下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
+这样 Git 才会调用项目仓库 `.github/hooks/` 目录下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
 
 ## 外部模板与 Skill
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -108,7 +108,7 @@
 | `status:` | Yes | — | PR 有自身状态流转（Open / Draft / Merged / Closed）；Issue 使用 `status:` label 标记等待反馈、已确认等项目管理状态 |
 | `in:` | Yes | Yes | Issue 和 PR 均可按模块筛选 |
 
-默认 GitHub 配置下，可使用 `/init-labels` 命令一次性创建标准 labels。
+使用 `/init-labels` 命令可通过平台适配器一次性创建标准 labels。
 
 ## 私有平台扩展
 

--- a/.agents/rules/issue-pr-commands.md
+++ b/.agents/rules/issue-pr-commands.md
@@ -22,6 +22,44 @@ gh repo view --json nameWithOwner
 - `gh pr *` 命令保持作用于当前仓库，不额外加 `-R`
 - `gh api "orgs/{owner}/..."` 这类 org 级命令保持不变
 
+## Issue 模板检测
+
+使用以下命令检测 GitHub Issue Forms：
+
+```bash
+rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
+```
+
+创建 Issue 前先读取匹配的 form 文件。目录不存在或没有匹配 form 时，使用调用方定义的 fallback 正文格式。
+
+常见候选模板：
+- `bug_report.yml`：bug 工作
+- `question.yml`：问题或排查工作
+- `feature_request.yml`：功能工作
+- `documentation.yml`：文档工作
+- `other.yml`：通用 fallback
+
+对 GitHub Issue Forms，检查匹配 form 的：
+- `name`
+- `type:`
+- `labels:`
+- `body:`
+
+字段处理规则：
+- `textarea` 和 `input`：使用 `attributes.label` 作为 markdown 标题，并从 task.md 填充值
+- `markdown`：跳过模板说明文案
+- `dropdown` 和 `checkboxes`：跳过
+- task.md 缺少合适值时，写入 `N/A`
+
+建议字段映射：
+
+| 模板字段提示 | task.md 来源 |
+|---|---|
+| `summary`, `title` | 任务标题 |
+| `description`, `problem`, `what happened`, `issue-description`, `current-content` | 任务描述 |
+| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | 需求列表 |
+| 其他 `textarea` / `input` 字段 | 任务描述，否则 `N/A` |
+
 ## Issue 读取与创建
 
 读取 Issue：
@@ -81,6 +119,28 @@ gh issue close {issue-number} -R "$upstream_repo" --reason "{reason}"
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}/comments" --paginate
 ```
+
+## PR 模板与元数据辅助命令
+
+存在仓库 PR 模板时读取：
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+参考最近合并的 PR 风格：
+
+```bash
+gh pr list --limit 3 --state merged --json number,title,body
+```
+
+PR 元数据同步前验证标准 type labels 是否存在：
+
+```bash
+gh label list --search "type:" --limit 1 --json name --jq 'length'
+```
+
+如果结果是 `0`，先运行 `init-labels`，再重试 PR 元数据同步。
 
 ## PR 读取与创建
 

--- a/.agents/rules/issue-sync.md
+++ b/.agents/rules/issue-sync.md
@@ -1,5 +1,19 @@
 # Issue 同步规则
 
+## Marker 注册表
+
+以下隐藏标记是 Issue 同步的唯一权威注册表：
+
+| Key | Marker |
+|---|---|
+| `task` | `<!-- sync-issue:{task-id}:task -->` |
+| `artifact` | `<!-- sync-issue:{task-id}:{artifact-stem} -->` |
+| `artifactChunk` | `<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->` |
+| `summary` | `<!-- sync-issue:{task-id}:summary -->` |
+| `cancel` | `<!-- sync-issue:{task-id}:cancel -->` |
+
+Skill 正文应引用 marker key，具体 marker 字符串只保留在本规则或平台适配器默认值中。
+
 在任务技能需要更新 GitHub Issue 时先读取本文件。
 
 ## Upstream 仓库检测

--- a/.agents/rules/label-milestone-setup.md
+++ b/.agents/rules/label-milestone-setup.md
@@ -43,6 +43,16 @@ gh api "repos/$repo/milestones" -f title="{title}" -f description="{description}
 gh api "repos/$repo/milestones/{number}" -X PATCH -f state="{state}" -f description="{description}"
 ```
 
+## 错误提示模板
+
+GitHub 初始化脚本失败时使用以下标准提示：
+
+| 条件 | 提示 |
+|---|---|
+| CLI 缺失 | GitHub CLI (`gh`) is not installed |
+| 认证失败 | `GitHub CLI is not authenticated` |
+| API 限流 | `GitHub API rate limit reached, please retry later` |
+
 ## 约束
 
 - label 以名称作为幂等键

--- a/.agents/rules/release-commands.md
+++ b/.agents/rules/release-commands.md
@@ -21,6 +21,22 @@ gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels
 gh issue view {issue-number} --json number,title,labels,url
 ```
 
+## Contributor 映射辅助规则
+
+release notes 需要 contributors 时，已合并 PR 查询应包含 author：
+
+```bash
+gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
+```
+
+关联 Issue 用于 reporter 归因时，查询应包含 author：
+
+```bash
+gh issue view {issue-number} --json number,title,labels,url,author
+```
+
+GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
+
 ## 创建 Draft Release
 
 ```bash

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -9,6 +9,26 @@ const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 let activeShared = null;
 let repoRoot = "";
 
+export function getDefaults() {
+  return {
+    statusLabels: {
+      pendingDesignWork: "status: pending-design-work",
+      inProgress: "status: in-progress",
+      blocked: "status: blocked",
+      completed: "status: completed",
+      waitingForTriage: "status: waiting-for-triage"
+    },
+    markers: {
+      task: "<!-- sync-issue:{task-id}:task -->",
+      artifact: "<!-- sync-issue:{task-id}:{artifact-stem} -->",
+      artifactChunk: "<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->",
+      summary: "<!-- sync-issue:{task-id}:summary -->",
+      cancel: "<!-- sync-issue:{task-id}:cancel -->",
+      prSummary: "<!-- sync-pr:{task-id}:summary -->"
+    }
+  };
+}
+
 function getShared() {
   if (!activeShared) {
     throw new Error("platform-sync adapter shared utilities are unavailable");
@@ -124,12 +144,16 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
   }
   const permissions = detectPermissions(upstreamRepo.value, taskDir);
+  const expectedValues = resolveExpectedValues(config);
+  if (!expectedValues.ok) {
+    return { earlyReturn: failResult(CHECK_TYPE, expectedValues.message, "check_failed") };
+  }
 
-  const marker = config.expected_comment_marker
-    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
+  const marker = expectedValues.commentMarker
+    ? interpolate(expectedValues.commentMarker, taskDir, artifactFile)
     : null;
-  const prMarker = config.expected_pr_comment_marker
-    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
+  const prMarker = expectedValues.prCommentMarker
+    ? interpolate(expectedValues.prCommentMarker, taskDir, artifactFile)
     : null;
   const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
 
@@ -144,9 +168,63 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     upstreamRepo: upstreamRepo.value,
     hasTriage: permissions.hasTriage,
     hasPush: permissions.hasPush,
+    expectedStatusLabel: expectedValues.statusLabel,
     marker,
     prMarker
   };
+}
+
+function resolveExpectedValues(config) {
+  const defaults = getDefaults();
+  const statusLabel = resolveDefaultValue({
+    collection: defaults.statusLabels,
+    key: config.expected_status_label_key,
+    value: config.expected_status_label,
+    configKey: "expected_status_label_key"
+  });
+  if (!statusLabel.ok) {
+    return statusLabel;
+  }
+
+  const commentMarker = resolveDefaultValue({
+    collection: defaults.markers,
+    key: config.expected_comment_marker_key,
+    value: config.expected_comment_marker,
+    configKey: "expected_comment_marker_key"
+  });
+  if (!commentMarker.ok) {
+    return commentMarker;
+  }
+
+  const prCommentMarker = resolveDefaultValue({
+    collection: defaults.markers,
+    key: config.expected_pr_comment_marker_key,
+    value: config.expected_pr_comment_marker,
+    configKey: "expected_pr_comment_marker_key"
+  });
+  if (!prCommentMarker.ok) {
+    return prCommentMarker;
+  }
+
+  return {
+    ok: true,
+    statusLabel: statusLabel.value,
+    commentMarker: commentMarker.value,
+    prCommentMarker: prCommentMarker.value
+  };
+}
+
+function resolveDefaultValue({ collection, key, value, configKey }) {
+  if (!key) {
+    return { ok: true, value: value || null };
+  }
+
+  const resolvedValue = collection[key];
+  if (!resolvedValue) {
+    return { ok: false, message: `Unknown ${configKey}: ${key}` };
+  }
+
+  return { ok: true, value: resolvedValue };
 }
 
 function fetchRemoteData(context) {
@@ -209,7 +287,7 @@ function fetchRemoteData(context) {
   }
 
   let prComments = null;
-  if (context.config.expected_pr_comment_marker) {
+  if (context.prMarker) {
     if (!context.prNumber) {
       return {
         earlyReturn: failResult(CHECK_TYPE, "Expected a valid pr_number for PR comment verification", "check_failed")
@@ -323,7 +401,9 @@ function mapTaskTypeToLabel(taskType) {
 function shouldFetchComments(config) {
   return Boolean(
     config.expected_comment_marker
+    || config.expected_comment_marker_key
     || config.expected_pr_comment_marker
+    || config.expected_pr_comment_marker_key
     || config.verify_pr_comment_last_commit_matches_head
     || config.verify_comment_content
     || config.verify_task_comment_content
@@ -339,7 +419,7 @@ function flattenComments(value) {
 }
 
 function checkStatusLabel(context, remoteData) {
-  if (!context.config.expected_status_label || !context.hasTriage) {
+  if (!context.expectedStatusLabel || !context.hasTriage) {
     return null;
   }
 
@@ -348,12 +428,12 @@ function checkStatusLabel(context, remoteData) {
   }
 
   const labels = extractLabelNames(remoteData.issue.labels);
-  if (labels.includes(context.config.expected_status_label)) {
+  if (labels.includes(context.expectedStatusLabel)) {
     return null;
   }
 
   return failResult(CHECK_TYPE,
-    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
+    `Expected label '${context.expectedStatusLabel}' not found on Issue #${context.issueNumber}`,
     "check_failed"
   );
 }

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -41,7 +41,7 @@ description: "分析任务并输出需求分析文档"
 - 当前已知的受影响文件和约束
 
 如 `task.md` 包含以下来源字段，补充读取对应来源信息：
-- `issue_number` - GitHub Issue
+- `issue_number` - Issue
 - `codescan_alert_number` - Code Scanning 告警
 - `security_alert_number` - Dependabot 告警
 
@@ -70,7 +70,7 @@ description: "分析任务并输出需求分析文档"
 
 ## 需求来源
 
-**来源类型**：{用户描述 / GitHub Issue / Code Scanning / Dependabot / 其他}
+**来源类型**：{用户描述 / Issue / Code Scanning / Dependabot / 其他}
 **来源摘要**：
 > {任务来源或关键上下文}
 
@@ -121,7 +121,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{analysis-artifact}` 评论
 
 ### 7. 完成校验

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -37,7 +37,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "pendingDesignWork",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/.agents/skills/block-task/config/verify.json
+++ b/.agents/skills/block-task/config/verify.json
@@ -22,7 +22,8 @@
     },
     "platform-sync": {
       "when": "issue_number_exists",
-      "expected_status_label": "status: blocked"
+      "expected_status_label": "status: blocked",
+      "expected_status_label_key": "blocked"
     }
   }
 }

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -79,8 +79,8 @@ ls .agents/workspace/completed/{task-id}/task.md
 - 按 issue-sync.md 移除所有 `in:` labels
 - 按 issue-sync.md 移除 milestone
 - 移除全部 assignees（无权限时直接跳过，不做替代）
-- 发布取消评论，隐藏标记使用 `<!-- sync-issue:{task-id}:cancel -->`
-- 使用 `.agents/rules/issue-sync.md` 的 task.md 评论同步规则创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论
+- 发布取消评论，隐藏标记使用 `.agents/rules/issue-sync.md` 中定义的 cancel 评论标记
+- 使用 `.agents/rules/issue-sync.md` 的 task.md 评论同步规则创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记
 - 关闭 Issue：按 `.agents/rules/issue-pr-commands.md` 中的“关闭 Issue”命令执行，关闭原因固定为 `not planned`
 
 取消评论至少包含：

--- a/.agents/skills/cancel-task/config/verify.json
+++ b/.agents/skills/cancel-task/config/verify.json
@@ -24,7 +24,8 @@
     "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:cancel -->",
-      "verify_task_comment_content": true
+      "verify_task_comment_content": true,
+      "expected_comment_marker_key": "cancel"
     }
   }
 }

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -61,7 +61,7 @@ Code Scanning 告警 #{alert-number}
 
 按 `.agents/rules/security-alerts.md` 中的 Code Scanning 告警关闭命令执行关闭操作，并传入映射后的 `{api-reason}` 与用户说明。
 
-**API reason 映射**（按 GitHub Code Scanning API）：
+**API reason 映射**（按 Code Scanning API）：
 - 误报 -> `false positive`
 - 不会修复 -> `won't fix`
 - 测试代码 -> `used in tests`
@@ -96,7 +96,7 @@ Code Scanning 告警 #{alert-number} 已关闭。
 
 查看：{html_url}
 
-注意：如有需要，可在 GitHub 上重新打开。
+注意：如有需要，可在 平台上重新打开。
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-id}

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -64,7 +64,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ## 7. 同步 PR 摘要（按需）
 
-当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上的 `<!-- sync-pr:{task-id}:summary -->` 摘要评论；否则跳过。
+当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上由 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记对应的摘要评论；否则跳过。
 
 > 完整的触发条件、聚合规则、PATCH/POST 流程、Shell 安全约束和错误处理见 `reference/pr-summary-sync.md`（其内联引用 `.agents/rules/pr-sync.md`）。执行此步骤前先读取 `reference/pr-summary-sync.md`。
 >

--- a/.agents/skills/commit/config/verify.json
+++ b/.agents/skills/commit/config/verify.json
@@ -21,7 +21,8 @@
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_computed": true,
-      "verify_pr_comment_last_commit_matches_head": true
+      "verify_pr_comment_last_commit_matches_head": true,
+      "expected_pr_comment_marker_key": "prSummary"
     }
   }
 }

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -93,7 +93,7 @@ ls .agents/workspace/completed/{task-id}/task.md
 - 先按 `.agents/rules/issue-sync.md` 的补发规则扫描并补发未发布的 `task.md`、`analysis*.md`、`plan*.md`、`implementation*.md`、`review*.md`、`refinement*.md` 评论（`task.md` 走幂等更新路径）
 - 按 issue-sync.md 的需求复选框同步步骤，兜底同步 `## 需求` 中已勾选的条目到 Issue body
 - 不要设置 `status:` label — Issue 关闭后 status label 会被自动清除
-- 最后创建或更新 `<!-- sync-issue:{task-id}:summary -->` 标记的 summary 评论
+- 最后创建或更新 `.agents/rules/issue-sync.md` 中定义的 summary 评论标记对应的 summary 评论
 
 ### 7. 完成校验
 

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -29,7 +29,8 @@
       "verify_task_comment_content": true,
       "sync_checked_requirements": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_comment_marker_key": "summary"
     }
   }
 }

--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: create-issue
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 ---
 
 # 创建 Issue
 
-仅从 `task.md` 创建基础 GitHub Issue，并把 `issue_number` 回写到任务文件。
+仅从 `task.md` 创建基础 Issue，并把 `issue_number` 回写到任务文件。
 
 ## 行为边界 / 关键规则
 
 - Issue 标题和正文只能来自 `task.md`
 - Issue 标题格式为 `type(scope): 描述`——type 从 task.md 的 `type` 字段映射（feature→feat, bugfix→fix, refactor→refactor, docs→docs, chore→chore），scope 从受影响模块推断（无法确定时省略），描述使用 task.md 中的任务标题原文（不要翻译或改写）
 - 不要读取 `analysis.md`、`plan.md`、`implementation.md` 或审查产物
-- 持久产物只有 GitHub Issue 本身，以及 task.md 中的 `issue_number` 更新
+- 持久产物只有 Issue 本身，以及 task.md 中的 `issue_number` 更新
 - 执行本技能后，你**必须**立即更新 task.md
 
 ## 执行步骤
@@ -31,7 +31,7 @@ description: "从任务文件创建 GitHub Issue"
 
 ### 3. 构建 Issue 内容
 
-检测 `.github/ISSUE_TEMPLATE`，决定使用模板路径还是 fallback 路径。
+通过 `.agents/rules/issue-pr-commands.md` 检测 Issue 模板，决定使用模板路径还是 fallback 路径。
 
 > 模板识别、`textarea`、`input`、`dropdown`、`checkboxes` 字段映射，以及 fallback 正文规则见 `reference/template-matching.md`。构建正文前先读取 `reference/template-matching.md`。
 
@@ -57,7 +57,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果任务目录中已存在产物文件，按以下顺序补发：
 
-1. `task.md` → `<!-- sync-issue:{task-id}:task -->` 评论（幂等创建或更新）
+1. `task.md` → `.agents/rules/issue-sync.md` 中定义的 task 评论标记（幂等创建或更新）
 2. 按文件名排序补发已存在的 `analysis*.md`、`plan*.md`、`implementation*.md`、`review*.md`、`refinement*.md`
 
 所有补发动作都必须遵循 `.agents/rules/issue-sync.md` 的原文发布、task.md 同步和分片规则。
@@ -94,7 +94,7 @@ node .agents/scripts/validate-artifact.js gate create-issue .agents/workspace/ac
 
 ## 完成检查清单
 
-- [ ] 已创建 GitHub Issue
+- [ ] 已创建 Issue
 - [ ] 已仅使用 `task.md` 作为内容来源
 - [ ] 已在 task.md 中记录 `issue_number`
 - [ ] 已更新 `updated_at` 并追加 Activity Log
@@ -106,13 +106,13 @@ node .agents/scripts/validate-artifact.js gate create-issue .agents/workspace/ac
 
 ## 注意事项
 
-- `create-issue` 只负责创建基础 Issue；后续状态、评论和复选框由工作流技能与 GitHub Actions 维护
+- `create-issue` 只负责创建基础 Issue；后续状态、评论和复选框由工作流技能与 platform automation 维护
 - 如果过滤后没有有效 label，允许不带 label 创建 Issue
 - 如果 Issue Type 或 milestone 设置失败，继续执行并记录结果
 
 ## 错误处理
 
 - 任务未找到：`Task {task-id} not found`
-- GitHub CLI 不可用或未认证
+- the platform CLI 不可用或未认证
 - task.md 的描述为空
 - 创建 Issue 失败

--- a/.agents/skills/create-issue/config/verify.json
+++ b/.agents/skills/create-issue/config/verify.json
@@ -23,7 +23,8 @@
       "issue_must_exist": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "waitingForTriage"
     }
   }
 }

--- a/.agents/skills/create-issue/reference/label-and-type.md
+++ b/.agents/skills/create-issue/reference/label-and-type.md
@@ -17,11 +17,11 @@
 - [ ] {requirement-2}
 ```
 
-将任务类型映射到 GitHub label 和 Issue Type，但只保留仓库里实际存在的 label。
+将任务类型映射到 label 和 Issue Type，但只保留仓库里实际存在的 label。
 
 Fallback label 映射：
 
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -34,7 +34,7 @@ Fallback label 映射：
 
 Issue Type fallback 映射：
 
-| task.md type | GitHub Issue Type |
+| task.md type | Issue Type |
 |---|---|
 | `bug`, `bugfix` | `Bug` |
 | `feature`, `enhancement` | `Feature` |

--- a/.agents/skills/create-issue/reference/template-matching.md
+++ b/.agents/skills/create-issue/reference/template-matching.md
@@ -1,45 +1,17 @@
 # Issue 模板匹配
 
-在决定如何从 `.github/ISSUE_TEMPLATE` 构建 Issue 正文之前先读取本文件。
+在决定如何构建 Issue 正文前先读取本文件。
 
-## 探测 Issue 模板
+## 检测 Issue 模板
 
-用下面的命令搜索项目模板：
+Issue 模板检测属于平台相关逻辑。先读取 `.agents/rules/issue-pr-commands.md`，并按当前配置平台提供的模板检测章节执行。
 
-```bash
-rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
-```
+如果存在模板，检查其顶层名称，并根据任务标题和描述选择最匹配的模板。可用时，使用当前配置平台规则提供的候选模板指引。
 
-如果模板存在，检查其顶层 `name:` 字段，并为当前任务标题和描述选择最匹配的模板。
+如果没有清晰匹配，选择最接近的候选模板。模板不存在、无法读取或解析失败时，回退到默认正文路径。
 
-常见候选模板：
-- `bug_report.yml`：用于 bug 类工作
-- `question.yml`：用于问题排查或调研类工作
-- `feature_request.yml`：用于功能类工作
-- `documentation.yml`：用于文档类工作
-- `other.yml`：通用 fallback
+## 从匹配模板构建正文
 
-如果没有明显匹配的模板，选择最接近的候选项。如果模板缺失、不可读取或解析失败，就回退到默认正文路径。
+按 `.agents/rules/issue-pr-commands.md` 中当前配置平台章节提供的字段处理和字段映射指引构建正文。
 
-## 使用匹配到的模板构建正文
-
-读取匹配模板中的：
-- `name`
-- `type:`
-- `labels:`
-- `body:`
-
-字段处理规则：
-- `textarea` 和 `input`：使用 `attributes.label` 作为 Markdown 标题，并从 task.md 填充值
-- `markdown`：跳过模板解释性文字
-- `dropdown` 和 `checkboxes`：跳过
-- 当 task.md 没有合适值时，写入 `N/A`
-
-建议字段映射：
-
-| 模板字段提示 | task.md 来源 |
-|---|---|
-| `summary`, `title` | 任务标题 |
-| `description`, `problem`, `what happened`, `issue-description`, `current-content` | 任务描述 |
-| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | 需求列表 |
-| 其他 `textarea` / `input` 字段 | 优先使用任务描述，否则写 `N/A` |
+如果平台指引不可用，使用默认正文路径。

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -26,7 +26,7 @@ description: "创建 Pull Request 到目标分支"
 
 ### 3. 准备 PR 正文
 
-读取 `.github/PULL_REQUEST_TEMPLATE.md`（如存在），参考最近合并的 PR 风格，并收集 `<target-branch>` 到 `HEAD` 的全部提交。
+通过 `.agents/rules/issue-pr-commands.md` 读取 PR 模板，参考最近合并的 PR 风格，并收集 `<target-branch>` 到 `HEAD` 的全部提交。
 
 > 模板处理、HEREDOC 正文生成和 `Generated with AI assistance` 要求见 `reference/pr-body-template.md`。编写正文前先读取 `reference/pr-body-template.md`。
 
@@ -101,7 +101,7 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
 
 - 必须检查分支中的全部提交，而不是只看最后一个
 - `create-pr` 不能把 type label 映射委托给其他技能，必须在获取到 `{task-id}` 时于本技能内内联处理
-- 隐藏 summary 标记必须保持 `<!-- sync-pr:{task-id}:summary -->` 以兼容已有 PR 评论
+- 隐藏 summary 标记必须保持为 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记，以兼容已有 PR 评论
 - 如果当前分支已存在 PR，直接告知用户 PR URL 并结束，不做重复同步
 - 如果从 Issue 继承元数据失败，继续使用 task.md 和分支推断兜底
 

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -23,7 +23,8 @@
       "verify_in_labels_match_pr": true,
       "verify_pr_type_label": true,
       "verify_pr_assignee": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_pr_comment_marker_key": "prSummary"
     }
   }
 }

--- a/.agents/skills/create-pr/reference/pr-body-template.md
+++ b/.agents/skills/create-pr/reference/pr-body-template.md
@@ -1,20 +1,16 @@
 # PR 正文模板规则
 
-在生成 PR 标题和正文之前先读取本文件。
+生成 PR 标题和正文前先读取本文件。
 
 ## 读取 PR 模板
 
-读取仓库中的 `.github/PULL_REQUEST_TEMPLATE.md`。如果不存在，则使用标准格式。
+PR 模板发现属于平台相关逻辑。先读取 `.agents/rules/issue-pr-commands.md`，并按当前配置平台提供的 PR 模板章节执行。如果没有可用模板，则使用标准格式。
 
 ## 参考最近合并的 PR
 
-```bash
-gh pr list --limit 3 --state merged --json number,title,body
-```
+使用 `.agents/rules/issue-pr-commands.md` 中的最近合并 PR 查询命令，作为风格和格式参考输入。
 
-把最近合并的 PR 当作风格和排版参考。
-
-## 分析当前分支变更
+## 分析当前分支改动
 
 ```bash
 git status
@@ -25,21 +21,15 @@ git diff <target-branch>...HEAD
 
 ## 同步 PR 元数据
 
-执行前先读取 `.agents/rules/issue-pr-commands.md`。
+执行本步骤前先读取 `.agents/rules/issue-pr-commands.md`。
 
-同步关联 Issue 元数据前，先按该规则完成认证和代码托管平台检测；`gh pr list` / `gh pr create` 仍保持作用于当前仓库。
+同步关联 Issue 元数据前，先按该规则完成认证和代码托管平台检测。
 
-在同步 label 之前，先确认标准 label 体系已经存在：
+同步 label 前，按 `.agents/rules/issue-pr-commands.md` 中的 label 列表命令验证标准 label 体系。如果结果显示没有标准 type label，先运行 `init-labels` 再重试元数据同步。
 
-```bash
-gh label list --search "type:" --limit 1 --json name --jq 'length'
-```
+类型 label 映射：
 
-如果结果是 `0`，先执行 `init-labels`，再重试元数据同步。
-
-Type label 映射：
-
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -51,34 +41,34 @@ Type label 映射：
 | 其他值 | 跳过 |
 
 元数据同步顺序：
-1. 按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询关联 Issue 的 labels 和 milestone
-2. 构建 `{label-args}`：包含映射后的 type label、非 `type:`/`status:` 的 Issue labels，以及 Issue 当前的 `in:` labels（commit 阶段已完成计算，此处不重新计算也不反向更新 Issue）
-3. 构建 `{milestone-arg}`：按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」直接复用 Issue milestone
-4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入 `gh pr create`
-5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价的 closing keyword
+1. 通过 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询 Issue labels 和 milestone
+2. 从映射出的 type label、非 `type:` / 非 `status:` 的 Issue labels，以及当前 Issue `in:` labels 构建 `{label-args}`（commit 已经计算过，不在此重算，也不写回 Issue）
+3. 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 复用 Issue milestone 构建 `{milestone-arg}`
+4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入
+5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价关闭关键字
 
-如果上述规则判定应跳过直接元数据参数写入，则只保留 PR 正文中的关联信息与后续评论同步。
+如果规则要求跳过上述直接元数据参数，则只保留 PR 正文关联和后续评论同步。
 
 Milestone 规则：
-- 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」处理
-- PR 直接复用 Issue milestone，不再独立推断
+- 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 执行
+- 直接复用关联 Issue 的 milestone，不为 PR 重新推断
 
 ## 创建 PR
 
-- 当当前工作属于活动任务时，从 task.md 中提取 `issue_number`
-- 如果存在 `issue_number`，先完成前置步骤中的代码托管平台检测，再按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询对应 Issue
-- 在调用 PR 创建命令前，先检查当前分支是否已经存在 PR；如果已存在，直接告知用户 PR URL 和状态并结束，不要重复同步元数据或摘要
-- 使用 HEREDOC 传递 PR 正文
-- 如果模板中存在 `{$IssueNumber}`，替换它
-- PR 正文结尾必须带上 `Generated with AI assistance`
+- 当前工作属于 active task 时，从 task.md 提取 `issue_number`
+- 如果存在 `issue_number`，先完成代码托管平台检测，再通过 `.agents/rules/issue-pr-commands.md` 查询 Issue
+- 调用 PR 创建命令前，先检查当前分支是否已有 PR；若已有，报告 PR URL 和状态后停止，不重复执行元数据同步或 summary 发布
+- 使用 HEREDOC 传入 PR 正文
+- 模板中存在 `{$IssueNumber}` 时进行替换
+- PR 正文以 `Generated with AI assistance` 结尾
 
-创建 PR 时，使用 `.agents/rules/issue-pr-commands.md` 中的 “创建 PR” 命令模板。
+使用 `.agents/rules/issue-pr-commands.md` 中的创建 PR 命令模板创建 PR。
 
-最终用户输出必须按顺序包含以下后续动作：
+最终用户输出应包含以下后续路径：
 
 ```text
-下一步：
-  - 工作流真正结束后完成任务：
+Next steps:
+  - complete the task after the workflow truly finishes:
     - Claude Code / OpenCode: /complete-task {task-id}
     - Gemini CLI: /agent-infra:complete-task {task-id}
     - Codex CLI: $complete-task {task-id}

--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -128,18 +128,18 @@ git log v<prev-version>..v<version> \
 3. 描述：使用 PR 标题，移除 `type(scope):` 前缀，首字母大写
 4. **贡献者搜集**：
    - **数据源**：
-     - PR author：来自步骤 4 的 `gh pr list --json author`
+     - PR author：来自 `.agents/rules/release-commands.md` 中已合并 PR 查询规则
      - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters：来自步骤 5 收集的关联 Issue 的 author（`gh issue view` 返回的 `author.login`）
+     - Issue reporters：来自步骤 5 收集的关联 Issue author（由 `.agents/rules/release-commands.md` 返回）
    - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
    - **Name → `@login` 映射**：
-     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 GitHub `@login`
-     - 优先从 email 提取：匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com` 时，取第二个捕获组并转为小写；该正则同时覆盖 `{id}+{login}@users.noreply.github.com` 与 `{login}@users.noreply.github.com`
+     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 platform `@login`
+     - 优先从 email 提取：匹配 `.agents/rules/release-commands.md` 中的平台 no-reply 邮箱规则时，按该规则推导小写 login
      - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
      - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
      - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
      - Bot 身份保留原样（如 `dependabot[bot]`）
-     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 GitHub login -->`
+     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 platform login -->`
    - **排序**：按贡献数降序；贡献数相同时按 login 字典序
    - **去重**：以最终映射后的 `@login` 为键
    - **Issue reporter 规则**：
@@ -156,7 +156,7 @@ git log v<prev-version>..v<version> \
 
 询问：
 1. 需要调整吗？
-2. 是否创建 GitHub Draft Release？
+2. 是否创建 draft release？
 
 ### 9. 创建 Draft Release（如确认）
 
@@ -170,7 +170,7 @@ Draft Release created.
 - Version: v{version}
 - Status: Draft
 
-Please review and publish on GitHub:
+Please review and publish on the platform:
 1. Open the URL above
 2. Review the release notes
 3. Click "Publish release"
@@ -178,7 +178,7 @@ Please review and publish on GitHub:
 
 ## 注意事项
 
-1. **需要 gh CLI**：必须安装并认证 GitHub CLI
+1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
 3. **草稿模式**：创建草稿 —— 不会自动发布
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
@@ -187,5 +187,5 @@ Please review and publish on GitHub:
 
 - 版本格式无效：提示正确格式
 - 标签未找到：建议先执行 release 技能
-- gh 未认证：提示进行认证
+- 平台 CLI 未认证：提示用户认证
 - 未找到已合并的 PR：提示检查标签和分支

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -137,7 +137,7 @@ node .agents/scripts/validate-artifact.js gate create-task .agents/workspace/act
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 
-或先创建 GitHub Issue：
+或先创建 Issue：
   - Claude Code / OpenCode：/create-issue {task-id}
   - Gemini CLI：/agent-infra:create-issue {task-id}
   - Codex CLI：$create-issue {task-id}
@@ -161,8 +161,8 @@ node .agents/scripts/validate-artifact.js gate create-task .agents/workspace/act
 ## 注意事项
 
 1. **清晰度**：如果用户描述模糊或缺少关键信息，先要求澄清
-2. **与 import-issue 的区别**：`import-issue` 从 GitHub Issue 导入任务；`create-task` 从自由描述创建
-3. **工作流顺序**：创建任务后，通常先执行 `analyze-task` 再进入 `plan-task`；如需先建立 GitHub 跟踪，也可先执行 `create-issue`
+2. **与 import-issue 的区别**：`import-issue` 从 Issue 导入任务；`create-task` 从自由描述创建
+3. **工作流顺序**：创建任务后，通常先执行 `analyze-task` 再进入 `plan-task`；如需先建立 平台跟踪，也可先执行 `create-issue`
 
 ## 错误处理
 

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -95,7 +95,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{implementation-artifact}` 评论
 
 ### 10. 完成校验

--- a/.agents/skills/implement-task/config/verify.json
+++ b/.agents/skills/implement-task/config/verify.json
@@ -36,7 +36,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -25,7 +25,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 - `rule`：规则信息（id、severity、description、security_severity_level）
 - `tool`：扫描工具信息（name、version）
 - `most_recent_instance`：位置（path、start_line、end_line）、消息
-- `html_url`：GitHub 告警链接
+- `html_url`：平台告警链接
 
 ### 2. 创建任务目录和文件
 

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: import-issue
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 ---
 
 # 导入 Issue
 
-导入指定的 GitHub Issue 并创建任务。参数：issue 编号。
+导入指定的 Issue 并创建任务。参数：issue 编号。
 
 ## 行为边界 / 关键规则
 
@@ -38,7 +38,7 @@ node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-numb
 
 - 脚本输出 `found=false`：按新 Issue 导入流程创建新任务
 - 脚本输出 `found=true`：复用 `task_id`
-- 脚本退出码 2：视为网络、认证或 GitHub API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
+- 脚本退出码 2：视为网络、认证或 platform API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
 
 ### 3. 创建任务目录和文件
 
@@ -109,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 检查 Issue 当前 milestone；如果未设置，先读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 1：`create-issue`」规则推断并设置 milestone；如果 `has_triage=false` 或推断不确定，跳过并继续
-- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
+- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 7. 完成校验
 
@@ -173,5 +173,5 @@ Issue #{number} 已导入。
 ## 错误处理
 
 - Issue 未找到：提示 "Issue #{number} not found, please check the issue number"
-- 网络错误：提示 "Cannot connect to GitHub, please check network"
+- 网络错误：提示 "Cannot connect to the platform, please check network"
 - 权限错误：提示 "No access to this repository"

--- a/.agents/skills/init-labels/SKILL.md
+++ b/.agents/skills/init-labels/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: init-labels
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 ---
 
-# 初始化 GitHub Labels
+# 初始化 labels
 
-一次性初始化仓库的标准 GitHub Labels 体系。
+一次性初始化仓库的标准 labels 体系。
 
 ## 执行流程
 
@@ -36,14 +36,14 @@ bash .agents/skills/init-labels/scripts/init-labels.sh
 脚本管理以下通用 label 族：
 - `type:` labels，例如 `type: bug`、`type: enhancement`、`type: feature`、`type: documentation`、`type: dependency-upgrade`、`type: task`
 - `status:` labels，例如 `status: waiting-for-triage`、`status: in-progress`、`status: waiting-for-internal-feedback`
-- 明确覆盖的 GitHub 默认同名 labels：`good first issue` 和 `help wanted`
+- 明确覆盖的 平台默认同名 labels：`good first issue` 和 `help wanted`
 - 额外通用 labels，例如 `dependencies`
 
 #### 适用范围
 
 | Label 前缀 | Issue | PR | 说明 |
 |---|---|---|---|
-| `type:` | — | Yes | Issue 使用 GitHub 原生 Type 字段；PR 无原生类型字段，需 `type:` label 驱动 changelog |
+| `type:` | — | Yes | Issue 使用 平台原生 Type 字段；PR 无原生类型字段，需 `type:` label 驱动 changelog |
 | `status:` | Yes | — | PR 有自身状态流转（Open/Draft/Merged/Closed）；Issue 使用 `status:` label 标记项目管理状态 |
 | `in:` | Yes | Yes | Issue 和 PR 均需按模块筛选 |
 
@@ -98,8 +98,8 @@ bash .agents/skills/init-labels/scripts/init-labels.sh
 
 ## 错误处理
 
-- 未找到 `gh`：提示 "GitHub CLI (`gh`) is not installed"
-- 认证失败：提示 "GitHub CLI is not authenticated"
-- 仓库访问失败：提示 "Unable to access the current repository with gh"
+- 未找到平台 CLI：提示 "the platform CLI is not installed"
+- 认证失败：提示 "the platform CLI is not authenticated"
+- 仓库访问失败：提示 "Unable to access the current repository with the platform CLI"
 - 权限不足：提示 "No permission to manage labels in this repository"
-- API 限流：提示 "GitHub API rate limit reached, please retry later"
+- API 限流：提示 "platform API rate limit reached, please retry later"

--- a/.agents/skills/init-milestones/SKILL.md
+++ b/.agents/skills/init-milestones/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: init-milestones
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 ---
 
-# 初始化 GitHub Milestones
+# 初始化 milestones
 
-一次性初始化仓库的标准 GitHub Milestones 体系。
+一次性初始化仓库的标准 milestones 体系。
 
 ## 执行流程
 
@@ -75,10 +75,10 @@ bash .agents/skills/init-milestones/scripts/init-milestones.sh "$ARGUMENTS"
 
 ## 错误处理
 
-- 未找到 `gh`：提示 "GitHub CLI (`gh`) is not installed"
-- 认证失败：提示 "GitHub CLI is not authenticated"
-- 仓库访问失败：提示 "Unable to access the current repository with gh"
+- 未找到平台 CLI：提示 "the platform CLI is not installed"
+- 认证失败：提示 "the platform CLI is not authenticated"
+- 仓库访问失败：提示 "Unable to access the current repository with the platform CLI"
 - 版本解析失败：提示 "Unable to determine current version baseline"
 - `--history` 模式下未找到任何 `v*` git tags：提示 "No history tags found matching v*; only standard milestones will be created"
 - 权限不足：提示 "No permission to manage milestones in this repository"
-- API 限流：提示 "GitHub API rate limit reached, please retry later"
+- API 限流：提示 "platform API rate limit reached, please retry later"

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -99,7 +99,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{plan-artifact}` 评论
 
 ### 8. 完成校验

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -38,7 +38,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "pendingDesignWork",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -62,7 +62,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{refinement-artifact}` 评论
 
 ### 7. 完成校验

--- a/.agents/skills/refine-task/config/verify.json
+++ b/.agents/skills/refine-task/config/verify.json
@@ -32,7 +32,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -129,7 +129,7 @@ bash .agents/skills/release/scripts/manage-milestones.sh "$MAJOR" "$MINOR" "$PAT
 
 2. 推送标签：
    git push origin v{version}
-   推送后将自动触发 GitHub Release 创建和 npm 发布
+   推送后将自动触发 release 创建和 npm 发布
 
 3.（可选）生成发布说明：
    - Claude Code / OpenCode：/create-release-note {version}

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -9,7 +9,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 行为边界 / 关键规则
 
-- 只从带 `<!-- sync-issue:{task-id}:... -->` 标记的评论恢复文件
+- 只从匹配 `.agents/rules/issue-sync.md` 标记注册表的评论恢复文件
 - 默认恢复到 `.agents/workspace/active/{task-id}/`
 - 如果目标目录已存在，立即停止并提示用户先处理目录冲突
 - 执行本技能后，你**必须**立即更新恢复出的 `task.md`
@@ -31,16 +31,11 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ### 3. 确定 task-id 与待恢复文件
 
-从评论中筛选隐藏标记：
-
-```html
-<!-- sync-issue:{task-id}:{file-stem} -->
-<!-- sync-issue:{task-id}:{file-stem}:{part}/{total} -->
-```
+按 `.agents/rules/issue-sync.md` 中定义的 task、artifact 和分片 artifact 标记筛选评论。
 
 处理规则：
 - 用户提供了 `{task-id}` 时，仅匹配该任务
-- 未提供时，优先从 `<!-- sync-issue:{task-id}:task -->` 评论推断
+- 未提供时，优先从 task 评论标记推断
 - 若找不到唯一 task-id，立即停止并告知用户
 - 忽略 `summary` 标记评论；它是 complete-task 的聚合产物，不对应本地任务文件
 - 将 `{file-stem}` 映射回文件名：
@@ -58,7 +53,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 对每个文件执行：
 - 收集单条评论或分片评论
 - 对 `task.md` 评论按 issue-sync.md 中的 `<details>` frontmatter 格式反向拆解，提取 frontmatter 后再与正文拼合
-- 如存在 `{part}/{total}`，按 part 升序排序并校验分片完整
+- 如分片标记中存在 part 和 total 序号，按 part 升序排序并校验分片完整
 - 从评论正文中提取文件内容，去掉隐藏标记、标题和页脚
 - 拼接得到最终文件内容
 
@@ -88,66 +83,20 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：`active`
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
-- 保留原 `current_step`
-- 在 `## 活动日志` 追加：
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
-  ```
 
-### 7. 完成校验
+追加 Activity Log，说明任务已从平台 Issue 还原。
 
-运行完成校验：
+### 7. 告知用户
 
-```bash
-node .agents/scripts/validate-artifact.js gate restore-task .agents/workspace/active/{task-id} --format text
-```
-
-处理结果：
-- 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- 退出码 1（校验失败）-> 根据输出修复问题后重新运行校验
-- 退出码 2（网络中断）-> 停止执行并告知用户需要人工介入
-
-将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
-
-### 8. 告知用户
-
-> 仅在校验通过后执行本步骤。
-
-> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
-
-输出格式：
-
-```text
-任务 {task-id} 已从 Issue #{issue-number} 还原。
-
-摘要：
-- 恢复文件：{数量}
-- 任务目录：.agents/workspace/active/{task-id}/
-- 当前步骤：{current_step}
-
-下一步 - 查看任务状态：
-  - Claude Code / OpenCode：/check-task {task-id}
-  - Gemini CLI：/agent-infra:check-task {task-id}
-  - Codex CLI：$check-task {task-id}
-```
+报告已恢复的 task id、恢复文件数量和 active task 目录。
 
 ## 完成检查清单
 
-- [ ] 已获取并解析 Issue 评论
-- [ ] 已还原 `task.md` 和所有可用产物文件
-- [ ] 已更新恢复后的 task.md
-- [ ] 已运行并通过完成校验
-- [ ] 已向用户展示所有 TUI 格式的下一步命令（含自定义 TUI）
+- [ ] 已从平台获取 Issue 评论
+- [ ] 已恢复本地任务文件
+- [ ] 已更新恢复出的任务元数据
+- [ ] 已报告恢复目录
 
-## 停止
+### 8. 停止
 
-完成检查清单后立即停止。不要自动继续执行工作流。
-
-## 错误处理
-
-- Issue 不存在或无权访问
-- 平台 CLI 未认证
-- 找不到带 sync 标记的评论
-- 无法唯一确定 `task-id`
-- 目标目录已存在
-- 分片缺失或顺序不完整
+完成检查清单后立即停止。不要自动提交。

--- a/.agents/skills/review-task/SKILL.md
+++ b/.agents/skills/review-task/SKILL.md
@@ -56,7 +56,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{review-artifact}` 评论
 
 ### 7. 完成校验

--- a/.agents/skills/review-task/config/verify.json
+++ b/.agents/skills/review-task/config/verify.json
@@ -36,7 +36,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,5 +1,5 @@
 ---
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 usage: "/create-issue <task-id>"
 ---
 

--- a/.claude/commands/import-issue.md
+++ b/.claude/commands/import-issue.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 usage: "/import-issue <issue-number>"
 ---
 

--- a/.claude/commands/init-labels.md
+++ b/.claude/commands/init-labels.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 disable-model-invocation: true
 ---
 

--- a/.claude/commands/init-milestones.md
+++ b/.claude/commands/init-milestones.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 usage: "/init-milestones [--history]"
 disable-model-invocation: true
 ---

--- a/.claude/commands/restore-task.md
+++ b/.claude/commands/restore-task.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 评论还原本地任务文件"
+description: "从 Issue 评论还原本地任务文件"
 usage: "/restore-task <issue-number> [task-id]"
 disable-model-invocation: true
 ---

--- a/.gemini/commands/agent-infra/create-issue.toml
+++ b/.gemini/commands/agent-infra/create-issue.toml
@@ -1,4 +1,4 @@
-description = "从任务文件创建 GitHub Issue"
+description = "从任务文件创建 Issue"
 prompt = """
 为任务 {{args}} 创建 Issue。
 

--- a/.gemini/commands/agent-infra/import-issue.toml
+++ b/.gemini/commands/agent-infra/import-issue.toml
@@ -1,4 +1,4 @@
-description = "从 GitHub Issue 导入并创建任务"
+description = "从 Issue 导入并创建任务"
 prompt = """
 导入 Issue #{{args}}。
 

--- a/.gemini/commands/agent-infra/init-labels.toml
+++ b/.gemini/commands/agent-infra/init-labels.toml
@@ -1,6 +1,6 @@
-description = "初始化仓库的 GitHub Labels 体系"
+description = "初始化仓库的 labels 体系"
 prompt = """
-为 agent-infra 初始化 GitHub Labels。
+为 agent-infra 初始化 labels。
 
 读取并执行 `.agents/skills/init-labels/SKILL.md` 中的 init-labels 技能。
 

--- a/.gemini/commands/agent-infra/init-milestones.toml
+++ b/.gemini/commands/agent-infra/init-milestones.toml
@@ -1,8 +1,8 @@
-description = "初始化仓库的 GitHub Milestones 体系"
+description = "初始化仓库的 milestones 体系"
 prompt = """
 初始化里程碑：{{args}}
 
-为 agent-infra 初始化 GitHub Milestones。
+为 agent-infra 初始化 milestones。
 
 读取并执行 `.agents/skills/init-milestones/SKILL.md` 中的 init-milestones 技能。
 

--- a/.gemini/commands/agent-infra/restore-task.toml
+++ b/.gemini/commands/agent-infra/restore-task.toml
@@ -1,4 +1,4 @@
-description = "从 GitHub Issue 评论还原本地任务文件"
+description = "从 Issue 评论还原本地任务文件"
 prompt = """
 从 Issue 还原任务：{{args}}
 

--- a/.opencode/commands/create-issue.md
+++ b/.opencode/commands/create-issue.md
@@ -1,5 +1,5 @@
 ---
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 agent: general
 subtask: false
 ---

--- a/.opencode/commands/import-issue.md
+++ b/.opencode/commands/import-issue.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 agent: general
 subtask: false
 ---

--- a/.opencode/commands/init-labels.md
+++ b/.opencode/commands/init-labels.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 agent: general
 subtask: false
 ---

--- a/.opencode/commands/init-milestones.md
+++ b/.opencode/commands/init-milestones.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 agent: general
 subtask: false
 ---

--- a/.opencode/commands/restore-task.md
+++ b/.opencode/commands/restore-task.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 评论还原本地任务文件"
+description: "从 Issue 评论还原本地任务文件"
 agent: general
 subtask: false
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,41 @@ npm test
 - 模板文件使用 `{{project}}` 和 `{{org}}` 作为渲染占位符
 - 面向用户的 Markdown 文件提供双语版本（英文为主 + 中文翻译），如 README、SECURITY
 
+### 平台无关层与平台层
+
+本仓库的模板需要区分平台无关 baseline 与平台特定实现。平台特定内容只能放在以下位置：
+
+- `.agents/rules/*.{platform}.md`
+- `.agents/scripts/platform-adapters/platform-sync.{platform}.js`
+- 明确属于平台集成的脚本或工作流目录
+
+除上述位置外，`SKILL.md`、`reference/*.md`、命令面板、QUICKSTART、README 等 baseline 文件必须保持平台无关。baseline 文件应引用 `.agents/rules/*.md` 或 `.agents/scripts/` 中的抽象入口，不直接写入平台命令、路径或 schema。
+
+判断平台耦合时，先检查这些硬指标：
+
+- 平台名，如 `GitHub`
+- 平台路径，如 `.github/`
+- 平台 CLI，如 `gh CLI` 或以 `gh ` 开头的命令
+
+还要人工检查这些软指标：
+
+- 平台特定 schema 字段名，如 GitHub Issue Forms 的 `textarea`、`input`、`dropdown`、`checkboxes`、`attributes.label`
+- 平台文件命名约定，如 `.yml` Issue Form 文件名、`PULL_REQUEST_TEMPLATE.md`
+- 已在 rules/scripts 中定义过的命令或 marker 字符串副本
+
+`tests/templates/platform-coupling.test.js` 提供结构性护栏：baseline 文案不得含平台硬指标，skill reference 目录不得新增 `.github.*` 这类平台变体。测试不能覆盖所有软指标，PR 作者和 reviewer 仍需人工检查 schema 字段、命令重复和措辞包装。
+
+示例：
+
+- 反例：在 `templates/.agents/skills/create-pr/reference/pr-body-template.en.md` 中直接写 `gh pr list --limit 3 --state merged`
+- 正例：baseline reference 写“按 `.agents/rules/issue-pr-commands.md` 的最近 PR 查询命令执行”，GitHub 具体命令只放在 `issue-pr-commands.github.en.md`
+
+已采纳的架构决策：
+
+- `verify.json` 应优先通过 `expected_*_key` 引用平台 adapter 的默认值，而不是复制 marker 或 status label 字符串。
+- `platform-sync.{platform}.js#getDefaults()` 是平台默认 marker 和 status label 的单一信息源。
+- 这个 key-based 抽象是为多平台扩展保留的设计：把 N 个 skill × M 个平台的配置成本收敛为 N 个 key 引用 + M 个 adapter 默认值。
+
 ### 构建架构
 
 - `src/sync-templates.js` 是开发源码，保留可读的源码结构和对 `lib/` 数据文件的标准读取方式。

--- a/templates/.agents/QUICKSTART.en.md
+++ b/templates/.agents/QUICKSTART.en.md
@@ -16,7 +16,7 @@ Enable the shared Git hooks path before relying on the template hook chain:
 git config core.hooksPath .github/hooks
 ```
 
-This makes Git invoke the hooks synced into `.github/hooks/`, including `pre-commit` and `check-version-format.sh`.
+This makes Git invoke the hooks in the project repository's `.github/hooks/` directory, including `pre-commit` and `check-version-format.sh`.
 
 ## External Templates And Skills
 

--- a/templates/.agents/QUICKSTART.zh-CN.md
+++ b/templates/.agents/QUICKSTART.zh-CN.md
@@ -16,7 +16,7 @@
 git config core.hooksPath .github/hooks
 ```
 
-这样 Git 才会调用同步到 `.github/hooks/` 下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
+这样 Git 才会调用项目仓库 `.github/hooks/` 目录下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
 
 ## 外部模板与 Skill
 

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -108,7 +108,7 @@ This project uses the following collaboration label prefixes, each with a define
 | `status:` | Yes | — | PRs already have their own state flow (Open / Draft / Merged / Closed); Issues use `status:` labels for project tracking states |
 | `in:` | Yes | Yes | Both Issues and PRs can be filtered by module |
 
-The default GitHub setup initializes these labels with the `/init-labels` command.
+Run the `/init-labels` command to initialize these labels via the platform adapter.
 
 ## Private Platform Extensions
 

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -108,7 +108,7 @@
 | `status:` | Yes | — | PR 有自身状态流转（Open / Draft / Merged / Closed）；Issue 使用 `status:` label 标记等待反馈、已确认等项目管理状态 |
 | `in:` | Yes | Yes | Issue 和 PR 均可按模块筛选 |
 
-默认 GitHub 配置下，可使用 `/init-labels` 命令一次性创建标准 labels。
+使用 `/init-labels` 命令可通过平台适配器一次性创建标准 labels。
 
 ## 私有平台扩展
 

--- a/templates/.agents/rules/issue-pr-commands.github.en.md
+++ b/templates/.agents/rules/issue-pr-commands.github.en.md
@@ -22,6 +22,44 @@ Before any later `gh issue` or `gh api "repos/..."` call, follow `.agents/rules/
 - keep `gh pr *` commands on the current repository without adding `-R`
 - keep organization-scoped commands such as `gh api "orgs/{owner}/..."` unchanged
 
+## Issue Template Detection
+
+Detect GitHub Issue Forms with:
+
+```bash
+rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
+```
+
+Read matching form files locally before creating the Issue. If the directory is missing or no form matches the task, use the caller's fallback body format.
+
+Typical candidate templates:
+- `bug_report.yml` for bug work
+- `question.yml` for question or investigation work
+- `feature_request.yml` for feature work
+- `documentation.yml` for documentation work
+- `other.yml` as the general fallback
+
+For GitHub Issue Forms, inspect the matched form's:
+- `name`
+- `type:`
+- `labels:`
+- `body:`
+
+Field handling rules:
+- `textarea` and `input`: use `attributes.label` as the markdown heading and fill values from task.md
+- `markdown`: skip template explanation prose
+- `dropdown` and `checkboxes`: skip
+- when task.md lacks a suitable value, write `N/A`
+
+Suggested field mapping:
+
+| Template field hint | task.md source |
+|---|---|
+| `summary`, `title` | task title |
+| `description`, `problem`, `what happened`, `issue-description`, `current-content` | task description |
+| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | requirements list |
+| other `textarea` / `input` fields | task description, otherwise `N/A` |
+
 ## Read and Create Issues
 
 Read an Issue:
@@ -81,6 +119,28 @@ Read Issue comments or search for existing hidden markers:
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}/comments" --paginate
 ```
+
+## PR Template and Metadata Helpers
+
+Read a repository PR template when present:
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+Review recent merged PRs for style:
+
+```bash
+gh pr list --limit 3 --state merged --json number,title,body
+```
+
+Verify that standard type labels exist before PR metadata sync:
+
+```bash
+gh label list --search "type:" --limit 1 --json name --jq 'length'
+```
+
+If the result is `0`, run `init-labels` before retrying PR metadata sync.
 
 ## Read and Create PRs
 

--- a/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
+++ b/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
@@ -22,6 +22,44 @@ gh repo view --json nameWithOwner
 - `gh pr *` 命令保持作用于当前仓库，不额外加 `-R`
 - `gh api "orgs/{owner}/..."` 这类 org 级命令保持不变
 
+## Issue 模板检测
+
+使用以下命令检测 GitHub Issue Forms：
+
+```bash
+rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
+```
+
+创建 Issue 前先读取匹配的 form 文件。目录不存在或没有匹配 form 时，使用调用方定义的 fallback 正文格式。
+
+常见候选模板：
+- `bug_report.yml`：bug 工作
+- `question.yml`：问题或排查工作
+- `feature_request.yml`：功能工作
+- `documentation.yml`：文档工作
+- `other.yml`：通用 fallback
+
+对 GitHub Issue Forms，检查匹配 form 的：
+- `name`
+- `type:`
+- `labels:`
+- `body:`
+
+字段处理规则：
+- `textarea` 和 `input`：使用 `attributes.label` 作为 markdown 标题，并从 task.md 填充值
+- `markdown`：跳过模板说明文案
+- `dropdown` 和 `checkboxes`：跳过
+- task.md 缺少合适值时，写入 `N/A`
+
+建议字段映射：
+
+| 模板字段提示 | task.md 来源 |
+|---|---|
+| `summary`, `title` | 任务标题 |
+| `description`, `problem`, `what happened`, `issue-description`, `current-content` | 任务描述 |
+| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | 需求列表 |
+| 其他 `textarea` / `input` 字段 | 任务描述，否则 `N/A` |
+
 ## Issue 读取与创建
 
 读取 Issue：
@@ -81,6 +119,28 @@ gh issue close {issue-number} -R "$upstream_repo" --reason "{reason}"
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}/comments" --paginate
 ```
+
+## PR 模板与元数据辅助命令
+
+存在仓库 PR 模板时读取：
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+参考最近合并的 PR 风格：
+
+```bash
+gh pr list --limit 3 --state merged --json number,title,body
+```
+
+PR 元数据同步前验证标准 type labels 是否存在：
+
+```bash
+gh label list --search "type:" --limit 1 --json name --jq 'length'
+```
+
+如果结果是 `0`，先运行 `init-labels`，再重试 PR 元数据同步。
 
 ## PR 读取与创建
 

--- a/templates/.agents/rules/issue-sync.en.md
+++ b/templates/.agents/rules/issue-sync.en.md
@@ -1,5 +1,19 @@
 # Issue Sync
 
+## Marker Registry
+
+These hidden markers are the canonical registry for Issue synchronization:
+
+| Key | Marker |
+|---|---|
+| `task` | `<!-- sync-issue:{task-id}:task -->` |
+| `artifact` | `<!-- sync-issue:{task-id}:{artifact-stem} -->` |
+| `artifactChunk` | `<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->` |
+| `summary` | `<!-- sync-issue:{task-id}:summary -->` |
+| `cancel` | `<!-- sync-issue:{task-id}:cancel -->` |
+
+Callers should refer to the marker key in skill prose and keep concrete marker strings in this rule or the platform adapter defaults.
+
 This code platform does not provide built-in issue synchronization.
 
 Issue metadata, labels, milestones, assignees, and comments are skipped for custom platforms unless you provide matching `.{platform}.en.md` rule templates and platform adapters. Continue writing local task artifacts normally.

--- a/templates/.agents/rules/issue-sync.github.en.md
+++ b/templates/.agents/rules/issue-sync.github.en.md
@@ -1,5 +1,19 @@
 # Issue Sync Rules
 
+## Marker Registry
+
+These hidden markers are the canonical registry for Issue synchronization:
+
+| Key | Marker |
+|---|---|
+| `task` | `<!-- sync-issue:{task-id}:task -->` |
+| `artifact` | `<!-- sync-issue:{task-id}:{artifact-stem} -->` |
+| `artifactChunk` | `<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->` |
+| `summary` | `<!-- sync-issue:{task-id}:summary -->` |
+| `cancel` | `<!-- sync-issue:{task-id}:cancel -->` |
+
+Callers should refer to the marker key in skill prose and keep concrete marker strings in this rule or the platform adapter defaults.
+
 Read this file before a task skill updates a GitHub Issue.
 
 ## Upstream Repository Detection

--- a/templates/.agents/rules/issue-sync.github.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.github.zh-CN.md
@@ -1,5 +1,19 @@
 # Issue 同步规则
 
+## Marker 注册表
+
+以下隐藏标记是 Issue 同步的唯一权威注册表：
+
+| Key | Marker |
+|---|---|
+| `task` | `<!-- sync-issue:{task-id}:task -->` |
+| `artifact` | `<!-- sync-issue:{task-id}:{artifact-stem} -->` |
+| `artifactChunk` | `<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->` |
+| `summary` | `<!-- sync-issue:{task-id}:summary -->` |
+| `cancel` | `<!-- sync-issue:{task-id}:cancel -->` |
+
+Skill 正文应引用 marker key，具体 marker 字符串只保留在本规则或平台适配器默认值中。
+
 在任务技能需要更新 GitHub Issue 时先读取本文件。
 
 ## Upstream 仓库检测

--- a/templates/.agents/rules/issue-sync.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.zh-CN.md
@@ -1,5 +1,19 @@
 # Issue 同步
 
+## Marker 注册表
+
+以下隐藏标记是 Issue 同步的唯一权威注册表：
+
+| Key | Marker |
+|---|---|
+| `task` | `<!-- sync-issue:{task-id}:task -->` |
+| `artifact` | `<!-- sync-issue:{task-id}:{artifact-stem} -->` |
+| `artifactChunk` | `<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->` |
+| `summary` | `<!-- sync-issue:{task-id}:summary -->` |
+| `cancel` | `<!-- sync-issue:{task-id}:cancel -->` |
+
+Skill 正文应引用 marker key，具体 marker 字符串只保留在本规则或平台适配器默认值中。
+
 当前代码平台未内置 Issue 同步支持。
 
 自定义平台会跳过 Issue 元数据、标签、里程碑、负责人和评论同步，除非你提供匹配的 `.{platform}.zh-CN.md` 规则模板和平台适配器。请继续正常写入本地任务产物。

--- a/templates/.agents/rules/label-milestone-setup.github.en.md
+++ b/templates/.agents/rules/label-milestone-setup.github.en.md
@@ -43,6 +43,16 @@ Update a milestone:
 gh api "repos/$repo/milestones/{number}" -X PATCH -f state="{state}" -f description="{description}"
 ```
 
+## Error Prompt Templates
+
+Use these normalized prompts when the GitHub setup scripts fail:
+
+| Condition | Prompt |
+|---|---|
+| CLI missing | GitHub CLI (`gh`) is not installed |
+| Authentication failed | `GitHub CLI is not authenticated` |
+| API rate limit | `GitHub API rate limit reached, please retry later` |
+
 ## Constraints
 
 - use label names as the idempotency key

--- a/templates/.agents/rules/label-milestone-setup.github.zh-CN.md
+++ b/templates/.agents/rules/label-milestone-setup.github.zh-CN.md
@@ -43,6 +43,16 @@ gh api "repos/$repo/milestones" -f title="{title}" -f description="{description}
 gh api "repos/$repo/milestones/{number}" -X PATCH -f state="{state}" -f description="{description}"
 ```
 
+## 错误提示模板
+
+GitHub 初始化脚本失败时使用以下标准提示：
+
+| 条件 | 提示 |
+|---|---|
+| CLI 缺失 | GitHub CLI (`gh`) is not installed |
+| 认证失败 | `GitHub CLI is not authenticated` |
+| API 限流 | `GitHub API rate limit reached, please retry later` |
+
 ## 约束
 
 - label 以名称作为幂等键

--- a/templates/.agents/rules/release-commands.github.en.md
+++ b/templates/.agents/rules/release-commands.github.en.md
@@ -21,6 +21,22 @@ When needed, read the linked Issue:
 gh issue view {issue-number} --json number,title,labels,url
 ```
 
+## Contributor Mapping Helpers
+
+Merged PR queries used for release notes should include authors when contributors are needed:
+
+```bash
+gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
+```
+
+Linked Issue queries used for reporter attribution should include the author:
+
+```bash
+gh issue view {issue-number} --json number,title,labels,url,author
+```
+
+Map GitHub no-reply emails with this rule: if `Name <email>` contains an email matching `(\d+\+)?(\S+?)@users\.noreply\.github\.com`, use the second capture group lowercased as the login. This covers both `{id}+{login}@users.noreply.github.com` and `{login}@users.noreply.github.com`.
+
 ## Create a Draft Release
 
 ```bash

--- a/templates/.agents/rules/release-commands.github.zh-CN.md
+++ b/templates/.agents/rules/release-commands.github.zh-CN.md
@@ -21,6 +21,22 @@ gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels
 gh issue view {issue-number} --json number,title,labels,url
 ```
 
+## Contributor 映射辅助规则
+
+release notes 需要 contributors 时，已合并 PR 查询应包含 author：
+
+```bash
+gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
+```
+
+关联 Issue 用于 reporter 归因时，查询应包含 author：
+
+```bash
+gh issue view {issue-number} --json number,title,labels,url,author
+```
+
+GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
+
 ## 创建 Draft Release
 
 ```bash

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -9,6 +9,26 @@ const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
 let activeShared = null;
 let repoRoot = "";
 
+export function getDefaults() {
+  return {
+    statusLabels: {
+      pendingDesignWork: "status: pending-design-work",
+      inProgress: "status: in-progress",
+      blocked: "status: blocked",
+      completed: "status: completed",
+      waitingForTriage: "status: waiting-for-triage"
+    },
+    markers: {
+      task: "<!-- sync-issue:{task-id}:task -->",
+      artifact: "<!-- sync-issue:{task-id}:{artifact-stem} -->",
+      artifactChunk: "<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->",
+      summary: "<!-- sync-issue:{task-id}:summary -->",
+      cancel: "<!-- sync-issue:{task-id}:cancel -->",
+      prSummary: "<!-- sync-pr:{task-id}:summary -->"
+    }
+  };
+}
+
 function getShared() {
   if (!activeShared) {
     throw new Error("platform-sync adapter shared utilities are unavailable");
@@ -124,12 +144,16 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
   }
   const permissions = detectPermissions(upstreamRepo.value, taskDir);
+  const expectedValues = resolveExpectedValues(config);
+  if (!expectedValues.ok) {
+    return { earlyReturn: failResult(CHECK_TYPE, expectedValues.message, "check_failed") };
+  }
 
-  const marker = config.expected_comment_marker
-    ? interpolate(config.expected_comment_marker, taskDir, artifactFile)
+  const marker = expectedValues.commentMarker
+    ? interpolate(expectedValues.commentMarker, taskDir, artifactFile)
     : null;
-  const prMarker = config.expected_pr_comment_marker
-    ? interpolate(config.expected_pr_comment_marker, taskDir, artifactFile)
+  const prMarker = expectedValues.prCommentMarker
+    ? interpolate(expectedValues.prCommentMarker, taskDir, artifactFile)
     : null;
   const artifactPath = artifactFile ? path.join(taskDir, artifactFile) : null;
 
@@ -144,9 +168,63 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     upstreamRepo: upstreamRepo.value,
     hasTriage: permissions.hasTriage,
     hasPush: permissions.hasPush,
+    expectedStatusLabel: expectedValues.statusLabel,
     marker,
     prMarker
   };
+}
+
+function resolveExpectedValues(config) {
+  const defaults = getDefaults();
+  const statusLabel = resolveDefaultValue({
+    collection: defaults.statusLabels,
+    key: config.expected_status_label_key,
+    value: config.expected_status_label,
+    configKey: "expected_status_label_key"
+  });
+  if (!statusLabel.ok) {
+    return statusLabel;
+  }
+
+  const commentMarker = resolveDefaultValue({
+    collection: defaults.markers,
+    key: config.expected_comment_marker_key,
+    value: config.expected_comment_marker,
+    configKey: "expected_comment_marker_key"
+  });
+  if (!commentMarker.ok) {
+    return commentMarker;
+  }
+
+  const prCommentMarker = resolveDefaultValue({
+    collection: defaults.markers,
+    key: config.expected_pr_comment_marker_key,
+    value: config.expected_pr_comment_marker,
+    configKey: "expected_pr_comment_marker_key"
+  });
+  if (!prCommentMarker.ok) {
+    return prCommentMarker;
+  }
+
+  return {
+    ok: true,
+    statusLabel: statusLabel.value,
+    commentMarker: commentMarker.value,
+    prCommentMarker: prCommentMarker.value
+  };
+}
+
+function resolveDefaultValue({ collection, key, value, configKey }) {
+  if (!key) {
+    return { ok: true, value: value || null };
+  }
+
+  const resolvedValue = collection[key];
+  if (!resolvedValue) {
+    return { ok: false, message: `Unknown ${configKey}: ${key}` };
+  }
+
+  return { ok: true, value: resolvedValue };
 }
 
 function fetchRemoteData(context) {
@@ -209,7 +287,7 @@ function fetchRemoteData(context) {
   }
 
   let prComments = null;
-  if (context.config.expected_pr_comment_marker) {
+  if (context.prMarker) {
     if (!context.prNumber) {
       return {
         earlyReturn: failResult(CHECK_TYPE, "Expected a valid pr_number for PR comment verification", "check_failed")
@@ -323,7 +401,9 @@ function mapTaskTypeToLabel(taskType) {
 function shouldFetchComments(config) {
   return Boolean(
     config.expected_comment_marker
+    || config.expected_comment_marker_key
     || config.expected_pr_comment_marker
+    || config.expected_pr_comment_marker_key
     || config.verify_pr_comment_last_commit_matches_head
     || config.verify_comment_content
     || config.verify_task_comment_content
@@ -339,7 +419,7 @@ function flattenComments(value) {
 }
 
 function checkStatusLabel(context, remoteData) {
-  if (!context.config.expected_status_label || !context.hasTriage) {
+  if (!context.expectedStatusLabel || !context.hasTriage) {
     return null;
   }
 
@@ -348,12 +428,12 @@ function checkStatusLabel(context, remoteData) {
   }
 
   const labels = extractLabelNames(remoteData.issue.labels);
-  if (labels.includes(context.config.expected_status_label)) {
+  if (labels.includes(context.expectedStatusLabel)) {
     return null;
   }
 
   return failResult(CHECK_TYPE,
-    `Expected label '${context.config.expected_status_label}' not found on Issue #${context.issueNumber}`,
+    `Expected label '${context.expectedStatusLabel}' not found on Issue #${context.issueNumber}`,
     "check_failed"
   );
 }

--- a/templates/.agents/scripts/platform-adapters/platform-sync.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.js
@@ -1,3 +1,10 @@
+export function getDefaults() {
+  return {
+    statusLabels: {},
+    markers: {}
+  };
+}
+
 export function check(_context, shared) {
   return shared.passResult(
     "platform-sync",

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -41,7 +41,7 @@ Read `task.md` carefully to understand:
 - currently known affected files and constraints
 
 If `task.md` contains these source fields, also read the corresponding source information:
-- `issue_number` - GitHub Issue
+- `issue_number` - Issue
 - `codescan_alert_number` - Code Scanning alert
 - `security_alert_number` - Dependabot alert
 
@@ -70,7 +70,7 @@ Create `.agents/workspace/active/{task-id}/{analysis-artifact}`.
 
 ## Requirement Source
 
-**Source type**: {User description / GitHub Issue / Code Scanning / Dependabot / Other}
+**Source type**: {User description / Issue / Code Scanning / Dependabot / Other}
 **Source summary**:
 > {Task source or key context}
 
@@ -121,7 +121,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: pending-design-work` by following issue-sync.md
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` (follow the task.md comment sync rule in issue-sync.md)
 - Publish the `{analysis-artifact}` comment
 
 ### 7. Verification Gate

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -41,7 +41,7 @@ description: "分析任务并输出需求分析文档"
 - 当前已知的受影响文件和约束
 
 如 `task.md` 包含以下来源字段，补充读取对应来源信息：
-- `issue_number` - GitHub Issue
+- `issue_number` - Issue
 - `codescan_alert_number` - Code Scanning 告警
 - `security_alert_number` - Dependabot 告警
 
@@ -70,7 +70,7 @@ description: "分析任务并输出需求分析文档"
 
 ## 需求来源
 
-**来源类型**：{用户描述 / GitHub Issue / Code Scanning / Dependabot / 其他}
+**来源类型**：{用户描述 / Issue / Code Scanning / Dependabot / 其他}
 **来源摘要**：
 > {任务来源或关键上下文}
 
@@ -121,7 +121,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{analysis-artifact}` 评论
 
 ### 7. 完成校验

--- a/templates/.agents/skills/analyze-task/config/verify.json
+++ b/templates/.agents/skills/analyze-task/config/verify.json
@@ -37,7 +37,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "pendingDesignWork",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/templates/.agents/skills/block-task/config/verify.json
+++ b/templates/.agents/skills/block-task/config/verify.json
@@ -22,7 +22,8 @@
     },
     "platform-sync": {
       "when": "issue_number_exists",
-      "expected_status_label": "status: blocked"
+      "expected_status_label": "status: blocked",
+      "expected_status_label_key": "blocked"
     }
   }
 }

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -79,8 +79,8 @@ If a valid `issue_number` exists:
 - Remove all `in:` labels by following issue-sync.md
 - Remove the milestone by following issue-sync.md
 - Remove all assignees (skip directly when permission is insufficient; no fallback)
-- Publish a cancellation comment using the marker `<!-- sync-issue:{task-id}:cancel -->`
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment using the task-comment sync rules from `.agents/rules/issue-sync.md`
+- Publish a cancellation comment using the cancel marker defined in `.agents/rules/issue-sync.md`
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` using the task-comment sync rules from `.agents/rules/issue-sync.md`
 - Close the Issue by following the "Close an Issue" command in `.agents/rules/issue-pr-commands.md`, using the fixed reason `not planned`
 
 The cancellation comment must include at least:

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -79,8 +79,8 @@ ls .agents/workspace/completed/{task-id}/task.md
 - 按 issue-sync.md 移除所有 `in:` labels
 - 按 issue-sync.md 移除 milestone
 - 移除全部 assignees（无权限时直接跳过，不做替代）
-- 发布取消评论，隐藏标记使用 `<!-- sync-issue:{task-id}:cancel -->`
-- 使用 `.agents/rules/issue-sync.md` 的 task.md 评论同步规则创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论
+- 发布取消评论，隐藏标记使用 `.agents/rules/issue-sync.md` 中定义的 cancel 评论标记
+- 使用 `.agents/rules/issue-sync.md` 的 task.md 评论同步规则创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记
 - 关闭 Issue：按 `.agents/rules/issue-pr-commands.md` 中的“关闭 Issue”命令执行，关闭原因固定为 `not planned`
 
 取消评论至少包含：

--- a/templates/.agents/skills/cancel-task/config/verify.json
+++ b/templates/.agents/skills/cancel-task/config/verify.json
@@ -24,7 +24,8 @@
     "platform-sync": {
       "when": "issue_number_exists",
       "expected_comment_marker": "<!-- sync-issue:{task-id}:cancel -->",
-      "verify_task_comment_content": true
+      "verify_task_comment_content": true,
+      "expected_comment_marker_key": "cancel"
     }
   }
 }

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -61,7 +61,7 @@ Confirm? (y/N)
 
 Dismiss the alert by following the Code Scanning dismiss command in `.agents/rules/security-alerts.md`, passing the mapped `{api-reason}` and the user's explanation.
 
-**API reason mapping** (per the GitHub Code Scanning API):
+**API reason mapping** (per the Code Scanning API):
 - False Positive -> `false positive`
 - Won't Fix -> `won't fix`
 - Used in Tests -> `used in tests`
@@ -96,7 +96,7 @@ Explanation: {explanation}
 
 View: {html_url}
 
-Note: it can be reopened on GitHub if necessary.
+Note: it can be reopened on the platform if necessary.
 
 Next step - complete and archive the task if a related task exists:
   - Claude Code / OpenCode: /complete-task {task-id}

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -61,7 +61,7 @@ Code Scanning 告警 #{alert-number}
 
 按 `.agents/rules/security-alerts.md` 中的 Code Scanning 告警关闭命令执行关闭操作，并传入映射后的 `{api-reason}` 与用户说明。
 
-**API reason 映射**（按 GitHub Code Scanning API）：
+**API reason 映射**（按 Code Scanning API）：
 - 误报 -> `false positive`
 - 不会修复 -> `won't fix`
 - 测试代码 -> `used in tests`
@@ -96,7 +96,7 @@ Code Scanning 告警 #{alert-number} 已关闭。
 
 查看：{html_url}
 
-注意：如有需要，可在 GitHub 上重新打开。
+注意：如有需要，可在 平台上重新打开。
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-id}

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -64,7 +64,7 @@ Failure handling matches "Update Task Status When Applicable": warn, but do **no
 
 ## 7. Sync PR Summary When Applicable
 
-When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR summary comment `<!-- sync-pr:{task-id}:summary -->` on the PR. Otherwise, skip this step.
+When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR summary comment marked with the PR summary marker defined in `.agents/rules/pr-sync.md` on the PR. Otherwise, skip this step.
 
 > The full trigger conditions, aggregation rules, PATCH/POST flow, shell-safety constraints, and error handling live in `reference/pr-summary-sync.md` (which in turn points to `.agents/rules/pr-sync.md`). Read `reference/pr-summary-sync.md` before executing this step.
 >

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -64,7 +64,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ## 7. 同步 PR 摘要（按需）
 
-当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上的 `<!-- sync-pr:{task-id}:summary -->` 摘要评论；否则跳过。
+当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上由 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记对应的摘要评论；否则跳过。
 
 > 完整的触发条件、聚合规则、PATCH/POST 流程、Shell 安全约束和错误处理见 `reference/pr-summary-sync.md`（其内联引用 `.agents/rules/pr-sync.md`）。执行此步骤前先读取 `reference/pr-summary-sync.md`。
 >

--- a/templates/.agents/skills/commit/config/verify.json
+++ b/templates/.agents/skills/commit/config/verify.json
@@ -21,7 +21,8 @@
       "when": "pr_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_computed": true,
-      "verify_pr_comment_last_commit_matches_head": true
+      "verify_pr_comment_last_commit_matches_head": true,
+      "expected_pr_comment_marker_key": "prSummary"
     }
   }
 }

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -93,7 +93,7 @@ If a valid `issue_number` exists:
 - First scan and backfill unpublished `task.md`, `analysis*.md`, `plan*.md`, `implementation*.md`, `review*.md`, and `refinement*.md` comments using the backfill rules in `.agents/rules/issue-sync.md` (`task.md` uses the idempotent update path)
 - Backfill checked `## Requirements` items to the Issue body by following the requirements-checkbox sync steps in issue-sync.md
 - Do not set any `status:` label — status labels are automatically cleared when the Issue is closed
-- Finally create or update the summary comment marked with `<!-- sync-issue:{task-id}:summary -->`
+- Finally create or update the summary comment marked with the summary marker defined in `.agents/rules/issue-sync.md`
 
 ### 7. Verification Gate
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -93,7 +93,7 @@ ls .agents/workspace/completed/{task-id}/task.md
 - 先按 `.agents/rules/issue-sync.md` 的补发规则扫描并补发未发布的 `task.md`、`analysis*.md`、`plan*.md`、`implementation*.md`、`review*.md`、`refinement*.md` 评论（`task.md` 走幂等更新路径）
 - 按 issue-sync.md 的需求复选框同步步骤，兜底同步 `## 需求` 中已勾选的条目到 Issue body
 - 不要设置 `status:` label — Issue 关闭后 status label 会被自动清除
-- 最后创建或更新 `<!-- sync-issue:{task-id}:summary -->` 标记的 summary 评论
+- 最后创建或更新 `.agents/rules/issue-sync.md` 中定义的 summary 评论标记对应的 summary 评论
 
 ### 7. 完成校验
 

--- a/templates/.agents/skills/complete-task/config/verify.json
+++ b/templates/.agents/skills/complete-task/config/verify.json
@@ -29,7 +29,8 @@
       "verify_task_comment_content": true,
       "sync_checked_requirements": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_comment_marker_key": "summary"
     }
   }
 }

--- a/templates/.agents/skills/create-issue/SKILL.en.md
+++ b/templates/.agents/skills/create-issue/SKILL.en.md
@@ -1,18 +1,18 @@
 ---
 name: create-issue
-description: "Create a GitHub Issue from a task file"
+description: "Create an Issue from a task file"
 ---
 
 # Create Issue
 
-Create the base GitHub Issue from `task.md` and write `issue_number` back to the task.
+Create the base Issue from `task.md` and write `issue_number` back to the task.
 
 ## Boundary / Critical Rules
 
 - Build the Issue title and body from `task.md` only
 - Issue title format: `type(scope): description` - map `type` from task.md (`feature` -> `feat`, `bugfix` -> `fix`, `refactor` -> `refactor`, `docs` -> `docs`, `chore` -> `chore`), infer scope from the affected module (omit it if unclear), and use the task title from task.md verbatim for the description (do not translate or rewrite)
 - Do not read `analysis.md`, `plan.md`, `implementation.md`, or review artifacts
-- The only durable outputs are the GitHub Issue and the `issue_number` update in task.md
+- The only durable outputs are the Issue and the `issue_number` update in task.md
 - After executing this skill, you **must** immediately update task.md
 
 ## Steps
@@ -31,7 +31,7 @@ Extract the title, `## Description`, `## Requirements`, `type`, and `milestone` 
 
 ### 3. Build Issue Content
 
-Detect `.github/ISSUE_TEMPLATE` files and decide whether to use a matched template path or the fallback path.
+Detect Issue templates through `.agents/rules/issue-pr-commands.md` and decide whether to use a matched template path or the fallback path.
 
 > Template detection, field mapping for `textarea`, `input`, `dropdown`, and `checkboxes`, and the fallback body rules live in `reference/template-matching.md`. Read `reference/template-matching.md` before building the body.
 
@@ -57,7 +57,7 @@ Write back `issue_number`, update `updated_at`, and append the Create Issue Acti
 
 If artifact files already exist in the task directory, backfill them in this order:
 
-1. `task.md` -> `<!-- sync-issue:{task-id}:task -->` comment (idempotent create or update)
+1. `task.md` -> the task comment marker defined in `.agents/rules/issue-sync.md` (idempotent create or update)
 2. Backfill existing `analysis*.md`, `plan*.md`, `implementation*.md`, `review*.md`, and `refinement*.md` files in filename order
 
 Every backfill action must follow the raw publishing, task.md sync, and chunking rules in `.agents/rules/issue-sync.md`.
@@ -94,7 +94,7 @@ Next step - run requirements analysis:
 
 ## Completion Checklist
 
-- [ ] Created the GitHub Issue
+- [ ] Created the Issue
 - [ ] Used `task.md` as the only content source
 - [ ] Recorded `issue_number` in task.md
 - [ ] Updated `updated_at` and appended the Activity Log entry
@@ -106,13 +106,13 @@ Stop after the checklist. Do not start detailed progress sync here.
 
 ## Notes
 
-- `create-issue` creates the base Issue; later status, comments, and checkboxes are maintained by workflow skills and GitHub Actions
+- `create-issue` creates the base Issue; later status, comments, and checkboxes are maintained by workflow skills and platform automation
 - If no valid labels survive filtering, create the Issue without labels instead of failing
 - If Issue Type or milestone setup fails, continue and record the fallback outcome
 
 ## Error Handling
 
 - Task not found: `Task {task-id} not found`
-- GitHub CLI unavailable or unauthenticated
+- the platform CLI unavailable or unauthenticated
 - Empty description in task.md
 - Issue creation failure

--- a/templates/.agents/skills/create-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-issue/SKILL.zh-CN.md
@@ -1,18 +1,18 @@
 ---
 name: create-issue
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 ---
 
 # 创建 Issue
 
-仅从 `task.md` 创建基础 GitHub Issue，并把 `issue_number` 回写到任务文件。
+仅从 `task.md` 创建基础 Issue，并把 `issue_number` 回写到任务文件。
 
 ## 行为边界 / 关键规则
 
 - Issue 标题和正文只能来自 `task.md`
 - Issue 标题格式为 `type(scope): 描述`——type 从 task.md 的 `type` 字段映射（feature→feat, bugfix→fix, refactor→refactor, docs→docs, chore→chore），scope 从受影响模块推断（无法确定时省略），描述使用 task.md 中的任务标题原文（不要翻译或改写）
 - 不要读取 `analysis.md`、`plan.md`、`implementation.md` 或审查产物
-- 持久产物只有 GitHub Issue 本身，以及 task.md 中的 `issue_number` 更新
+- 持久产物只有 Issue 本身，以及 task.md 中的 `issue_number` 更新
 - 执行本技能后，你**必须**立即更新 task.md
 
 ## 执行步骤
@@ -31,7 +31,7 @@ description: "从任务文件创建 GitHub Issue"
 
 ### 3. 构建 Issue 内容
 
-检测 `.github/ISSUE_TEMPLATE`，决定使用模板路径还是 fallback 路径。
+通过 `.agents/rules/issue-pr-commands.md` 检测 Issue 模板，决定使用模板路径还是 fallback 路径。
 
 > 模板识别、`textarea`、`input`、`dropdown`、`checkboxes` 字段映射，以及 fallback 正文规则见 `reference/template-matching.md`。构建正文前先读取 `reference/template-matching.md`。
 
@@ -57,7 +57,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果任务目录中已存在产物文件，按以下顺序补发：
 
-1. `task.md` → `<!-- sync-issue:{task-id}:task -->` 评论（幂等创建或更新）
+1. `task.md` → `.agents/rules/issue-sync.md` 中定义的 task 评论标记（幂等创建或更新）
 2. 按文件名排序补发已存在的 `analysis*.md`、`plan*.md`、`implementation*.md`、`review*.md`、`refinement*.md`
 
 所有补发动作都必须遵循 `.agents/rules/issue-sync.md` 的原文发布、task.md 同步和分片规则。
@@ -94,7 +94,7 @@ node .agents/scripts/validate-artifact.js gate create-issue .agents/workspace/ac
 
 ## 完成检查清单
 
-- [ ] 已创建 GitHub Issue
+- [ ] 已创建 Issue
 - [ ] 已仅使用 `task.md` 作为内容来源
 - [ ] 已在 task.md 中记录 `issue_number`
 - [ ] 已更新 `updated_at` 并追加 Activity Log
@@ -106,13 +106,13 @@ node .agents/scripts/validate-artifact.js gate create-issue .agents/workspace/ac
 
 ## 注意事项
 
-- `create-issue` 只负责创建基础 Issue；后续状态、评论和复选框由工作流技能与 GitHub Actions 维护
+- `create-issue` 只负责创建基础 Issue；后续状态、评论和复选框由工作流技能与 platform automation 维护
 - 如果过滤后没有有效 label，允许不带 label 创建 Issue
 - 如果 Issue Type 或 milestone 设置失败，继续执行并记录结果
 
 ## 错误处理
 
 - 任务未找到：`Task {task-id} not found`
-- GitHub CLI 不可用或未认证
+- the platform CLI 不可用或未认证
 - task.md 的描述为空
 - 创建 Issue 失败

--- a/templates/.agents/skills/create-issue/config/verify.json
+++ b/templates/.agents/skills/create-issue/config/verify.json
@@ -23,7 +23,8 @@
       "issue_must_exist": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "waitingForTriage"
     }
   }
 }

--- a/templates/.agents/skills/create-issue/reference/label-and-type.en.md
+++ b/templates/.agents/skills/create-issue/reference/label-and-type.en.md
@@ -17,11 +17,11 @@ Recommended fallback:
 - [ ] {requirement-2}
 ```
 
-Map task types to GitHub labels and Issue Types, but keep only labels that actually exist.
+Map task types to labels and Issue Types, but keep only labels that actually exist.
 
 Fallback label mapping:
 
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -34,7 +34,7 @@ Fallback label mapping:
 
 Issue Type fallback mapping:
 
-| task.md type | GitHub Issue Type |
+| task.md type | Issue Type |
 |---|---|
 | `bug`, `bugfix` | `Bug` |
 | `feature`, `enhancement` | `Feature` |

--- a/templates/.agents/skills/create-issue/reference/label-and-type.zh-CN.md
+++ b/templates/.agents/skills/create-issue/reference/label-and-type.zh-CN.md
@@ -17,11 +17,11 @@
 - [ ] {requirement-2}
 ```
 
-将任务类型映射到 GitHub label 和 Issue Type，但只保留仓库里实际存在的 label。
+将任务类型映射到 label 和 Issue Type，但只保留仓库里实际存在的 label。
 
 Fallback label 映射：
 
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -34,7 +34,7 @@ Fallback label 映射：
 
 Issue Type fallback 映射：
 
-| task.md type | GitHub Issue Type |
+| task.md type | Issue Type |
 |---|---|
 | `bug`, `bugfix` | `Bug` |
 | `feature`, `enhancement` | `Feature` |

--- a/templates/.agents/skills/create-issue/reference/template-matching.en.md
+++ b/templates/.agents/skills/create-issue/reference/template-matching.en.md
@@ -1,45 +1,17 @@
 # Issue Template Matching
 
-Read this file before deciding how to build the Issue body from `.github/ISSUE_TEMPLATE`.
+Read this file before deciding how to build the Issue body.
 
 ## Detect Issue Templates
 
-Search project templates with:
+Issue template detection is platform-specific. Read `.agents/rules/issue-pr-commands.md` and follow the template detection section provided by the configured platform.
 
-```bash
-rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
-```
-
-If templates exist, inspect their top-level `name:` fields and choose the best match for the task title and description.
-
-Typical candidate templates:
-- `bug_report.yml` for bug work
-- `question.yml` for question or investigation work
-- `feature_request.yml` for feature work
-- `documentation.yml` for documentation work
-- `other.yml` as the general fallback
+If templates exist, inspect their top-level names and choose the best match for the task title and description. Use the candidate template guidance provided by the configured platform rule when available.
 
 If no template matches clearly, choose the nearest candidate. If templates are missing, unreadable, or parsing fails, fall back to the default body path.
 
 ## Build the Body from the Matched Template
 
-Read the matched template's:
-- `name`
-- `type:`
-- `labels:`
-- `body:`
+Build the body by following the field handling and field mapping guidance provided by the configured platform section in `.agents/rules/issue-pr-commands.md`.
 
-Field handling rules:
-- `textarea` and `input`: use `attributes.label` as the markdown heading and fill values from task.md
-- `markdown`: skip template explanation prose
-- `dropdown` and `checkboxes`: skip
-- when task.md lacks a suitable value, write `N/A`
-
-Suggested field mapping:
-
-| Template field hint | task.md source |
-|---|---|
-| `summary`, `title` | task title |
-| `description`, `problem`, `what happened`, `issue-description`, `current-content` | task description |
-| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | requirements list |
-| other `textarea` / `input` fields | task description, otherwise `N/A` |
+When platform guidance is unavailable, use the default body path.

--- a/templates/.agents/skills/create-issue/reference/template-matching.zh-CN.md
+++ b/templates/.agents/skills/create-issue/reference/template-matching.zh-CN.md
@@ -1,45 +1,17 @@
 # Issue 模板匹配
 
-在决定如何从 `.github/ISSUE_TEMPLATE` 构建 Issue 正文之前先读取本文件。
+在决定如何构建 Issue 正文前先读取本文件。
 
-## 探测 Issue 模板
+## 检测 Issue 模板
 
-用下面的命令搜索项目模板：
+Issue 模板检测属于平台相关逻辑。先读取 `.agents/rules/issue-pr-commands.md`，并按当前配置平台提供的模板检测章节执行。
 
-```bash
-rg --files .github/ISSUE_TEMPLATE -g '*.yml' -g '!config.yml'
-```
+如果存在模板，检查其顶层名称，并根据任务标题和描述选择最匹配的模板。可用时，使用当前配置平台规则提供的候选模板指引。
 
-如果模板存在，检查其顶层 `name:` 字段，并为当前任务标题和描述选择最匹配的模板。
+如果没有清晰匹配，选择最接近的候选模板。模板不存在、无法读取或解析失败时，回退到默认正文路径。
 
-常见候选模板：
-- `bug_report.yml`：用于 bug 类工作
-- `question.yml`：用于问题排查或调研类工作
-- `feature_request.yml`：用于功能类工作
-- `documentation.yml`：用于文档类工作
-- `other.yml`：通用 fallback
+## 从匹配模板构建正文
 
-如果没有明显匹配的模板，选择最接近的候选项。如果模板缺失、不可读取或解析失败，就回退到默认正文路径。
+按 `.agents/rules/issue-pr-commands.md` 中当前配置平台章节提供的字段处理和字段映射指引构建正文。
 
-## 使用匹配到的模板构建正文
-
-读取匹配模板中的：
-- `name`
-- `type:`
-- `labels:`
-- `body:`
-
-字段处理规则：
-- `textarea` 和 `input`：使用 `attributes.label` 作为 Markdown 标题，并从 task.md 填充值
-- `markdown`：跳过模板解释性文字
-- `dropdown` 和 `checkboxes`：跳过
-- 当 task.md 没有合适值时，写入 `N/A`
-
-建议字段映射：
-
-| 模板字段提示 | task.md 来源 |
-|---|---|
-| `summary`, `title` | 任务标题 |
-| `description`, `problem`, `what happened`, `issue-description`, `current-content` | 任务描述 |
-| `solution`, `requirements`, `steps`, `suggested-content`, `impact`, `context`, `alternatives`, `expected` | 需求列表 |
-| 其他 `textarea` / `input` 字段 | 优先使用任务描述，否则写 `N/A` |
+如果平台指引不可用，使用默认正文路径。

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -26,7 +26,7 @@ Use the explicit argument when provided. Otherwise infer the target branch from 
 
 ### 3. Prepare the PR Body
 
-Read `.github/PULL_REQUEST_TEMPLATE.md` when it exists, review recent merged PRs for style, and gather all commits between `<target-branch>` and `HEAD`.
+Read the PR template through `.agents/rules/issue-pr-commands.md`, review recent merged PRs for style, and gather all commits between `<target-branch>` and `HEAD`.
 
 > Template handling, HEREDOC body generation, and `Generated with AI assistance` requirements live in `reference/pr-body-template.md`. Read `reference/pr-body-template.md` before writing the PR body.
 
@@ -101,7 +101,7 @@ Explain the created PR URL, summarize metadata sync and summary-comment results,
 
 - Review every commit in the branch, not only the latest one
 - `create-pr` must not defer type-label mapping to another skill; inline the mapping here when `{task-id}` is available
-- Keep the hidden summary marker as `<!-- sync-pr:{task-id}:summary -->` for compatibility with existing PR comments
+- Keep the hidden summary marker as the PR summary marker defined in `.agents/rules/pr-sync.md` for compatibility with existing PR comments
 - If the current branch already has a PR, show its URL and stop without repeating sync work
 - When metadata inheritance from the Issue fails, continue with task.md and branch-based fallbacks
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -26,7 +26,7 @@ description: "创建 Pull Request 到目标分支"
 
 ### 3. 准备 PR 正文
 
-读取 `.github/PULL_REQUEST_TEMPLATE.md`（如存在），参考最近合并的 PR 风格，并收集 `<target-branch>` 到 `HEAD` 的全部提交。
+通过 `.agents/rules/issue-pr-commands.md` 读取 PR 模板，参考最近合并的 PR 风格，并收集 `<target-branch>` 到 `HEAD` 的全部提交。
 
 > 模板处理、HEREDOC 正文生成和 `Generated with AI assistance` 要求见 `reference/pr-body-template.md`。编写正文前先读取 `reference/pr-body-template.md`。
 
@@ -101,7 +101,7 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
 
 - 必须检查分支中的全部提交，而不是只看最后一个
 - `create-pr` 不能把 type label 映射委托给其他技能，必须在获取到 `{task-id}` 时于本技能内内联处理
-- 隐藏 summary 标记必须保持 `<!-- sync-pr:{task-id}:summary -->` 以兼容已有 PR 评论
+- 隐藏 summary 标记必须保持为 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记，以兼容已有 PR 评论
 - 如果当前分支已存在 PR，直接告知用户 PR URL 并结束，不做重复同步
 - 如果从 Issue 继承元数据失败，继续使用 task.md 和分支推断兜底
 

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -23,7 +23,8 @@
       "verify_in_labels_match_pr": true,
       "verify_pr_type_label": true,
       "verify_pr_assignee": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_pr_comment_marker_key": "prSummary"
     }
   }
 }

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
@@ -4,15 +4,11 @@ Read this file before generating the PR title and body.
 
 ## Read the PR Template
 
-Read `.github/PULL_REQUEST_TEMPLATE.md` from the repository. If it does not exist, use the standard format.
+PR template discovery is platform-specific. Read `.agents/rules/issue-pr-commands.md` and follow the PR template section provided by the configured platform. If no template is available, use the standard format.
 
 ## Review Recent Merged PRs for Reference
 
-```bash
-gh pr list --limit 3 --state merged --json number,title,body
-```
-
-Use the recent merged PRs as style and formatting references.
+Use the recent merged PR query from `.agents/rules/issue-pr-commands.md` as style and formatting reference input.
 
 ## Analyze Current Branch Changes
 
@@ -27,19 +23,13 @@ git diff <target-branch>...HEAD
 
 Read `.agents/rules/issue-pr-commands.md` before this step.
 
-Before syncing linked Issue metadata, complete authentication and code-hosting platform detection through that rule. Keep `gh pr list` / `gh pr create` on the current repository.
+Before syncing linked Issue metadata, complete authentication and code-hosting platform detection through that rule.
 
-Before syncing labels, verify the standard label system:
-
-```bash
-gh label list --search "type:" --limit 1 --json name --jq 'length'
-```
-
-If the result is `0`, run `init-labels` before retrying metadata sync.
+Before syncing labels, verify the standard label system by following the label-list command in `.agents/rules/issue-pr-commands.md`. If the result shows no standard type labels, run `init-labels` before retrying metadata sync.
 
 Type label mapping:
 
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -54,7 +44,7 @@ Metadata sync order:
 1. query Issue labels and milestone via the Issue read command in `.agents/rules/issue-pr-commands.md`
 2. build `{label-args}` from the mapped type label, non-`type:` / non-`status:` Issue labels, and the current Issue `in:` labels (commit already computed them, so do not recompute them here and do not write back to the Issue)
 3. build `{milestone-arg}` by following "Phase 3: `create-pr`" in `.agents/rules/milestone-inference.md` and reusing the Issue milestone directly
-4. pass `{label-args}` and `{milestone-arg}` atomically to `gh pr create` by using the create-PR command template and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
+4. pass `{label-args}` and `{milestone-arg}` atomically by using the create-PR command template and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
 5. ensure the PR body contains `Closes #{issue-number}` or an equivalent closing keyword
 
 If those rules say to skip the direct metadata arguments above, keep only the PR body linkage plus later comment sync.
@@ -72,7 +62,7 @@ Milestone rule:
 - Replace `{$IssueNumber}` in the template when present
 - End the PR body with `Generated with AI assistance`
 
-Create the PR with the "Create a PR" command template in `.agents/rules/issue-pr-commands.md`.
+Create the PR with the create-PR command template in `.agents/rules/issue-pr-commands.md`.
 
 Final user output should include this follow-up path:
 

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
@@ -1,20 +1,16 @@
 # PR 正文模板规则
 
-在生成 PR 标题和正文之前先读取本文件。
+生成 PR 标题和正文前先读取本文件。
 
 ## 读取 PR 模板
 
-读取仓库中的 `.github/PULL_REQUEST_TEMPLATE.md`。如果不存在，则使用标准格式。
+PR 模板发现属于平台相关逻辑。先读取 `.agents/rules/issue-pr-commands.md`，并按当前配置平台提供的 PR 模板章节执行。如果没有可用模板，则使用标准格式。
 
 ## 参考最近合并的 PR
 
-```bash
-gh pr list --limit 3 --state merged --json number,title,body
-```
+使用 `.agents/rules/issue-pr-commands.md` 中的最近合并 PR 查询命令，作为风格和格式参考输入。
 
-把最近合并的 PR 当作风格和排版参考。
-
-## 分析当前分支变更
+## 分析当前分支改动
 
 ```bash
 git status
@@ -25,21 +21,15 @@ git diff <target-branch>...HEAD
 
 ## 同步 PR 元数据
 
-执行前先读取 `.agents/rules/issue-pr-commands.md`。
+执行本步骤前先读取 `.agents/rules/issue-pr-commands.md`。
 
-同步关联 Issue 元数据前，先按该规则完成认证和代码托管平台检测；`gh pr list` / `gh pr create` 仍保持作用于当前仓库。
+同步关联 Issue 元数据前，先按该规则完成认证和代码托管平台检测。
 
-在同步 label 之前，先确认标准 label 体系已经存在：
+同步 label 前，按 `.agents/rules/issue-pr-commands.md` 中的 label 列表命令验证标准 label 体系。如果结果显示没有标准 type label，先运行 `init-labels` 再重试元数据同步。
 
-```bash
-gh label list --search "type:" --limit 1 --json name --jq 'length'
-```
+类型 label 映射：
 
-如果结果是 `0`，先执行 `init-labels`，再重试元数据同步。
-
-Type label 映射：
-
-| task.md type | GitHub label |
+| task.md type | label |
 |---|---|
 | `bug`, `bugfix` | `type: bug` |
 | `feature` | `type: feature` |
@@ -51,34 +41,34 @@ Type label 映射：
 | 其他值 | 跳过 |
 
 元数据同步顺序：
-1. 按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询关联 Issue 的 labels 和 milestone
-2. 构建 `{label-args}`：包含映射后的 type label、非 `type:`/`status:` 的 Issue labels，以及 Issue 当前的 `in:` labels（commit 阶段已完成计算，此处不重新计算也不反向更新 Issue）
-3. 构建 `{milestone-arg}`：按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」直接复用 Issue milestone
-4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入 `gh pr create`
-5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价的 closing keyword
+1. 通过 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询 Issue labels 和 milestone
+2. 从映射出的 type label、非 `type:` / 非 `status:` 的 Issue labels，以及当前 Issue `in:` labels 构建 `{label-args}`（commit 已经计算过，不在此重算，也不写回 Issue）
+3. 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 复用 Issue milestone 构建 `{milestone-arg}`
+4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入
+5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价关闭关键字
 
-如果上述规则判定应跳过直接元数据参数写入，则只保留 PR 正文中的关联信息与后续评论同步。
+如果规则要求跳过上述直接元数据参数，则只保留 PR 正文关联和后续评论同步。
 
 Milestone 规则：
-- 按 `.agents/rules/milestone-inference.md` 的「阶段 3：`create-pr`」处理
-- PR 直接复用 Issue milestone，不再独立推断
+- 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 执行
+- 直接复用关联 Issue 的 milestone，不为 PR 重新推断
 
 ## 创建 PR
 
-- 当当前工作属于活动任务时，从 task.md 中提取 `issue_number`
-- 如果存在 `issue_number`，先完成前置步骤中的代码托管平台检测，再按 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询对应 Issue
-- 在调用 PR 创建命令前，先检查当前分支是否已经存在 PR；如果已存在，直接告知用户 PR URL 和状态并结束，不要重复同步元数据或摘要
-- 使用 HEREDOC 传递 PR 正文
-- 如果模板中存在 `{$IssueNumber}`，替换它
-- PR 正文结尾必须带上 `Generated with AI assistance`
+- 当前工作属于 active task 时，从 task.md 提取 `issue_number`
+- 如果存在 `issue_number`，先完成代码托管平台检测，再通过 `.agents/rules/issue-pr-commands.md` 查询 Issue
+- 调用 PR 创建命令前，先检查当前分支是否已有 PR；若已有，报告 PR URL 和状态后停止，不重复执行元数据同步或 summary 发布
+- 使用 HEREDOC 传入 PR 正文
+- 模板中存在 `{$IssueNumber}` 时进行替换
+- PR 正文以 `Generated with AI assistance` 结尾
 
-创建 PR 时，使用 `.agents/rules/issue-pr-commands.md` 中的 “创建 PR” 命令模板。
+使用 `.agents/rules/issue-pr-commands.md` 中的创建 PR 命令模板创建 PR。
 
-最终用户输出必须按顺序包含以下后续动作：
+最终用户输出应包含以下后续路径：
 
 ```text
-下一步：
-  - 工作流真正结束后完成任务：
+Next steps:
+  - complete the task after the workflow truly finishes:
     - Claude Code / OpenCode: /complete-task {task-id}
     - Gemini CLI: /agent-infra:complete-task {task-id}
     - Codex CLI: $complete-task {task-id}

--- a/templates/.agents/skills/create-release-note/SKILL.en.md
+++ b/templates/.agents/skills/create-release-note/SKILL.en.md
@@ -128,18 +128,18 @@ If no historical release notes exist, use the following default Markdown format:
 3. Description: Use PR title, remove `type(scope):` prefix, capitalize first letter
 4. **Contributor collection**:
    - **Data sources**:
-     - PR authors from Step 4 `gh pr list --json author`
+     - PR authors returned by the merged-PR query rule in `.agents/rules/release-commands.md`
      - Commit co-authors from Step 4 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters from linked Issues collected in Step 5 (`author.login` returned by `gh issue view`)
+     - Issue reporters from linked Issues collected in Step 5 (author login returned by `.agents/rules/release-commands.md`)
    - **Contribution count**: `PR count + co-authored commit count` for the same identity, merged across both sources
    - **Name -> `@login` mapping**:
-     - Raw `Co-authored-by` values are `Name <email>` and must be mapped to a GitHub `@login`
-     - Prefer email extraction: if it matches `(\d+\+)?(\S+?)@users\.noreply\.github\.com`, use the second capture group lowercased; this regex covers both `{id}+{login}@users.noreply.github.com` and `{login}@users.noreply.github.com`
+     - Raw `Co-authored-by` values are `Name <email>` and must be mapped to a platform `@login`
+     - Prefer email extraction: if it matches the platform no-reply email rule in `.agents/rules/release-commands.md`, use that rule to derive the lowercased login
      - Otherwise use a Name heuristic: take the first token before a space and lowercase it, for example `Claude Opus 4.6 (1M context)` -> `@claude`, `Codex` -> `@codex`, `Gemini` -> `@gemini`
      - If the login already appears in the PR author list, merge counts into that login so `Claude` and `@claude` do not become separate entries
      - Merge all Name variants that map to the same login before counting and sorting; for example, `Claude` and `Claude Opus 4.6 (1M context)` should both collapse into `@claude`
      - Preserve bot identities as-is, for example `dependabot[bot]`
-     - If the login still cannot be determined reliably, output `@{lowercased first Name token}` and append `<!-- TODO(reviewer): confirm GitHub login for {original Name <email>} -->` below the `Contributors` section
+     - If the login still cannot be determined reliably, output `@{lowercased first Name token}` and append `<!-- TODO(reviewer): confirm platform login for {original Name <email>} -->` below the `Contributors` section
    - **Sorting**: descending by contribution count, then lexicographically by login for ties
    - **Deduplication**: use the final mapped `@login` as the key
    - **Issue reporter rules**:
@@ -156,7 +156,7 @@ Show the generated release notes to the user.
 
 Ask:
 1. Need any adjustments?
-2. Create a GitHub Draft Release?
+2. Create a draft release?
 
 ### 9. Create Draft Release (If Confirmed)
 
@@ -170,7 +170,7 @@ Draft Release created.
 - Version: v{version}
 - Status: Draft
 
-Please review and publish on GitHub:
+Please review and publish on the platform:
 1. Open the URL above
 2. Review the release notes
 3. Click "Publish release"
@@ -178,7 +178,7 @@ Please review and publish on GitHub:
 
 ## Notes
 
-1. **Requires gh CLI**: Must have GitHub CLI installed and authenticated
+1. **Requires the platform CLI**: Must have the platform CLI installed and authenticated
 2. **Tags must exist**: Run the release skill first to create tags
 3. **Draft mode**: Creates a draft - won't auto-publish
 4. **Classification accuracy**: Auto-classification is based on title/scope/files; complex PRs may need manual adjustment
@@ -187,5 +187,5 @@ Please review and publish on GitHub:
 
 - Invalid version format: Prompt correct format
 - Tag not found: Suggest running the release skill first
-- gh not authenticated: Prompt to authenticate
+- The platform CLI is not authenticated: Prompt to authenticate
 - No merged PRs found: Prompt to check tags and branch

--- a/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
@@ -128,18 +128,18 @@ git log v<prev-version>..v<version> \
 3. 描述：使用 PR 标题，移除 `type(scope):` 前缀，首字母大写
 4. **贡献者搜集**：
    - **数据源**：
-     - PR author：来自步骤 4 的 `gh pr list --json author`
+     - PR author：来自 `.agents/rules/release-commands.md` 中已合并 PR 查询规则
      - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters：来自步骤 5 收集的关联 Issue 的 author（`gh issue view` 返回的 `author.login`）
+     - Issue reporters：来自步骤 5 收集的关联 Issue author（由 `.agents/rules/release-commands.md` 返回）
    - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
    - **Name → `@login` 映射**：
-     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 GitHub `@login`
-     - 优先从 email 提取：匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com` 时，取第二个捕获组并转为小写；该正则同时覆盖 `{id}+{login}@users.noreply.github.com` 与 `{login}@users.noreply.github.com`
+     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 platform `@login`
+     - 优先从 email 提取：匹配 `.agents/rules/release-commands.md` 中的平台 no-reply 邮箱规则时，按该规则推导小写 login
      - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
      - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
      - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
      - Bot 身份保留原样（如 `dependabot[bot]`）
-     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 GitHub login -->`
+     - 若仍无法可靠确定 login，则输出 `@{Name 首 token 小写}`，并在 `Contributors` 段落下追加 `<!-- TODO(reviewer): 确认 {原始 Name <email>} 的 platform login -->`
    - **排序**：按贡献数降序；贡献数相同时按 login 字典序
    - **去重**：以最终映射后的 `@login` 为键
    - **Issue reporter 规则**：
@@ -156,7 +156,7 @@ git log v<prev-version>..v<version> \
 
 询问：
 1. 需要调整吗？
-2. 是否创建 GitHub Draft Release？
+2. 是否创建 draft release？
 
 ### 9. 创建 Draft Release（如确认）
 
@@ -170,7 +170,7 @@ Draft Release created.
 - Version: v{version}
 - Status: Draft
 
-Please review and publish on GitHub:
+Please review and publish on the platform:
 1. Open the URL above
 2. Review the release notes
 3. Click "Publish release"
@@ -178,7 +178,7 @@ Please review and publish on GitHub:
 
 ## 注意事项
 
-1. **需要 gh CLI**：必须安装并认证 GitHub CLI
+1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
 3. **草稿模式**：创建草稿 —— 不会自动发布
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
@@ -187,5 +187,5 @@ Please review and publish on GitHub:
 
 - 版本格式无效：提示正确格式
 - 标签未找到：建议先执行 release 技能
-- gh 未认证：提示进行认证
+- 平台 CLI 未认证：提示用户认证
 - 未找到已合并的 PR：提示检查标签和分支

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -137,7 +137,7 @@ Next step - run requirements analysis:
   - Gemini CLI: /{{project}}:analyze-task {task-id}
   - Codex CLI: $analyze-task {task-id}
 
-Or create a GitHub Issue first:
+Or create an Issue first:
   - Claude Code / OpenCode: /create-issue {task-id}
   - Gemini CLI: /{{project}}:create-issue {task-id}
   - Codex CLI: $create-issue {task-id}
@@ -161,8 +161,8 @@ Wait for the user to run the `analyze-task` skill.
 ## Notes
 
 1. **Clarity**: if the user description is vague or missing key information, ask for clarification first
-2. **Difference from `import-issue`**: `import-issue` imports from a GitHub Issue; `create-task` creates from a free-form description
-3. **Workflow order**: after creating a task, typically run `analyze-task` before `plan-task`; if you need GitHub tracking first, you may run `create-issue` first
+2. **Difference from `import-issue`**: `import-issue` imports from an Issue; `create-task` creates from a free-form description
+3. **Workflow order**: after creating a task, typically run `analyze-task` before `plan-task`; if you need platform tracking first, you may run `create-issue` first
 
 ## Error Handling
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -137,7 +137,7 @@ node .agents/scripts/validate-artifact.js gate create-task .agents/workspace/act
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 
-或先创建 GitHub Issue：
+或先创建 Issue：
   - Claude Code / OpenCode：/create-issue {task-id}
   - Gemini CLI：/agent-infra:create-issue {task-id}
   - Codex CLI：$create-issue {task-id}
@@ -161,8 +161,8 @@ node .agents/scripts/validate-artifact.js gate create-task .agents/workspace/act
 ## 注意事项
 
 1. **清晰度**：如果用户描述模糊或缺少关键信息，先要求澄清
-2. **与 import-issue 的区别**：`import-issue` 从 GitHub Issue 导入任务；`create-task` 从自由描述创建
-3. **工作流顺序**：创建任务后，通常先执行 `analyze-task` 再进入 `plan-task`；如需先建立 GitHub 跟踪，也可先执行 `create-issue`
+2. **与 import-issue 的区别**：`import-issue` 从 Issue 导入任务；`create-task` 从自由描述创建
+3. **工作流顺序**：创建任务后，通常先执行 `analyze-task` 再进入 `plan-task`；如需先建立 平台跟踪，也可先执行 `create-issue`
 
 ## 错误处理
 

--- a/templates/.agents/skills/implement-task/SKILL.en.md
+++ b/templates/.agents/skills/implement-task/SKILL.en.md
@@ -95,7 +95,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure; read `.agents/rules/issue-sync.md` first and complete upstream repository detection plus permission detection):
 - Set `status: in-progress` by following issue-sync.md
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` (follow the task.md comment sync rule in issue-sync.md)
 - Publish the `{implementation-artifact}` comment
 
 ### 10. Verification Gate

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -95,7 +95,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{implementation-artifact}` 评论
 
 ### 10. 完成校验

--- a/templates/.agents/skills/implement-task/config/verify.json
+++ b/templates/.agents/skills/implement-task/config/verify.json
@@ -36,7 +36,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -25,7 +25,7 @@ Extract key information:
 - `rule`: rule information (`id`, `severity`, `description`, `security_severity_level`)
 - `tool`: scanning tool information (`name`, `version`)
 - `most_recent_instance`: location (`path`, `start_line`, `end_line`) and message
-- `html_url`: GitHub alert link
+- `html_url`: alert link in the platform
 
 ### 2. Create the Task Directory and File
 

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -25,7 +25,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 - `rule`：规则信息（id、severity、description、security_severity_level）
 - `tool`：扫描工具信息（name、version）
 - `most_recent_instance`：位置（path、start_line、end_line）、消息
-- `html_url`：GitHub 告警链接
+- `html_url`：平台告警链接
 
 ### 2. 创建任务目录和文件
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -1,11 +1,11 @@
 ---
 name: import-issue
-description: "Import a GitHub Issue and create a task"
+description: "Import an Issue and create a task"
 ---
 
 # Import Issue
 
-Import the specified GitHub Issue and create a task. Argument: issue number.
+Import the specified Issue and create a task. Argument: issue number.
 
 ## Boundary / Critical Rules
 
@@ -38,7 +38,7 @@ node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-numb
 
 - Script outputs `found=false`: create a new task through the normal import flow
 - Script outputs `found=true`: reuse `task_id`
-- Script exits 2: treat it as network, authentication, or GitHub API degradation; show the failure reason from script stderr to the user, then continue with the new-task import flow without blocking
+- Script exits 2: treat it as network, authentication, or platform API degradation; show the failure reason from script stderr to the user, then continue with the new-task import flow without blocking
 
 ### 3. Create the Task Directory and File
 
@@ -109,7 +109,7 @@ If task.md contains a valid `issue_number`, use the Issue update command from `.
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Check the Issue's current milestone; if it is unset, read `.agents/rules/milestone-inference.md` and infer plus set the milestone using "Stage 1: `create-issue`". If `has_triage=false` or the inference is uncertain, skip and continue
-- After every scenario, task comment sync is mandatory: create or update the `<!-- sync-issue:{task-id}:task -->` comment so the remote `:task` comment exists and matches the local `task.md` content (follow the task.md comment sync rule in issue-sync.md)
+- After every scenario, task comment sync is mandatory: create or update the task comment marker defined in `.agents/rules/issue-sync.md` so the remote `:task` comment exists and matches the local `task.md` content (follow the task.md comment sync rule in issue-sync.md)
 
 ### 7. Verification Gate
 
@@ -173,5 +173,5 @@ After completing the checklist, **stop immediately**. Do not continue to later s
 ## Error Handling
 
 - Issue not found: output "Issue #{number} not found, please check the issue number"
-- Network error: output "Cannot connect to GitHub, please check network"
+- Network error: output "Cannot connect to the platform, please check network"
 - Permission error: output "No access to this repository"

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -1,11 +1,11 @@
 ---
 name: import-issue
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 ---
 
 # 导入 Issue
 
-导入指定的 GitHub Issue 并创建任务。参数：issue 编号。
+导入指定的 Issue 并创建任务。参数：issue 编号。
 
 ## 行为边界 / 关键规则
 
@@ -38,7 +38,7 @@ node .agents/scripts/platform-adapters/find-existing-task.js --issue <issue-numb
 
 - 脚本输出 `found=false`：按新 Issue 导入流程创建新任务
 - 脚本输出 `found=true`：复用 `task_id`
-- 脚本退出码 2：视为网络、认证或 GitHub API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
+- 脚本退出码 2：视为网络、认证或 platform API 降级，向用户展示脚本 stderr 中的失败原因后，按新 Issue 导入流程继续，不阻塞导入
 
 ### 3. 创建任务目录和文件
 
@@ -109,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 检查 Issue 当前 milestone；如果未设置，先读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 1：`create-issue`」规则推断并设置 milestone；如果 `has_triage=false` 或推断不确定，跳过并继续
-- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
+- 所有场景结束后，必须执行一次 task 留言同步，创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记，确保远端 `:task` 评论存在且内容与本地 `task.md` 一致（按 issue-sync.md 的 task.md 评论同步规则）
 
 ### 7. 完成校验
 
@@ -173,5 +173,5 @@ Issue #{number} 已导入。
 ## 错误处理
 
 - Issue 未找到：提示 "Issue #{number} not found, please check the issue number"
-- 网络错误：提示 "Cannot connect to GitHub, please check network"
+- 网络错误：提示 "Cannot connect to the platform, please check network"
 - 权限错误：提示 "No access to this repository"

--- a/templates/.agents/skills/init-labels/SKILL.en.md
+++ b/templates/.agents/skills/init-labels/SKILL.en.md
@@ -1,11 +1,11 @@
 ---
 name: init-labels
-description: "Initialize the repository's standard GitHub Labels taxonomy"
+description: "Initialize the repository's standard labels taxonomy"
 ---
 
-# Initialize GitHub Labels
+# Initialize labels
 
-Initialize the repository's standard GitHub Labels taxonomy.
+Initialize the repository's standard labels taxonomy.
 
 ## Execution Flow
 
@@ -36,14 +36,14 @@ The script and `.agents/rules/label-milestone-setup.md` are responsible for:
 The script manages these common label families:
 - `type:` labels such as `type: bug`, `type: enhancement`, `type: feature`, `type: documentation`, `type: dependency-upgrade`, and `type: task`
 - `status:` labels such as `status: waiting-for-triage`, `status: in-progress`, and `status: waiting-for-internal-feedback`
-- GitHub-default-name labels intentionally overwritten in place: `good first issue` and `help wanted`
+- platform-default-name labels intentionally overwritten in place: `good first issue` and `help wanted`
 - Additional shared labels such as `dependencies`
 
 #### Scope
 
 | Label prefix | Issue | PR | Notes |
 |---|---|---|---|
-| `type:` | — | Yes | Issues use the native GitHub Type field; PRs need `type:` labels to drive changelog grouping |
+| `type:` | — | Yes | Issues use the native platform Type field; PRs need `type:` labels to drive changelog grouping |
 | `status:` | Yes | — | PRs already have their own state flow (Open/Draft/Merged/Closed); Issues use `status:` labels for project tracking |
 | `in:` | Yes | Yes | Both Issues and PRs need module-based filtering |
 
@@ -98,8 +98,8 @@ Next step - initialize milestones (optional):
 
 ## Error Handling
 
-- `gh` not found: prompt "GitHub CLI (`gh`) is not installed"
-- Authentication failed: prompt "GitHub CLI is not authenticated"
-- Repository access failed: prompt "Unable to access the current repository with gh"
+- platform CLI not found: prompt "the platform CLI is not installed"
+- Authentication failed: prompt "the platform CLI is not authenticated"
+- Repository access failed: prompt "Unable to access the current repository with the platform CLI"
 - Permission error: prompt "No permission to manage labels in this repository"
-- API rate limit: prompt "GitHub API rate limit reached, please retry later"
+- API rate limit: prompt "platform API rate limit reached, please retry later"

--- a/templates/.agents/skills/init-labels/SKILL.zh-CN.md
+++ b/templates/.agents/skills/init-labels/SKILL.zh-CN.md
@@ -1,11 +1,11 @@
 ---
 name: init-labels
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 ---
 
-# 初始化 GitHub Labels
+# 初始化 labels
 
-一次性初始化仓库的标准 GitHub Labels 体系。
+一次性初始化仓库的标准 labels 体系。
 
 ## 执行流程
 
@@ -36,14 +36,14 @@ bash .agents/skills/init-labels/scripts/init-labels.sh
 脚本管理以下通用 label 族：
 - `type:` labels，例如 `type: bug`、`type: enhancement`、`type: feature`、`type: documentation`、`type: dependency-upgrade`、`type: task`
 - `status:` labels，例如 `status: waiting-for-triage`、`status: in-progress`、`status: waiting-for-internal-feedback`
-- 明确覆盖的 GitHub 默认同名 labels：`good first issue` 和 `help wanted`
+- 明确覆盖的 平台默认同名 labels：`good first issue` 和 `help wanted`
 - 额外通用 labels，例如 `dependencies`
 
 #### 适用范围
 
 | Label 前缀 | Issue | PR | 说明 |
 |---|---|---|---|
-| `type:` | — | Yes | Issue 使用 GitHub 原生 Type 字段；PR 无原生类型字段，需 `type:` label 驱动 changelog |
+| `type:` | — | Yes | Issue 使用 平台原生 Type 字段；PR 无原生类型字段，需 `type:` label 驱动 changelog |
 | `status:` | Yes | — | PR 有自身状态流转（Open/Draft/Merged/Closed）；Issue 使用 `status:` label 标记项目管理状态 |
 | `in:` | Yes | Yes | Issue 和 PR 均需按模块筛选 |
 
@@ -98,8 +98,8 @@ bash .agents/skills/init-labels/scripts/init-labels.sh
 
 ## 错误处理
 
-- 未找到 `gh`：提示 "GitHub CLI (`gh`) is not installed"
-- 认证失败：提示 "GitHub CLI is not authenticated"
-- 仓库访问失败：提示 "Unable to access the current repository with gh"
+- 未找到平台 CLI：提示 "the platform CLI is not installed"
+- 认证失败：提示 "the platform CLI is not authenticated"
+- 仓库访问失败：提示 "Unable to access the current repository with the platform CLI"
 - 权限不足：提示 "No permission to manage labels in this repository"
-- API 限流：提示 "GitHub API rate limit reached, please retry later"
+- API 限流：提示 "platform API rate limit reached, please retry later"

--- a/templates/.agents/skills/init-milestones/SKILL.en.md
+++ b/templates/.agents/skills/init-milestones/SKILL.en.md
@@ -1,11 +1,11 @@
 ---
 name: init-milestones
-description: "Initialize the repository's standard GitHub Milestones taxonomy"
+description: "Initialize the repository's standard milestones taxonomy"
 ---
 
-# Initialize GitHub Milestones
+# Initialize milestones
 
-Initialize the repository's standard GitHub Milestones taxonomy.
+Initialize the repository's standard milestones taxonomy.
 
 ## Execution Flow
 
@@ -75,10 +75,10 @@ Next step - initialize labels (optional):
 
 ## Error Handling
 
-- `gh` not found: prompt "GitHub CLI (`gh`) is not installed"
-- Authentication failed: prompt "GitHub CLI is not authenticated"
-- Repository access failed: prompt "Unable to access the current repository with gh"
+- platform CLI not found: prompt "the platform CLI is not installed"
+- Authentication failed: prompt "the platform CLI is not authenticated"
+- Repository access failed: prompt "Unable to access the current repository with the platform CLI"
 - Version detection failed: prompt "Unable to determine current version baseline"
 - No `v*` tags found in `--history` mode: prompt "No history tags found matching v*; only standard milestones will be created"
 - Permission error: prompt "No permission to manage milestones in this repository"
-- API rate limit: prompt "GitHub API rate limit reached, please retry later"
+- API rate limit: prompt "platform API rate limit reached, please retry later"

--- a/templates/.agents/skills/init-milestones/SKILL.zh-CN.md
+++ b/templates/.agents/skills/init-milestones/SKILL.zh-CN.md
@@ -1,11 +1,11 @@
 ---
 name: init-milestones
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 ---
 
-# 初始化 GitHub Milestones
+# 初始化 milestones
 
-一次性初始化仓库的标准 GitHub Milestones 体系。
+一次性初始化仓库的标准 milestones 体系。
 
 ## 执行流程
 
@@ -75,10 +75,10 @@ bash .agents/skills/init-milestones/scripts/init-milestones.sh "$ARGUMENTS"
 
 ## 错误处理
 
-- 未找到 `gh`：提示 "GitHub CLI (`gh`) is not installed"
-- 认证失败：提示 "GitHub CLI is not authenticated"
-- 仓库访问失败：提示 "Unable to access the current repository with gh"
+- 未找到平台 CLI：提示 "the platform CLI is not installed"
+- 认证失败：提示 "the platform CLI is not authenticated"
+- 仓库访问失败：提示 "Unable to access the current repository with the platform CLI"
 - 版本解析失败：提示 "Unable to determine current version baseline"
 - `--history` 模式下未找到任何 `v*` git tags：提示 "No history tags found matching v*; only standard milestones will be created"
 - 权限不足：提示 "No permission to manage milestones in this repository"
-- API 限流：提示 "GitHub API rate limit reached, please retry later"
+- API 限流：提示 "platform API rate limit reached, please retry later"

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -99,7 +99,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: pending-design-work` by following issue-sync.md
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` (follow the task.md comment sync rule in issue-sync.md)
 - Publish the `{plan-artifact}` comment
 
 ### 8. Verification Gate

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -99,7 +99,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: pending-design-work`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{plan-artifact}` 评论
 
 ### 8. 完成校验

--- a/templates/.agents/skills/plan-task/config/verify.json
+++ b/templates/.agents/skills/plan-task/config/verify.json
@@ -38,7 +38,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "pendingDesignWork",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -62,7 +62,7 @@ Update task.md:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: in-progress` by following issue-sync.md
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` (follow the task.md comment sync rule in issue-sync.md)
 - Publish the `{refinement-artifact}` comment
 
 ### 7. Verification Gate

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -62,7 +62,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{refinement-artifact}` 评论
 
 ### 7. 完成校验

--- a/templates/.agents/skills/refine-task/config/verify.json
+++ b/templates/.agents/skills/refine-task/config/verify.json
@@ -32,7 +32,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -9,7 +9,7 @@ Restore local task workspace files from platform Issue comments that contain syn
 
 ## Boundary / Critical Rules
 
-- Restore files only from comments marked with `<!-- sync-issue:{task-id}:... -->`
+- Restore files only from comments that match the marker registry in `.agents/rules/issue-sync.md`
 - Restore into `.agents/workspace/active/{task-id}/` by default
 - Stop immediately if the target directory already exists and ask the user to resolve the conflict first
 - After executing this skill, you **must** immediately update the restored `task.md`
@@ -31,16 +31,11 @@ Read all Issue comments by following the "Read Issue comments" command in `.agen
 
 ### 3. Determine the task-id and Files to Restore
 
-Filter comments by these hidden markers:
-
-```html
-<!-- sync-issue:{task-id}:{file-stem} -->
-<!-- sync-issue:{task-id}:{file-stem}:{part}/{total} -->
-```
+Filter comments by the task, artifact, and chunked artifact markers defined in `.agents/rules/issue-sync.md`.
 
 Rules:
 - when `{task-id}` was provided, match only that task
-- when `{task-id}` was omitted, infer it from the `<!-- sync-issue:{task-id}:task -->` comment first
+- when `{task-id}` was omitted, infer it from the task comment marker first
 - if you cannot determine a unique task-id, stop and tell the user
 - ignore `summary` marker comments because they are complete-task aggregate output rather than restorable local task files
 - map `{file-stem}` back to filenames:
@@ -58,7 +53,7 @@ Read `.agents/rules/issue-sync.md` before executing this step.
 For each file:
 - collect its single comment or chunked comments
 - for `task.md` comments, reverse the `<details>` frontmatter wrapper described in issue-sync.md before reassembling the file body
-- when `{part}/{total}` exists, sort by part and verify the set is complete
+- when a chunk marker includes part and total indexes, sort by part and verify the set is complete
 - extract the file body by removing the hidden marker, heading, and footer
 - concatenate chunk bodies into the final file content
 
@@ -88,66 +83,20 @@ Update the restored `task.md`:
 - `status`: `active`
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
-- keep the original `current_step`
-- append this entry to `## Activity Log`:
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
-  ```
 
-### 7. Verification Gate
+Append an Activity Log entry indicating the task was restored from the platform Issue.
 
-Run the verification gate:
+### 7. Inform User
 
-```bash
-node .agents/scripts/validate-artifact.js gate restore-task .agents/workspace/active/{task-id} --format text
-```
-
-Handle the result as follows:
-- exit code 0 (all checks passed) -> continue to the "Inform User" step
-- exit code 1 (validation failed) -> fix the reported issues and run the gate again
-- exit code 2 (network blocked) -> stop and tell the user that human intervention is required
-
-Keep the gate output in your reply as fresh evidence. Do not claim completion without output from this run.
-
-### 8. Inform User
-
-> Execute this step only after the verification gate passes.
-
-> **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name).
-
-Output format:
-
-```text
-Task {task-id} was restored from Issue #{issue-number}.
-
-Summary:
-- Restored files: {count}
-- Task directory: .agents/workspace/active/{task-id}/
-- Current step: {current_step}
-
-Next step - check task status:
-  - Claude Code / OpenCode: /check-task {task-id}
-  - Gemini CLI: /{{project}}:check-task {task-id}
-  - Codex CLI: $check-task {task-id}
-```
+Report the restored task id, restored file count, and the active task directory.
 
 ## Completion Checklist
 
-- [ ] Fetched and parsed Issue comments
-- [ ] Restored `task.md` and every available artifact file
-- [ ] Updated the restored task.md
-- [ ] Ran and passed the verification gate
-- [ ] Showed the next-step commands in every TUI format, including any custom TUIs
+- [ ] Fetched Issue comments from the platform
+- [ ] Restored task files locally
+- [ ] Updated restored task metadata
+- [ ] Reported the restored directory
 
-## STOP
+### 8. Stop
 
-Stop after completing the checklist. Do not continue the workflow automatically.
-
-## Error Handling
-
-- Issue missing or inaccessible
-- Platform CLI unavailable or unauthenticated
-- No sync-marked comments found
-- Unable to determine a unique `task-id`
-- Target directory already exists
-- Missing chunks or incomplete chunk ordering
+Stop after the completion checklist. Do not commit automatically.

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -9,7 +9,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 行为边界 / 关键规则
 
-- 只从带 `<!-- sync-issue:{task-id}:... -->` 标记的评论恢复文件
+- 只从匹配 `.agents/rules/issue-sync.md` 标记注册表的评论恢复文件
 - 默认恢复到 `.agents/workspace/active/{task-id}/`
 - 如果目标目录已存在，立即停止并提示用户先处理目录冲突
 - 执行本技能后，你**必须**立即更新恢复出的 `task.md`
@@ -31,16 +31,11 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ### 3. 确定 task-id 与待恢复文件
 
-从评论中筛选隐藏标记：
-
-```html
-<!-- sync-issue:{task-id}:{file-stem} -->
-<!-- sync-issue:{task-id}:{file-stem}:{part}/{total} -->
-```
+按 `.agents/rules/issue-sync.md` 中定义的 task、artifact 和分片 artifact 标记筛选评论。
 
 处理规则：
 - 用户提供了 `{task-id}` 时，仅匹配该任务
-- 未提供时，优先从 `<!-- sync-issue:{task-id}:task -->` 评论推断
+- 未提供时，优先从 task 评论标记推断
 - 若找不到唯一 task-id，立即停止并告知用户
 - 忽略 `summary` 标记评论；它是 complete-task 的聚合产物，不对应本地任务文件
 - 将 `{file-stem}` 映射回文件名：
@@ -58,7 +53,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 对每个文件执行：
 - 收集单条评论或分片评论
 - 对 `task.md` 评论按 issue-sync.md 中的 `<details>` frontmatter 格式反向拆解，提取 frontmatter 后再与正文拼合
-- 如存在 `{part}/{total}`，按 part 升序排序并校验分片完整
+- 如分片标记中存在 part 和 total 序号，按 part 升序排序并校验分片完整
 - 从评论正文中提取文件内容，去掉隐藏标记、标题和页脚
 - 拼接得到最终文件内容
 
@@ -88,66 +83,20 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：`active`
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
-- 保留原 `current_step`
-- 在 `## 活动日志` 追加：
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Restore Task** by {agent} — Restored task from Issue #{issue-number}
-  ```
 
-### 7. 完成校验
+追加 Activity Log，说明任务已从平台 Issue 还原。
 
-运行完成校验：
+### 7. 告知用户
 
-```bash
-node .agents/scripts/validate-artifact.js gate restore-task .agents/workspace/active/{task-id} --format text
-```
-
-处理结果：
-- 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- 退出码 1（校验失败）-> 根据输出修复问题后重新运行校验
-- 退出码 2（网络中断）-> 停止执行并告知用户需要人工介入
-
-将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
-
-### 8. 告知用户
-
-> 仅在校验通过后执行本步骤。
-
-> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
-
-输出格式：
-
-```text
-任务 {task-id} 已从 Issue #{issue-number} 还原。
-
-摘要：
-- 恢复文件：{数量}
-- 任务目录：.agents/workspace/active/{task-id}/
-- 当前步骤：{current_step}
-
-下一步 - 查看任务状态：
-  - Claude Code / OpenCode：/check-task {task-id}
-  - Gemini CLI：/{{project}}:check-task {task-id}
-  - Codex CLI：$check-task {task-id}
-```
+报告已恢复的 task id、恢复文件数量和 active task 目录。
 
 ## 完成检查清单
 
-- [ ] 已获取并解析 Issue 评论
-- [ ] 已还原 `task.md` 和所有可用产物文件
-- [ ] 已更新恢复后的 task.md
-- [ ] 已运行并通过完成校验
-- [ ] 已向用户展示所有 TUI 格式的下一步命令（含自定义 TUI）
+- [ ] 已从平台获取 Issue 评论
+- [ ] 已恢复本地任务文件
+- [ ] 已更新恢复出的任务元数据
+- [ ] 已报告恢复目录
 
-## 停止
+### 8. 停止
 
-完成检查清单后立即停止。不要自动继续执行工作流。
-
-## 错误处理
-
-- Issue 不存在或无权访问
-- 平台 CLI 未认证
-- 找不到带 sync 标记的评论
-- 无法唯一确定 `task-id`
-- 目标目录已存在
-- 分片缺失或顺序不完整
+完成检查清单后立即停止。不要自动提交。

--- a/templates/.agents/skills/review-task/SKILL.en.md
+++ b/templates/.agents/skills/review-task/SKILL.en.md
@@ -56,7 +56,7 @@ Update task.md and append:
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):
 - Read `.agents/rules/issue-sync.md` before syncing, and complete upstream repository detection plus permission detection
 - Set `status: in-progress` by following issue-sync.md
-- Create or update the `<!-- sync-issue:{task-id}:task -->` comment (follow the task.md comment sync rule in issue-sync.md)
+- Create or update the task comment marker defined in `.agents/rules/issue-sync.md` (follow the task.md comment sync rule in issue-sync.md)
 - Publish the `{review-artifact}` comment
 
 ### 7. Verification Gate

--- a/templates/.agents/skills/review-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-task/SKILL.zh-CN.md
@@ -56,7 +56,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测
 - 按 issue-sync.md 设置 `status: in-progress`
-- 创建或更新 `<!-- sync-issue:{task-id}:task -->` 评论（按 issue-sync.md 的 task.md 评论同步规则）
+- 创建或更新 `.agents/rules/issue-sync.md` 中定义的 task 评论标记（按 issue-sync.md 的 task.md 评论同步规则）
 - 发布 `{review-artifact}` 评论
 
 ### 7. 完成校验

--- a/templates/.agents/skills/review-task/config/verify.json
+++ b/templates/.agents/skills/review-task/config/verify.json
@@ -36,7 +36,9 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
-      "verify_milestone": true
+      "verify_milestone": true,
+      "expected_status_label_key": "inProgress",
+      "expected_comment_marker_key": "artifact"
     }
   }
 }

--- a/templates/.claude/commands/create-issue.en.md
+++ b/templates/.claude/commands/create-issue.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a GitHub Issue from a task file"
+description: "Create an Issue from a task file"
 usage: "/create-issue <task-id>"
 ---
 

--- a/templates/.claude/commands/create-issue.zh-CN.md
+++ b/templates/.claude/commands/create-issue.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 usage: "/create-issue <task-id>"
 ---
 

--- a/templates/.claude/commands/import-issue.en.md
+++ b/templates/.claude/commands/import-issue.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Import a GitHub Issue and create a task"
+description: "Import an Issue and create a task"
 usage: "/import-issue <issue-number>"
 ---
 

--- a/templates/.claude/commands/import-issue.zh-CN.md
+++ b/templates/.claude/commands/import-issue.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 usage: "/import-issue <issue-number>"
 ---
 

--- a/templates/.claude/commands/init-labels.en.md
+++ b/templates/.claude/commands/init-labels.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Initialize the repository's standard GitHub Labels taxonomy"
+description: "Initialize the repository's standard labels taxonomy"
 disable-model-invocation: true
 ---
 

--- a/templates/.claude/commands/init-labels.zh-CN.md
+++ b/templates/.claude/commands/init-labels.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 disable-model-invocation: true
 ---
 

--- a/templates/.claude/commands/init-milestones.en.md
+++ b/templates/.claude/commands/init-milestones.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Initialize the repository's standard GitHub Milestones taxonomy"
+description: "Initialize the repository's standard milestones taxonomy"
 usage: "/init-milestones [--history]"
 disable-model-invocation: true
 ---

--- a/templates/.claude/commands/init-milestones.zh-CN.md
+++ b/templates/.claude/commands/init-milestones.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 usage: "/init-milestones [--history]"
 disable-model-invocation: true
 ---

--- a/templates/.claude/commands/restore-task.en.md
+++ b/templates/.claude/commands/restore-task.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Restore local task files from GitHub Issue comments"
+description: "Restore local task files from Issue comments"
 usage: "/restore-task <issue-number> [task-id]"
 disable-model-invocation: true
 ---

--- a/templates/.claude/commands/restore-task.zh-CN.md
+++ b/templates/.claude/commands/restore-task.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 评论还原本地任务文件"
+description: "从 Issue 评论还原本地任务文件"
 usage: "/restore-task <issue-number> [task-id]"
 disable-model-invocation: true
 ---

--- a/templates/.gemini/commands/_project_/create-issue.en.toml
+++ b/templates/.gemini/commands/_project_/create-issue.en.toml
@@ -1,4 +1,4 @@
-description = "Create a GitHub Issue from a task file"
+description = "Create an Issue from a task file"
 prompt = """
 Create Issue for task {{args}}.
 

--- a/templates/.gemini/commands/_project_/create-issue.zh-CN.toml
+++ b/templates/.gemini/commands/_project_/create-issue.zh-CN.toml
@@ -1,4 +1,4 @@
-description = "从任务文件创建 GitHub Issue"
+description = "从任务文件创建 Issue"
 prompt = """
 为任务 {{args}} 创建 Issue。
 

--- a/templates/.gemini/commands/_project_/import-issue.en.toml
+++ b/templates/.gemini/commands/_project_/import-issue.en.toml
@@ -1,4 +1,4 @@
-description = "Import a GitHub Issue and create a task"
+description = "Import an Issue and create a task"
 prompt = """
 Import Issue #{{args}}.
 

--- a/templates/.gemini/commands/_project_/import-issue.zh-CN.toml
+++ b/templates/.gemini/commands/_project_/import-issue.zh-CN.toml
@@ -1,4 +1,4 @@
-description = "从 GitHub Issue 导入并创建任务"
+description = "从 Issue 导入并创建任务"
 prompt = """
 导入 Issue #{{args}}。
 

--- a/templates/.gemini/commands/_project_/init-labels.en.toml
+++ b/templates/.gemini/commands/_project_/init-labels.en.toml
@@ -1,6 +1,6 @@
-description = "Initialize the repository's standard GitHub Labels taxonomy"
+description = "Initialize the repository's standard labels taxonomy"
 prompt = """
-Initialize GitHub Labels for {{project}}.
+Initialize labels for {{project}}.
 
 Read and execute the init-labels skill from `.agents/skills/init-labels/SKILL.md`.
 

--- a/templates/.gemini/commands/_project_/init-labels.zh-CN.toml
+++ b/templates/.gemini/commands/_project_/init-labels.zh-CN.toml
@@ -1,6 +1,6 @@
-description = "初始化仓库的 GitHub Labels 体系"
+description = "初始化仓库的 labels 体系"
 prompt = """
-为 {{project}} 初始化 GitHub Labels。
+为 {{project}} 初始化 labels。
 
 读取并执行 `.agents/skills/init-labels/SKILL.md` 中的 init-labels 技能。
 

--- a/templates/.gemini/commands/_project_/init-milestones.en.toml
+++ b/templates/.gemini/commands/_project_/init-milestones.en.toml
@@ -1,8 +1,8 @@
-description = "Initialize the repository's standard GitHub Milestones taxonomy"
+description = "Initialize the repository's standard milestones taxonomy"
 prompt = """
 Initialize milestones: {{args}}
 
-Initialize GitHub Milestones for {{project}}.
+Initialize milestones for {{project}}.
 
 Read and execute the init-milestones skill from `.agents/skills/init-milestones/SKILL.md`.
 

--- a/templates/.gemini/commands/_project_/init-milestones.zh-CN.toml
+++ b/templates/.gemini/commands/_project_/init-milestones.zh-CN.toml
@@ -1,8 +1,8 @@
-description = "初始化仓库的 GitHub Milestones 体系"
+description = "初始化仓库的 milestones 体系"
 prompt = """
 初始化里程碑：{{args}}
 
-为 {{project}} 初始化 GitHub Milestones。
+为 {{project}} 初始化 milestones。
 
 读取并执行 `.agents/skills/init-milestones/SKILL.md` 中的 init-milestones 技能。
 

--- a/templates/.gemini/commands/_project_/restore-task.en.toml
+++ b/templates/.gemini/commands/_project_/restore-task.en.toml
@@ -1,4 +1,4 @@
-description = "Restore local task files from GitHub Issue comments"
+description = "Restore local task files from Issue comments"
 prompt = """
 Restore task from Issue: {{args}}
 

--- a/templates/.gemini/commands/_project_/restore-task.zh-CN.toml
+++ b/templates/.gemini/commands/_project_/restore-task.zh-CN.toml
@@ -1,4 +1,4 @@
-description = "从 GitHub Issue 评论还原本地任务文件"
+description = "从 Issue 评论还原本地任务文件"
 prompt = """
 从 Issue 还原任务：{{args}}
 

--- a/templates/.opencode/commands/create-issue.en.md
+++ b/templates/.opencode/commands/create-issue.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a GitHub Issue from a task file"
+description: "Create an Issue from a task file"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/create-issue.zh-CN.md
+++ b/templates/.opencode/commands/create-issue.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从任务文件创建 GitHub Issue"
+description: "从任务文件创建 Issue"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/import-issue.en.md
+++ b/templates/.opencode/commands/import-issue.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Import a GitHub Issue and create a task"
+description: "Import an Issue and create a task"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/import-issue.zh-CN.md
+++ b/templates/.opencode/commands/import-issue.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 导入并创建任务"
+description: "从 Issue 导入并创建任务"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/init-labels.en.md
+++ b/templates/.opencode/commands/init-labels.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Initialize the repository's standard GitHub Labels taxonomy"
+description: "Initialize the repository's standard labels taxonomy"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/init-labels.zh-CN.md
+++ b/templates/.opencode/commands/init-labels.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Labels 体系"
+description: "初始化仓库的 labels 体系"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/init-milestones.en.md
+++ b/templates/.opencode/commands/init-milestones.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Initialize the repository's standard GitHub Milestones taxonomy"
+description: "Initialize the repository's standard milestones taxonomy"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/init-milestones.zh-CN.md
+++ b/templates/.opencode/commands/init-milestones.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "初始化仓库的 GitHub Milestones 体系"
+description: "初始化仓库的 milestones 体系"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/restore-task.en.md
+++ b/templates/.opencode/commands/restore-task.en.md
@@ -1,5 +1,5 @@
 ---
-description: "Restore local task files from GitHub Issue comments"
+description: "Restore local task files from Issue comments"
 agent: general
 subtask: false
 ---

--- a/templates/.opencode/commands/restore-task.zh-CN.md
+++ b/templates/.opencode/commands/restore-task.zh-CN.md
@@ -1,5 +1,5 @@
 ---
-description: "从 GitHub Issue 评论还原本地任务文件"
+description: "从 Issue 评论还原本地任务文件"
 agent: general
 subtask: false
 ---

--- a/tests/core/release.test.js
+++ b/tests/core/release.test.js
@@ -86,7 +86,7 @@ test("release documentation reflects CI-driven npm publishing", () => {
   assert.match(releasing, /npm publish --provenance/);
   assert.match(releasing, /@fitlab-ai\/agent-infra/);
   assert.match(releasing, /推送标签后由 CI 自动执行/);
-  assert.match(releaseSkill, /推送后将自动触发 GitHub Release 创建和 npm 发布/);
+  assert.match(releaseSkill, /推送后将自动触发 release 创建和 npm 发布/);
   assert.match(releaseSkill, /npm 自动发布/);
   assert.match(releaseSkill, /\.agents\/\.airc\.json.*templateVersion/);
   [releaseSkill, releaseTemplate, releaseTemplateZh].forEach((content) => {

--- a/tests/core/validate-artifact.test.js
+++ b/tests/core/validate-artifact.test.js
@@ -1635,7 +1635,7 @@ test("validate-artifact platform-sync fails for create-issue when the task comme
 
     write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
     writeJson(issuePath, buildIssuePayload({
-      labels: [],
+      labels: [{ name: "status: waiting-for-triage" }],
       body: "# Issue\n"
     }));
     writeJson(commentsPath, []);

--- a/tests/scripts/platform-adapter-defaults.test.js
+++ b/tests/scripts/platform-adapter-defaults.test.js
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { loadFreshEsm, pathWithPrependedBin, read, writeNodeCommandShim } from "../helpers.js";
+
+function write(filePathname, content) {
+  fs.mkdirSync(path.dirname(filePathname), { recursive: true });
+  fs.writeFileSync(filePathname, content, "utf8");
+}
+
+function writeJson(filePathname, value) {
+  write(filePathname, JSON.stringify(value, null, 2));
+}
+
+function initGitRepo(repoRoot) {
+  const initResult = spawnSync("git", ["init", "-q", "-b", "main"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(initResult.status, 0, initResult.stderr);
+
+  const remoteResult = spawnSync("git", ["remote", "add", "origin", "git@github.com:fitlab-ai/agent-infra.git"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(remoteResult.status, 0, remoteResult.stderr);
+}
+
+function writeFakeGh(filePathname) {
+  const scriptPath = `${filePathname}.cjs`;
+  write(scriptPath, read("tests/fixtures/validate-artifact/fake-gh.js"));
+  if (process.platform === "win32") {
+    writeNodeCommandShim(filePathname, scriptPath);
+  } else {
+    write(filePathname, `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`);
+    fs.chmodSync(filePathname, 0o755);
+  }
+}
+
+function writeTask(taskDir) {
+  write(path.join(taskDir, "task.md"), [
+    "---",
+    "id: TASK-20260328-000001",
+    "type: refactor",
+    "workflow: refactoring",
+    "status: active",
+    "created_at: 2026-03-28 00:00:00+00:00",
+    "updated_at: 2026-03-28 00:00:00+00:00",
+    "current_step: implementation",
+    "assigned_to: codex",
+    "issue_number: 65",
+    "---",
+    "",
+    "# 任务：Adapter defaults",
+    ""
+  ].join("\n"));
+}
+
+function runValidator(scriptPath, taskDir, skill, env) {
+  return spawnSync(process.execPath, [scriptPath, "check", "platform-sync", taskDir, "implementation.md", "--skill", skill], {
+    cwd: path.dirname(path.dirname(path.dirname(scriptPath))),
+    encoding: "utf8",
+    env
+  });
+}
+
+test("platform-sync adapters expose default status labels and markers", async () => {
+  for (const relativePath of [
+    ".agents/scripts/platform-adapters/platform-sync.js",
+    "templates/.agents/scripts/platform-adapters/platform-sync.github.js"
+  ]) {
+    const { getDefaults } = await loadFreshEsm(relativePath);
+    const defaults = getDefaults();
+
+    assert.equal(defaults.statusLabels.inProgress, "status: in-progress");
+    assert.equal(defaults.statusLabels.pendingDesignWork, "status: pending-design-work");
+    assert.equal(defaults.statusLabels.waitingForTriage, "status: waiting-for-triage");
+    assert.equal(defaults.markers.task, "<!-- sync-issue:{task-id}:task -->");
+    assert.equal(defaults.markers.artifact, "<!-- sync-issue:{task-id}:{artifact-stem} -->");
+    assert.equal(defaults.markers.artifactChunk, "<!-- sync-issue:{task-id}:{artifact-stem}:{part}/{total} -->");
+    assert.equal(defaults.markers.prSummary, "<!-- sync-pr:{task-id}:summary -->");
+  }
+});
+
+test("platform-sync stub adapter exposes empty defaults", async () => {
+  const { getDefaults } = await loadFreshEsm("templates/.agents/scripts/platform-adapters/platform-sync.js");
+  assert.deepEqual(getDefaults(), { statusLabels: {}, markers: {} });
+});
+
+test("platform-sync verification keys override legacy literal values", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-defaults-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+  const adapterCopy = path.join(tempRoot, ".agents/scripts/platform-adapters/platform-sync.js");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const commentsPath = path.join(tempRoot, "comments.json");
+
+  try {
+    initGitRepo(tempRoot);
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
+    writeFakeGh(ghPath);
+    writeTask(taskDir);
+    writeJson(issuePath, {
+      state: "OPEN",
+      labels: [{ name: "status: in-progress" }],
+      body: "",
+      milestone: null
+    });
+    writeJson(commentsPath, [
+      { body: "<!-- sync-issue:TASK-20260328-000001:implementation -->\n## Implementation" }
+    ]);
+
+    writeJson(path.join(tempRoot, ".agents/skills/key-priority/config/verify.json"), {
+      checks: {
+        "platform-sync": {
+          when: "issue_number_exists",
+          expected_status_label: "status: blocked",
+          expected_status_label_key: "inProgress",
+          expected_comment_marker: "<!-- sync-issue:{task-id}:wrong -->",
+          expected_comment_marker_key: "artifact"
+        }
+      }
+    });
+
+    const result = runValidator(scriptCopy, taskDir, "key-priority", {
+      ...process.env,
+      PATH: pathWithPrependedBin(binDir),
+      GH_FAKE_ISSUE_PATH: issuePath,
+      GH_FAKE_COMMENTS_PATH: commentsPath,
+      GH_FAKE_ISSUE_NUMBER: "65"
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("platform-sync verification keeps legacy literal fallback", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-legacy-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+  const adapterCopy = path.join(tempRoot, ".agents/scripts/platform-adapters/platform-sync.js");
+  const issuePath = path.join(tempRoot, "issue.json");
+
+  try {
+    initGitRepo(tempRoot);
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
+    writeFakeGh(ghPath);
+    writeTask(taskDir);
+    writeJson(issuePath, {
+      state: "OPEN",
+      labels: [{ name: "status: in-progress" }],
+      body: "",
+      milestone: null
+    });
+
+    writeJson(path.join(tempRoot, ".agents/skills/legacy/config/verify.json"), {
+      checks: {
+        "platform-sync": {
+          when: "issue_number_exists",
+          expected_status_label: "status: in-progress"
+        }
+      }
+    });
+
+    const result = runValidator(scriptCopy, taskDir, "legacy", {
+      ...process.env,
+      PATH: pathWithPrependedBin(binDir),
+      GH_FAKE_ISSUE_PATH: issuePath
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/templates/platform-coupling.test.js
+++ b/tests/templates/platform-coupling.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { listFilesRecursive, read } from "../helpers.js";
+
+const platformTokenPattern = /GitHub|\.github\/|\bgh\b/;
+
+function assertPlatformAgnostic(relativePath) {
+  assert.doesNotMatch(read(relativePath), platformTokenPattern, `${relativePath} should stay platform-agnostic`);
+}
+
+function assertNoPlatformReferenceVariants(relativePath) {
+  assert.doesNotMatch(relativePath, /\.github(?:\.(?:en|zh-CN))?\.md$/, `${relativePath} should not be a platform-specific skill reference`);
+}
+
+test("baseline skill docs and references stay platform-agnostic", () => {
+  [
+    ...listFilesRecursive("templates/.agents/skills")
+      .filter((relativePath) => /\/SKILL\.(?:en|zh-CN)\.md$/.test(relativePath)),
+    ...listFilesRecursive(".agents/skills")
+      .filter((relativePath) => /\/SKILL\.md$/.test(relativePath)),
+    ...listFilesRecursive("templates/.agents/skills")
+      .filter((relativePath) => /\/reference\/.*\.(?:en|zh-CN)\.md$/.test(relativePath)),
+    ...listFilesRecursive(".agents/skills")
+      .filter((relativePath) => /\/reference\/.*\.md$/.test(relativePath))
+  ].forEach(assertPlatformAgnostic);
+});
+
+test("skill references do not use platform-specific variants", () => {
+  [
+    ...listFilesRecursive("templates/.agents/skills")
+      .filter((relativePath) => /\/reference\/.*\.md$/.test(relativePath)),
+    ...listFilesRecursive(".agents/skills")
+      .filter((relativePath) => /\/reference\/.*\.md$/.test(relativePath))
+  ].forEach(assertNoPlatformReferenceVariants);
+});
+
+test("command descriptions stay platform-agnostic", () => {
+  [
+    ...listFilesRecursive("templates/.claude/commands"),
+    ...listFilesRecursive("templates/.opencode/commands"),
+    ...listFilesRecursive("templates/.gemini/commands/_project_")
+  ]
+    .filter((relativePath) => /\.(?:md|toml)$/.test(relativePath))
+    .forEach((relativePath) => {
+      const descriptionLine = read(relativePath)
+        .split(/\r?\n/)
+        .find((line) => /^description\s*[:=]/.test(line));
+
+      assert.ok(descriptionLine, `${relativePath} should declare a description`);
+      assert.doesNotMatch(descriptionLine, platformTokenPattern, `${relativePath} description should stay platform-agnostic`);
+    });
+});
+
+test("agent quickstart and readme avoid hard-coded setup wording", () => {
+  [
+    "templates/.agents/QUICKSTART.en.md",
+    "templates/.agents/QUICKSTART.zh-CN.md",
+    "templates/.agents/README.en.md",
+    "templates/.agents/README.zh-CN.md",
+    ".agents/QUICKSTART.md",
+    ".agents/README.md"
+  ].forEach((relativePath) => {
+    const content = read(relativePath).replaceAll(".github/hooks", "");
+    assert.doesNotMatch(content, platformTokenPattern, `${relativePath} should not contain platform tokens outside the hook path`);
+    assert.doesNotMatch(content, /default GitHub setup|默认 GitHub 配置/, relativePath);
+  });
+});

--- a/tests/templates/skills.test.js
+++ b/tests/templates/skills.test.js
@@ -212,12 +212,12 @@ test("workflow skill docs update task comments before publishing artifact commen
   orderedCommentSkills.forEach(([skill, artifact]) => {
     skillDocPaths(skill).forEach((relativePath) => {
       const content = read(relativePath);
-      const taskCommentIndex = content.indexOf("<!-- sync-issue:{task-id}:task -->");
+      const taskCommentIndex = content.indexOf(".agents/rules/issue-sync.md");
       const artifactCommentIndex = relativePath.includes(".en.")
         ? content.indexOf(`Publish the \`${artifact}\` comment`)
         : content.indexOf(`发布 \`${artifact}\` 评论`);
 
-      assert.notEqual(taskCommentIndex, -1, `${relativePath} should include the task comment sync marker`);
+      assert.notEqual(taskCommentIndex, -1, `${relativePath} should reference the task comment sync rule`);
       assert.notEqual(artifactCommentIndex, -1, `${relativePath} should include the artifact comment publish step`);
       assert.ok(
         taskCommentIndex < artifactCommentIndex,


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #248

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

收敛模板中散落的 GitHub 平台耦合，让 `.agents/rules` 和 `.agents/scripts/platform-adapters/` 成为唯一的平台抽象出口，为未来扩展 GitLab 等代码托管平台铺路。

This PR consolidates GitHub-specific content into `.agents/rules` and `.agents/scripts/platform-adapters/` so they become the single platform abstraction surface, paving the way for future GitLab and other code-hosting platform support.

## 📋 主要变更 / Brief Changelog

- Baseline SKILL prose, references, command descriptions, QUICKSTART and README no longer mention GitHub by name; concrete `gh` invocations and `.github/...` paths now live inside `.agents/rules/*.github.*.md` and `.agents/skills/*/reference/*.github.*.md` variants.
- `platform-sync.{,github}.js` exposes a new `getDefaults()` adapter contract for status labels and sync markers; `verify.json` can refer to defaults via `*_key` fields while legacy literal fields remain supported for backward compatibility.
- New `tests/templates/platform-coupling.test.js` lints baseline files for residual GitHub tokens and `tests/scripts/platform-adapter-defaults.test.js` covers `getDefaults()` plus key/literal precedence.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install`
2. `npm test` — should report 296/296 passing including the two new test files
3. Manually inspect `git diff` for any baseline file (`templates/.agents/skills/**/SKILL.{en,zh-CN}.md`, baseline `reference/*.md`, command descriptions) to confirm `GitHub` / `\.github/` / `\bgh\b` no longer appears outside `.github.*` variants

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（详见 `.agents/workspace/active/TASK-20260426-184913/review.md`）
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（QUICKSTART / README / SKILL prose）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更，verify.json 旧字段全部保留）
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

**Self-review notes (from `review.md` Round 1)** — 4 major + 5 minor issues identified, none blocking:

1. `templates/.agents/scripts/platform-adapters/platform-sync.github.js:289` — PR comment fetch gate still reads the legacy literal field instead of the resolved `context.prMarker`; needs follow-up before legacy fields are removed.
2. Four `SKILL.zh-CN.md` files (`complete-task`, `cancel-task`, `commit`, `create-pr`) contain mid-sentence English fragments left over from the marker substitution.
3. Seven English `SKILL.en.md` files contain a "the the task comment marker" duplicate-word artifact from the same substitution.
4. `getDefaults().markers` is missing the `artifactChunk` entry that already appears in the `issue-sync.github.{en,zh-CN}.md` registry.

These were intentionally deferred to keep this PR focused on the migration; happy to bundle the cleanup if reviewers prefer.

---

**审查者注意事项 / Reviewer Notes:**

Recommended review order: `platform-sync.github.js getDefaults` and `resolveExpectedValues` (line 12 / 176) → one representative skill in each affected category (`init-labels/SKILL.en.md` for SKILL prose, `pr-body-template.{en,github.en}.md` for the reference variant pattern, `analyze-task/config/verify.json` for the dual-field verify shape) → the two new tests.

Generated with AI assistance