### PR TITLE
feat(sandbox): auto :z bind mounts under SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ These configurations are not actively tested in this release:
 
 - **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
 - **Podman** instead of Docker: Track [#257](https://github.com/fitlab-ai/agent-infra/issues/257).
-- **SELinux-enforcing** hosts (Fedora / RHEL) may need manual mount labels: Track [#258](https://github.com/fitlab-ai/agent-infra/issues/258).
+- **SELinux-enforcing** hosts (Fedora / RHEL): `ai sandbox create` automatically labels bind mounts with Docker's shared `:z` flag — no setup required. Set `AGENT_INFRA_SELINUX_DISABLE=1` to opt out for debugging.
 - `ai sandbox vm` is a no-op on Linux. Linux uses native Docker directly with no VM to manage; use `ai sandbox create`, `ai sandbox exec`, `ai sandbox refresh`, `ai sandbox ls`, `ai sandbox rebuild`, `ai sandbox rm` directly.
 
 ### Windows

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -286,7 +286,7 @@ Linux 直接使用宿主内核上的原生 Docker，没有受管 VM。`sandbox.v
 
 - **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
 - 用 **Podman** 替代 Docker：后续跟踪 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
-- **SELinux enforcing** 宿主机（Fedora / RHEL）可能需要手动加挂载标签：后续跟踪 [#258](https://github.com/fitlab-ai/agent-infra/issues/258)。
+- **SELinux enforcing** 宿主机（Fedora / RHEL）：`ai sandbox create` 会自动给 bind mount 加 Docker 共享 `:z` 标签，无需手动准备。如需排障可设 `AGENT_INFRA_SELINUX_DISABLE=1` 关闭。
 - `ai sandbox vm` 在 Linux 上是空操作。Linux 直接使用 native Docker，没有 VM 需要管理；请直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox refresh`、`ai sandbox ls`、`ai sandbox rebuild`、`ai sandbox rm`。
 
 ### Windows

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -33,6 +33,7 @@ import {
 import { resolveTaskBranch } from '../task-resolver.js';
 import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../tools.js';
 import { hostJoin, toEnginePath, volumeArg } from '../engines/wsl2-paths.js';
+import { validateSelinuxDisableEnv } from '../engines/selinux.js';
 import { assertClaudeCredentialsAvailable } from '../credentials.js';
 
 const OPENCODE_YOLO_PERMISSION = '{"*":"allow","read":"allow","bash":"allow","edit":"allow","webfetch":"allow","external_directory":"allow","doom_loop":"allow"}';
@@ -742,6 +743,8 @@ export async function create(args) {
   if (positionals.length < 1 || positionals.length > 2) {
     throw new Error(USAGE);
   }
+
+  validateSelinuxDisableEnv();
 
   const config = loadConfig();
   const [branchOrTaskId, base] = positionals;

--- a/lib/sandbox/engines/selinux.js
+++ b/lib/sandbox/engines/selinux.js
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+
+const SELINUX_ENFORCE_PATH = '/sys/fs/selinux/enforce';
+const detectionCache = new WeakMap();
+const VALID_DISABLE_VALUES = new Set([undefined, '', '0', '1']);
+
+function isDisabled(env) {
+  return env?.AGENT_INFRA_SELINUX_DISABLE === '1';
+}
+
+function readEnforceFlag(fsImpl) {
+  try {
+    return fsImpl.readFileSync(SELINUX_ENFORCE_PATH, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+function isSelinuxEnforcing(fsImpl, platform) {
+  let cache = detectionCache.get(fsImpl);
+  if (!cache) {
+    cache = new Map();
+    detectionCache.set(fsImpl, cache);
+  }
+
+  if (cache.has(platform)) {
+    return cache.get(platform);
+  }
+
+  const enforcing = readEnforceFlag(fsImpl) === '1';
+  cache.set(platform, enforcing);
+  return enforcing;
+}
+
+export function selinuxLabelForMount(engine, options = {}) {
+  const {
+    fs: fsImpl = fs,
+    platform = process.platform,
+    env = process.env
+  } = options;
+
+  if (engine !== 'native' || platform !== 'linux') {
+    return null;
+  }
+  if (isDisabled(env)) {
+    return null;
+  }
+  if (!isSelinuxEnforcing(fsImpl, platform)) {
+    return null;
+  }
+
+  return 'z';
+}
+
+export function validateSelinuxDisableEnv(env = process.env) {
+  const value = env?.AGENT_INFRA_SELINUX_DISABLE;
+  if (!VALID_DISABLE_VALUES.has(value)) {
+    throw new Error('Invalid AGENT_INFRA_SELINUX_DISABLE value. Expected 1 to disable, or unset/0 for default.');
+  }
+}

--- a/lib/sandbox/engines/wsl2-paths.js
+++ b/lib/sandbox/engines/wsl2-paths.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { selinuxLabelForMount } from './selinux.js';
 
 const WINDOWS_DRIVE_PATH_PATTERN = /^([A-Za-z]):[\\/](.*)$/;
 const UNC_PATH_PATTERN = /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+/;
@@ -42,6 +43,17 @@ export function toEnginePath(engine, value) {
   return windowsPathToWslPath(value);
 }
 
-export function volumeArg(engine, hostPath, containerPath, suffix = '') {
-  return `${toEnginePath(engine, hostPath)}:${containerPath}${suffix}`;
+export function volumeArg(engine, hostPath, containerPath, suffix = '', options = {}) {
+  const { selinux = 'shared', ...selinuxOptions } = options;
+  const flags = suffix.replace(/^:/, '').split(',').filter(Boolean);
+
+  if (selinux !== 'none') {
+    const label = selinuxLabelForMount(engine, selinuxOptions);
+    if (label && !flags.includes(label)) {
+      flags.push(label);
+    }
+  }
+
+  const composedSuffix = flags.length > 0 ? `:${flags.join(',')}` : '';
+  return `${toEnginePath(engine, hostPath)}:${containerPath}${composedSuffix}`;
 }

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -82,6 +82,18 @@ function withFakeStty(exitCode, fn) {
   }
 }
 
+function fakeSelinuxFs(flag) {
+  return {
+    reads: 0,
+    readFileSync(pathname, encoding) {
+      assert.equal(pathname, "/sys/fs/selinux/enforce");
+      assert.equal(encoding, "utf8");
+      this.reads += 1;
+      return flag;
+    }
+  };
+}
+
 test("runInteractive emits terminal reset on normal exit", () => {
   const output = withFakeStty(0, () => withTTY(true, () => captureStdoutWrite(() => {
     const status = runInteractive(process.execPath, ["-e", "process.exit(0)"]);
@@ -151,6 +163,25 @@ test("sandbox create help documents the host aliases file", () => {
   assert.match(output, /Usage: ai sandbox create <branch> \[base\] \[--cpu <n>\] \[--memory <n>\]/);
   assert.match(output, /~\/\.agent-infra\/aliases\/sandbox\.sh/);
   assert.match(output, /\/home\/devuser\/\.bash_aliases/);
+});
+
+test("sandbox create rejects invalid selinux disable environment before loading config", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const previousValue = process.env.AGENT_INFRA_SELINUX_DISABLE;
+
+  try {
+    process.env.AGENT_INFRA_SELINUX_DISABLE = "invalid";
+    await assert.rejects(
+      () => sandboxCreate.create(["feature/selinux-invalid-env"]),
+      /Invalid AGENT_INFRA_SELINUX_DISABLE/
+    );
+  } finally {
+    if (previousValue === undefined) {
+      delete process.env.AGENT_INFRA_SELINUX_DISABLE;
+    } else {
+      process.env.AGENT_INFRA_SELINUX_DISABLE = previousValue;
+    }
+  }
 });
 
 test("sandbox rm defaults local branch deletion confirmation to yes", () => {
@@ -1187,6 +1218,94 @@ test("volumeArg converts host mount paths for WSL2", async () => {
     wsl2Paths.volumeArg("native", "/repo/.ssh", "/home/devuser/.ssh", ":ro"),
     "/repo/.ssh:/home/devuser/.ssh:ro"
   );
+});
+
+test("volumeArg without selinux fallback stays unchanged", async () => {
+  const wsl2Paths = await loadFreshEsm("lib/sandbox/engines/wsl2-paths.js");
+
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo", "/workspace", "", {
+      platform: "darwin",
+      fs: fakeSelinuxFs("1\n"),
+      env: {}
+    }),
+    "/repo:/workspace"
+  );
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo", "/workspace", ":ro", {
+      platform: "linux",
+      fs: fakeSelinuxFs("0\n"),
+      env: {}
+    }),
+    "/repo:/workspace:ro"
+  );
+});
+
+test("volumeArg adds shared selinux labels on native enforcing hosts", async () => {
+  const wsl2Paths = await loadFreshEsm("lib/sandbox/engines/wsl2-paths.js");
+  const fsImpl = fakeSelinuxFs("1\n");
+
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo", "/workspace", "", {
+      platform: "linux",
+      fs: fsImpl,
+      env: {}
+    }),
+    "/repo:/workspace:z"
+  );
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo/.ssh", "/home/devuser/.ssh", ":ro", {
+      platform: "linux",
+      fs: fsImpl,
+      env: {}
+    }),
+    "/repo/.ssh:/home/devuser/.ssh:ro,z"
+  );
+});
+
+test("volumeArg respects selinux label controls", async () => {
+  const wsl2Paths = await loadFreshEsm("lib/sandbox/engines/wsl2-paths.js");
+
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo", "/workspace", "", {
+      platform: "linux",
+      fs: fakeSelinuxFs("1\n"),
+      env: { AGENT_INFRA_SELINUX_DISABLE: "1" }
+    }),
+    "/repo:/workspace"
+  );
+  assert.equal(
+    wsl2Paths.volumeArg("native", "/repo", "/workspace", "", {
+      platform: "linux",
+      fs: fakeSelinuxFs("1\n"),
+      env: {},
+      selinux: "none"
+    }),
+    "/repo:/workspace"
+  );
+});
+
+test("volumeArg ignores selinux labels for non-native engines", async () => {
+  const wsl2Paths = await loadFreshEsm("lib/sandbox/engines/wsl2-paths.js");
+  const fsImpl = fakeSelinuxFs("1\n");
+
+  assert.equal(
+    wsl2Paths.volumeArg("wsl2", "F:\\repo", "/workspace", "", {
+      platform: "linux",
+      fs: fsImpl,
+      env: {}
+    }),
+    "/mnt/f/repo:/workspace"
+  );
+  assert.equal(
+    wsl2Paths.volumeArg("orbstack", "/repo", "/workspace", "", {
+      platform: "linux",
+      fs: fsImpl,
+      env: {}
+    }),
+    "/repo:/workspace"
+  );
+  assert.equal(fsImpl.reads, 0);
 });
 
 test("rebuild buildArgs converts Docker build paths for WSL2", async () => {

--- a/tests/cli/selinux.test.js
+++ b/tests/cli/selinux.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadFreshEsm } from "../helpers.js";
+
+function fakeSelinuxFs(flag) {
+  return {
+    reads: 0,
+    readFileSync(pathname, encoding) {
+      assert.equal(pathname, "/sys/fs/selinux/enforce");
+      assert.equal(encoding, "utf8");
+      this.reads += 1;
+      return flag;
+    }
+  };
+}
+
+test("selinuxLabelForMount returns null outside native linux", async () => {
+  const { selinuxLabelForMount } = await loadFreshEsm("lib/sandbox/engines/selinux.js");
+  const fsImpl = fakeSelinuxFs("1\n");
+
+  assert.equal(selinuxLabelForMount("wsl2", { platform: "linux", fs: fsImpl, env: {} }), null);
+  assert.equal(selinuxLabelForMount("native", { platform: "darwin", fs: fsImpl, env: {} }), null);
+  assert.equal(fsImpl.reads, 0);
+});
+
+test("selinuxLabelForMount returns null when enforcing flag is absent", async () => {
+  const { selinuxLabelForMount } = await loadFreshEsm("lib/sandbox/engines/selinux.js");
+  const fsImpl = {
+    readFileSync() {
+      const error = new Error("missing");
+      error.code = "ENOENT";
+      throw error;
+    }
+  };
+
+  assert.equal(selinuxLabelForMount("native", { platform: "linux", fs: fsImpl, env: {} }), null);
+});
+
+test("selinuxLabelForMount reads enforcing flag once per injected filesystem", async () => {
+  const { selinuxLabelForMount } = await loadFreshEsm("lib/sandbox/engines/selinux.js");
+  const fsImpl = fakeSelinuxFs("1\n");
+  const options = { platform: "linux", fs: fsImpl, env: {} };
+
+  assert.equal(selinuxLabelForMount("native", options), "z");
+  assert.equal(selinuxLabelForMount("native", options), "z");
+  assert.equal(fsImpl.reads, 1);
+});
+
+test("selinuxLabelForMount supports disable environment controls", async () => {
+  const { selinuxLabelForMount } = await loadFreshEsm("lib/sandbox/engines/selinux.js");
+
+  assert.equal(selinuxLabelForMount("native", {
+    platform: "linux",
+    fs: fakeSelinuxFs("1\n"),
+    env: {}
+  }), "z");
+  assert.equal(selinuxLabelForMount("native", {
+    platform: "linux",
+    fs: fakeSelinuxFs("1\n"),
+    env: { AGENT_INFRA_SELINUX_DISABLE: "0" }
+  }), "z");
+  assert.equal(selinuxLabelForMount("native", {
+    platform: "linux",
+    fs: fakeSelinuxFs("1\n"),
+    env: { AGENT_INFRA_SELINUX_DISABLE: "" }
+  }), "z");
+  assert.equal(selinuxLabelForMount("native", {
+    platform: "linux",
+    fs: fakeSelinuxFs("1\n"),
+    env: { AGENT_INFRA_SELINUX_DISABLE: "1" }
+  }), null);
+});
+
+test("validateSelinuxDisableEnv rejects invalid disable values", async () => {
+  const { validateSelinuxDisableEnv } = await loadFreshEsm("lib/sandbox/engines/selinux.js");
+
+  assert.doesNotThrow(() => validateSelinuxDisableEnv({}));
+  assert.doesNotThrow(() => validateSelinuxDisableEnv({ AGENT_INFRA_SELINUX_DISABLE: "" }));
+  assert.doesNotThrow(() => validateSelinuxDisableEnv({ AGENT_INFRA_SELINUX_DISABLE: "0" }));
+  assert.doesNotThrow(() => validateSelinuxDisableEnv({ AGENT_INFRA_SELINUX_DISABLE: "1" }));
+  assert.throws(
+    () => validateSelinuxDisableEnv({ AGENT_INFRA_SELINUX_DISABLE: "invalid" }),
+    /Invalid AGENT_INFRA_SELINUX_DISABLE/
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #258

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #258

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

在 SELinux enforcing 主机（Fedora / RHEL / CentOS Stream / AlmaLinux / Rocky）上，Docker bind mount 的宿主路径若没有 `container_file_t` 类型标签，容器内进程会得到 `Permission denied`。本 PR 让 native Docker sandbox 在这些主机上自动给所有 bind mount 加 Docker 共享 `:z` 标签，无需任何手动准备。

On SELinux enforcing hosts (Fedora / RHEL family), Docker bind mounts without the `container_file_t` label cause `Permission denied` inside the container. This PR makes the native Docker sandbox auto-attach Docker's shared `:z` label on those hosts, with no manual setup required.

## 📋 主要变更 / Brief Changelog

- 新增 `lib/sandbox/engines/selinux.js`：检测 `/sys/fs/selinux/enforce`，仅在 `engine='native'` + `platform='linux'` + enforcing 三条同时满足时返回标签 `'z'`，否则 `null`；进程内按注入式 fs 缓存
- 扩展 `lib/sandbox/engines/wsl2-paths.js::volumeArg`，新增可选第 5 参数 `options.selinux`（`'shared'` 默认 / `'none'` 跳过）；现有调用点零修改
- `lib/sandbox/commands/create.js` 入口新增 `validateSelinuxDisableEnv()`，在 `parseArgs` 之后、`loadConfig()` 之前对 `AGENT_INFRA_SELINUX_DISABLE` 取值做早失败校验（接受 `unset` / `''` / `'0'` / `'1'`）
- 默认行为：enforcing 主机自动给所有 bind mount 加 `:z`，与原 `:ro` 等 suffix 通过逗号组合（如 `:ro,z`）
- 逃生通道：`AGENT_INFRA_SELINUX_DISABLE=1` 关闭自动行为，便于排障
- 中英 README "Known limitations on Linux" 段落同步更新为单行说明

不暴露 `:Z`（私有标签）路径，避免破坏宿主敏感目录（`~/.ssh` / `.git` 等）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

**自动化（已通过）**：

1. `npm test` —— 376 个测试全绿，包含 5 个新增 SELinux 单元测试（依赖注入式 fs/platform/env，不依赖真实 SELinux 主机）
2. `node --test tests/cli/selinux.test.js tests/cli/sandbox.test.js` —— 148 个用例覆盖：检测路径、env 校验、`volumeArg` 与 `:ro` 组合、非 native engine 跳过

**手动验收（待办，需 Fedora 40+ enforcing 主机）**：

```bash
# A. 默认行为应工作
getenforce            # 必须返回 Enforcing
ai sandbox create selinux-test main
docker exec <container> sh -lc 'ls /workspace && touch /workspace/.hello'
docker inspect <container> --format '{{json .HostConfig.Binds}}'  # 应能看到 ":z"

# B. opt-out 后复现原始故障
AGENT_INFRA_SELINUX_DISABLE=1 ai sandbox create selinux-disable main
docker exec <container> sh -lc 'ls /workspace' 2>&1 | grep -i 'permission denied'  # 期望失败

# C. setenforce 0 后回归对照
sudo setenforce 0
ai sandbox create selinux-permissive main
docker inspect <container> --format '{{json .HostConfig.Binds}}'  # 应不包含 ":z"
sudo setenforce 1

# D. 宿主敏感目录无副作用
ls -laZ ~/.ssh        # 标签应仍是 ssh_home_t，不被改写
```

验收输出会在跑完后回填到本 PR 描述。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / Manual SELinux verification on Fedora pending

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] GitHub Issue 已存在 / Issue exists
- [x] PR 只解决一个 Issue / Single-issue PR
- [x] commit 主题与正文有意义 / Commit subject and body are meaningful

**代码质量 / Code Quality:**

- [x] 遵循项目代码规范 / Follows coding standards
- [x] 已自我审查（5 轮 review + 3 轮 refine）/ Self-reviewed (5 review rounds + 3 refine rounds)
- [x] 复杂逻辑已注释 / Comments where needed

**测试要求 / Testing Requirements:**

- [x] 已编写单元测试 / Unit tests added
- [x] 跨模块依赖已 mock（注入式 fs/platform/env）/ Cross-module deps mocked
- [x] Lint 通过 / Lint passes
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 文档已更新 / Documentation updated (中英 README)
- [x] 无破坏性变更 / No breaking changes
- [x] 已考虑向后兼容 / Backward compatible (volumeArg 新参数为可选)

## 📋 附加信息 / Additional Notes

**范围澄清**：

- Out of scope（已在 Issue #258 明确）：
  - rootless Docker → #256
  - Podman 支持 → #257
  - root UID 冲突 → #261
- 未在 GitHub-hosted CI 中加 Fedora job：`ubuntu-latest` 内核无 SELinux 模块，`setenforce` 不可用；自动化测试通过依赖注入覆盖标签逻辑，真实 enforcing 主机的端到端验收走人工路径。

**审查者注意事项 / Reviewer Notes:**

- 重点审查范围：`selinux.js` 的检测条件、`volumeArg` 与现有 `:ro` 组合的拼接（`:ro,z`）、`validateSelinuxDisableEnv` 在入口的位置
- `:Z`（私有标签）已被刻意不暴露，原因是它会原地 chcon 宿主路径，破坏 sshd / 桌面工具
- 5 轮 review 与 3 轮 refine 详见 Issue #258 的产物评论链；最终设计落到："native + linux + enforce=1 + !disabled → 加 :z" 单一语义

---

Generated with AI assistance
