### PR TITLE
feat(sandbox): support Linux native Docker engine end-to-end

### DIFF
--- a/.github/workflows/sandbox-linux-e2e.yml
+++ b/.github/workflows/sandbox-linux-e2e.yml
@@ -1,0 +1,98 @@
+name: Sandbox Linux E2E
+
+on:
+  pull_request:
+    paths:
+      - "bin/cli.js"
+      - "lib/sandbox/**"
+      - "install.sh"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/sandbox-linux-e2e.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "bin/cli.js"
+      - "lib/sandbox/**"
+      - "install.sh"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/sandbox-linux-e2e.yml"
+  workflow_dispatch:
+
+jobs:
+  sandbox-linux:
+    name: Linux native Docker sandbox lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Link local CLI
+        run: npm link
+
+      - name: Prepare host state
+        run: |
+          mkdir -p "$HOME/.claude"
+          cat > "$HOME/.claude/.credentials.json" <<'JSON'
+          {
+            "accessToken": "stub-access-token",
+            "refreshToken": "stub-refresh-token",
+            "expiresAt": "2999-01-01T00:00:00.000Z",
+            "scopes": ["user:profile", "user:sessions:claude_code"]
+          }
+          JSON
+
+      - name: Prepare test repository
+        run: |
+          mkdir -p /tmp/test-repo/.agents
+          cd /tmp/test-repo
+          git init
+          git config user.name "agent-infra CI"
+          git config user.email "agent-infra-ci@example.com"
+          git branch -M main
+          cat > .agents/.airc.json <<'JSON'
+          {
+            "project": "linux-e2e",
+            "org": "fitlab-ai",
+            "sandbox": {
+              "runtimes": ["node20"],
+              "tools": ["claude-code"]
+            }
+          }
+          JSON
+          printf '# linux e2e\n' > README.md
+          git add README.md .agents/.airc.json
+          git commit -m "chore: prepare linux sandbox e2e fixture"
+
+      - name: Run sandbox lifecycle
+        working-directory: /tmp/test-repo
+        run: |
+          docker info
+          ai sandbox create test-branch main
+          ai sandbox ls
+          container="$(docker ps --filter "label=linux-e2e.sandbox.branch=test-branch" --format '{{.Names}}' | head -n 1)"
+          test -n "$container"
+          docker exec "$container" sh -lc 'echo hello && node --version'
+
+      - name: Cleanup sandbox artifacts
+        if: always()
+        run: |
+          docker ps -aq --filter "label=linux-e2e.sandbox" | xargs -r docker rm -f
+          docker images -q --filter "label=linux-e2e.sandbox" | xargs -r docker rmi -f
+          git -C /tmp/test-repo worktree remove --force "$HOME/.agent-infra/worktrees/linux-e2e/test-branch" 2>/dev/null || true
+          git -C /tmp/test-repo branch -D test-branch 2>/dev/null || true
+          rm -rf "$HOME/.agent-infra/worktrees/linux-e2e" "$HOME/.agent-infra/sandboxes"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,23 @@ Open the project in any AI TUI and run `update-agent-infra`:
 
 This detects the packaged template version and renders all managed files. The same command is used both for first-time setup and for future template upgrades.
 
