### PR TITLE
fix(validate-artifact): 修复 sandbox worktree 模式下的 PR HEAD 检测

### DIFF
--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -498,7 +498,7 @@ function checkPrCommentLastCommit(context, remoteData) {
     );
   }
 
-  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  const headResult = resolvePrHeadSha(context);
   if (!headResult.ok) {
     return headResult.type === "check_failed"
       ? failResult(CHECK_TYPE, headResult.message, headResult.type)
@@ -1135,6 +1135,51 @@ function gitText(args, cwd) {
   }
 
   return { ok: true, value: String(result.stdout || "").trim() };
+}
+
+function resolvePrHeadSha(context) {
+  const fallback = () => withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  const branch = String(context.task?.metadata?.branch || "").trim();
+  if (!branch) {
+    return fallback();
+  }
+
+  const worktreeList = withRetry(() => gitText(["worktree", "list", "--porcelain"], context.taskDir));
+  if (!worktreeList.ok) {
+    return fallback();
+  }
+
+  const matchedWorktree = findWorktreeForBranch(worktreeList.value, branch);
+  if (!matchedWorktree) {
+    return fallback();
+  }
+
+  const headInWorktree = withRetry(() => gitText(["rev-parse", "HEAD"], matchedWorktree));
+  if (!headInWorktree.ok) {
+    return fallback();
+  }
+
+  return headInWorktree;
+}
+
+function findWorktreeForBranch(porcelainOutput, branch) {
+  let currentWorktree = "";
+  for (const rawLine of String(porcelainOutput || "").split("\n")) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("worktree ")) {
+      currentWorktree = line.slice("worktree ".length).trim();
+      continue;
+    }
+
+    if (line.startsWith("branch refs/heads/")) {
+      const usedBranch = line.slice("branch refs/heads/".length).trim();
+      if (usedBranch === branch && currentWorktree) {
+        return currentWorktree;
+      }
+    }
+  }
+
+  return null;
 }
 
 function withRetry(operation) {

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -498,7 +498,7 @@ function checkPrCommentLastCommit(context, remoteData) {
     );
   }
 
