### PR TITLE
fix(sandbox): allow root host UID for image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=18); c
 
 These configurations are not actively tested in this release:
 
-- Running `ai sandbox create` as **root** (uid 0): image build fails on `useradd`. Track [#261](https://github.com/fitlab-ai/agent-infra/issues/261).
 - **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
 - **Podman** instead of Docker: Track [#257](https://github.com/fitlab-ai/agent-infra/issues/257).
 - **SELinux-enforcing** hosts (Fedora / RHEL) may need manual mount labels: Track [#258](https://github.com/fitlab-ai/agent-infra/issues/258).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -268,7 +268,6 @@ agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器
 
 下列场景在本期未做主动验证：
 
-- 以 **root**（uid 0）运行 `ai sandbox create`：image build 在 `useradd` 步骤失败。后续跟踪 [#261](https://github.com/fitlab-ai/agent-infra/issues/261)。
 - **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
 - 用 **Podman** 替代 Docker：后续跟踪 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
 - **SELinux enforcing** 宿主机（Fedora / RHEL）可能需要手动加挂载标签：后续跟踪 [#258](https://github.com/fitlab-ai/agent-infra/issues/258)。

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -7,8 +7,15 @@ ENV TZ=Asia/Shanghai
 
 ARG HOST_UID=1000
 ARG HOST_GID=1000
-RUN (groupadd -g ${HOST_GID} devuser || true) && \
-    useradd -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser
+# Root host uid 0 collides with container root; -o lets devuser share uid 0
+# while keeping a real passwd entry that USER devuser can resolve.
+RUN if [ "${HOST_UID}" = "0" ]; then \
+        (groupadd -o -g ${HOST_GID} devuser || true) && \
+        useradd -o -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser; \
+    else \
+        (groupadd -g ${HOST_GID} devuser || true) && \
+        useradd -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser; \
+    fi
 
 RUN apt-get update && apt-get install -y \
     curl wget git vim file \

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1336,6 +1336,58 @@ test("buildImage uses verbose docker build output while keeping host UID/GID loo
   ]);
 });
 
+test("buildImage forwards HOST_UID=0 and HOST_GID=0 unchanged when host runs as root", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const calls = [];
+
+  sandboxCreate.buildImage(
+    { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
+    [{ npmPackage: "@acme/tool" }],
+    "/tmp/Dockerfile",
+    "sig-123",
+    {
+      runFn(cmd, args) {
+        calls.push({ type: "run", cmd, args });
+        if (cmd === "id" && args[0] === "-u") {
+          return "0";
+        }
+        if (cmd === "id" && args[0] === "-g") {
+          return "0";
+        }
+        throw new Error(`unexpected quiet command: ${cmd} ${args.join(" ")}`);
+      },
+      runVerboseFn(cmd, args, opts) {
+        calls.push({ type: "verbose", cmd, args, opts });
+      }
+    }
+  );
+
+  assert.deepEqual(calls.slice(0, 2), [
+    { type: "run", cmd: "id", args: ["-u"] },
+    { type: "run", cmd: "id", args: ["-g"] }
+  ]);
+  assert.equal(calls.length, 3);
+  assert.equal(calls[2].type, "verbose");
+  assert.equal(calls[2].cmd, "docker");
+  assert.equal(calls[2].opts.cwd, "/repo");
+  assert.deepEqual(calls[2].args.slice(0, 7), [
+    "build",
+    "-t",
+    "demo-sandbox:latest",
+    "--build-arg",
+    "HOST_UID=0",
+    "--build-arg",
+    "HOST_GID=0"
+  ]);
+});
+
+test("base.dockerfile guards root host uid with useradd -o", () => {
+  const content = fs.readFileSync(filePath("lib/sandbox/runtimes/base.dockerfile"), "utf8");
+
+  assert.match(content, /if \[ "\$\{HOST_UID\}" = "0" \]/);
+  assert.match(content, /useradd -o -u \$\{HOST_UID\}/);
+});
+
 test("commandErrorMessage prefers stderr over the generic execFileSync message", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #261

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

修复 #261：在 Linux 上以 root（uid=0）运行 `ai sandbox create` 时，`base.dockerfile` 的 `useradd -u 0 -g 0 ...` 会与容器内已有的 root 冲突，整条 RUN 退出 4，导致 image build 失败。该路径在阿里云 ECS、华为云 ECS 等 root 默认登录的国内云主机上**必踩**，但 GitHub Actions runner（uid 1001）等 CI 环境完全不触发，因此 PR #260（Linux native sandbox）的 `sandbox-linux-e2e.yml` 跑绿后才在实机冒烟时暴露。

采用 Issue body 推荐的方案 B 的 B-2 变体：在 `base.dockerfile` 内对 `HOST_UID` 显式分支，root 路径下用 `groupadd -o` / `useradd -o` 允许非唯一 uid/gid，让 `devuser` 与容器内 `root` 共享 uid 0，同时保留可被 `USER devuser` 解析的 passwd entry；非 root 路径与原命令逐字一致，零回归风险。`buildImage` 不在 Node.js 侧做 uid 重写，修复责任完全落在 Dockerfile 一侧。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/runtimes/base.dockerfile`：新增 `if [ "${HOST_UID}" = "0" ]; then ... else ... fi` 分支，root 路径加 `-o` 标志；其余 RUN 与现有 `apt-get` / `tmux` 编译块保持原状。
- `tests/cli/sandbox.test.js`：新增两条测试 —— `buildImage forwards HOST_UID=0 ...`（mock `runFn` 返回 `'0'`，断言 `--build-arg HOST_UID=0/HOST_GID=0` 透传，且 `buildImage` 没在 Node.js 侧做额外 uid 调用）以及 `base.dockerfile guards root host uid with useradd -o`（结构性断言 root 分支与 `-o` 标志存在）。
- `README.md` / `README.zh-CN.md`：从 “Linux known limitations / 已知限制” 删除 `root (uid 0)` 创建失败条目（问题已解决）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. **单元测试**：本地 `npm test` 全量 314/314 通过；新增的 root 路径测试与 Dockerfile 结构性测试均 pass。
2. **CI 兜底**：现有 `sandbox-linux-e2e.yml`（runner uid=1001）继续走 `else` 分支，行为与合并前完全等价，应保持绿。
3. **实机验证（待 merge 前补）**：
   - **Owner**：任务发起人 @CodeCasterX
   - **环境**：阿里云 ECS Ubuntu 22.04，root 默认登录
   - **流程**：按 issue body 复现脚本走完 `ai sandbox create test-branch main` → `ai sandbox exec test-branch -- id` / `whoami` / `ls /home/devuser` → `ai sandbox rm test-branch`
   - **要求**：merge 前在本 PR 评论里贴出三段日志（create 时长、exec 输出、rm 成功）。如 merge 前实机不可用，请在 PR 标题前缀 `[awaiting smoke]` 或挂阻塞 label。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（Aliyun ECS 实机验证 owner 已分配，merge 前补；见上）

## 📋 附加信息 / Additional Notes

**升级注意 / Upgrade impact**：本次改动会改变 `base.dockerfile` 的内容，从而让 `dockerfileSignature`（`lib/sandbox/dockerfile.js:55-60` 取 sha256 前 12 位）变化。**既有 sandbox 用户在升级到含本 fix 的版本后，第一次执行 `ai sandbox create` 或 `ai sandbox rebuild` 会触发一次性的 image rebuild**（耗时与初次构建相当），属预期行为，无需代码兜底，但建议在 release notes 中提示。

**Follow-up 备注**：`tests/cli/sandbox.test.js` 中的 Dockerfile 结构性断言用 `${HOST_UID}` 字面正则（非 `$HOST_UID`），未来若 base.dockerfile 改写为不带花括号的 shell 语法，需要把测试松绑或拆成 “分支存在 / `-o` 标志存在” 两条独立断言；不在本 PR 范围内处理。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（Round 1 + Round 2，均 Approved；见 Issue #261 审查评论）
- [x] 我已经为复杂的代码添加了必要的注释（base.dockerfile root 分支 why-注释，含修复机制）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock（`runFn` / `runVerboseFn` 注入）
- [x] 单元测试通过 (`npm test` 314/314)

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（`README.md` + `README.zh-CN.md` 双语同步删除已知限制条目）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（Dockerfile signature 变化导致一次性 rebuild，已在「附加信息」中说明）
- [x] 我已经考虑了向后兼容性（非 root 分支命令逐字保留，CI/macOS/Linux 非 root 行为不变）

---

Generated with AI assistance