+### Linux Prerequisites
+
+Linux uses the native Docker Engine directly; there is no managed VM to start or stop.
+
+1. Install Docker Engine for your distribution: <https://docs.docker.com/engine/install/>
+2. Start and enable the daemon: `sudo systemctl enable --now docker`
+3. Allow your user to run Docker without `sudo`: `sudo usermod -aG docker $USER`, then open a new login shell or run `newgrp docker`
+
+GPG signing works when the host `gpg-agent` and signing key are available to the sandbox setup. If key sync fails, `ai sandbox create` falls back to a sanitized Git config so commits still work without host signing state.
+
+Known Linux limits:
+
+- Rootless Docker is not supported yet; follow-up: [#256](https://github.com/fitlab-ai/agent-infra/issues/256)
+- Podman is not supported yet; follow-up: [#257](https://github.com/fitlab-ai/agent-infra/issues/257)
+- SELinux-enforcing hosts such as Fedora or RHEL may need mount label handling; follow-up: [#258](https://github.com/fitlab-ai/agent-infra/issues/258)
+- `ai sandbox vm` is only for managed macOS engines. On Linux, use `ai sandbox create`, `ai sandbox exec`, `ai sandbox ls`, `ai sandbox rebuild`, and `ai sandbox rm` directly.
+
 ### Sandbox aliases and GitHub CLI
 
 `ai sandbox create` now bootstraps the host-side aliases file at `~/.agent-infra/aliases/sandbox.sh` on first run. The generated file includes ready-to-edit yolo shortcuts for Claude, Codex, Gemini CLI, and OpenCode, and every sandbox syncs that file into `/home/devuser/.bash_aliases`.

--- a/README.md
+++ b/README.md
@@ -193,23 +193,6 @@ Open the project in any AI TUI and run `update-agent-infra`:
 
 This detects the packaged template version and renders all managed files. The same command is used both for first-time setup and for future template upgrades.
 
-### Linux Prerequisites
-
-Linux uses the native Docker Engine directly; there is no managed VM to start or stop.
-
-1. Install Docker Engine for your distribution: <https://docs.docker.com/engine/install/>
-2. Start and enable the daemon: `sudo systemctl enable --now docker`
-3. Allow your user to run Docker without `sudo`: `sudo usermod -aG docker $USER`, then open a new login shell or run `newgrp docker`
-
-GPG signing works when the host `gpg-agent` and signing key are available to the sandbox setup. If key sync fails, `ai sandbox create` falls back to a sanitized Git config so commits still work without host signing state.
-
-Known Linux limits:
-
-- Rootless Docker is not supported yet; follow-up: [#256](https://github.com/fitlab-ai/agent-infra/issues/256)
-- Podman is not supported yet; follow-up: [#257](https://github.com/fitlab-ai/agent-infra/issues/257)
-- SELinux-enforcing hosts such as Fedora or RHEL may need mount label handling; follow-up: [#258](https://github.com/fitlab-ai/agent-infra/issues/258)
-- `ai sandbox vm` is only for managed macOS engines. On Linux, use `ai sandbox create`, `ai sandbox exec`, `ai sandbox ls`, `ai sandbox rebuild`, and `ai sandbox rm` directly.
-
 ### Sandbox aliases and GitHub CLI
 
 `ai sandbox create` now bootstraps the host-side aliases file at `~/.agent-infra/aliases/sandbox.sh` on first run. The generated file includes ready-to-edit yolo shortcuts for Claude, Codex, Gemini CLI, and OpenCode, and every sandbox syncs that file into `/home/devuser/.bash_aliases`.
@@ -252,6 +235,48 @@ agent-infra is intentionally simple: a bootstrap CLI creates the seed configurat
 │               .agents/  ·  AGENTS.md                  │
 └───────────────────────────────────────────────────────┘
 ```
+
+<a id="platform-support"></a>
+
+## Platform Support
+
+agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=18); container-related features (`ai sandbox *`) additionally need Docker.
+
+### macOS
+
+- `ai init`, `ai sync`, etc.: works out of the box after `npm install -g @fitlab-ai/agent-infra` (or Homebrew).
+- `ai sandbox *`: requires Colima, OrbStack, or Docker Desktop. Colima is the default engine on macOS — when it is selected and the `colima` command is missing, agent-infra auto-installs and starts Colima via Homebrew on first run. To use OrbStack or Docker Desktop instead, set `sandbox.engine` in `.agents/.airc.json`.
+
+### Linux
+
+- `ai init`, `ai sync`, etc.: works out of the box after `npm install -g @fitlab-ai/agent-infra`.
+- `ai sandbox *`: requires Docker Engine on the host. Quick setup:
+
+  ```bash
+  # 1. Install Docker Engine — see https://docs.docker.com/engine/install/
+  # 2. Start the daemon and enable on boot
+  sudo systemctl enable --now docker
+  # 3. Skip 'sudo' for docker: add yourself to the docker group
+  sudo usermod -aG docker $USER && newgrp docker
+  ```
+
+  Validate with `docker info` — it should succeed without sudo.
+
+  GPG signing works when the host `gpg-agent` and signing key are available; if key sync fails, `ai sandbox create` falls back to a sanitized Git config so commits still work without host signing state.
+
+#### Known limitations on Linux
+
+These configurations are not actively tested in this release:
+
+- Running `ai sandbox create` as **root** (uid 0): image build fails on `useradd`. Track [#261](https://github.com/fitlab-ai/agent-infra/issues/261).
+- **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
+- **Podman** instead of Docker: Track [#257](https://github.com/fitlab-ai/agent-infra/issues/257).
+- **SELinux-enforcing** hosts (Fedora / RHEL) may need manual mount labels: Track [#258](https://github.com/fitlab-ai/agent-infra/issues/258).
+- `ai sandbox vm` is a no-op on Linux. Linux uses native Docker directly with no VM to manage; use `ai sandbox create`, `ai sandbox exec`, `ai sandbox ls`, `ai sandbox rebuild`, `ai sandbox rm` directly.
+
+### Windows
+
+WSL2 support is tracked in [#184](https://github.com/fitlab-ai/agent-infra/issues/184).
 
 <a id="what-you-get"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,6 +193,23 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 该命令会检测当前打包模板版本并渲染所有受管理文件。首次安装和后续升级都使用同一条命令。
 
+### Linux 前置条件
+
+Linux 会直接使用宿主机的 native Docker Engine；不需要启动或停止受管理的 VM。
+
+1. 按发行版安装 Docker Engine：<https://docs.docker.com/engine/install/>
+2. 启动并设置 daemon 开机自启：`sudo systemctl enable --now docker`
+3. 允许当前用户不带 `sudo` 运行 Docker：`sudo usermod -aG docker $USER`，然后打开新的登录 shell 或运行 `newgrp docker`
+
+当宿主机 `gpg-agent` 和签名 key 可用于沙箱初始化时，GPG signing 可以正常工作。如果 key 同步失败，`ai sandbox create` 会回退到清理后的 Git config，让提交仍可在没有宿主签名状态的情况下继续。
+
+Linux 已知限制：
+
+- 暂不支持 rootless Docker；后续跟踪：[#256](https://github.com/fitlab-ai/agent-infra/issues/256)
+- 暂不支持 Podman；后续跟踪：[#257](https://github.com/fitlab-ai/agent-infra/issues/257)
+- Fedora 或 RHEL 等启用 SELinux enforcing 的宿主机可能需要额外挂载标签处理；后续跟踪：[#258](https://github.com/fitlab-ai/agent-infra/issues/258)
+- `ai sandbox vm` 仅用于 macOS 受管理引擎。Linux 上直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox ls`、`ai sandbox rebuild` 和 `ai sandbox rm`。
+
 ### 沙箱 aliases 与 GitHub CLI
 
 `ai sandbox create` 在首次运行时会自动生成宿主机侧的 `~/.agent-infra/aliases/sandbox.sh`。该文件内置了 Claude、Codex、Gemini CLI 和 OpenCode 的 yolo 快捷命令模板，你可以直接修改；每次创建沙箱时，这个文件都会同步到容器内的 `/home/devuser/.bash_aliases`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,23 +193,6 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 该命令会检测当前打包模板版本并渲染所有受管理文件。首次安装和后续升级都使用同一条命令。
 
-### Linux 前置条件
-
-Linux 会直接使用宿主机的 native Docker Engine；不需要启动或停止受管理的 VM。
-
-1. 按发行版安装 Docker Engine：<https://docs.docker.com/engine/install/>
-2. 启动并设置 daemon 开机自启：`sudo systemctl enable --now docker`
-3. 允许当前用户不带 `sudo` 运行 Docker：`sudo usermod -aG docker $USER`，然后打开新的登录 shell 或运行 `newgrp docker`
-
-当宿主机 `gpg-agent` 和签名 key 可用于沙箱初始化时，GPG signing 可以正常工作。如果 key 同步失败，`ai sandbox create` 会回退到清理后的 Git config，让提交仍可在没有宿主签名状态的情况下继续。
-
-Linux 已知限制：
-
-- 暂不支持 rootless Docker；后续跟踪：[#256](https://github.com/fitlab-ai/agent-infra/issues/256)
-- 暂不支持 Podman；后续跟踪：[#257](https://github.com/fitlab-ai/agent-infra/issues/257)
-- Fedora 或 RHEL 等启用 SELinux enforcing 的宿主机可能需要额外挂载标签处理；后续跟踪：[#258](https://github.com/fitlab-ai/agent-infra/issues/258)
-- `ai sandbox vm` 仅用于 macOS 受管理引擎。Linux 上直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox ls`、`ai sandbox rebuild` 和 `ai sandbox rm`。
-
 ### 沙箱 aliases 与 GitHub CLI
 
 `ai sandbox create` 在首次运行时会自动生成宿主机侧的 `~/.agent-infra/aliases/sandbox.sh`。该文件内置了 Claude、Codex、Gemini CLI 和 OpenCode 的 yolo 快捷命令模板，你可以直接修改；每次创建沙箱时，这个文件都会同步到容器内的 `/home/devuser/.bash_aliases`。
@@ -252,6 +235,48 @@ agent-infra 的结构刻意保持简单：引导 CLI 负责生成种子配置，
 │               .agents/  ·  AGENTS.md                  │
 └───────────────────────────────────────────────────────┘
 ```
+
+<a id="platform-support"></a>
+
+## 平台支持
+
+agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器相关功能（`ai sandbox *`）额外需要 Docker。
+
+### macOS
+
+- `ai init`、`ai sync` 等：执行 `npm install -g @fitlab-ai/agent-infra`（或 Homebrew 安装）后开箱即用。
+- `ai sandbox *`：需要 Colima、OrbStack 或 Docker Desktop。macOS 默认引擎是 Colima —— 当选用 Colima 且宿主机没有 `colima` 命令时，agent-infra 会在首次运行时通过 Homebrew 自动安装并启动。如需使用 OrbStack 或 Docker Desktop，请在 `.agents/.airc.json` 中设置 `sandbox.engine`。
+
+### Linux
+
+- `ai init`、`ai sync` 等：执行 `npm install -g @fitlab-ai/agent-infra` 后开箱即用。
+- `ai sandbox *`：需要宿主机已安装 Docker Engine。三步配置：
+
+  ```bash
+  # 1. 安装 Docker Engine —— 见 https://docs.docker.com/engine/install/
+  # 2. 启动 daemon 并设置开机自启
+  sudo systemctl enable --now docker
+  # 3. 让当前用户免 sudo 跑 docker：加入 docker 组
+  sudo usermod -aG docker $USER && newgrp docker
+  ```
+
+  验证：执行 `docker info` 应在不带 sudo 的情况下成功。
+
+  当宿主机 `gpg-agent` 和签名 key 可用时，GPG signing 可正常工作；如果 key 同步失败，`ai sandbox create` 会回退到清理后的 Git config，让提交仍可在没有宿主签名状态的情况下继续。
+
+#### Linux 已知限制
+
+下列场景在本期未做主动验证：
+
+- 以 **root**（uid 0）运行 `ai sandbox create`：image build 在 `useradd` 步骤失败。后续跟踪 [#261](https://github.com/fitlab-ai/agent-infra/issues/261)。
+- **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
+- 用 **Podman** 替代 Docker：后续跟踪 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
+- **SELinux enforcing** 宿主机（Fedora / RHEL）可能需要手动加挂载标签：后续跟踪 [#258](https://github.com/fitlab-ai/agent-infra/issues/258)。
+- `ai sandbox vm` 在 Linux 上是空操作。Linux 直接使用 native Docker，没有 VM 需要管理；请直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox ls`、`ai sandbox rebuild`、`ai sandbox rm`。
+
+### Windows
+
+WSL2 支持在 [#184](https://github.com/fitlab-ai/agent-infra/issues/184) 跟踪。
 
 <a id="what-you-get"></a>
 

--- a/install.sh
+++ b/install.sh
@@ -36,21 +36,9 @@ info "Installing $NPM_PACKAGE via npm ..."
 npm install -g "$NPM_PACKAGE"
 ok "agent-infra installed successfully!"
 
-case "$(uname -s)" in
-  Linux)
-    if ! command -v docker >/dev/null 2>&1; then
-      warn "Docker is not installed. Install Docker Engine before using 'ai sandbox create': https://docs.docker.com/engine/install/"
-    elif ! docker info >/dev/null 2>&1; then
-      warn "Docker is installed, but the daemon is not ready. Try: sudo systemctl enable --now docker"
-      warn "If permission is denied, add your user to the docker group: sudo usermod -aG docker \$USER"
-    else
-      ok "Docker is ready."
-    fi
-    ;;
-  Darwin)
-    ok "macOS detected. Sandbox commands will use Colima/OrbStack via Homebrew on first run."
-    ;;
-esac
+if [ "$(uname -s)" = "Linux" ] && ! command -v docker >/dev/null 2>&1; then
+  warn "Note: 'ai sandbox' requires Docker Engine. See README 'Platform Support → Linux'."
+fi
 
 # ---------- done ----------
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,22 @@ info "Installing $NPM_PACKAGE via npm ..."
 npm install -g "$NPM_PACKAGE"
 ok "agent-infra installed successfully!"
 
+case "$(uname -s)" in
+  Linux)
+    if ! command -v docker >/dev/null 2>&1; then
+      warn "Docker is not installed. Install Docker Engine before using 'ai sandbox create': https://docs.docker.com/engine/install/"
+    elif ! docker info >/dev/null 2>&1; then
+      warn "Docker is installed, but the daemon is not ready. Try: sudo systemctl enable --now docker"
+      warn "If permission is denied, add your user to the docker group: sudo usermod -aG docker \$USER"
+    else
+      ok "Docker is ready."
+    fi
+    ;;
+  Darwin)
+    ok "macOS detected. Sandbox commands will use Colima/OrbStack via Homebrew on first run."
+    ;;
+esac
+
 # ---------- done ----------
 echo ""
 echo "  Next step: cd into your project and run:"

--- a/lib/sandbox/commands/vm.js
+++ b/lib/sandbox/commands/vm.js
@@ -15,7 +15,13 @@ import { runOk, runSafe } from '../shell.js';
 
 const USAGE = `Usage: ai sandbox vm <status|start|stop> [--cpu <n>] [--memory <n>]`;
 
-function ensureManagedVm(engine) {
+export function ensureManagedVm(engine) {
+  if (engine === 'native') {
+    throw new Error(
+      "Linux native Docker does not use a managed VM. Use 'ai sandbox create' directly."
+    );
+  }
+
   if (!isManagedEngine(engine)) {
     throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
   }

--- a/lib/sandbox/constants.js
+++ b/lib/sandbox/constants.js
@@ -88,6 +88,9 @@ export function parsePositiveIntegerOption(value, optionName) {
 }
 
 export function detectHostResources() {
+  // Resource hints are for engines that pre-allocate a managed VM. macOS uses
+  // sysctl for Colima defaults, while the generic fallback supports WSL2 or
+  // other direct callers that need conservative CPU and memory defaults.
   if (process.platform === 'darwin') {
     try {
       const hostCpu = Number(execFileSync('sysctl', ['-n', 'hw.ncpu'], { encoding: 'utf8' }).trim());

--- a/lib/sandbox/engine.js
+++ b/lib/sandbox/engine.js
@@ -132,6 +132,43 @@ export async function ensureDockerDesktop(
   }
 }
 
+export async function ensureNativeDocker(
+  _config,
+  _onMessage,
+  { runOkFn = runOk, runSafeFn = runSafe } = {}
+) {
+  if (!runOkFn('which', ['docker'])) {
+    throw new Error([
+      'Docker is not installed.',
+      'Install Docker Engine for your distribution: https://docs.docker.com/engine/install/',
+      'Then start the daemon with: sudo systemctl enable --now docker',
+      'If you want to run Docker without sudo, add your user to the docker group: sudo usermod -aG docker $USER'
+    ].join('\n'));
+  }
+
+  if (runOkFn('docker', ['info'])) {
+    return;
+  }
+
+  const serverVersion = runSafeFn('docker', ['version', '--format', '{{.Server.Version}}']);
+  if (!serverVersion) {
+    throw new Error([
+      'Docker daemon is not running or is unreachable.',
+      'Start it with: sudo systemctl start docker',
+      'Enable it on boot with: sudo systemctl enable docker',
+      'If you use rootless or remote Docker, verify DOCKER_HOST points at a reachable socket.',
+      'Then retry: ai sandbox create <branch>'
+    ].join('\n'));
+  }
+
+  throw new Error([
+    'Docker is installed, but the current user may lack permission to use the daemon.',
+    'Add your user to the docker group: sudo usermod -aG docker $USER',
+    'Open a new login shell or run: newgrp docker',
+    'For rootless Docker, make sure DOCKER_HOST points at the rootless daemon socket.'
+  ].join('\n'));
+}
+
 export async function ensureDocker(config, onMessage) {
   const engine = detectEngine(config);
 
@@ -151,9 +188,7 @@ export async function ensureDocker(config, onMessage) {
   }
 
   if (engine === 'native') {
-    if (!runOk('docker', ['info'])) {
-      throw new Error('Docker daemon is not running. Please start Docker first.');
-    }
+    await ensureNativeDocker(config, onMessage);
     return;
   }
 

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1647,6 +1647,87 @@ test("ensureDockerDesktop reports when Docker Desktop is not running", async () 
   }
 });
 
+test("ensureNativeDocker throws install hint when docker is not installed", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  await assert.rejects(
+    () => sandboxEngine.ensureNativeDocker({}, null, {
+      runOkFn(cmd, args) {
+        assert.equal(cmd, "which");
+        assert.deepEqual(args, ["docker"]);
+        return false;
+      },
+      runSafeFn() {
+        assert.fail("docker version should not run when docker is missing");
+      }
+    }),
+    /not installed[\s\S]*docs\.docker\.com/
+  );
+});
+
+test("ensureNativeDocker throws daemon-down hint when docker info fails and version returns nothing", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const checks = [];
+
+  await assert.rejects(
+    () => sandboxEngine.ensureNativeDocker({}, null, {
+      runOkFn(cmd, args) {
+        checks.push([cmd, ...args]);
+        if (cmd === "which") {
+          return true;
+        }
+        if (cmd === "docker" && args[0] === "info") {
+          return false;
+        }
+        throw new Error(`unexpected check: ${cmd} ${args.join(" ")}`);
+      },
+      runSafeFn(cmd, args) {
+        assert.equal(cmd, "docker");
+        assert.deepEqual(args, ["version", "--format", "{{.Server.Version}}"]);
+        return "";
+      }
+    }),
+    /daemon is not running[\s\S]*systemctl start docker[\s\S]*DOCKER_HOST/
+  );
+  assert.deepEqual(checks, [
+    ["which", "docker"],
+    ["docker", "info"]
+  ]);
+});
+
+test("ensureNativeDocker throws permission hint when docker info fails but version succeeds", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  await assert.rejects(
+    () => sandboxEngine.ensureNativeDocker({}, null, {
+      runOkFn(cmd, args) {
+        if (cmd === "which") {
+          return true;
+        }
+        if (cmd === "docker" && args[0] === "info") {
+          return false;
+        }
+        throw new Error(`unexpected check: ${cmd} ${args.join(" ")}`);
+      },
+      runSafeFn(cmd, args) {
+        assert.equal(cmd, "docker");
+        assert.deepEqual(args, ["version", "--format", "{{.Server.Version}}"]);
+        return "25.0.0";
+      }
+    }),
+    /lack permission[\s\S]*usermod -aG docker/
+  );
+});
+
+test("ensureManagedVm gives Linux-specific message for native engine", async () => {
+  const sandboxVm = await loadFreshEsm("lib/sandbox/commands/vm.js");
+
+  assert.throws(
+    () => sandboxVm.ensureManagedVm("native"),
+    /does not use a managed VM/
+  );
+});
+
 test("startManagedVm uses OrbStack status instead of Docker daemon state", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const checks = [];


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #199

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

补齐 Linux native Docker 引擎的「开箱即用」体验，让 macOS / Linux 在沙箱使用上达到等价水平。

v0.5.0 后 macOS 通过 Colima 完成了沙箱体验闭环，但 Linux 仅有占位实现：`engine === 'native'` 只校验一次 `docker info`，三种失败状态（未装 docker / daemon 未起 / 用户无 docker 组权限）都抛同一句无指引价值的错误。本 PR 把 Linux 端的诊断、文档、CI 端到端三块同时补齐。

**显式不做（本期评估结论 → 已开 follow-up）**：
- rootless docker → #256
- podman → #257
- SELinux 自动 `:Z` 标签 → #258

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/engine.js` 新增 `ensureNativeDocker`：三态诊断（未装 / daemon down / 无权限），daemon-down 文案兼顾 rootless / remote `DOCKER_HOST`
- `lib/sandbox/commands/vm.js` 给 native 引擎专属错误：`Linux native Docker does not use a managed VM. Use 'ai sandbox create' directly.`
- `lib/sandbox/constants.js` 在 `detectHostResources` 加正向用途注释（managed-VM engines only）
- `install.sh` Linux 上加非阻塞 docker 检测；macOS 加 Colima/OrbStack 提示
- `README.md` + `README.zh-CN.md` 新增 Linux Prerequisites / Linux 前置条件章节，列已知限制并 cross-link follow-up issues
- `tests/cli/sandbox.test.js` 4 个新单测覆盖 `ensureNativeDocker` 三态 + `ensureManagedVm` native 分支，断言锁住可执行命令关键词（`systemctl start docker`、`usermod -aG docker`、`DOCKER_HOST`）
- `.github/workflows/sandbox-linux-e2e.yml` 新增 Linux 端到端 workflow：ubuntu-latest + label-based docker exec 冒烟 + `always()` cleanup；`pull_request` + `push:main` + `workflow_dispatch` 触发，paths 限制在沙箱相关源文件

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 单元：`node --test tests/cli/sandbox.test.js`（123 通过）
2. 全量：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js`（313 通过）
3. CI 端到端：`Sandbox Linux E2E` workflow ✅ 跑绿（1m41s，ubuntu-latest）
4. **手动实机冒烟**（已完成，结果以 comment 形式附在本 PR）：
   - ✅ OrbStack Linux Machine (Ubuntu 24.04 / amd64 / Docker 29.4.1)：full lifecycle + 态 2 daemon-down 错误诊断验证
   - ✅ 阿里云 ECS (Ubuntu 22.04 / amd64 / Docker 29.4.1)：full lifecycle (3m04s) + 态 2 验证；**意外发现 root 用户 UID 0 冲突 bug，已开 follow-up issue #261**

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（OrbStack + 阿里云 ECS 实机已完成，详见 PR comments）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（4 轮 review/refinement，详见 Issue #199 评论）
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock（依赖注入 `runOkFn`/`runSafeFn`）
- [x] 代码检查通过
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（README 双语 Linux 章节）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（**无破坏性变更**：仅扩展 native 分支的诊断与文档）
- [x] 我已经考虑了向后兼容性（macOS 路径完全未触及；不引入新配置项）

## 📋 附加信息 / Additional Notes

**关闭范围**：Closes #199（issue #159 多平台跟踪保持 OPEN，Linux 部分由本 PR 完成；Windows/WSL2 仍在 #184 跟踪）。

**Follow-up issues**：
- #256 evaluate rootless docker support on Linux（plan 阶段评估结论保留；README 中 cross-link）
- #257 evaluate podman support（plan 阶段评估结论保留；README 中 cross-link）
- #258 handle SELinux mount labels automatically（plan 阶段评估结论保留；README 中 cross-link）
- **#261 root user UID 0 conflict in `ai sandbox create`**（云 VM 冒烟时新发现的 bug；阿里云/华为云/腾讯云 ECS 默认 root 登录场景必踩；不在本 PR 范围）

**关键决策记录**：
- 不引入 `containerEngine` 抽象层 —— 严格匹配 issue #199「评估」语义，避免过度工程
- `detectHostResources` 仅加注释不做 cgroup 适配 —— Linux native 路径不调用此函数
- `install.sh` 仅检测不安装 docker —— 跨发行版包管理水太深，由用户自行处理
- `templateVersion` 在本分支保持 `v0.5.8` —— 跟随 main 上 #3949e1b 的测试放宽（templateVersion 跟踪上一发布版而非 alpha 版本）

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `.github/workflows/sandbox-linux-e2e.yml` 在 `ubuntu-latest` 上的首次运行结果：如果 `gh auth token` / Claude credentials stub / image build 时长任一处出问题，会在 Checks 里直接暴露
- `ensureNativeDocker` 的三态判断使用 `docker version --format '{{.Server.Version}}'` 区分 daemon-down 和 permission-denied —— 如果在某发行版下行为不符合预期，在评论中告知
- 本任务的 review/refinement 历史在 issue #199 评论里完整保留，可作为决策追溯参考

Generated with AI assistance.