-  const headResult = withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  const headResult = resolvePrHeadSha(context);
   if (!headResult.ok) {
     return headResult.type === "check_failed"
       ? failResult(CHECK_TYPE, headResult.message, headResult.type)
@@ -1135,6 +1135,51 @@ function gitText(args, cwd) {
   }
 
   return { ok: true, value: String(result.stdout || "").trim() };
+}
+
+function resolvePrHeadSha(context) {
+  const fallback = () => withRetry(() => gitText(["rev-parse", "HEAD"], context.taskDir));
+  const branch = String(context.task?.metadata?.branch || "").trim();
+  if (!branch) {
+    return fallback();
+  }
+
+  const worktreeList = withRetry(() => gitText(["worktree", "list", "--porcelain"], context.taskDir));
+  if (!worktreeList.ok) {
+    return fallback();
+  }
+
+  const matchedWorktree = findWorktreeForBranch(worktreeList.value, branch);
+  if (!matchedWorktree) {
+    return fallback();
+  }
+
+  const headInWorktree = withRetry(() => gitText(["rev-parse", "HEAD"], matchedWorktree));
+  if (!headInWorktree.ok) {
+    return fallback();
+  }
+
+  return headInWorktree;
+}
+
+function findWorktreeForBranch(porcelainOutput, branch) {
+  let currentWorktree = "";
+  for (const rawLine of String(porcelainOutput || "").split("\n")) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("worktree ")) {
+      currentWorktree = line.slice("worktree ".length).trim();
+      continue;
+    }
+
+    if (line.startsWith("branch refs/heads/")) {
+      const usedBranch = line.slice("branch refs/heads/".length).trim();
+      if (usedBranch === branch && currentWorktree) {
+        return currentWorktree;
+      }
+    }
+  }
+
+  return null;
 }
 
 function withRetry(operation) {

--- a/tests/core/validate-artifact.test.js
+++ b/tests/core/validate-artifact.test.js
@@ -291,6 +291,33 @@ function createHeadCommit(repoRoot) {
   return revParseResult.stdout.trim();
 }
 
+function addWorktree(repoRoot, worktreePath, branch) {
+  const result = spawnSync("git", ["worktree", "add", worktreePath, "-b", branch], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function commitInWorktree(worktreePath, message) {
+  const commitResult = spawnSync("git", ["commit", "--allow-empty", "-qm", message], {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(commitResult.status, 0, commitResult.stderr);
+
+  const revParseResult = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(revParseResult.status, 0, revParseResult.stderr);
+
+  return revParseResult.stdout.trim();
+}
+
 test("validate-artifact gate passes for implement-task with fresh task and artifact", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-pass-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");
@@ -1395,6 +1422,159 @@ test("validate-artifact platform-sync passes for commit when summary comment exi
     }));
     writeJson(prCommentsPath, [
       { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${headSha} -->\n## Review Summary\n\nLooks good.` }
+    ]);
+
+    const result = runValidator([
+      "check",
+      "platform-sync",
+      taskDir,
+      "--skill",
+      "commit"
+    ], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        GH_FAKE_ISSUE_PATH: issuePath,
+        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
+        GH_FAKE_ISSUE_NUMBER: "65",
+        GH_FAKE_PR_NUMBER: "77"
+      }
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.type, "platform-sync");
+    assert.equal(payload.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync passes for commit with last-commit from task branch worktree", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-worktree-pass-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const worktreePath = path.join(tempRoot, "sandbox-worktree");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+  const branch = "agent-infra-feature-pr";
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    const mainSha = createHeadCommit(tempRoot);
+    addWorktree(tempRoot, worktreePath, branch);
+    const prSha = commitInWorktree(worktreePath, "sandbox commit");
+    assert.notEqual(prSha, mainSha);
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({ branch, issue_number: "65", pr_number: "77" }));
+    writeJson(issuePath, buildIssuePayload({
+      labels: [],
+      body: "# Issue\n"
+    }));
+    writeJson(prCommentsPath, [
+      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${prSha} -->\n## Review Summary\n\nLooks good.` }
+    ]);
+
+    const result = runValidator([
+      "check",
+      "platform-sync",
+      taskDir,
+      "--skill",
+      "commit"
+    ], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        GH_FAKE_ISSUE_PATH: issuePath,
+        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
+        GH_FAKE_ISSUE_NUMBER: "65",
+        GH_FAKE_PR_NUMBER: "77"
+      }
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.type, "platform-sync");
+    assert.equal(payload.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync falls back to taskDir HEAD when task branch is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-no-branch-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    const mainSha = createHeadCommit(tempRoot);
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
+    writeJson(issuePath, buildIssuePayload({
+      labels: [],
+      body: "# Issue\n"
+    }));
+    writeJson(prCommentsPath, [
+      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${mainSha} -->\n## Review Summary\n\nLooks good.` }
+    ]);
+
+    const result = runValidator([
+      "check",
+      "platform-sync",
+      taskDir,
+      "--skill",
+      "commit"
+    ], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        GH_FAKE_ISSUE_PATH: issuePath,
+        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
+        GH_FAKE_ISSUE_NUMBER: "65",
+        GH_FAKE_PR_NUMBER: "77"
+      }
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.type, "platform-sync");
+    assert.equal(payload.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync falls back to taskDir HEAD when task branch worktree is unmatched", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-unmatched-branch-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    const mainSha = createHeadCommit(tempRoot);
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      branch: "agent-infra-feature-missing",
+      issue_number: "65",
+      pr_number: "77"
+    }));
+    writeJson(issuePath, buildIssuePayload({
+      labels: [],
+      body: "# Issue\n"
+    }));
+    writeJson(prCommentsPath, [
+      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${mainSha} -->\n## Review Summary\n\nLooks good.` }
     ]);
 
     const result = runValidator([


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #264

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

修复 `validate-artifact` 在 sandbox worktree 模式下的 PR HEAD 误判：当 task workspace 通过 docker bind mount 共享自主 worktree、真实 PR commit 落在 sandbox 创建的独立 worktree 上时，原逻辑直接在 task workspace cwd 跑 `git rev-parse HEAD`，拿到的是 main 分支头而不是 PR 分支头，导致 `<!-- last-commit: <sha> -->` 元数据校验误报失败，阻塞 `/commit` 与 `/create-pr` 工作流。

修复后 validator 能在多 worktree 状态下正确识别 PR 分支真正所在的 worktree，让 sandbox 工作流不再需要手动绕过。

## 📋 主要变更 / Brief Changelog

- `checkPrCommentLastCommit` 改为调用新的 `resolvePrHeadSha`：先从 `task.md` frontmatter 读 `branch`，再用 `git worktree list --porcelain` 找匹配 worktree 并在其中 `git rev-parse HEAD`
- 缺 `branch` 字段、worktree 列表解析失败、未匹配或在匹配 worktree 内 rev-parse 失败时，**全部回退**到现有 `cwd = taskDir` 行为，单 worktree 场景零行为变化
- 模板 GitHub platform adapter (`templates/.agents/scripts/platform-adapters/platform-sync.github.js`) 同步修改，与 deployed 副本保持 byte-for-byte 一致
- 新增三个测试用例：worktree 场景 last-commit 校验通过 / 缺 `branch` fallback / `branch` 设置但 worktree 未匹配 fallback

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/core/validate-artifact.test.js` —— 40 用例全过，包括三个新增 worktree 场景用例与现有 last-commit pass/mismatch/missing 用例
2. `node --test tests/scripts/platform-adapter-defaults.test.js tests/templates/platform-coupling.test.js` —— 双写一致性与默认值校验全过
3. `npm test` —— pre-commit hook 跑全量 317 用例，0 失败

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（pre-commit hook 全量 `npm test`）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（task workspace `review.md`：0 blocker / 0 major / 0 minor）
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档（无文档变更：纯实现修复，行为对外契约不变）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更）
- [x] 我已经考虑了向后兼容性（单 worktree / 缺 `branch` 路径全部 fallback 到原行为）

## 📋 附加信息 / Additional Notes

- 候选方案 B（`--pr-head <sha>` 显式参数）作为未来 escape hatch 暂未实现；候选方案 C（`git for-each-ref`）因依赖 ref store 同步语义被否决，详见 task workspace `plan.md`。
- task workspace 内部追踪：`TASK-20260429-235730`。

---

**审查者注意事项 / Reviewer Notes:**

- `resolvePrHeadSha` 的四个失败分支是否都正确回退到 `cwd = taskDir`
- `findWorktreeForBranch` 的 porcelain 解析是否能稳健忽略 `HEAD <sha>` / `detached` / `locked` / `prunable` 等其他字段
- 三个新增测试用例是否准确复现 sandbox worktree 与 fallback 边界

Generated with AI assistance.
