### PR TITLE
feat(sandbox): 沙箱 OrbStack/Docker Desktop 补齐 vm 配置读取

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,16 @@ agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=18); c
 - `ai init`, `ai sync`, etc.: works out of the box after `npm install -g @fitlab-ai/agent-infra` (or Homebrew).
 - `ai sandbox *`: requires Colima, OrbStack, or Docker Desktop. Colima is the default engine on macOS — when it is selected and the `colima` command is missing, agent-infra auto-installs and starts Colima via Homebrew on first run. To use OrbStack or Docker Desktop instead, set `sandbox.engine` in `.agents/.airc.json`.
 
+#### Engine resource configuration
+
+| Engine | `vm.cpu` | `vm.memory` | `vm.disk` | Apply mode | Notes |
+|--------|----------|-------------|-----------|------------|-------|
+| Colima | applied | applied | applied | on-start | VM must be restarted (`ai sandbox vm stop && ai sandbox vm start`) for changes to take effect. |
+| OrbStack | applied | applied | warned | hot | Applied via `orb config set` on every invocation. OrbStack manages disk via thin provisioning. |
+| Docker Desktop | warned | warned | warned | manual | Resources must be set in Docker Desktop GUI (Settings -> Resources). |
+
+`vm.memory` and `--memory` values are expressed in GiB.
+
 ### Linux
 
 - `ai init`, `ai sync`, etc.: works out of the box after `npm install -g @fitlab-ai/agent-infra`.
@@ -264,6 +274,10 @@ agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=18); c
 
   GPG signing works when the host `gpg-agent` and signing key are available; if key sync fails, `ai sandbox create` falls back to a sanitized Git config so commits still work without host signing state.
 
+#### Engine resource configuration
+
+Linux uses native Docker on the host kernel, so there is no managed VM. `sandbox.vm.*` and the `--cpu / --memory` flags do not apply. To cap container resources, use `docker run --cpus / --memory` per container or configure host cgroups.
+
 #### Known limitations on Linux
 
 These configurations are not actively tested in this release:
@@ -275,7 +289,12 @@ These configurations are not actively tested in this release:
 
 ### Windows
 
