### PR TITLE
feat(sandbox): bidirectional Claude credentials sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 `ai sandbox exec` also forwards a small terminal-detection whitelist (`TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `LC_TERMINAL`, `LC_TERMINAL_VERSION`) into the container. This keeps interactive TUIs aligned with the host terminal for behaviors such as Claude Code's Shift+Enter newline support, without passing through the full host environment.
 
-`ai sandbox refresh` syncs the host's Claude Code credentials into all sandbox project copies under `~/.agent-infra/credentials/*`. It inspects the host Keychain, probes `claude /status` when host credentials look stale, and rewrites each project copy only when the bytes differ — so token rotations propagate to long-running sandboxes without rebuilding them.
+`ai sandbox exec` and `ai sandbox refresh` reconcile Claude Code credentials in both directions across the host credential store and every sandbox project copy under `~/.agent-infra/credentials/*`. When a long-running sandbox refreshes OAuth tokens first, the next entry or refresh command writes the freshest valid copy back to the host Keychain or `~/.claude/.credentials.json`; when the host is fresher, it updates the project copies. If every copy is stale, `ai sandbox refresh` probes `claude /status` and asks you to log in only when the probe cannot recover credentials.
 
 <a id="architecture-overview"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,7 +201,7 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 `ai sandbox exec` 也会向容器透传一小组终端检测白名单变量（`TERM_PROGRAM`、`TERM_PROGRAM_VERSION`、`LC_TERMINAL`、`LC_TERMINAL_VERSION`）。这样可以让交互式 TUI 保持与宿主终端一致的行为，例如 Claude Code 的 `Shift+Enter` 换行支持，同时避免把整个宿主环境灌入容器。
 
-`ai sandbox refresh` 用于把宿主机 Claude Code 凭证同步到 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本。它会检查宿主 Keychain 状态、在凭证过期时尝试 `claude /status` 探活、仅在字节不同时重写每个项目副本——这样 host token 轮换可以传播到正在运行的沙箱，无需重建。
+`ai sandbox exec` 和 `ai sandbox refresh` 会在宿主机凭证存储与 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本之间做双向 reconcile。长时间运行的沙箱如果先刷新了 OAuth token，下一次进入或刷新命令会把最新有效副本回写到宿主 Keychain 或 `~/.claude/.credentials.json`；宿主机更新时也会继续覆盖项目副本。如果所有副本都已失效，`ai sandbox refresh` 会尝试 `claude /status` 探活，只有探活无法恢复时才提示重新登录。
 
 <a id="architecture-overview"></a>
 

--- a/lib/sandbox/commands/enter.js
+++ b/lib/sandbox/commands/enter.js
@@ -1,7 +1,7 @@
 import { loadConfig } from '../config.js';
 import { assertValidBranchName, containerNameCandidates } from '../constants.js';
 import { detectEngine } from '../engine.js';
-import { formatRemaining, syncClaudeCredentialsFromKeychain } from '../credentials.js';
+import { formatRemaining, reconcileClaudeCredentials } from '../credentials.js';
 import { runInteractiveEngine, runSafeEngine } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
 
@@ -75,14 +75,22 @@ export function enter(args) {
 
   if (config.tools.includes('claude-code')) {
     try {
-      const result = syncClaudeCredentialsFromKeychain(config.home, config.project);
+      // Scan all projects so a refresh from a neighbouring sandbox can still flow back to the host.
+      const result = reconcileClaudeCredentials(config.home);
       if (result.status === 'STALE_ACCESS') {
         process.stderr.write(
           'Warning: Claude Code credentials on host appear stale. Run "ai sandbox refresh" or "claude /login" to renew.\n'
         );
       } else if (result.status === 'MISSING') {
         process.stderr.write('Warning: Claude Code credentials missing on host. Run "claude /login" to authenticate.\n');
-      } else if (result.status === 'OK' && result.written) {
+      } else if (result.status === 'KEYCHAIN_WRITE_FAILED') {
+        process.stderr.write(
+          `Warning: A sandbox refresh produced newer credentials but host Keychain write failed (${result.warnings.join('; ')}). Run "ai sandbox refresh" again or "claude /status" on the host to retry.\n`
+        );
+      } else if (result.status === 'OK' && result.authoritative !== 'host') {
+        const message = `Synced Claude Code credentials from sandbox refresh back to host (expires in ${formatRemaining(result.expiresAt)})`;
+        process.stderr.write(process.stderr.isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`);
+      } else if (result.status === 'OK' && result.filesWritten.length > 0) {
         const message = `Synced Claude Code credentials from host Keychain (expires in ${formatRemaining(result.expiresAt)})`;
         process.stderr.write(process.stderr.isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`);
       }

--- a/lib/sandbox/commands/refresh.js
+++ b/lib/sandbox/commands/refresh.js
@@ -1,12 +1,9 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { homedir } from 'node:os';
 import { parseArgs } from 'node:util';
 import {
-  claudeCredentialsPath,
+  discoverProjects,
   formatRemaining,
-  inspectClaudeKeychainStatus,
-  syncClaudeCredentialsFromKeychain
+  reconcileClaudeCredentials
 } from '../credentials.js';
 import { runProbe } from '../shell.js';
 
@@ -25,22 +22,14 @@ export function probeClaudeStatus(spawnFn = runProbe) {
   };
 }
 
-function discoverProjects(home) {
-  const credentialsRoot = path.join(home, '.agent-infra', 'credentials');
-  if (!fs.existsSync(credentialsRoot)) {
-    return [];
-  }
-
-  return fs.readdirSync(credentialsRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((project) => fs.existsSync(claudeCredentialsPath(home, project)));
-}
-
 export async function refresh(args, deps = {}) {
   const {
     spawnFn = runProbe,
     execFn,
+    readFn,
+    existsFn,
+    writeFn,
+    writeHostFn,
     discoverFn = discoverProjects,
     writeStdout = (chunk) => process.stdout.write(chunk),
     writeStderr = (chunk) => process.stderr.write(chunk)
@@ -67,8 +56,9 @@ export async function refresh(args, deps = {}) {
     return 0;
   }
 
-  let inspection = inspectClaudeKeychainStatus(home, execFn);
-  if (inspection.status === 'STALE_ACCESS') {
+  const reconcileOptions = { execFn, readFn, existsFn, writeFn, writeHostFn, projects };
+  let result = reconcileClaudeCredentials(home, reconcileOptions);
+  if (result.status === 'STALE_ACCESS' && result.authoritative === null) {
     writeStdout('Host credentials appear stale; probing claude /status to trigger refresh...\n');
     const probe = probeClaudeStatus(spawnFn);
     if (!probe.ok) {
@@ -77,31 +67,37 @@ export async function refresh(args, deps = {}) {
       return 1;
     }
     writeStdout('Probe succeeded; re-inspecting host credentials.\n');
-    inspection = inspectClaudeKeychainStatus(home, execFn);
+    result = reconcileClaudeCredentials(home, reconcileOptions);
   }
 
-  if (inspection.status === 'MISSING') {
+  if (result.status === 'MISSING') {
     writeStderr('No Claude Code credentials found on host.\n');
     writeStderr('Run "claude /login" on the host to authenticate.\n');
     return 1;
   }
 
-  if (inspection.status !== 'OK') {
+  if (result.status === 'KEYCHAIN_WRITE_FAILED') {
+    writeStderr(`[host] keychain write failed: ${result.warnings.join('; ') || 'unknown error'}\n`);
+    return 1;
+  }
+
+  if (result.status !== 'OK') {
     writeStderr('Host credentials still invalid after probe; run "claude /login".\n');
     return 1;
   }
 
-  let anyFailed = false;
-  for (const project of projects) {
-    try {
-      const result = syncClaudeCredentialsFromKeychain(home, project, { execFn, inspection });
-      const action = result.written ? 'updated' : 'unchanged';
-      writeStdout(`[${project}] ${action}; expires in ${formatRemaining(result.expiresAt)}\n`);
-    } catch (error) {
-      anyFailed = true;
-      writeStderr(`[${project}] sync failed: ${error.message}\n`);
-    }
+  if (result.authoritative && result.authoritative !== 'host' && result.hostWritten) {
+    writeStdout(`[host] reconciled from ${result.authoritative}\n`);
   }
 
-  return anyFailed ? 1 : 0;
+  for (const project of projects) {
+    const action = result.filesWritten.includes(project) ? 'updated' : 'unchanged';
+    writeStdout(`[${project}] ${action}; expires in ${formatRemaining(result.expiresAt)}\n`);
+  }
+
+  for (const failure of result.fileErrors) {
+    writeStderr(`[${failure.project}] sync failed: ${failure.error}\n`);
+  }
+
+  return result.fileErrors.length > 0 ? 1 : 0;
 }

--- a/lib/sandbox/credentials.js
+++ b/lib/sandbox/credentials.js
@@ -201,7 +201,12 @@ function shouldWriteEndpoint(authoritative, target) {
     return authoritative.expiresAt > target.expiresAt;
   }
 
-  return authoritative.blob !== target.blob;
+  // Both endpoints are OK but expiresAt is not comparable (one or both non-numeric,
+  // or values are equal at the same millisecond). Stay conservative and refuse to
+  // write — a real rotation will produce a strictly larger expiresAt next time.
+  // This guards against leaner host blobs (e.g. stored without subscriptionType)
+  // overwriting a richer mount blob solely on the basis of byte differences.
+  return false;
 }
 
 export function reconcileClaudeCredentials(home, options = {}) {

--- a/lib/sandbox/credentials.js
+++ b/lib/sandbox/credentials.js
@@ -1,8 +1,11 @@
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { hostJoin } from './engines/wsl2-paths.js';
 
+// Reconcile treats the freshest valid endpoint as authoritative so sandbox
+// token rotations can flow back to the host credential store.
 function validateClaudeCredentialsBlob(raw, blob = null) {
   const trimmed = typeof raw === 'string' ? raw.trim() : '';
   if (!trimmed) {
@@ -31,7 +34,20 @@ function validateClaudeCredentialsBlob(raw, blob = null) {
   };
 }
 
-export function inspectClaudeKeychainStatus(home, execFn = execFileSync) {
+export function readClaudeCredentialsFile(filePath, readFn = (targetPath) => fs.readFileSync(targetPath, 'utf8'), existsFn = fs.existsSync) {
+  if (!existsFn(filePath)) {
+    return { status: 'MISSING' };
+  }
+
+  try {
+    const raw = readFn(filePath);
+    return validateClaudeCredentialsBlob(raw, raw);
+  } catch {
+    return { status: 'STALE_ACCESS' };
+  }
+}
+
+export function inspectClaudeKeychainStatus(home, execFn = execFileSync, options = {}) {
   if (process.platform === 'darwin') {
     try {
       const keychainAccount = path.basename(home);
@@ -53,16 +69,15 @@ export function inspectClaudeKeychainStatus(home, execFn = execFileSync) {
   }
 
   const credentialsPath = path.join(home, '.claude', '.credentials.json');
-  if (!fs.existsSync(credentialsPath)) {
-    return { status: 'MISSING' };
-  }
+  return readClaudeCredentialsFile(credentialsPath, options.readFn, options.existsFn);
+}
 
-  try {
-    const raw = fs.readFileSync(credentialsPath, 'utf8');
-    return validateClaudeCredentialsBlob(raw, raw);
-  } catch {
-    return { status: 'STALE_ACCESS' };
-  }
+export function inspectClaudeMountFile(home, project, options = {}) {
+  return readClaudeCredentialsFile(
+    claudeCredentialsPath(home, project),
+    options.readFn,
+    options.existsFn
+  );
 }
 
 export function extractClaudeCredentialsBlob(home, execFn = execFileSync) {
@@ -88,36 +103,203 @@ export function writeClaudeCredentialsFile(home, project, blob) {
   fs.chmodSync(filePath, 0o600);
 }
 
-export function syncClaudeCredentialsFromKeychain(home, project, options = {}) {
+export function discoverProjects(home) {
+  const credentialsRoot = hostJoin(home, '.agent-infra', 'credentials');
+  if (!fs.existsSync(credentialsRoot)) {
+    return [];
+  }
+
+  return fs.readdirSync(credentialsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((project) => fs.existsSync(claudeCredentialsPath(home, project)));
+}
+
+export function writeClaudeCredentialsToHost(home, blob, options = {}) {
+  const {
+    execFn = execFileSync,
+    mkdirFn = fs.mkdirSync,
+    chmodFn = fs.chmodSync,
+    writeFileFn = fs.writeFileSync,
+    renameFn = fs.renameSync,
+    rmFn = fs.rmSync,
+    randomFn = () => randomBytes(6).toString('hex')
+  } = options;
+
+  try {
+    if (process.platform === 'darwin') {
+      execFn('security', [
+        'add-generic-password',
+        '-U',
+        '-a',
+        path.basename(home),
+        '-s',
+        'Claude Code-credentials',
+        '-w',
+        blob
+      ], {
+        stdio: ['ignore', 'ignore', 'pipe']
+      });
+      return { ok: true };
+    }
+
+    const dir = path.join(home, '.claude');
+    const targetPath = path.join(dir, '.credentials.json');
+    const tmpPath = `${targetPath}.tmp.${process.pid}.${randomFn()}`;
+
+    try {
+      mkdirFn(dir, { recursive: true, mode: 0o700 });
+      chmodFn(dir, 0o700);
+      writeFileFn(tmpPath, blob, { mode: 0o600 });
+      chmodFn(tmpPath, 0o600);
+      renameFn(tmpPath, targetPath);
+      return { ok: true };
+    } catch (error) {
+      try {
+        rmFn(tmpPath, { force: true });
+      } catch {
+        // Best-effort cleanup only.
+      }
+      return { ok: false, error: error.message };
+    }
+  } catch (error) {
+    return { ok: false, error: error.message };
+  }
+}
+
+function endpointNameForFile(project) {
+  return `file:${project}`;
+}
+
+function chooseAuthoritativeEndpoint(endpoints) {
+  const okEndpoints = endpoints.filter((endpoint) => endpoint.status === 'OK');
+  if (okEndpoints.length === 0) {
+    return null;
+  }
+
+  const hostEndpoint = okEndpoints.find((endpoint) => endpoint.name === 'host');
+  if (hostEndpoint && typeof hostEndpoint.expiresAt !== 'number') {
+    return hostEndpoint;
+  }
+
+  const withExpiresAt = okEndpoints.filter((endpoint) => typeof endpoint.expiresAt === 'number');
+  if (withExpiresAt.length > 0) {
+    return withExpiresAt.reduce((best, endpoint) => (
+      endpoint.expiresAt > best.expiresAt ? endpoint : best
+    ));
+  }
+
+  return okEndpoints.find((endpoint) => endpoint.name === 'host') ?? okEndpoints[0];
+}
+
+function shouldWriteEndpoint(authoritative, target) {
+  if (target.status !== 'OK') {
+    return true;
+  }
+
+  if (typeof authoritative.expiresAt === 'number' && typeof target.expiresAt === 'number') {
+    return authoritative.expiresAt > target.expiresAt;
+  }
+
+  return authoritative.blob !== target.blob;
+}
+
+export function reconcileClaudeCredentials(home, options = {}) {
   const {
     execFn = execFileSync,
     writeFn = writeClaudeCredentialsFile,
-    readFn = (filePath) => fs.readFileSync(filePath, 'utf8'),
-    existsFn = fs.existsSync,
+    writeHostFn = writeClaudeCredentialsToHost,
+    readFn,
+    existsFn,
+    discoverFn = discoverProjects,
+    projects = null,
+    singleProject = null,
     inspection = null
   } = options;
 
-  const currentInspection = inspection ?? inspectClaudeKeychainStatus(home, execFn);
-  if (currentInspection.status !== 'OK') {
-    return { status: currentInspection.status, written: false };
+  const effectiveProjects = singleProject
+    ? [singleProject]
+    : (projects ?? discoverFn(home));
+  const hostInspection = inspection ?? inspectClaudeKeychainStatus(home, execFn, { readFn, existsFn });
+  const hostEndpoint = { name: 'host', ...hostInspection };
+  const fileEndpoints = effectiveProjects.map((project) => ({
+    name: endpointNameForFile(project),
+    project,
+    ...inspectClaudeMountFile(home, project, { readFn, existsFn })
+  }));
+  const endpoints = [hostEndpoint, ...fileEndpoints];
+  const authoritative = chooseAuthoritativeEndpoint(endpoints);
+
+  if (!authoritative) {
+    const hasStaleEndpoint = endpoints.some((endpoint) => endpoint.status === 'STALE_ACCESS');
+    return {
+      status: hasStaleEndpoint ? 'STALE_ACCESS' : 'MISSING',
+      authoritative: null,
+      expiresAt: null,
+      hostWritten: false,
+      filesWritten: [],
+      fileErrors: [],
+      warnings: []
+    };
   }
 
-  const targetPath = claudeCredentialsPath(home, project);
-  let existing = null;
-  if (existsFn(targetPath)) {
-    try {
-      existing = readFn(targetPath);
-    } catch {
-      existing = null;
+  const warnings = [];
+  const filesWritten = [];
+  const fileErrors = [];
+  let hostWritten = false;
+  let hostWriteFailed = false;
+
+  if (authoritative.name !== 'host' && shouldWriteEndpoint(authoritative, hostEndpoint)) {
+    const result = writeHostFn(home, authoritative.blob, { execFn });
+    if (result?.ok) {
+      hostWritten = true;
+    } else {
+      hostWriteFailed = true;
+      warnings.push(result?.error ?? 'unknown error');
     }
   }
 
-  if (existing === currentInspection.blob) {
-    return { status: 'OK', written: false, expiresAt: currentInspection.expiresAt };
+  for (const endpoint of fileEndpoints) {
+    if (endpoint.name === authoritative.name || !shouldWriteEndpoint(authoritative, endpoint)) {
+      continue;
+    }
+
+    try {
+      writeFn(home, endpoint.project, authoritative.blob);
+      filesWritten.push(endpoint.project);
+    } catch (error) {
+      fileErrors.push({ project: endpoint.project, error: error.message });
+    }
   }
 
-  writeFn(home, project, currentInspection.blob);
-  return { status: 'OK', written: true, expiresAt: currentInspection.expiresAt };
+  return {
+    status: hostWriteFailed ? 'KEYCHAIN_WRITE_FAILED' : 'OK',
+    authoritative: authoritative.name,
+    expiresAt: authoritative.expiresAt ?? null,
+    hostWritten,
+    filesWritten,
+    fileErrors,
+    warnings
+  };
+}
+
+export function syncClaudeCredentialsFromKeychain(home, project, options = {}) {
+  const result = reconcileClaudeCredentials(home, {
+    ...options,
+    singleProject: project
+  });
+  if (result.status !== 'OK' && result.status !== 'KEYCHAIN_WRITE_FAILED') {
+    return {
+      status: result.status,
+      written: false
+    };
+  }
+
+  return {
+    status: result.status === 'KEYCHAIN_WRITE_FAILED' ? 'OK' : result.status,
+    written: result.filesWritten.includes(project),
+    expiresAt: result.expiresAt
+  };
 }
 
 export function formatRemaining(expiresAt) {

--- a/tests/cli/sandbox-credentials.test.js
+++ b/tests/cli/sandbox-credentials.test.js
@@ -272,6 +272,136 @@ test("inspectClaudeKeychainStatus reports Linux credential states", async () => 
   }
 });
 
+test("inspectClaudeMountFile reports mounted credential states", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-mount-inspect-"));
+  const targetPath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+  const rawBlob = validBlob({ expiresAt: 987654 });
+
+  try {
+    assert.equal(credentials.inspectClaudeMountFile(tmpDir, "demo").status, "MISSING");
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, "not-json", "utf8");
+    assert.equal(credentials.inspectClaudeMountFile(tmpDir, "demo").status, "STALE_ACCESS");
+    fs.writeFileSync(targetPath, rawBlob, "utf8");
+    assert.deepEqual(credentials.inspectClaudeMountFile(tmpDir, "demo"), {
+      status: "OK",
+      blob: rawBlob,
+      expiresAt: 987654
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("discoverProjects lists project credential copies only", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-discover-"));
+
+  try {
+    fs.mkdirSync(path.join(tmpDir, ".agent-infra", "credentials", "alpha", "claude-code"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".agent-infra", "credentials", "beta", "claude-code"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agent-infra", "credentials", "alpha", "claude-code", ".credentials.json"),
+      validBlob(),
+      "utf8"
+    );
+
+    assert.deepEqual(credentials.discoverProjects(tmpDir), ["alpha"]);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("writeClaudeCredentialsToHost updates macOS Keychain credentials", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const rawBlob = validBlob();
+
+  withPlatform("darwin", () => {
+    assert.deepEqual(credentials.writeClaudeCredentialsToHost("/Users/demo", rawBlob, {
+      execFn: (cmd, args, options) => {
+        assert.equal(cmd, "security");
+        assert.deepEqual(args, [
+          "add-generic-password",
+          "-U",
+          "-a",
+          "demo",
+          "-s",
+          "Claude Code-credentials",
+          "-w",
+          rawBlob
+        ]);
+        assert.deepEqual(options, {
+          stdio: ["ignore", "ignore", "pipe"]
+        });
+      }
+    }), { ok: true });
+  });
+});
+
+test("writeClaudeCredentialsToHost returns a soft failure when macOS Keychain write fails", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  withPlatform("darwin", () => {
+    const result = credentials.writeClaudeCredentialsToHost("/Users/demo", validBlob(), {
+      execFn: () => {
+        throw new Error("keychain locked");
+      }
+    });
+
+    assert.deepEqual(result, { ok: false, error: "keychain locked" });
+  });
+});
+
+test("writeClaudeCredentialsToHost atomically replaces Linux host credentials", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-write-"));
+  const targetPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const rawBlob = validBlob();
+
+  try {
+    withPlatform("linux", () => {
+      assert.deepEqual(credentials.writeClaudeCredentialsToHost(tmpDir, rawBlob, {
+        randomFn: () => "fixed"
+      }), { ok: true });
+    });
+
+    assertModeBits(path.dirname(targetPath), 0o700);
+    assertModeBits(targetPath, 0o600);
+    assert.equal(fs.readFileSync(targetPath, "utf8"), rawBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("writeClaudeCredentialsToHost preserves Linux host credentials when rename fails", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-rename-fail-"));
+  const targetDir = path.join(tmpDir, ".claude");
+  const targetPath = path.join(targetDir, ".credentials.json");
+
+  try {
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(targetPath, "original", "utf8");
+
+    withPlatform("linux", () => {
+      const result = credentials.writeClaudeCredentialsToHost(tmpDir, validBlob(), {
+        randomFn: () => "fixed",
+        renameFn: () => {
+          throw new Error("rename failed");
+        }
+      });
+
+      assert.deepEqual(result, { ok: false, error: "rename failed" });
+    });
+
+    assert.equal(fs.readFileSync(targetPath, "utf8"), "original");
+    assert.equal(fs.existsSync(`${targetPath}.tmp.${process.pid}.fixed`), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("syncClaudeCredentialsFromKeychain writes only when destination bytes differ", async () => {
   const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
   const rawBlob = validBlob({ expiresAt: 123456 });
@@ -328,5 +458,256 @@ test("syncClaudeCredentialsFromKeychain and formatRemaining handle unavailable o
     assert.equal(credentials.formatRemaining(now + 5 * 60 * 60_000 + 47 * 60_000), "5h 47m");
   } finally {
     Date.now = originalNow;
+  }
+});
+
+test("reconcileClaudeCredentials writes project files when host credentials are newer", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-newer-"));
+  const hostBlob = validBlob({ accessToken: "host", expiresAt: 200 });
+  const fileBlob = validBlob({ accessToken: "file", expiresAt: 100 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.equal(result.authoritative, "host");
+    assert.deepEqual(result.filesWritten, ["demo"]);
+    assert.equal(fs.readFileSync(filePath, "utf8"), hostBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials writes host credentials when a project file is newer", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-file-newer-"));
+  const hostBlob = validBlob({ accessToken: "host", expiresAt: 100 });
+  const fileBlob = validBlob({ accessToken: "file", expiresAt: 200 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"],
+      writeHostFn: (home, blob) => credentials.writeClaudeCredentialsToHost(home, blob, { randomFn: () => "fixed" })
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.equal(result.authoritative, "file:demo");
+    assert.equal(result.hostWritten, true);
+    assert.equal(fs.readFileSync(hostPath, "utf8"), fileBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials picks the freshest credentials across multiple project files", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-multi-"));
+  const hostBlob = validBlob({ accessToken: "host", expiresAt: 100 });
+  const alphaBlob = validBlob({ accessToken: "alpha", expiresAt: 200 });
+  const betaBlob = validBlob({ accessToken: "beta", expiresAt: 300 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const alphaPath = path.join(tmpDir, ".agent-infra", "credentials", "alpha", "claude-code", ".credentials.json");
+  const betaPath = path.join(tmpDir, ".agent-infra", "credentials", "beta", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(alphaPath), { recursive: true });
+    fs.mkdirSync(path.dirname(betaPath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(alphaPath, alphaBlob, "utf8");
+    fs.writeFileSync(betaPath, betaBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["alpha", "beta"]
+    }));
+
+    assert.equal(result.authoritative, "file:beta");
+    assert.equal(result.hostWritten, true);
+    assert.deepEqual(result.filesWritten, ["alpha"]);
+    assert.equal(fs.readFileSync(hostPath, "utf8"), betaBlob);
+    assert.equal(fs.readFileSync(alphaPath, "utf8"), betaBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials keeps host authoritative when host expiresAt is unknown", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-unknown-expiry-"));
+  const hostBlob = validBlob({ accessToken: "host", expiresAt: undefined });
+  const fileBlob = validBlob({ accessToken: "file", expiresAt: 300 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.equal(result.authoritative, "host");
+    assert.deepEqual(result.filesWritten, ["demo"]);
+    assert.equal(fs.readFileSync(filePath, "utf8"), hostBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials reports KEYCHAIN_WRITE_FAILED when host write fails", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const fileBlob = validBlob({ expiresAt: 200 });
+
+  withPlatform("darwin", () => {
+    const result = credentials.reconcileClaudeCredentials("/Users/demo", {
+      projects: ["demo"],
+      execFn: () => {
+        throw new Error("missing");
+      },
+      readFn: () => fileBlob,
+      existsFn: () => true,
+      writeHostFn: () => ({ ok: false, error: "keychain locked" })
+    });
+
+    assert.equal(result.status, "KEYCHAIN_WRITE_FAILED");
+    assert.equal(result.authoritative, "file:demo");
+    assert.deepEqual(result.warnings, ["keychain locked"]);
+  });
+});
+
+test("reconcileClaudeCredentials skips writes when expiresAt values are equal", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-equal-"));
+  const hostBlob = validBlob({ accessToken: "host", expiresAt: 100 });
+  const fileBlob = validBlob({ accessToken: "file", expiresAt: 100 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.authoritative, "host");
+    assert.equal(result.hostWritten, false);
+    assert.deepEqual(result.filesWritten, []);
+    assert.equal(fs.readFileSync(filePath, "utf8"), fileBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials restores missing host credentials from a project file", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-missing-"));
+  const fileBlob = validBlob({ expiresAt: 200 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.equal(result.authoritative, "file:demo");
+    assert.equal(result.hostWritten, true);
+    assert.equal(fs.readFileSync(hostPath, "utf8"), fileBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials falls back to host one-way sync when files are stale", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-file-stale-"));
+  const hostBlob = validBlob({ expiresAt: 200 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, "not-json", "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.equal(result.authoritative, "host");
+    assert.deepEqual(result.filesWritten, ["demo"]);
+    assert.equal(fs.readFileSync(filePath, "utf8"), hostBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials reports stale when no endpoint has valid credentials", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-stale-"));
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, "not-json", "utf8");
+    fs.writeFileSync(filePath, "not-json", "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "STALE_ACCESS");
+    assert.equal(result.authoritative, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials reports missing when no endpoint exists", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-missing-"));
+
+  try {
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "MISSING");
+    assert.equal(result.authoritative, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/tests/cli/sandbox-credentials.test.js
+++ b/tests/cli/sandbox-credentials.test.js
@@ -548,7 +548,13 @@ test("reconcileClaudeCredentials picks the freshest credentials across multiple 
   }
 });
 
-test("reconcileClaudeCredentials keeps host authoritative when host expiresAt is unknown", async () => {
+test("reconcileClaudeCredentials keeps host authoritative but does not overwrite mount when host expiresAt is unknown", async () => {
+  // Host is selected as authoritative (chooseAuthoritativeEndpoint early-returns
+  // host when its expiresAt is non-numeric) but shouldWriteEndpoint stays
+  // conservative: it refuses to overwrite a mount that is already OK with a
+  // numeric expiresAt, because the host blob may be leaner (missing fields like
+  // subscriptionType). A real rotation will produce a strictly larger expiresAt
+  // and let the right side win cleanly next time.
   const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-unknown-expiry-"));
   const hostBlob = validBlob({ accessToken: "host", expiresAt: undefined });
@@ -568,8 +574,8 @@ test("reconcileClaudeCredentials keeps host authoritative when host expiresAt is
 
     assert.equal(result.status, "OK");
     assert.equal(result.authoritative, "host");
-    assert.deepEqual(result.filesWritten, ["demo"]);
-    assert.equal(fs.readFileSync(filePath, "utf8"), hostBlob);
+    assert.deepEqual(result.filesWritten, []);
+    assert.equal(fs.readFileSync(filePath, "utf8"), fileBlob);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -707,6 +713,122 @@ test("reconcileClaudeCredentials reports missing when no endpoint exists", async
 
     assert.equal(result.status, "MISSING");
     assert.equal(result.authoritative, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials does not overwrite mount when host expiresAt is missing", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-no-expires-"));
+  const hostBlob = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "host-access",
+      refreshToken: "host-refresh",
+      scopes: ["user:profile", "user:sessions:claude_code"]
+    }
+  });
+  const fileBlob = validBlob({ accessToken: "file-access", expiresAt: 999_999_999_999 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.deepEqual(result.filesWritten, []);
+    assert.equal(result.hostWritten, false);
+    assert.equal(fs.readFileSync(filePath, "utf8"), fileBlob);
+    assert.equal(fs.readFileSync(hostPath, "utf8"), hostBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials does not overwrite mount when host expiresAt is a non-numeric value", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-host-string-expires-"));
+  const hostBlob = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "host-access",
+      refreshToken: "host-refresh",
+      scopes: ["user:profile", "user:sessions:claude_code"],
+      expiresAt: "1778233047257"
+    }
+  });
+  const fileBlob = validBlob({ accessToken: "file-access", expiresAt: 1778233047257 });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "demo", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["demo"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.deepEqual(result.filesWritten, []);
+    assert.equal(result.hostWritten, false);
+    assert.equal(fs.readFileSync(filePath, "utf8"), fileBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("reconcileClaudeCredentials preserves mount subscriptionType when host blob is leaner (production incident regression)", async () => {
+  // Regression for the manual verification incident: host Keychain held a blob
+  // missing subscriptionType, the mount file held the full blob with
+  // subscriptionType=max, and reconcile was overwriting the mount with the
+  // leaner host blob — silently downgrading the user from max tier.
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-reconcile-prod-incident-"));
+  const hostBlob = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "shared-access",
+      refreshToken: "shared-refresh",
+      scopes: ["user:profile", "user:sessions:claude_code"],
+      expiresAt: "1778233047257"
+    }
+  });
+  const fileBlob = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: "shared-access",
+      refreshToken: "shared-refresh",
+      scopes: ["user:profile", "user:sessions:claude_code"],
+      expiresAt: 1778233047257,
+      subscriptionType: "max",
+      rateLimitTier: "tier-3"
+    }
+  });
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "agent-infra", "claude-code", ".credentials.json");
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const result = withPlatform("linux", () => credentials.reconcileClaudeCredentials(tmpDir, {
+      projects: ["agent-infra"]
+    }));
+
+    assert.equal(result.status, "OK");
+    assert.deepEqual(result.filesWritten, []);
+    const mountAfter = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    assert.equal(mountAfter.claudeAiOauth.subscriptionType, "max");
+    assert.equal(mountAfter.claudeAiOauth.rateLimitTier, "tier-3");
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/cli/sandbox-refresh.test.js
+++ b/tests/cli/sandbox-refresh.test.js
@@ -272,6 +272,62 @@ test("refresh reports unchanged status when destination matches blob", async () 
   }
 });
 
+test("refresh reconciles from a newer project file without probing claude status", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-refresh-file-newer-"));
+  const hostBlob = validBlob(100);
+  const fileBlob = validBlob(200);
+  const hostPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const filePath = path.join(tmpDir, ".agent-infra", "credentials", "agent-infra", "claude-code", ".credentials.json");
+  const stdout = [];
+  let probeCalled = false;
+
+  try {
+    fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(hostPath, hostBlob, "utf8");
+    fs.writeFileSync(filePath, fileBlob, "utf8");
+
+    const code = await withHome(tmpDir, () => withPlatform("linux", () => refresh([], {
+      discoverFn: () => ["agent-infra"],
+      spawnFn: () => {
+        probeCalled = true;
+        return { status: 0, stderr: "" };
+      },
+      writeStdout: (chunk) => stdout.push(chunk),
+      writeStderr: () => {}
+    })));
+
+    assert.equal(code, 0);
+    assert.equal(probeCalled, false);
+    assert.match(stdout.join(""), /\[host\] reconciled from file:agent-infra/);
+    assert.match(stdout.join(""), /\[agent-infra\] unchanged;/);
+    assert.equal(fs.readFileSync(hostPath, "utf8"), fileBlob);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("refresh exits 1 when newer sandbox credentials cannot be written to host", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const stderr = [];
+
+  const code = await withPlatform("darwin", () => refresh([], {
+    discoverFn: () => ["agent-infra"],
+    execFn: () => {
+      throw new Error("missing");
+    },
+    readFn: () => validBlob(200),
+    existsFn: () => true,
+    writeHostFn: () => ({ ok: false, error: "keychain locked" }),
+    writeStdout: () => {},
+    writeStderr: (chunk) => stderr.push(chunk)
+  }));
+
+  assert.equal(code, 1);
+  assert.match(stderr.join(""), /keychain write failed: keychain locked/);
+});
+
 test("refresh continues on per-project sync failure and exits 1 at end", async () => {
   const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-refresh-fail-"));

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -760,6 +760,7 @@ test("sandbox exec reconciles newer Claude credentials from a neighbouring proje
   const binDir = path.join(tmpDir, "bin");
   const logPath = path.join(tmpDir, "docker-log.jsonl");
   const dockerPath = path.join(binDir, "docker");
+  const fakeKeychainPath = path.join(tmpDir, "fake-keychain.json");
   const hostCredentialsPath = path.join(tmpDir, ".claude", ".credentials.json");
   const alphaCredentialsPath = path.join(
     tmpDir,
@@ -814,6 +815,36 @@ node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.ar
     );
     fs.chmodSync(dockerPath, 0o755);
 
+    if (process.platform === "darwin") {
+      // Inject a fake `security` shim so the CLI subprocess does not touch the
+      // real macOS Keychain on CI runners (which can hang on add-generic-password
+      // due to login keychain ACL prompts). The shim reports MISSING for reads
+      // and persists writes to FAKE_KEYCHAIN_FILE so the assertion can read back.
+      const securityShimPath = path.join(binDir, "security");
+      fs.writeFileSync(
+        securityShimPath,
+        `#!/bin/sh
+case "$1" in
+  find-generic-password) exit 44 ;;
+  add-generic-password)
+    shift
+    while [ $# -gt 0 ]; do
+      if [ "$1" = "-w" ]; then
+        shift
+        printf '%s' "$1" > "$FAKE_KEYCHAIN_FILE"
+        exit 0
+      fi
+      shift
+    done
+    exit 1 ;;
+esac
+exit 2
+`,
+        "utf8"
+      );
+      fs.chmodSync(securityShimPath, 0o755);
+    }
+
     const result = spawnSync(
       process.execPath,
       [filePath("bin/cli.js"), "sandbox", "exec", "agent-infra-feature-cli-generic-sandbox", "true"],
@@ -822,7 +853,8 @@ node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.ar
         env: {
           ...envWithPrependedPath(gitSafeEnv(), binDir),
           HOME: tmpDir,
-          DOCKER_LOG_PATH: logPath
+          DOCKER_LOG_PATH: logPath,
+          FAKE_KEYCHAIN_FILE: fakeKeychainPath
         },
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"]
@@ -831,7 +863,11 @@ node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.ar
 
     assert.equal(result.status, 0);
     assert.match(result.stderr, /from sandbox refresh/);
-    assert.equal(fs.readFileSync(hostCredentialsPath, "utf8"), newerBlob);
+    if (process.platform === "darwin") {
+      assert.equal(fs.readFileSync(fakeKeychainPath, "utf8"), newerBlob);
+    } else {
+      assert.equal(fs.readFileSync(hostCredentialsPath, "utf8"), newerBlob);
+    }
     assert.equal(fs.readFileSync(alphaCredentialsPath, "utf8"), newerBlob);
     assert.equal(fs.readFileSync(betaCredentialsPath, "utf8"), newerBlob);
   } finally {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync, execSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -92,6 +92,17 @@ function fakeSelinuxFs(flag) {
       return flag;
     }
   };
+}
+
+function validClaudeCredentialsBlob(expiresAt) {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: `token-${expiresAt}`,
+      refreshToken: `refresh-${expiresAt}`,
+      scopes: ["user:profile", "user:sessions:claude_code"],
+      expiresAt
+    }
+  });
 }
 
 test("runInteractive emits terminal reset on normal exit", () => {
@@ -734,6 +745,95 @@ node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.ar
       assert.match(dockerCalls[0][5], /tmux has-session/);
       assert.match(dockerCalls[0][5], /tmux new-session -t "\$SESSION"/);
     }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox exec reconciles newer Claude credentials from a neighbouring project", () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-credentials-"));
+  const repoDir = path.join(tmpDir, "repo");
+  const binDir = path.join(tmpDir, "bin");
+  const logPath = path.join(tmpDir, "docker-log.jsonl");
+  const dockerPath = path.join(binDir, "docker");
+  const hostCredentialsPath = path.join(tmpDir, ".claude", ".credentials.json");
+  const alphaCredentialsPath = path.join(
+    tmpDir,
+    ".agent-infra",
+    "credentials",
+    "alpha",
+    "claude-code",
+    ".credentials.json"
+  );
+  const betaCredentialsPath = path.join(
+    tmpDir,
+    ".agent-infra",
+    "credentials",
+    "beta",
+    "claude-code",
+    ".credentials.json"
+  );
+  const alphaBlob = validClaudeCredentialsBlob(Date.now() + 5_400_000);
+  const newerBlob = validClaudeCredentialsBlob(Date.now() + 7_200_000);
+
+  try {
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.mkdirSync(path.join(repoDir, ".agents"), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.dirname(hostCredentialsPath), { recursive: true });
+    fs.mkdirSync(path.dirname(alphaCredentialsPath), { recursive: true });
+    fs.mkdirSync(path.dirname(betaCredentialsPath), { recursive: true });
+    execSync("git init", { cwd: repoDir, env: gitSafeEnv(), stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(repoDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "alpha",
+        org: "fitlab-ai",
+        sandbox: { tools: ["claude-code"] }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.writeFileSync(hostCredentialsPath, validClaudeCredentialsBlob(Date.now() + 3_600_000), "utf8");
+    fs.writeFileSync(alphaCredentialsPath, alphaBlob, "utf8");
+    fs.writeFileSync(betaCredentialsPath, newerBlob, "utf8");
+    fs.writeFileSync(
+      dockerPath,
+      `#!/bin/sh
+set -eu
+if [ "$1" = "ps" ]; then
+  printf '%s\\n' alpha-dev-agent-infra-feature-cli-generic-sandbox
+  exit 0
+fi
+node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)) + "\\n")' "$DOCKER_LOG_PATH" "$@"
+`,
+      "utf8"
+    );
+    fs.chmodSync(dockerPath, 0o755);
+
+    const result = spawnSync(
+      process.execPath,
+      [filePath("bin/cli.js"), "sandbox", "exec", "agent-infra-feature-cli-generic-sandbox", "true"],
+      {
+        cwd: repoDir,
+        env: {
+          ...envWithPrependedPath(gitSafeEnv(), binDir),
+          HOME: tmpDir,
+          DOCKER_LOG_PATH: logPath
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"]
+      }
+    );
+
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /from sandbox refresh/);
+    assert.equal(fs.readFileSync(hostCredentialsPath, "utf8"), newerBlob);
+    assert.equal(fs.readFileSync(alphaCredentialsPath, "utf8"), newerBlob);
+    assert.equal(fs.readFileSync(betaCredentialsPath, "utf8"), newerBlob);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #283

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #283

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix（修复 PR #281 的单向同步缺口，且包含一个 commit-后回归 fix）
- [x] ✨ 新功能 / New feature（沙箱 → 宿主机 反向回写，多副本仲裁）
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update（README 中英同步「双向同步与多副本仲裁」段落）
- [x] 🚀 功能增强 / Feature enhancement（`syncClaudeCredentialsFromKeychain` 改为 `reconcileClaudeCredentials` 薄封装，公共 API 兼容）
- [ ] 其他

## 📝 变更目的 / Purpose of the Change

PR #281（commit `a844b90`）实现的是单向同步：`宿主机 Keychain → 项目凭证文件 → 容器内（live bind-mount）`。但 Anthropic OAuth refresh token 是**轮换式**的 —— 任意一方刷新成功，旧 refresh token 立即被服务端作废。

2026-05-05 出现的真实事故链路：

1. 宿主机和沙箱凭证同时超过 8 小时（access token 过期，refresh token 仍有效）。
2. 沙箱启动后立刻在容器内运行 `claude`，Claude Code 用 refresh token 自动换取了一对**新的** access + refresh token，**通过 bind-mount 写穿到宿主机** `~/.agent-infra/credentials/<project>/claude-code/.credentials.json`。
3. Anthropic OAuth 服务器作废了旧 refresh token。
4. 宿主机 macOS Keychain 仍是旧 refresh token，已被服务端作废。
5. 宿主机再运行 `claude` 时刷新失败 → 被迫 `claude /login` 重新登录。

根本原因：容器内自动刷新后的新 token，没有任何机制反向回写到宿主机 Keychain（macOS）/ `~/.claude/.credentials.json`（Linux）。

本 PR 把 `lib/sandbox/credentials.js` 的同步状态机从「单向 sync」升级为「双向 reconcile」：以两端中 `expiresAt` 较大者为权威，按需写回**任意一端**。

## 📋 主要变更 / Brief Changelog

### 核心：reconcile 状态机（`lib/sandbox/credentials.js`）

- 新增 `reconcileClaudeCredentials(home, options)`：读 host + 所有项目挂载文件 → 仲裁权威源（最大 `expiresAt`）→ 双向写。返回 `{ status, authoritative, expiresAt, hostWritten, filesWritten[], warnings[] }`。
- 新增 `writeClaudeCredentialsToHost(home, blob, options)`：处理「写回宿主机」的平台分歧 —— macOS 调 `security add-generic-password -U`，Linux/WSL2 走「临时文件 + 原子 rename」（mode 0600，dir 0700）。全程 try/catch，**不抛**，失败返回 `{ ok: false, error }` 走 fail-soft。
- 新增 `inspectClaudeMountFile(home, project, options)` + 提取 `readClaudeCredentialsFile`：复用现有 `validateClaudeCredentialsBlob` 校验文件端 token 完整性，避免把损坏的文件写回 Keychain。
- 把 `discoverProjects` 从 `commands/refresh.js` 私有提升到 `credentials.js` 并导出，供 `enter.js` / `refresh.js` 共用。
- `syncClaudeCredentialsFromKeychain` 改为 `reconcileClaudeCredentials` 的薄封装（保留导出名，PR #281 的所有调用方与测试零震荡）。
- 新增结果状态：`KEYCHAIN_WRITE_FAILED`（文件端权威但 Keychain 写失败），fail-soft 路径与现有一致。

### 入口切换

- `lib/sandbox/commands/enter.js`：调用从 `syncClaudeCredentialsFromKeychain(home, project)` 换成 `reconcileClaudeCredentials(home)`（默认扫描全部项目，避免邻居项目更新被遗漏）。新增两条文案：`Synced Claude Code credentials from sandbox refresh back to host (expires in ...)` 与 `Warning: ... host Keychain write failed (...). Run "ai sandbox refresh" again or "claude /status" on the host to retry.`。整体仍包在 try/catch，fail-soft 不阻塞 `docker exec`。
- `lib/sandbox/commands/refresh.js`：复用提升后的 `discoverProjects` + 直接调 `reconcileClaudeCredentials`。`STALE_ACCESS` 分支仅在 `authoritative === null`（文件端无任何 OK 副本可救回）才触发现有 `probeClaudeStatus` 兜底；输出新增 `[host] reconciled from file:<project>` / `[host] keychain write failed: ...`；`KEYCHAIN_WRITE_FAILED` 退出码 1。

### Round 3 后回归修复（commit `537b871`）

`6d3bdff` 落地后 manual verification 发现一个边界 bug：当两端都是 `OK` 但 `expiresAt` 不可比较（一端非数字 / 字段缺失 / 同毫秒平局）时，原 `shouldWriteEndpoint` fallback 到字节比较，会让一个**字段更少**的 host blob（例如缺 `subscriptionType`）覆盖一个**字段更全**的 mount blob。事故原版正是这种形状。

修复：`shouldWriteEndpoint` 在 `expiresAt` 不可比较时直接 `return false`（`lib/sandbox/credentials.js:195-211`），两端都不动，等下一次真 rotation 拉开 `expiresAt` 数值差距再决策。3 个新回归 case 直接复刻事故 fixture（缺 `subscriptionType` / `expiresAt` 是字符串 / mount 含 `max + tier-3`）。

### 文档

- `README.md` / `README.zh-CN.md`：在 sandbox 章节同步「双向同步与多副本仲裁」一句话说明，中英对齐。

## 🧪 验证变更 / Verifying this Change

### 自动化测试

`npx -y node@22 --test`：**397/397 通过**（394 → 397，新增 3 个 round 3 后回归 case）。

新增/扩展 case 覆盖：

- `inspectClaudeMountFile` × 3（OK / STALE_ACCESS / MISSING）
- `writeClaudeCredentialsToHost` × 4（darwin 调用 `security -U`、execFn 抛错 → ok:false、linux 原子 rename、rename 失败时保留原文件）
- `reconcileClaudeCredentials` × 9（host 较新 / file 较新 / 多副本取最大 / Keychain 写失败 / `expiresAt` 平局不写 / host MISSING 时从 file 反向 / file 全 STALE 退化为单向 / 两端 STALE / 两端 MISSING）
- 平局 / 非数字 `expiresAt` × 3（缺字段 / 字符串 / 事故复刻）
- `refresh.js` × 3（多副本 reconcile 输出顺序、authoritative=file 时跳过 `probeClaudeStatus`、`KEYCHAIN_WRITE_FAILED` exit=1）
- `enter.js` × 2（authoritative=file 文案、`KEYCHAIN_WRITE_FAILED` 文案）

### 端到端手动验证（macOS Docker Desktop / VirtioFS）

`tmp/verify-bidirectional-sync.sh`（不在本 PR）端到端复现事故链路并验证修复：

1. 快照 host + mount `expiresAt = T0` ✓
2. 篡改 mount `expiresAt = 0`（保 inode；`mv` 会改 inode 让 VirtioFS bind mount 集体失效，所以用 `> file` 重写）
3. `docker exec ... claude /status` 触发 Anthropic 轮换 → mount `expiresAt = T1 > T0` ✓
4. 验证 host 仍停在 T0、mount 已到 T1 —— 事故场景**已复现** ✓
5. 跑 `node bin/cli.js sandbox refresh`（被测代码）→ 输出 `[host] reconciled from file:agent-infra` ✓
6. 断言 host `expiresAt == mount expiresAt == T1` ✓
7. 断言 host blob 与 mount blob **byte-identical**（sha256 一致，证明不是只同步了 `expiresAt`、整个 blob 完整搬过去了）✓
8. host 端 `claude /status` 命中 Anthropic 不再 401，证明回填的 token **服务端有效** ✓

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / Manual end-to-end verification on macOS Docker Desktop

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 已存在关联 Issue（#283）/ Issue exists
- [x] PR 只解决一个 Issue / Single-issue PR
- [x] 每个 commit 都有有意义的主题行和正文 / Each commit has meaningful subject + body

**代码质量 / Code Quality:**

- [x] 遵循项目代码规范 / Follows coding standards
- [x] 已自我审查（4 轮 review + 2 轮 refine）/ Self-reviewed (4 review rounds + 2 refine rounds)
- [x] 复杂逻辑已注释（`shouldWriteEndpoint` 的「平局不写」语义、reconcile 仲裁规则）/ Comments where needed

**测试要求 / Testing Requirements:**

- [x] 已编写单元测试（19+ 个新增 case）/ Unit tests added
- [x] 跨模块依赖已 mock（`execFn` / `readFn` / `writeFn` / `existsFn` 全部注入，单测无真实 `security` 调用）/ Cross-module deps mocked
- [ ] 代码检查通过 / Lint checks pass（项目尚未配置 lint 工具，CLAUDE.md 已注明）
- [x] 单元测试通过 / Unit tests pass（397/397 on Node 22）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 文档已更新（README 中英文）/ Documentation updated
- [x] 无破坏性变更（所有 PR #281 的公共导出名保留）/ No breaking changes
- [x] 已考虑向后兼容（`syncClaudeCredentialsFromKeychain` 退化为薄封装，旧调用方零改动）/ Backward compatible

## 📋 附加信息 / Additional Notes

### 设计选择

- **零守护进程**：不引入 LaunchAgent / systemd，反向同步只在 `ai sandbox exec` / `ai sandbox refresh` 入口被动触发。事故链路只要在「下次 host `claude` 之前」同步即可，不要求实时。
- **多副本仲裁**：last-writer-wins —— 服务端只接受最后一次轮换的 refresh token，多副本场景下取所有副本中 `expiresAt` 最大者作为权威，与服务端语义对齐。
- **平局保守**：两端 `expiresAt` 相等或不可比较时**两端都不写**（refinement-r2 修订），避免「字段更少的 host blob 覆盖字段更全的 mount blob」这一事故原版形状。原 plan §边界情况第 5 条字面要求「不一致时保守保留 host」，refinement-r2 校准为「保守 = 都不动」。
- **fail-soft**：Keychain 写失败 / 权限拒绝 / IO 失败 / JSON 损坏都不阻塞 `docker exec` 主流程；`enter.js` 仍把整段 reconcile 包在 try/catch 里。

### 不在本 PR 范围

- 后台 daemon / launchd 周期同步（已在 plan §方案对比 B 拒绝）。
- 容器 → host hook（增加 attack surface 与跨机通信成本，超出 CLI 工具定位）。
- plan §边界情况第 5 条文本同步到新语义（refinement-r2 已显式标注「下个 round 同步 plan 文本」）；事故 fixture 系统化（`leanBlob` / `richBlob` 矩阵）作为 follow-up，本轮通过 3 个事故复刻 case 直接对症。

### 审查者注意事项 / Reviewer Notes

- **重点关注 `shouldWriteEndpoint`**：`expiresAt` 不可比较时直接 `return false` 是 review-r3 → refinement-r2 → review-r4 跨 3 个阶段确认下来的语义。3 个新回归 case 中的「production incident regression」一例即直接复刻事故 fixture。
- **重点关注 `writeClaudeCredentialsToHost` 平台分歧**：darwin 路径完全交给 `security -U`，linux 路径手写「临时文件 + atomic rename」，两条都通过 `execFn` / `writeFn` 注入测试，无真实 `security` 副作用。
- **重点关注 `enter.js` fail-soft 路径**：reconcile 抛任何异常都不应阻塞 `docker exec`；新增的两条文案是 stderr 提示，不改 exit code。
- **跨平台覆盖**：Linux / macOS 由本地 + CI 单测覆盖；Windows WSL2 路径走 `hostJoin`（PR #188 已有），本 PR 未独立验证 Windows 端到端。
- **review history**：4 轮 review（#1 5 minor → #2 0/0/0 → #3 1 blocker → #4 0/0/0）+ 2 轮 refine 完整记录在 task workspace。

---

Generated with AI assistance