### PR TITLE
ci: 全平台 PR 测试矩阵（Linux/Win/macOS）+ Node 升至 22

### DIFF
--- a/.agents/scripts/platform-adapters/find-existing-task.js
+++ b/.agents/scripts/platform-adapters/find-existing-task.js
@@ -1,5 +1,5 @@
-import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import spawn from "cross-spawn";
 
 const markerPattern = /^<!-- sync-issue:(TASK-\d{8}-\d{6}):([a-z][a-z0-9-]*) -->$/;
 
@@ -44,12 +44,9 @@ function usage() {
 
 function runGh(args) {
   const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
-  const result = spawnSync(ghBin, args, {
+  const result = spawn.sync(ghBin, args, {
     encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
-    // Windows gh installations commonly resolve to gh.cmd; Node 22 rejects
-    // direct .cmd/.bat spawning without a shell as part of BatBadBut hardening.
-    shell: process.platform === "win32"
+    maxBuffer: 10 * 1024 * 1024
   });
 
   if (result.error) {

--- a/.agents/scripts/platform-adapters/find-existing-task.js
+++ b/.agents/scripts/platform-adapters/find-existing-task.js
@@ -46,7 +46,10 @@ function runGh(args) {
   const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
   const result = spawnSync(ghBin, args, {
     encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024
+    maxBuffer: 10 * 1024 * 1024,
+    // Windows gh installations commonly resolve to gh.cmd; Node 22 rejects
+    // direct .cmd/.bat spawning without a shell as part of BatBadBut hardening.
+    shell: process.platform === "win32"
   });
 
   if (result.error) {

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { spawnSync } from "node:child_process";
+import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
@@ -1034,7 +1034,7 @@ function resolveUpstreamRepo(taskDir) {
 }
 
 function resolveOwnerRepo(taskDir) {
-  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
+  const gitResult = spawn.sync("git", ["remote", "get-url", "origin"], {
     cwd: taskDir,
     encoding: "utf8"
   });
@@ -1097,12 +1097,11 @@ function ghText(args, cwd) {
 }
 
 function ghCommand(args, cwd) {
-  const command = resolveCommand("gh");
-  const result = spawnSync(command, args, commandOptions(command, {
+  const result = spawn.sync("gh", args, {
     cwd,
     encoding: "utf8",
     env: process.env
-  }));
+  });
 
   if (result.status !== 0) {
     const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
@@ -1118,12 +1117,11 @@ function ghPaginatedJson(args, cwd) {
 }
 
 function gitText(args, cwd) {
-  const command = resolveCommand("git");
-  const result = spawnSync(command, args, commandOptions(command, {
+  const result = spawn.sync("git", args, {
     cwd,
     encoding: "utf8",
     env: process.env
-  }));
+  });
 
   if (result.status !== 0) {
     const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
@@ -1235,39 +1233,6 @@ function sleep(delayMs) {
   }
 
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
-}
-
-function resolveCommand(cmd) {
-  if (process.platform !== "win32" || path.extname(cmd)) {
-    return cmd;
-  }
-
-  const pathValue = process.env.Path || process.env.PATH || "";
-  const extensions = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
-    .split(";")
-    .filter(Boolean);
-
-  for (const dir of pathValue.split(path.delimiter).filter(Boolean)) {
-    for (const extension of extensions) {
-      const lowerCandidate = path.join(dir, `${cmd}${extension.toLowerCase()}`);
-      if (fs.existsSync(lowerCandidate)) {
-        return lowerCandidate;
-      }
-      const upperCandidate = path.join(dir, `${cmd}${extension.toUpperCase()}`);
-      if (fs.existsSync(upperCandidate)) {
-        return upperCandidate;
-      }
-    }
-  }
-
-  return cmd;
-}
-
-function commandOptions(cmd, options) {
-  if (process.platform === "win32" && /\.(?:bat|cmd)$/i.test(cmd)) {
-    return { ...options, shell: true };
-  }
-  return options;
 }
 
 function interpolate(template, taskDir, artifactFile) {

--- a/.agents/skills/test-integration/SKILL.md
+++ b/.agents/skills/test-integration/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 ## 1. 验证前置条件
 
-确认 Node.js >= 18 已安装（用于内置测试运行器）。
+确认 Node.js >= 22 已安装（用于内置测试运行器）。
 
 ```bash
 node --version

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,7 +50,7 @@ npm test
 
 ## 测试要求
 
-- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 18）
+- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 22）
 - 运行命令：`npm test`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Default: auto-detect text files and force LF on checkout
+* text=auto eol=lf
+
+# Source code (explicit, in case detection fails)
+*.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+*.jsonc text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.md text eol=lf
+
+# Shell scripts must be LF (executed on Linux/macOS, also fine on Git Bash for Windows)
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf
+
+# Windows-specific scripts must be CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+
+# Binary files (no diff, no merge)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.gz binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
 

--- a/.github/workflows/sandbox-linux-e2e.yml
+++ b/.github/workflows/sandbox-linux-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,9 +12,14 @@ concurrency:
 
 jobs:
   unit-tests:
-    name: Run npm test on Node 20
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} / Node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: [22]
     permissions:
       contents: read
     steps:
@@ -24,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Read package version from released commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js t
 
 ## 测试要求
 
-- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 18）
+- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 22）
 - 运行命令：`node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js tests/scripts/*.test.js`
 - 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@
 ### 前置条件
 
 - Git
-- Node.js >= 18（用于内置测试运行器 `node:test`）
+- Node.js >= 22（用于内置测试运行器 `node:test`）
 - Shell（sh/bash/zsh）
 
 ### 快速开始
@@ -155,7 +155,7 @@ npm test
 
 ## 测试
 
-- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 18）
+- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 22）
 - 构建命令：`npm run build`（修改 `src/`、`lib/defaults.json` 或版本信息后需要运行）
 - 运行命令：`npm test`
 - 等价于：`node scripts/build-inline.js --check && node --test tests/*.test.js`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://www.npmjs.com/package/@fitlab-ai/agent-infra"><img src="https://img.shields.io/npm/v/@fitlab-ai/agent-infra" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@fitlab-ai/agent-infra"><img src="https://img.shields.io/npm/dm/@fitlab-ai/agent-infra" alt="npm downloads"></a>
   <a href="License.txt"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D18-brightgreen?logo=node.js" alt="Node.js >= 18"></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-brightgreen?logo=node.js" alt="Node.js >= 22"></a>
   <a href="https://github.com/fitlab-ai/agent-infra/releases"><img src="https://img.shields.io/github/v/release/fitlab-ai/agent-infra" alt="GitHub release"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
@@ -240,7 +240,7 @@ agent-infra is intentionally simple: a bootstrap CLI creates the seed configurat
 
 ## Platform Support
 
-agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=18); container-related features (`ai sandbox *`) additionally need Docker.
+agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=22); container-related features (`ai sandbox *`) additionally need Docker.
 
 ### macOS
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
   <a href="https://www.npmjs.com/package/@fitlab-ai/agent-infra"><img src="https://img.shields.io/npm/v/@fitlab-ai/agent-infra" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@fitlab-ai/agent-infra"><img src="https://img.shields.io/npm/dm/@fitlab-ai/agent-infra" alt="npm downloads"></a>
   <a href="License.txt"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D18-brightgreen?logo=node.js" alt="Node.js >= 18"></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-brightgreen?logo=node.js" alt="Node.js >= 22"></a>
   <a href="https://github.com/fitlab-ai/agent-infra/releases"><img src="https://img.shields.io/github/v/release/fitlab-ai/agent-infra" alt="GitHub release"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
@@ -240,7 +240,7 @@ agent-infra 的结构刻意保持简单：引导 CLI 负责生成种子配置，
 
 ## 平台支持
 
-agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器相关功能（`ai sandbox *`）额外需要 Docker。
+agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=22)；容器相关功能（`ai sandbox *`）额外需要 Docker。
 
 ### macOS
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,9 +3,9 @@ import { VERSION } from '../lib/version.js';
 
 // Node.js version check
 const major = parseInt(process.versions.node.split('.')[0], 10);
-if (major < 18) {
+if (major < 22) {
   process.stderr.write(
-    `agent-infra requires Node.js >= 18 (current: ${process.version})\n`
+    `agent-infra requires Node.js >= 22 (current: ${process.version})\n`
   );
   process.exit(1);
 }

--- a/install.sh
+++ b/install.sh
@@ -13,21 +13,21 @@ err()   { printf '  \033[1;31m✗\033[0m %s\n' "$*" >&2; }
 
 # ---------- pre-checks ----------
 if ! command -v node >/dev/null 2>&1; then
-  err "Node.js >= 18 is required but not found."
+  err "Node.js >= 22 is required but not found."
   err "Install Node.js: https://nodejs.org/"
   exit 1
 fi
 
 NODE_MAJOR=$(node -e 'process.stdout.write(String(parseInt(process.versions.node)))' 2>/dev/null || echo 0)
-if [ "$NODE_MAJOR" -lt 18 ] 2>/dev/null; then
-  err "Node.js >= 18 is required (current: $(node --version))."
+if [ "$NODE_MAJOR" -lt 22 ] 2>/dev/null; then
+  err "Node.js >= 22 is required (current: $(node --version))."
   err "Please upgrade: https://nodejs.org/"
   exit 1
 fi
 
 if ! command -v npm >/dev/null 2>&1; then
   err "npm is required but not found."
-  err "npm is bundled with Node.js >= 18. Please reinstall Node.js: https://nodejs.org/"
+  err "npm is bundled with Node.js >= 22. Please reinstall Node.js: https://nodejs.org/"
   exit 1
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.3.0",
+        "cross-spawn": "^7.0.6",
         "picocolors": "1.1.1"
       },
       "bin": {
@@ -48,6 +49,20 @@
         "node": ">= 20.12.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -72,17 +87,68 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ai": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@clack/core": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "1.3.0",
+    "cross-spawn": "^7.0.6",
     "picocolors": "1.1.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "templates/"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "keywords": [
     "ai",

--- a/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
+++ b/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
@@ -1,5 +1,5 @@
-import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import spawn from "cross-spawn";
 
 const markerPattern = /^<!-- sync-issue:(TASK-\d{8}-\d{6}):([a-z][a-z0-9-]*) -->$/;
 
@@ -44,12 +44,9 @@ function usage() {
 
 function runGh(args) {
   const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
-  const result = spawnSync(ghBin, args, {
+  const result = spawn.sync(ghBin, args, {
     encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
-    // Windows gh installations commonly resolve to gh.cmd; Node 22 rejects
-    // direct .cmd/.bat spawning without a shell as part of BatBadBut hardening.
-    shell: process.platform === "win32"
+    maxBuffer: 10 * 1024 * 1024
   });
 
   if (result.error) {

--- a/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
+++ b/templates/.agents/scripts/platform-adapters/find-existing-task.github.js
@@ -46,7 +46,10 @@ function runGh(args) {
   const ghBin = process.env.IMPORT_ISSUE_GH_BIN || "gh";
   const result = spawnSync(ghBin, args, {
     encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024
+    maxBuffer: 10 * 1024 * 1024,
+    // Windows gh installations commonly resolve to gh.cmd; Node 22 rejects
+    // direct .cmd/.bat spawning without a shell as part of BatBadBut hardening.
+    shell: process.platform === "win32"
   });
 
   if (result.error) {

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { spawnSync } from "node:child_process";
+import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
@@ -1034,7 +1034,7 @@ function resolveUpstreamRepo(taskDir) {
 }
 
 function resolveOwnerRepo(taskDir) {
-  const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
+  const gitResult = spawn.sync("git", ["remote", "get-url", "origin"], {
     cwd: taskDir,
     encoding: "utf8"
   });
@@ -1097,12 +1097,11 @@ function ghText(args, cwd) {
 }
 
 function ghCommand(args, cwd) {
-  const command = resolveCommand("gh");
-  const result = spawnSync(command, args, commandOptions(command, {
+  const result = spawn.sync("gh", args, {
     cwd,
     encoding: "utf8",
     env: process.env
-  }));
+  });
 
   if (result.status !== 0) {
     const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
@@ -1118,12 +1117,11 @@ function ghPaginatedJson(args, cwd) {
 }
 
 function gitText(args, cwd) {
-  const command = resolveCommand("git");
-  const result = spawnSync(command, args, commandOptions(command, {
+  const result = spawn.sync("git", args, {
     cwd,
     encoding: "utf8",
     env: process.env
-  }));
+  });
 
   if (result.status !== 0) {
     const stderr = `${result.stderr || ""}${result.stdout || ""}`.trim();
@@ -1235,39 +1233,6 @@ function sleep(delayMs) {
   }
 
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
-}
-
-function resolveCommand(cmd) {
-  if (process.platform !== "win32" || path.extname(cmd)) {
-    return cmd;
-  }
-
-  const pathValue = process.env.Path || process.env.PATH || "";
-  const extensions = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
-    .split(";")
-    .filter(Boolean);
-
-  for (const dir of pathValue.split(path.delimiter).filter(Boolean)) {
-    for (const extension of extensions) {
-      const lowerCandidate = path.join(dir, `${cmd}${extension.toLowerCase()}`);
-      if (fs.existsSync(lowerCandidate)) {
-        return lowerCandidate;
-      }
-      const upperCandidate = path.join(dir, `${cmd}${extension.toUpperCase()}`);
-      if (fs.existsSync(upperCandidate)) {
-        return upperCandidate;
-      }
-    }
-  }
-
-  return cmd;
-}
-
-function commandOptions(cmd, options) {
-  if (process.platform === "win32" && /\.(?:bat|cmd)$/i.test(cmd)) {
-    return { ...options, shell: true };
-  }
-  return options;
 }
 
 function interpolate(template, taskDir, artifactFile) {

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -293,7 +293,7 @@ test("agent-infra init records optional external skill sources", () => {
 });
 
 test("installed sync-templates.js executes inside a type=module project", () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-esm-"));
+  const tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-esm-")));
   const cli = filePath("bin/cli.js");
 
   try {

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -293,7 +293,7 @@ test("agent-infra init records optional external skill sources", () => {
 });
 
 test("installed sync-templates.js executes inside a type=module project", () => {
-  const tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-esm-")));
+  const tmpDir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-esm-")));
   const cli = filePath("bin/cli.js");
 
   try {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -12,6 +12,7 @@ import {
   filePath,
   gitSafeEnv,
   loadFreshEsm,
+  onPlatforms,
   withGitSafeProcessEnv
 } from "../helpers.js";
 import { restoreTerminal, runInteractive } from "../../lib/sandbox/shell.js";
@@ -218,7 +219,7 @@ test("sandbox create fails before preparing a temporary Dockerfile when Claude c
   }
 });
 
-test("sandbox vm stop warns instead of stopping when OrbStack is not running", async () => {
+test("sandbox vm stop warns instead of stopping when OrbStack is not running", onPlatforms("darwin", "linux"), async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-vm-stop-orb-"));
   const repoDir = path.join(tmpDir, "repo");
   const binDir = path.join(tmpDir, "bin");

--- a/tests/core/release.test.js
+++ b/tests/core/release.test.js
@@ -19,6 +19,7 @@ test("package metadata supports scoped npm publishing", () => {
   });
   assert.deepEqual(Object.keys(pkg.dependencies).sort(), [
     "@clack/prompts",
+    "cross-spawn",
     "picocolors"
   ]);
   assert.equal(

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -121,6 +121,14 @@ function assertModeBits(filePathname, expectedMode) {
   assertEqual(actualMode, expectedMode);
 }
 
+function onPlatforms(...allowed) {
+  return {
+    skip: allowed.includes(process.platform)
+      ? false
+      : `requires ${allowed.join("/")} (current: ${process.platform})`
+  };
+}
+
 function assertEqual(actual, expected) {
   if (actual !== expected) {
     throw new Error(`Expected mode ${expected.toString(8)}, got ${actual.toString(8)}`);
@@ -402,6 +410,7 @@ export {
   pathWithPrependedBin,
   read,
   renderPlaceholders,
+  onPlatforms,
   supportsPosixModeBits,
   withGitSafeProcessEnv,
   writeNodeCommandShim,

--- a/tests/scripts/platform-adapter-defaults.test.js
+++ b/tests/scripts/platform-adapter-defaults.test.js
@@ -23,6 +23,12 @@ function writeJson(filePathname, value) {
   write(filePathname, JSON.stringify(value, null, 2));
 }
 
+function linkNodeModules(tempRoot) {
+  const source = path.join(process.cwd(), "node_modules");
+  const target = path.join(tempRoot, "node_modules");
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}
+
 function writeFakeGh(filePathname) {
   const scriptPath = `${filePathname}.cjs`;
   write(scriptPath, read("tests/fixtures/validate-artifact/fake-gh.js"));
@@ -97,6 +103,7 @@ test("platform-sync verification keys override legacy literal values", () => {
   try {
     initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
     write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }));
+    linkNodeModules(tempRoot);
     write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
     write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
     writeFakeGh(ghPath);
@@ -149,6 +156,7 @@ test("platform-sync verification keeps legacy literal fallback", () => {
   try {
     initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
     write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }));
+    linkNodeModules(tempRoot);
     write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
     write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
     writeFakeGh(ghPath);


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #242

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality) — 新增三平台 CI 矩阵
- [x] 💥 破坏性变更 / Breaking change (minor) — `engines.node` 由 `>=18` 收紧为 `>=22`

## 📝 变更目的 / Purpose of the Change

PR 合入前缺乏跨平台测试覆盖，仓库现有 `unit-tests.yml` 仅在 `ubuntu-latest` × Node 20 单点验证；Windows / macOS 兼容性问题只能在 release 阶段或下游用户手中暴露。

本 PR 把 PR 单测扩展为 Linux / Windows / macOS × Node 22 的三平台矩阵，并顺势消除"声明 vs 测试不一致"：原仓库声明支持 Node 18，但 CI 实际只跑 Node 20；Node 18（2025-04-30）和 Node 20（2026-04-30）现均已 EOL。本 PR 把全仓库 Node 版本声明（4 个 workflow / `engines.node` / lockfile / README badge / 平台说明 / `bin/cli.js` 自检 / `install.sh` / 贡献者文档 / AI 协作指南）统一收敛到 `>=22`，让"声明=测试"。

## 📋 主要变更 / Brief Changelog

- **`.github/workflows/unit-tests.yml`**：从单 OS 改造为 OS × Node 矩阵（`[ubuntu-latest, windows-latest, macos-latest]` × `[22]`）；`fail-fast: false` 一次性暴露全平台真实失败；矩阵 node 维度用单元素列表，便于后续直接加版本而无需改结构
- **`.github/workflows/{release,sandbox-linux-e2e,update-homebrew}.yml`**：`setup-node` 由 `node-version: 20` 升至 `22`，与 `unit-tests.yml` 矩阵 Node 版本对齐，避免仓库内 Node 版本割裂
- **`package.json` / `package-lock.json`**：`engines.node` 由 `>=18` 收紧为 `>=22`（minor breaking change），lockfile 元数据同步
- **`bin/cli.js` / `install.sh`**：CLI 启动自检和安装脚本前置检查从 `>=18` 升至 `>=22`，避免运行时门槛低于 `engines` 声明
- **`README.md` / `README.zh-CN.md`**：Node badge URL/alt 与 Platform Support 段落同步至 `>=22`
- **`CONTRIBUTING.md` / `AGENTS.md` / `.claude/CLAUDE.md` / `.agents/skills/test-integration/SKILL.md`**：贡献者文档与 AI 协作指引中的 `Node.js >= 18` 全部更新为 `>=22`，避免新贡献者按 18 安装后 `npm install` 立即报 `EBADENGINE`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. PR 创建后，确认 Actions 上 `Unit Tests` workflow 出现 3 个矩阵 job：`ubuntu-latest / Node 22`、`windows-latest / Node 22`、`macos-latest / Node 22`，全部 ✅
2. 抽查任一矩阵 job 的 `Setup Node.js` step 日志，确认实际使用的是 `Node.js v22.x.x`
3. 抽查任一矩阵 job 的 `Run tests` step 日志，确认 `# tests 323` / `# pass 323`，与本地相同
4. 本 PR 改动了 `package.json` / `install.sh`，会触发 `Sandbox Linux E2E` workflow，确认其 setup-node 升至 22 后仍通过

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests （本 PR 本质是 CI 改造，无新业务代码；测试覆盖通过 `unit-tests.yml` 的三平台矩阵首次验证保证）
- [x] 所有现有测试都通过 / All existing tests pass （本地 Node 22 下 `npm test` 全部 323 用例通过；pre-commit hook 跑 `test:core` 264/264 通过）
- [x] 我已经进行了手动测试 / I have performed manual testing （本地用 `npx -p node@22 -- bash -c 'npm install && npm test'` 完整跑通）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（2 轮 review，详见 #242 评论中的 review.md / review-r2.md）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code（无复杂代码）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when needed
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（README badge / 平台说明 / CONTRIBUTING / AGENTS / CLAUDE / test-integration SKILL）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking change documented：`engines.node` 由 `>=18` 收紧为 `>=22`，理由是 Node 18/20 均已 EOL，让声明等于 CI 实测
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（用户仍可在 Node 22 LTS 上正常使用，Node 22 维护至 2027-04-30）

## 📋 附加信息 / Additional Notes

- 本任务走了 1 轮 plan（含 Round 2 增补 engines 一致性决策）+ 1 轮 implementation + 2 轮 review + 1 轮 refinement，详细问题收敛见 Issue #242 各阶段评论
- 关于 `update-homebrew.yml`：该 workflow 仅做 `npm view` + `curl` + `git push`，对 Node 版本无实质依赖；本次升级是为了项目内 Node 版本统一（plan-r2 决策五），无功能影响
- Follow-up（不阻塞合并）：
  - 视 Windows / macOS 矩阵首次运行结果决定是否需要进一步处理（行尾、路径分隔符、EPERM 等），plan-r2「步骤 9」已给出处置清单
  - 后续如要扩展 Node 版本矩阵（如同时跑 22 + 24），只需在 `matrix.node` 里加值，结构已就绪
  - 维护者已决定 unit-tests **不**进 branch protection 的 required_status_checks（与 #263 一致）

---

**审查者注意事项 / Reviewer Notes:**

重点关注两处：
1. `unit-tests.yml` 矩阵 job 名称展开后形如 `ubuntu-latest / Node 22`，如未来要把 unit-tests 加入 required status checks 请用展开后的完整 name
2. `engines.node >=22` 是 minor breaking change：用户在 Node 18/20（均 EOL）上 `npm install` 会拿到 `EBADENGINE` 警告。若有积极的"放宽到 Node 20"的诉求请在评论中提出

Generated with AI assistance