-WSL2 support is tracked in [#184](https://github.com/fitlab-ai/agent-infra/issues/184).
+- `ai init`, `ai sync`, etc.: should work after `npm install -g @fitlab-ai/agent-infra` (Node.js >= 18). Not actively tested in this release.
+- `ai sandbox *`: not yet supported on Windows. WSL2 is the planned engine — current releases throw `WSL2 sandbox engine is not implemented yet; Windows sandbox support is reserved for a future implementation`. Tracked in [#184](https://github.com/fitlab-ai/agent-infra/issues/184).
+
+#### Engine resource configuration
+
+WSL2 is the planned sandbox engine on Windows. When implemented, `sandbox.vm.cpu` and `sandbox.vm.memory` are expected to apply on-start via `~/.wslconfig` + `wsl --shutdown` (`sandbox.vm.disk` is not applicable to WSL2). `vm.memory` and `--memory` values are expressed in GiB. Until then, all `vm.*` values and `--cpu / --memory` flags are not honored.
 
 <a id="what-you-get"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,6 +247,16 @@ agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器
 - `ai init`、`ai sync` 等：执行 `npm install -g @fitlab-ai/agent-infra`（或 Homebrew 安装）后开箱即用。
 - `ai sandbox *`：需要 Colima、OrbStack 或 Docker Desktop。macOS 默认引擎是 Colima —— 当选用 Colima 且宿主机没有 `colima` 命令时，agent-infra 会在首次运行时通过 Homebrew 自动安装并启动。如需使用 OrbStack 或 Docker Desktop，请在 `.agents/.airc.json` 中设置 `sandbox.engine`。
 
+#### 引擎资源配置
+
+| 引擎 | `vm.cpu` | `vm.memory` | `vm.disk` | 应用方式 | 说明 |
+|------|----------|-------------|-----------|----------|------|
+| Colima | 生效 | 生效 | 生效 | 启动时 | 变更需重启 VM（`ai sandbox vm stop && ai sandbox vm start`）后生效。 |
+| OrbStack | 生效 | 生效 | 警告 | 热应用 | 每次调用都会通过 `orb config set` 应用。OrbStack 通过 thin provisioning 管理磁盘。 |
+| Docker Desktop | 警告 | 警告 | 警告 | 手动 | 资源必须在 Docker Desktop GUI（Settings -> Resources）中设置。 |
+
+`vm.memory` 和 `--memory` 的单位是 GiB。
+
 ### Linux
 
 - `ai init`、`ai sync` 等：执行 `npm install -g @fitlab-ai/agent-infra` 后开箱即用。
@@ -264,6 +274,10 @@ agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器
 
   当宿主机 `gpg-agent` 和签名 key 可用时，GPG signing 可正常工作；如果 key 同步失败，`ai sandbox create` 会回退到清理后的 Git config，让提交仍可在没有宿主签名状态的情况下继续。
 
+#### 引擎资源配置
+
+Linux 直接使用宿主内核上的原生 Docker，没有受管 VM。`sandbox.vm.*` 与 `--cpu / --memory` 标志均不生效。如需限制容器资源，请用 `docker run --cpus / --memory` 设置单容器限制，或配置宿主 cgroups。
+
 #### Linux 已知限制
 
 下列场景在本期未做主动验证：
@@ -275,7 +289,12 @@ agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=18)；容器
 
 ### Windows
 
-WSL2 支持在 [#184](https://github.com/fitlab-ai/agent-infra/issues/184) 跟踪。
+- `ai init`、`ai sync` 等：执行 `npm install -g @fitlab-ai/agent-infra` 后理论上可用（需 Node.js >= 18）。本期未做主动验证。
+- `ai sandbox *`：Windows 暂不支持。WSL2 是规划中的引擎——当前版本会抛出 `WSL2 sandbox engine is not implemented yet; Windows sandbox support is reserved for a future implementation`。进展跟踪 [#184](https://github.com/fitlab-ai/agent-infra/issues/184)。
+
+#### 引擎资源配置
+
+WSL2 是 Windows 规划中的 sandbox 引擎。实现后，`sandbox.vm.cpu` 与 `sandbox.vm.memory` 预计通过 `~/.wslconfig` + `wsl --shutdown` 在启动时应用（`sandbox.vm.disk` 不适用于 WSL2）。`vm.memory` 和 `--memory` 的单位是 GiB。在此之前，所有 `vm.*` 值与 `--cpu / --memory` 标志均不生效。
 
 <a id="what-you-get"></a>
 

--- a/lib/sandbox/commands/vm.js
+++ b/lib/sandbox/commands/vm.js
@@ -23,7 +23,12 @@ export function ensureManagedVm(engine) {
   }
 
   if (!isManagedEngine(engine)) {
-    throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
+    throw new Error(
+      `VM management is unavailable for engine '${engineDisplayName(engine)}'. `
+      + (engine === ENGINES.DOCKER_DESKTOP
+        ? 'Docker Desktop is managed via its GUI (Settings -> Resources).'
+        : '')
+    );
   }
 }
 

--- a/lib/sandbox/engine.js
+++ b/lib/sandbox/engine.js
@@ -1,25 +1,39 @@
 import { platform } from 'node:os';
 import { detectHostResources } from './constants.js';
+import { getAdapter } from './engines/index.js';
 import { run, runOk, runSafe, runVerbose } from './shell.js';
 
 export const ENGINES = Object.freeze({
   COLIMA: 'colima',
   ORBSTACK: 'orbstack',
-  DOCKER_DESKTOP: 'docker-desktop'
+  DOCKER_DESKTOP: 'docker-desktop',
+  NATIVE: 'native',
+  WSL2: 'wsl2'
 });
 
-export const ENGINE_DOCKER_CONTEXT = Object.freeze({
-  [ENGINES.COLIMA]: 'colima',
-  [ENGINES.ORBSTACK]: 'orbstack',
-  [ENGINES.DOCKER_DESKTOP]: 'desktop-linux'
-});
+const CONFIG_ENGINES = new Set([
+  ENGINES.COLIMA,
+  ENGINES.ORBSTACK,
+  ENGINES.DOCKER_DESKTOP
+]);
 
-const VALID_CONFIG_ENGINES = new Set(Object.values(ENGINES));
+function runFns({
+  runFn = run,
+  runOkFn = runOk,
+  runSafeFn = runSafe,
+  runVerboseFn = runVerbose
+} = {}) {
+  return {
+    run: runFn,
+    runOk: runOkFn,
+    runSafe: runSafeFn,
+    runVerbose: runVerboseFn
+  };
+}
 
-function applyDockerContext(engine) {
-  const context = ENGINE_DOCKER_CONTEXT[engine];
-  if (context) {
-    process.env.DOCKER_CONTEXT = context;
+function applyDockerContext(adapter) {
+  if (adapter.dockerContext) {
+    process.env.DOCKER_CONTEXT = adapter.dockerContext;
   }
 }
 
@@ -28,7 +42,7 @@ export function validateSandboxEngine(engine) {
     return null;
   }
 
-  if (VALID_CONFIG_ENGINES.has(engine)) {
+  if (CONFIG_ENGINES.has(engine)) {
     return engine;
   }
 
@@ -43,10 +57,10 @@ export function detectEngine(config = {}, { platformFn = platform } = {}) {
   const configured = validateSandboxEngine(config.engine);
   const os = platformFn();
   if (os === 'linux') {
-    return 'native';
+    return ENGINES.NATIVE;
   }
   if (os === 'win32') {
-    return 'wsl2';
+    return ENGINES.WSL2;
   }
   if (os === 'darwin') {
     if (configured) {
@@ -58,145 +72,47 @@ export function detectEngine(config = {}, { platformFn = platform } = {}) {
   return 'unsupported';
 }
 
-function colimaArgs(config, runSafeFn = runSafe) {
-  const arch = runSafeFn('uname', ['-m']);
-  const defaults = detectHostResources();
-  const vm = config.vm ?? {};
-  const cpu = vm.cpu ?? defaults.cpu;
-  const memory = vm.memory ?? defaults.memory;
-  const disk = vm.disk ?? 60;
-  const args = ['start', '--cpu', String(cpu), '--memory', String(memory), '--disk', String(disk)];
-
-  if (arch === 'arm64') {
-    args.push('--arch', 'aarch64', '--vm-type=vz', '--mount-type=virtiofs');
-  } else {
-    args.push('--arch', 'x86_64');
-  }
-
-  return args;
+export function hasUserVmConfig(vm = {}) {
+  return vm.cpu != null || vm.memory != null || vm.disk != null;
 }
 
-export async function ensureColima(
-  config,
-  onMessage,
-  { runOkFn = runOk, runSafeFn = runSafe, runVerboseFn = runVerbose } = {}
+export function resolveEffectiveVm(
+  adapter,
+  userVm = {},
+  { detectHostResourcesFn = detectHostResources } = {}
 ) {
-  applyDockerContext(ENGINES.COLIMA);
+  let host = null;
+  const getHost = () => {
+    host ??= detectHostResourcesFn();
+    return host;
+  };
+  const defaults = adapter.defaultResources?.(getHost) ?? {};
 
-  if (!runOkFn('which', ['colima'])) {
-    onMessage?.('Installing colima + docker via Homebrew...');
-    runVerboseFn('brew', ['install', 'colima', 'docker']);
-  }
-
-  if (!runOkFn('colima', ['status'])) {
-    onMessage?.('Starting Colima VM...');
-    runVerboseFn('colima', colimaArgs(config, runSafeFn));
-  }
-
-  if (!runOkFn('docker', ['info'])) {
-    throw new Error('Docker daemon is not available after starting Colima');
-  }
+  return {
+    cpu: userVm.cpu ?? defaults.cpu ?? null,
+    memory: userVm.memory ?? defaults.memory ?? null,
+    disk: userVm.disk ?? defaults.disk ?? null
+  };
 }
 
-export async function ensureOrbStack(
-  _config,
-  onMessage,
-  { runOkFn = runOk, runVerboseFn = runVerbose } = {}
-) {
-  applyDockerContext(ENGINES.ORBSTACK);
-
-  if (!runOkFn('which', ['orb'])) {
-    onMessage?.('Installing OrbStack via Homebrew...');
-    runVerboseFn('brew', ['install', '--cask', 'orbstack']);
-  }
-
-  if (!runOkFn('docker', ['info'])) {
-    onMessage?.('Starting OrbStack...');
-    runVerboseFn('orb', ['start']);
-  }
-
-  if (!runOkFn('docker', ['info'])) {
-    throw new Error('Docker daemon is not available after starting OrbStack');
-  }
+function effectiveConfigFor(adapter, config) {
+  const userVm = config.vm ?? {};
+  return {
+    ...config,
+    userVm,
+    hasUserVmConfig,
+    vm: resolveEffectiveVm(adapter, userVm)
+  };
 }
 
-export async function ensureDockerDesktop(
-  _config,
-  onMessage,
-  { runOkFn = runOk } = {}
-) {
-  applyDockerContext(ENGINES.DOCKER_DESKTOP);
+export async function ensureDocker(config, onMessage, dependencies = {}) {
+  const engine = detectEngine(config, dependencies);
+  const adapter = getAdapter(engine);
+  const effectiveConfig = effectiveConfigFor(adapter, config);
 
-  if (!runOkFn('docker', ['info'])) {
-    throw new Error('Docker Desktop is not running. Please start Docker Desktop manually.');
-  }
-}
-
-export async function ensureNativeDocker(
-  _config,
-  _onMessage,
-  { runOkFn = runOk, runSafeFn = runSafe } = {}
-) {
-  if (!runOkFn('which', ['docker'])) {
-    throw new Error([
-      'Docker is not installed.',
-      'Install Docker Engine for your distribution: https://docs.docker.com/engine/install/',
-      'Then start the daemon with: sudo systemctl enable --now docker',
-      'If you want to run Docker without sudo, add your user to the docker group: sudo usermod -aG docker $USER'
-    ].join('\n'));
-  }
-
-  if (runOkFn('docker', ['info'])) {
-    return;
-  }
-
-  const serverVersion = runSafeFn('docker', ['version', '--format', '{{.Server.Version}}']);
-  if (!serverVersion) {
-    throw new Error([
-      'Docker daemon is not running or is unreachable.',
-      'Start it with: sudo systemctl start docker',
-      'Enable it on boot with: sudo systemctl enable docker',
-      'If you use rootless or remote Docker, verify DOCKER_HOST points at a reachable socket.',
-      'Then retry: ai sandbox create <branch>'
-    ].join('\n'));
-  }
-
-  throw new Error([
-    'Docker is installed, but the current user may lack permission to use the daemon.',
-    'Add your user to the docker group: sudo usermod -aG docker $USER',
-    'Open a new login shell or run: newgrp docker',
-    'For rootless Docker, make sure DOCKER_HOST points at the rootless daemon socket.'
-  ].join('\n'));
-}
-
-export async function ensureDocker(config, onMessage) {
-  const engine = detectEngine(config);
-
-  if (engine === ENGINES.COLIMA) {
-    await ensureColima(config, onMessage);
-    return;
-  }
-
-  if (engine === ENGINES.ORBSTACK) {
-    await ensureOrbStack(config, onMessage);
-    return;
-  }
-
-  if (engine === ENGINES.DOCKER_DESKTOP) {
-    await ensureDockerDesktop(config, onMessage);
-    return;
-  }
-
-  if (engine === 'native') {
-    await ensureNativeDocker(config, onMessage);
-    return;
-  }
-
-  if (engine === 'wsl2') {
-    throw new Error('Windows sandbox support is reserved for a future WSL2 implementation.');
-  }
-
-  throw new Error(`Unsupported sandbox engine: ${engine}`);
+  applyDockerContext(adapter);
+  const vmJustStarted = await adapter.ensure(effectiveConfig, onMessage, runFns(dependencies));
+  adapter.syncResources(effectiveConfig, onMessage, runFns(dependencies), { vmJustStarted });
 }
 
 export function isVmManaged(config = {}, dependencies = {}) {
@@ -205,52 +121,55 @@ export function isVmManaged(config = {}, dependencies = {}) {
 }
 
 export function isManagedEngine(engine) {
-  return engine === ENGINES.COLIMA || engine === ENGINES.ORBSTACK;
+  try {
+    return getAdapter(engine).managed;
+  } catch {
+    return false;
+  }
 }
 
 export function engineDisplayName(engine) {
-  const names = {
-    [ENGINES.COLIMA]: 'Colima',
-    [ENGINES.ORBSTACK]: 'OrbStack',
-    [ENGINES.DOCKER_DESKTOP]: 'Docker Desktop',
-    native: 'native Docker',
-    wsl2: 'WSL2'
-  };
-  return names[engine] ?? engine;
+  try {
+    return getAdapter(engine).displayName;
+  } catch {
+    return engine;
+  }
 }
 
 export function startManagedVm(
   config,
-  { platformFn = platform, runOkFn = runOk, runVerboseFn = runVerbose } = {}
+  { platformFn = platform, runOkFn = runOk, runSafeFn = runSafe, runVerboseFn = runVerbose, onMessage } = {}
 ) {
   const engine = detectEngine(config, { platformFn });
-  if (!isManagedEngine(engine)) {
-    throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
+  const adapter = getAdapter(engine);
+  if (!adapter.managed) {
+    throw new Error(`VM management is unavailable for engine '${adapter.displayName}'.`);
   }
 
-  if (engine === ENGINES.COLIMA && runOkFn('colima', ['status'])) {
-    return 'already-running';
-  }
-  if (engine === ENGINES.ORBSTACK && runOkFn('orb', ['status'])) {
-    return 'already-running';
-  }
-
-  if (engine === ENGINES.COLIMA) {
-    runVerboseFn('colima', colimaArgs(config));
-  } else if (engine === ENGINES.ORBSTACK) {
-    runVerboseFn('orb', ['start']);
-  }
-  return 'started';
+  const effectiveConfig = effectiveConfigFor(adapter, config);
+  applyDockerContext(adapter);
+  const result = adapter.startVm(
+    effectiveConfig,
+    onMessage,
+    runFns({ runOkFn, runSafeFn, runVerboseFn })
+  );
+  adapter.syncResources(
+    effectiveConfig,
+    onMessage,
+    runFns({ runOkFn, runSafeFn, runVerboseFn }),
+    { vmJustStarted: result === 'started' }
+  );
+  return result;
 }
 
 export function stopManagedVm(config, { platformFn = platform, runFn = run } = {}) {
   const engine = detectEngine(config, { platformFn });
-  if (engine === ENGINES.COLIMA) {
-    runFn('colima', ['stop']);
-    return 'stopped';
-  } else if (engine === ENGINES.ORBSTACK) {
-    runFn('orb', ['stop']);
-    return 'stopped';
+  const adapter = getAdapter(engine);
+  if (!adapter.managed) {
+    throw new Error(`VM management is unavailable for engine '${adapter.displayName}'.`);
   }
-  throw new Error(`VM management is unavailable for engine '${engineDisplayName(engine)}'.`);
+
+  // Stop commands do not read Docker context or VM resource values; keep the
+  // previous environment unchanged and pass the original config intentionally.
+  return adapter.stopVm(config, null, runFns({ runFn }));
 }

--- a/lib/sandbox/engines/colima.js
+++ b/lib/sandbox/engines/colima.js
@@ -1,0 +1,78 @@
+function colimaArgs(config, runSafeFn) {
+  const arch = runSafeFn('uname', ['-m']);
+  const vm = config.vm ?? {};
+  const args = ['start', '--cpu', String(vm.cpu), '--memory', String(vm.memory), '--disk', String(vm.disk)];
+
+  if (arch === 'arm64') {
+    args.push('--arch', 'aarch64', '--vm-type=vz', '--mount-type=virtiofs');
+  } else {
+    args.push('--arch', 'x86_64');
+  }
+
+  return args;
+}
+
+export const colimaAdapter = {
+  id: 'colima',
+  displayName: 'Colima',
+  dockerContext: 'colima',
+  managed: true,
+  canApplyResources: 'on-start',
+
+  defaultResources(getHost) {
+    const host = getHost();
+    return {
+      cpu: host.cpu,
+      memory: host.memory,
+      disk: 60
+    };
+  },
+
+  async ensure(config, onMessage, { runOk, runSafe, runVerbose }) {
+    let started = false;
+
+    if (!runOk('which', ['colima'])) {
+      onMessage?.('Installing colima + docker via Homebrew...');
+      runVerbose('brew', ['install', 'colima', 'docker']);
+    }
+
+    if (!runOk('colima', ['status'])) {
+      onMessage?.('Starting Colima VM...');
+      runVerbose('colima', colimaArgs(config, runSafe));
+      started = true;
+    }
+
+    if (!runOk('docker', ['info'])) {
+      throw new Error('Docker daemon is not available after starting Colima');
+    }
+
+    return started;
+  },
+
+  startVm(config, _onMessage, { runOk, runSafe, runVerbose }) {
+    if (runOk('colima', ['status'])) {
+      return 'already-running';
+    }
+
+    runVerbose('colima', colimaArgs(config, runSafe));
+    return 'started';
+  },
+
+  stopVm(_config, _onMessage, { run }) {
+    run('colima', ['stop']);
+    return 'stopped';
+  },
+
+  syncResources(config, onMessage, _runFns, { vmJustStarted } = {}) {
+    if (vmJustStarted || !config.hasUserVmConfig?.(config.userVm)) {
+      return;
+    }
+
+    onMessage?.(
+      'Warning: Colima VM is already running; restart with '
+      + '`ai sandbox vm stop && ai sandbox vm start` to apply new sandbox.vm.* values.'
+    );
+  }
+};
+
+export default colimaAdapter;

--- a/lib/sandbox/engines/docker-desktop.js
+++ b/lib/sandbox/engines/docker-desktop.js
@@ -1,0 +1,33 @@
+export const dockerDesktopAdapter = {
+  id: 'docker-desktop',
+  displayName: 'Docker Desktop',
+  dockerContext: 'desktop-linux',
+  managed: false,
+  canApplyResources: 'never',
+
+  defaultResources() {
+    return null;
+  },
+
+  async ensure(_config, _onMessage, { runOk }) {
+    if (!runOk('docker', ['info'])) {
+      throw new Error('Docker Desktop is not running. Please start Docker Desktop manually.');
+    }
+
+    return false;
+  },
+
+  syncResources(config, onMessage) {
+    if (!config.hasUserVmConfig?.(config.userVm)) {
+      return;
+    }
+
+    onMessage?.(
+      'Warning: Docker Desktop manages CPU/memory/disk via Settings -> Resources. '
+      + 'sandbox.vm.* values and --cpu/--memory flags are not applied for this engine. '
+      + 'Please configure resources in Docker Desktop GUI to match.'
+    );
+  }
+};
+
+export default dockerDesktopAdapter;

--- a/lib/sandbox/engines/index.js
+++ b/lib/sandbox/engines/index.js
@@ -1,0 +1,21 @@
+import { colimaAdapter } from './colima.js';
+import { dockerDesktopAdapter } from './docker-desktop.js';
+import { nativeAdapter } from './native.js';
+import { orbstackAdapter } from './orbstack.js';
+import { wsl2Adapter } from './wsl2.js';
+
+export const ADAPTERS = Object.freeze({
+  colima: colimaAdapter,
+  orbstack: orbstackAdapter,
+  'docker-desktop': dockerDesktopAdapter,
+  native: nativeAdapter,
+  wsl2: wsl2Adapter
+});
+
+export function getAdapter(engineId) {
+  const adapter = ADAPTERS[engineId];
+  if (!adapter) {
+    throw new Error(`No adapter registered for engine '${engineId}'`);
+  }
+  return adapter;
+}

--- a/lib/sandbox/engines/native.js
+++ b/lib/sandbox/engines/native.js
@@ -1,0 +1,57 @@
+export const nativeAdapter = {
+  id: 'native',
+  displayName: 'native Docker',
+  dockerContext: null,
+  managed: false,
+  canApplyResources: 'never',
+
+  defaultResources() {
+    return null;
+  },
+
+  async ensure(_config, _onMessage, { runOk, runSafe }) {
+    if (!runOk('which', ['docker'])) {
+      throw new Error([
+        'Docker is not installed.',
+        'Install Docker Engine for your distribution: https://docs.docker.com/engine/install/',
+        'Then start the daemon with: sudo systemctl enable --now docker',
+        'If you want to run Docker without sudo, add your user to the docker group: sudo usermod -aG docker $USER'
+      ].join('\n'));
+    }
+
+    if (runOk('docker', ['info'])) {
+      return false;
+    }
+
+    const serverVersion = runSafe('docker', ['version', '--format', '{{.Server.Version}}']);
+    if (!serverVersion) {
+      throw new Error([
+        'Docker daemon is not running or is unreachable.',
+        'Start it with: sudo systemctl start docker',
+        'Enable it on boot with: sudo systemctl enable docker',
+        'If you use rootless or remote Docker, verify DOCKER_HOST points at a reachable socket.',
+        'Then retry: ai sandbox create <branch>'
+      ].join('\n'));
+    }
+
+    throw new Error([
+      'Docker is installed, but the current user may lack permission to use the daemon.',
+      'Add your user to the docker group: sudo usermod -aG docker $USER',
+      'Open a new login shell or run: newgrp docker',
+      'For rootless Docker, make sure DOCKER_HOST points at the rootless daemon socket.'
+    ].join('\n'));
+  },
+
+  syncResources(config, onMessage) {
+    if (!config.hasUserVmConfig?.(config.userVm)) {
+      return;
+    }
+
+    onMessage?.(
+      'Warning: Linux native Docker has no managed VM; sandbox.vm.* is not applicable. '
+      + 'Use docker run --cpus / --memory per container or host cgroups.'
+    );
+  }
+};
+
+export default nativeAdapter;

--- a/lib/sandbox/engines/orbstack.js
+++ b/lib/sandbox/engines/orbstack.js
@@ -1,0 +1,75 @@
+export const orbstackAdapter = {
+  id: 'orbstack',
+  displayName: 'OrbStack',
+  dockerContext: 'orbstack',
+  managed: true,
+  canApplyResources: 'hot',
+
+  defaultResources() {
+    return null;
+  },
+
+  async ensure(_config, onMessage, { runOk, runVerbose }) {
+    let started = false;
+
+    if (!runOk('which', ['orb'])) {
+      onMessage?.('Installing OrbStack via Homebrew...');
+      runVerbose('brew', ['install', '--cask', 'orbstack']);
+    }
+
+    if (!runOk('docker', ['info'])) {
+      onMessage?.('Starting OrbStack...');
+      runVerbose('orb', ['start']);
+      started = true;
+    }
+
+    if (!runOk('docker', ['info'])) {
+      throw new Error('Docker daemon is not available after starting OrbStack');
+    }
+
+    return started;
+  },
+
+  startVm(_config, _onMessage, { runOk, runVerbose }) {
+    if (runOk('orb', ['status'])) {
+      return 'already-running';
+    }
+
+    runVerbose('orb', ['start']);
+    return 'started';
+  },
+
+  stopVm(_config, _onMessage, { run }) {
+    run('orb', ['stop']);
+    return 'stopped';
+  },
+
+  syncResources(config, onMessage, { runVerbose }) {
+    const vm = config?.vm ?? {};
+
+    if (vm.cpu != null) {
+      try {
+        runVerbose('orb', ['config', 'set', 'cpu', String(vm.cpu)]);
+      } catch {
+        onMessage?.(`Warning: failed to apply OrbStack cpu=${vm.cpu}; resource limit may not take effect.`);
+      }
+    }
+
+    if (vm.memory != null) {
+      try {
+        runVerbose('orb', ['config', 'set', 'memory_mib', String(vm.memory * 1024)]);
+      } catch {
+        onMessage?.(`Warning: failed to apply OrbStack memory=${vm.memory}GiB; resource limit may not take effect.`);
+      }
+    }
+
+    if (vm.disk != null) {
+      onMessage?.(
+        `Warning: OrbStack does not expose a fixed disk size; sandbox.vm.disk=${vm.disk} is ignored. `
+        + 'Manage storage via OrbStack settings GUI.'
+      );
+    }
+  }
+};
+
+export default orbstackAdapter;

--- a/lib/sandbox/engines/wsl2.js
+++ b/lib/sandbox/engines/wsl2.js
@@ -1,0 +1,22 @@
+const NOT_IMPLEMENTED = 'WSL2 sandbox engine is not implemented yet; Windows sandbox support is reserved for a future implementation.';
+
+function notImplemented() {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export const wsl2Adapter = {
+  id: 'wsl2',
+  displayName: 'WSL2',
+  dockerContext: null,
+  managed: true,
+  canApplyResources: 'on-start',
+
+  defaultResources: notImplemented,
+
+  ensure: notImplemented,
+  startVm: notImplemented,
+  stopVm: notImplemented,
+  syncResources: notImplemented
+};
+
+export default wsl2Adapter;

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1509,7 +1509,7 @@ test("ensureSandboxAliasesFile upgrades legacy OpenCode aliases to full yolo per
   }
 });
 
-test("ensureColima uses verbose commands for install and startup", async () => {
+test("ensureDocker uses Colima verbose commands for install and startup", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const messages = [];
   const verboseCalls = [];
@@ -1519,10 +1519,11 @@ test("ensureColima uses verbose commands for install and startup", async () => {
   try {
     delete process.env.DOCKER_CONTEXT;
 
-    await sandboxEngine.ensureColima(
-      { vm: { cpu: 4, memory: 8, disk: 60 } },
+    await sandboxEngine.ensureDocker(
+      { engine: "colima", vm: { cpu: 4, memory: 8, disk: 60 } },
       (message) => messages.push(message),
       {
+        platformFn: () => "darwin",
         runOkFn(cmd, args) {
           checks.push([cmd, ...args]);
           assert.equal(process.env.DOCKER_CONTEXT, "colima");
@@ -1633,7 +1634,178 @@ test("detectEngine does not apply Docker context", async () => {
   }
 });
 
-test("ensureOrbStack installs OrbStack and starts the Docker daemon", async () => {
+test("sandbox engine adapters expose the required shape", async () => {
+  const sandboxEngines = await loadFreshEsm("lib/sandbox/engines/index.js");
+
+  for (const adapter of Object.values(sandboxEngines.ADAPTERS)) {
+    assert.equal(typeof adapter.id, "string");
+    assert.equal(typeof adapter.displayName, "string");
+    assert.ok(adapter.dockerContext === null || typeof adapter.dockerContext === "string");
+    assert.equal(typeof adapter.managed, "boolean");
+    assert.match(adapter.canApplyResources, /^(hot|on-start|never)$/);
+    assert.equal(typeof adapter.defaultResources, "function");
+    assert.equal(typeof adapter.ensure, "function");
+    assert.equal(typeof adapter.syncResources, "function");
+    if (adapter.managed) {
+      assert.equal(typeof adapter.startVm, "function");
+      assert.equal(typeof adapter.stopVm, "function");
+    }
+  }
+});
+
+test("resolveEffectiveVm merges adapter defaults without changing user values", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const colimaAdapter = {
+    defaultResources(getHost) {
+      const host = getHost();
+      return { cpu: host.cpu, memory: host.memory, disk: 60 };
+    }
+  };
+  let detectCalls = 0;
+  const orbStackAdapter = {
+    defaultResources() {
+      return null;
+    }
+  };
+  const host = { cpu: 6, memory: 8 };
+
+  assert.deepEqual(
+    sandboxEngine.resolveEffectiveVm(colimaAdapter, {}, { detectHostResourcesFn: () => host }),
+    { cpu: 6, memory: 8, disk: 60 }
+  );
+  assert.deepEqual(
+    sandboxEngine.resolveEffectiveVm(colimaAdapter, { cpu: 4 }, { detectHostResourcesFn: () => host }),
+    { cpu: 4, memory: 8, disk: 60 }
+  );
+  assert.deepEqual(
+    sandboxEngine.resolveEffectiveVm(orbStackAdapter, {}, {
+      detectHostResourcesFn: () => {
+        detectCalls += 1;
+        return host;
+      }
+    }),
+    { cpu: null, memory: null, disk: null }
+  );
+  assert.equal(detectCalls, 0);
+});
+
+test("hasUserVmConfig recognizes only explicit resource values", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.equal(sandboxEngine.hasUserVmConfig({}), false);
+  assert.equal(sandboxEngine.hasUserVmConfig({ cpu: null }), false);
+  assert.equal(sandboxEngine.hasUserVmConfig({ cpu: 4 }), true);
+  assert.equal(sandboxEngine.hasUserVmConfig({ memory: 8 }), true);
+  assert.equal(sandboxEngine.hasUserVmConfig({ disk: 60 }), true);
+});
+
+test("Colima adapter warns when resource values change while VM is already running", async () => {
+  const { colimaAdapter } = await loadFreshEsm("lib/sandbox/engines/colima.js");
+  const messages = [];
+
+  assert.deepEqual(colimaAdapter.defaultResources(() => ({ cpu: 6, memory: 8 })), {
+    cpu: 6,
+    memory: 8,
+    disk: 60
+  });
+
+  colimaAdapter.syncResources(
+    { userVm: { cpu: 4 }, hasUserVmConfig: (vm) => vm.cpu != null },
+    (message) => messages.push(message),
+    {},
+    { vmJustStarted: true }
+  );
+  assert.deepEqual(messages, []);
+
+  colimaAdapter.syncResources(
+    { userVm: { cpu: 4 }, hasUserVmConfig: (vm) => vm.cpu != null },
+    (message) => messages.push(message),
+    {},
+    { vmJustStarted: false }
+  );
+  assert.match(messages[0], /Colima VM is already running/);
+});
+
+test("OrbStack adapter hot-applies CPU and memory and warns about disk", async () => {
+  const { orbstackAdapter } = await loadFreshEsm("lib/sandbox/engines/orbstack.js");
+  const verboseCalls = [];
+  const messages = [];
+
+  assert.equal(orbstackAdapter.defaultResources(), null);
+  orbstackAdapter.syncResources(
+    { vm: { cpu: 4, memory: 8, disk: 60 } },
+    (message) => messages.push(message),
+    {
+      runVerbose(cmd, args) {
+        verboseCalls.push([cmd, ...args]);
+      }
+    }
+  );
+
+  assert.deepEqual(verboseCalls, [
+    ["orb", "config", "set", "cpu", "4"],
+    ["orb", "config", "set", "memory_mib", "8192"]
+  ]);
+  assert.match(messages[0], /does not expose a fixed disk size/);
+});
+
+test("OrbStack adapter downgrades config failures to warnings", async () => {
+  const { orbstackAdapter } = await loadFreshEsm("lib/sandbox/engines/orbstack.js");
+  const messages = [];
+
+  orbstackAdapter.syncResources(
+    { vm: { cpu: 4, memory: null, disk: null } },
+    (message) => messages.push(message),
+    {
+      runVerbose() {
+        throw new Error("config failed");
+      }
+    }
+  );
+
+  assert.match(messages[0], /failed to apply OrbStack cpu=4/);
+});
+
+test("Docker Desktop adapter warns for explicit VM resources only", async () => {
+  const { dockerDesktopAdapter } = await loadFreshEsm("lib/sandbox/engines/docker-desktop.js");
+  const messages = [];
+  const hasUserVmConfig = (vm) => vm.cpu != null || vm.memory != null || vm.disk != null;
+
+  dockerDesktopAdapter.syncResources(
+    { userVm: { cpu: null }, hasUserVmConfig },
+    (message) => messages.push(message)
+  );
+  assert.deepEqual(messages, []);
+
+  dockerDesktopAdapter.syncResources(
+    { userVm: { cpu: 4 }, hasUserVmConfig },
+    (message) => messages.push(message)
+  );
+  assert.match(messages[0], /Docker Desktop manages CPU\/memory\/disk/);
+});
+
+test("native adapter warns that VM resources are not applicable", async () => {
+  const { nativeAdapter } = await loadFreshEsm("lib/sandbox/engines/native.js");
+  const messages = [];
+
+  nativeAdapter.syncResources(
+    { userVm: { memory: 8 }, hasUserVmConfig: (vm) => vm.memory != null },
+    (message) => messages.push(message)
+  );
+
+  assert.match(messages[0], /Linux native Docker has no managed VM/);
+});
+
+test("WSL2 adapter reserves VM operations for a future implementation", async () => {
+  const { wsl2Adapter } = await loadFreshEsm("lib/sandbox/engines/wsl2.js");
+
+  assert.throws(() => wsl2Adapter.defaultResources(), /Windows sandbox support is reserved/);
+  assert.throws(() => wsl2Adapter.ensure(), /WSL2 sandbox engine is not implemented yet/);
+  assert.throws(() => wsl2Adapter.syncResources(), /WSL2 sandbox engine is not implemented yet/);
+  assert.throws(() => wsl2Adapter.startVm(), /WSL2 sandbox engine is not implemented yet/);
+});
+
+test("ensureDocker installs OrbStack and starts the Docker daemon", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const messages = [];
   const verboseCalls = [];
@@ -1644,10 +1816,11 @@ test("ensureOrbStack installs OrbStack and starts the Docker daemon", async () =
   try {
     delete process.env.DOCKER_CONTEXT;
 
-    await sandboxEngine.ensureOrbStack(
-      {},
+    await sandboxEngine.ensureDocker(
+      { engine: "orbstack", vm: { cpu: null, memory: null, disk: null } },
       (message) => messages.push(message),
       {
+        platformFn: () => "darwin",
         runOkFn(cmd, args) {
           checks.push([cmd, ...args]);
           assert.equal(process.env.DOCKER_CONTEXT, "orbstack");
@@ -1685,7 +1858,7 @@ test("ensureOrbStack installs OrbStack and starts the Docker daemon", async () =
   }
 });
 
-test("ensureDockerDesktop reports when Docker Desktop is not running", async () => {
+test("ensureDocker reports when Docker Desktop is not running", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const previousDockerContext = process.env.DOCKER_CONTEXT;
 
@@ -1693,7 +1866,8 @@ test("ensureDockerDesktop reports when Docker Desktop is not running", async () 
     delete process.env.DOCKER_CONTEXT;
 
     await assert.rejects(
-      () => sandboxEngine.ensureDockerDesktop({}, null, {
+      () => sandboxEngine.ensureDocker({ engine: "docker-desktop" }, null, {
+        platformFn: () => "darwin",
         runOkFn(cmd, args) {
           assert.equal(cmd, "docker");
           assert.deepEqual(args, ["info"]);
@@ -1709,11 +1883,58 @@ test("ensureDockerDesktop reports when Docker Desktop is not running", async () 
   }
 });
 
-test("ensureNativeDocker throws install hint when docker is not installed", async () => {
+test("ensureDocker applies OrbStack resource flags after daemon checks", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const verboseCalls = [];
+
+  await sandboxEngine.ensureDocker(
+    { engine: "orbstack", vm: { cpu: 4, memory: null, disk: null } },
+    null,
+    {
+      platformFn: () => "darwin",
+      runOkFn(cmd, args) {
+        if (cmd === "which" && args[0] === "orb") {
+          return true;
+        }
+        if (cmd === "docker" && args[0] === "info") {
+          return true;
+        }
+        throw new Error(`unexpected check: ${cmd} ${args.join(" ")}`);
+      },
+      runVerboseFn(cmd, args) {
+        verboseCalls.push([cmd, ...args]);
+      }
+    }
+  );
+
+  assert.deepEqual(verboseCalls, [["orb", "config", "set", "cpu", "4"]]);
+});
+
+test("ensureDocker warns when Docker Desktop cannot apply explicit VM resources", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const messages = [];
+
+  await sandboxEngine.ensureDocker(
+    { engine: "docker-desktop", vm: { cpu: 4, memory: null, disk: null } },
+    (message) => messages.push(message),
+    {
+      platformFn: () => "darwin",
+      runOkFn(cmd, args) {
+        assert.deepEqual([cmd, ...args], ["docker", "info"]);
+        return true;
+      }
+    }
+  );
+
+  assert.match(messages[0], /Docker Desktop manages CPU\/memory\/disk/);
+});
+
+test("ensureDocker throws native install hint when docker is not installed", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
 
   await assert.rejects(
-    () => sandboxEngine.ensureNativeDocker({}, null, {
+    () => sandboxEngine.ensureDocker({}, null, {
+      platformFn: () => "linux",
       runOkFn(cmd, args) {
         assert.equal(cmd, "which");
         assert.deepEqual(args, ["docker"]);
@@ -1727,12 +1948,13 @@ test("ensureNativeDocker throws install hint when docker is not installed", asyn
   );
 });
 
-test("ensureNativeDocker throws daemon-down hint when docker info fails and version returns nothing", async () => {
+test("ensureDocker throws native daemon-down hint when docker info fails and version returns nothing", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const checks = [];
 
   await assert.rejects(
-    () => sandboxEngine.ensureNativeDocker({}, null, {
+    () => sandboxEngine.ensureDocker({}, null, {
+      platformFn: () => "linux",
       runOkFn(cmd, args) {
         checks.push([cmd, ...args]);
         if (cmd === "which") {
@@ -1757,11 +1979,12 @@ test("ensureNativeDocker throws daemon-down hint when docker info fails and vers
   ]);
 });
 
-test("ensureNativeDocker throws permission hint when docker info fails but version succeeds", async () => {
+test("ensureDocker throws native permission hint when docker info fails but version succeeds", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
 
   await assert.rejects(
-    () => sandboxEngine.ensureNativeDocker({}, null, {
+    () => sandboxEngine.ensureDocker({}, null, {
+      platformFn: () => "linux",
       runOkFn(cmd, args) {
         if (cmd === "which") {
           return true;
@@ -1787,6 +2010,15 @@ test("ensureManagedVm gives Linux-specific message for native engine", async () 
   assert.throws(
     () => sandboxVm.ensureManagedVm("native"),
     /does not use a managed VM/
+  );
+});
+
+test("ensureManagedVm points Docker Desktop users to the GUI", async () => {
+  const sandboxVm = await loadFreshEsm("lib/sandbox/commands/vm.js");
+
+  assert.throws(
+    () => sandboxVm.ensureManagedVm("docker-desktop"),
+    /VM management is unavailable[\s\S]*Docker Desktop is managed via its GUI/
   );
 });
 
@@ -1817,6 +2049,28 @@ test("startManagedVm uses OrbStack status instead of Docker daemon state", async
   assert.deepEqual(verboseCalls, [["orb", "start"]]);
 });
 
+test("startManagedVm applies OrbStack resources while leaving a running VM alone", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const verboseCalls = [];
+
+  const result = sandboxEngine.startManagedVm(
+    { engine: "orbstack", vm: { cpu: 2, memory: null, disk: null } },
+    {
+      platformFn: () => "darwin",
+      runOkFn(cmd, args) {
+        assert.deepEqual([cmd, ...args], ["orb", "status"]);
+        return true;
+      },
+      runVerboseFn(cmd, args) {
+        verboseCalls.push([cmd, ...args]);
+      }
+    }
+  );
+
+  assert.equal(result, "already-running");
+  assert.deepEqual(verboseCalls, [["orb", "config", "set", "cpu", "2"]]);
+});
+
 test("stopManagedVm reports unsupported engines instead of silently returning", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
 
@@ -1827,6 +2081,30 @@ test("stopManagedVm reports unsupported engines instead of silently returning", 
     ),
     /VM management is unavailable for engine 'Docker Desktop'/
   );
+});
+
+test("stopManagedVm does not change the current Docker context", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+  const previousDockerContext = process.env.DOCKER_CONTEXT;
+
+  try {
+    process.env.DOCKER_CONTEXT = "existing-context";
+
+    const result = sandboxEngine.stopManagedVm(
+      { engine: "orbstack" },
+      {
+        platformFn: () => "darwin",
+        runFn(cmd, args) {
+          assert.deepEqual([cmd, ...args], ["orb", "stop"]);
+        }
+      }
+    );
+
+    assert.equal(result, "stopped");
+    assert.equal(process.env.DOCKER_CONTEXT, "existing-context");
+  } finally {
+    restoreDockerContext(previousDockerContext);
+  }
 });
 
 test("isVmManaged and engineDisplayName describe supported engines", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #259

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 #259 中报告的"sandbox.vm.\* 配置在非 Colima 引擎下被静默丢弃"问题，并把 sandbox engine 这一层重构为按引擎能力分派的 adapter 形态，为未来加入 WSL2 等新引擎打地基。

原状：`lib/sandbox/engine.js` 仅 Colima 路径会读取 `sandbox.vm.{cpu,memory,disk}`，OrbStack 与 Docker Desktop 完全忽略这些字段；`ai sandbox vm start --cpu --memory` 与 `ai sandbox create --cpu --memory` 在非 Colima 引擎下被静默丢弃，用户配置的资源限制不生效却没有任何提示。

本次变更：
- 把每个 sandbox 引擎抽成独立 adapter，统一声明能力（`hot` / `on-start` / `never`）和资源应用 policy
- OrbStack 通过 `orb config set` 热应用 cpu/memory（disk 不支持时给出警告）
- Docker Desktop / Linux native 在用户显式设置 `sandbox.vm.*` 时输出明确警告，指引到 GUI 或 `docker run --cpus/--memory`
- Colima 行为完全不变（沿用现有 `colima start --cpu/--memory/--disk` 启动参数）
- WSL2 留占位 adapter，方便未来填充

## 📋 主要变更 / Brief Changelog

- **新增 adapter 层**：`lib/sandbox/engines/{colima,orbstack,docker-desktop,native,wsl2}.js` + `engines/index.js` 注册表；每个 adapter 实现统一接口（`id` / `displayName` / `dockerContext` / `managed` / `canApplyResources` / `defaultResources(getHost)` / `ensure` / `startVm` / `stopVm` / `syncResources`）。
- **重写调度层**：`lib/sandbox/engine.js` 从 257 行降到 169 行，退化为薄调度层；`ensureDocker` / `startManagedVm` / `stopManagedVm` 公开签名保持不变，调用方零改动。新增导出 `hasUserVmConfig` / `resolveEffectiveVm`。
- **资源应用 policy**：
  - Colima：`on-start`，VM 已运行时改 `vm.*` 警告"重启 VM 后才生效"
  - OrbStack：`hot`，每次 `ensureDocker` / `startManagedVm` 都同步配置（已运行也同步），失败降级为警告不阻塞 docker 启动
  - Docker Desktop：`never`，用户设了 `vm.*` 就警告 GUI 路径
  - Linux native：`never`，无 VM，提示 `docker run --cpus / --memory` 或宿主 cgroups
  - WSL2：占位，所有方法 throw `'WSL2 sandbox engine is not implemented yet; Windows sandbox support is reserved for a future implementation.'`
- **CLI 错误信息升级**：`lib/sandbox/commands/vm.js` 中 Docker Desktop 抛错附带 GUI 路径提示。
- **README 三平台拆开**：macOS / Linux / Windows 各自独立 `#### Engine resource configuration` 子段，只描述自己平台的引擎能力，避免跨平台信息混在 macOS 段下。中英文同步。
- **测试**：`tests/cli/sandbox.test.js` 从 122 测增到 139 测；现有 `ensureColima` 等用例迁移到 `ensureDocker` 入口断言等价；新增 adapter shape 测、`resolveEffectiveVm` lazy host 检测、`hasUserVmConfig`、OrbStack hot apply / 错误降级、Docker Desktop GUI 警告、native 不适用提示、WSL2 全方法 throw 等覆盖。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/sandbox.test.js` 全部 139 个用例通过
2. `npm test` 全量 335 个用例通过（pre-commit hook 已自动运行并通过）
3. 手动验证（macOS 真实环境，可选）：
   - OrbStack：`.airc.json` 设 `sandbox.vm.cpu=4, vm.memory=8`，`ai sandbox create demo` 应看到 `orb config set cpu 4` 与 `orb config set memory_mib 8192` 调用
   - Docker Desktop：`.airc.json` 设 `vm.cpu=4`，`ai sandbox create demo` 输出 GUI 警告
   - Colima（VM 已运行）：改 `vm.cpu` 后再 `ai sandbox create demo` 应警告"VM 已运行需重启"

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 说明：本次未做 macOS 真实环境的手工验证，全部通过 mock 命令覆盖；Linux native 路径与 WSL2 占位也仅有单测覆盖。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

> 项目尚未配置 lint 工具（CLAUDE.md 注明"暂未配置 lint 工具"），勾选项保持空缺。

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

**向后兼容性**：
- `ensureDocker` / `startManagedVm` / `stopManagedVm` 公开签名不变；CLI 入口（`ai sandbox create / vm start / vm stop / rebuild / rm`）行为对 Colima 用户完全一致
- 内部 `ensureColima` / `ensureOrbStack` / `ensureDockerDesktop` / `ensureNativeDocker` / `colimaArgs` 等具名导出已删除（仓库内仅 `lib/sandbox/commands/*.js` 引用，已迁移；模板镜像不引用）

**关联追踪**：
- WSL2 引擎实现：跟踪 [#184](https://github.com/fitlab-ai/agent-infra/issues/184)

Closes #259

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `lib/sandbox/engine.js` 调度层的 `effectiveConfigFor` / `resolveEffectiveVm` 是否完整保留旧 `vm.*` 默认值兜底（`detectHostResources` 现仅在 Colima/WSL2 走它的 adapter 才会被调用，OrbStack/Docker Desktop/native 不触发）
- `lib/sandbox/engines/orbstack.js` 中 `vm.memory` 到 `memory_mib` 的 GiB→MiB 转换是否符合 OrbStack CLI 预期（`vm.memory * 1024`）
- Docker Desktop 与 Linux native 的 warning 是否仅在用户显式设置 `vm.*` 时出现（已通过 `hasUserVmConfig(config.userVm)` 守卫，并有对应回归测试）

Generated with AI assistance