### PR TITLE
feat(sandbox): mount /share for host-container file exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,23 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 `ai sandbox refresh` syncs the host's Claude Code credentials into all sandbox project copies under `~/.agent-infra/credentials/*`. It inspects the host Keychain, probes `claude /status` when host credentials look stale, and rewrites each project copy only when the bytes differ — so token rotations propagate to long-running sandboxes without rebuilding them.
 
+### Host-sandbox file exchange
+
+`ai sandbox create` mounts two writable directories for dropping files between
+the host and the sandbox without polluting the git worktree:
+
+- `/share/common` <- `~/.agent-infra/share/<project>/common/` - visible to every
+  sandbox of the same project, regardless of branch.
+- `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/` -
+  exclusive to the current branch sandbox.
+
+These paths are intentionally hardcoded; there is no `.airc.json` knob. Both
+host directories are created automatically on first `create`. When you
+`ai sandbox rm <branch>` or `ai sandbox rm --all`, you will be prompted (default
+yes) to clean up the corresponding share dirs alongside the worktrees.
+Existing sandboxes pick up these mounts after `ai sandbox rm <branch>` and
+`ai sandbox create <branch>`.
+
 <a id="architecture-overview"></a>
 
 ## Architecture Overview

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,16 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 `ai sandbox refresh` 用于把宿主机 Claude Code 凭证同步到 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本。它会检查宿主 Keychain 状态、在凭证过期时尝试 `claude /status` 探活、仅在字节不同时重写每个项目副本——这样 host token 轮换可以传播到正在运行的沙箱，无需重建。
 
+### 宿主-沙箱文件交换
+
+`ai sandbox create` 会自动挂载两个可读写目录，方便宿主与容器之间互相 drop 文件，不污染 git 工作树：
+
+- `/share/common` <- `~/.agent-infra/share/<project>/common/`：项目级共享，跨分支可见。
+- `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/`：分支独占。
+
+这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；`ai sandbox rm <branch>` 与 `ai sandbox rm --all` 删除时会附带询问是否清理（默认 yes）。
+已有沙箱需要执行 `ai sandbox rm <branch>` 后再执行 `ai sandbox create <branch>`，才能加载新的挂载点。
+
 <a id="architecture-overview"></a>
 
 ## 架构概览

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -15,6 +15,8 @@ import {
   sandboxImageConfigLabel,
   sandboxLabel,
   sanitizeBranchName,
+  shareBranchDir,
+  shareCommonDir,
   worktreeDirCandidates
 } from '../constants.js';
 import { prepareDockerfile } from '../dockerfile.js';
@@ -773,6 +775,8 @@ export async function create(args) {
   );
   const container = containerName(effectiveConfig, branch);
   const worktree = worktreeCandidates.find((candidate) => fs.existsSync(candidate)) ?? worktreeCandidates[0];
+  const shareCommon = shareCommonDir(effectiveConfig);
+  const shareBranch = shareBranchDir(effectiveConfig, branch);
   const preparedDockerfile = prepareDockerfile(effectiveConfig);
   const baseBranch = base ?? runSafe('git', ['-C', effectiveConfig.repoRoot, 'branch', '--show-current']);
   const expectedImageSignature = buildSignature(preparedDockerfile, tools);
@@ -985,6 +989,8 @@ export async function create(args) {
           );
 
           fs.mkdirSync(workspaceDir, { recursive: true });
+          fs.mkdirSync(shareCommon, { recursive: true });
+          fs.mkdirSync(shareBranch, { recursive: true });
 
           runEngineTaskCommand(engine, 'docker', [
             'run',
@@ -1001,6 +1007,10 @@ export async function create(args) {
             volumeArg(engine, worktree, '/workspace'),
             '-v',
             volumeArg(engine, workspaceDir, '/workspace/.agents/workspace'),
+            '-v',
+            volumeArg(engine, shareCommon, '/share/common'),
+            '-v',
+            volumeArg(engine, shareBranch, '/share/branch'),
             '-v',
             volumeArg(
               engine,
@@ -1118,6 +1128,8 @@ Container: ${container}
 Image: ${effectiveConfig.imageName}
 Worktree: ${worktree}
 Host aliases: ${sandboxAliasesPath(effectiveConfig.home)}
+Share (common): ${shareCommon} -> /share/common
+Share (branch): ${shareBranch} -> /share/branch
 
 Management:
   ai sandbox ls

--- a/lib/sandbox/commands/rm.js
+++ b/lib/sandbox/commands/rm.js
@@ -9,6 +9,7 @@ import {
   containerNameCandidates,
   sandboxBranchLabel,
   sandboxLabel,
+  shareBranchDir,
   worktreeDirCandidates
 } from '../constants.js';
 import { ENGINES, detectEngine, engineDisplayName, isManagedEngine, stopManagedVm } from '../engine.js';
@@ -119,6 +120,19 @@ async function rmOne(config, tools, branch) {
     }
   }
 
+  const shareBranch = shareBranchDir(config, effectiveBranch);
+  if (fs.existsSync(shareBranch)) {
+    const shouldRemoveShare = await p.confirm({
+      message: `Remove share dir for branch '${effectiveBranch}' (${shareBranch})?`,
+      initialValue: true
+    });
+    if (!p.isCancel(shouldRemoveShare) && shouldRemoveShare) {
+      assertManagedPath(config.shareBase, shareBranch);
+      fs.rmSync(shareBranch, { recursive: true, force: true });
+      p.log.success(`Share dir removed: ${shareBranch}`);
+    }
+  }
+
   p.outro(pc.green('Sandbox removed'));
 }
 
@@ -171,6 +185,18 @@ async function rmAll(config, tools) {
       assertManagedPath(path.dirname(dir), dir);
       fs.rmSync(dir, { recursive: true, force: true });
       p.log.success(`Removed tool state: ${dir}`);
+    }
+  }
+
+  if (fs.existsSync(config.shareBase) && fs.readdirSync(config.shareBase).length > 0) {
+    const shouldRemoveAllShares = await p.confirm({
+      message: `Remove all share dirs for project (${config.shareBase})?`,
+      initialValue: true
+    });
+    if (!p.isCancel(shouldRemoveAllShares) && shouldRemoveAllShares) {
+      assertManagedPath(path.dirname(config.shareBase), config.shareBase);
+      fs.rmSync(config.shareBase, { recursive: true, force: true });
+      p.log.success(`Project share dirs removed: ${config.shareBase}`);
     }
   }
 

--- a/lib/sandbox/config.js
+++ b/lib/sandbox/config.js
@@ -70,6 +70,7 @@ export function loadConfig() {
     containerPrefix: `${project}-dev`,
     imageName: `${project}-sandbox:latest`,
     worktreeBase: hostJoin(home, '.agent-infra', 'worktrees', project),
+    shareBase: hostJoin(home, '.agent-infra', 'share', project),
     engine,
     runtimes: Array.isArray(sandbox.runtimes) && sandbox.runtimes.length > 0
       ? [...sandbox.runtimes]

--- a/lib/sandbox/constants.js
+++ b/lib/sandbox/constants.js
@@ -62,6 +62,18 @@ export function worktreeDirCandidates(config, branch) {
   return safeNameCandidates(branch).map((name) => hostJoin(config.worktreeBase, name));
 }
 
+export function shareDir(config) {
+  return config.shareBase;
+}
+
+export function shareCommonDir(config) {
+  return hostJoin(config.shareBase, 'common');
+}
+
+export function shareBranchDir(config, branch) {
+  return hostJoin(config.shareBase, 'branches', sanitizeBranchName(branch));
+}
+
 export function sandboxLabel(config) {
   return `${config.project}.sandbox`;
 }

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -331,6 +331,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.equal(config.engine, null);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME, ".agent-infra", "worktrees", "demo"));
+    assert.equal(config.shareBase, path.join(process.env.HOME, ".agent-infra", "share", "demo"));
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -3211,6 +3212,18 @@ test("assertValidBranchName rejects invalid branch names", async () => {
   const sandboxConstants = await loadFreshEsm("lib/sandbox/constants.js");
 
   assert.throws(() => sandboxConstants.assertValidBranchName("bad branch name"), /Invalid branch name/);
+});
+
+test("share helpers compose project share namespace under shareBase", async () => {
+  const sandboxConstants = await loadFreshEsm("lib/sandbox/constants.js");
+  const config = { shareBase: "/tmp/share/demo" };
+
+  assert.equal(sandboxConstants.shareDir(config), "/tmp/share/demo");
+  assert.equal(sandboxConstants.shareCommonDir(config), "/tmp/share/demo/common");
+  assert.equal(
+    sandboxConstants.shareBranchDir(config, "feat/foo"),
+    "/tmp/share/demo/branches/feat..foo"
+  );
 });
 
 test("resolveTaskBranch returns plain branch names unchanged", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #288

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #288

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

当前沙箱仅有 `/workspace`（git worktree）作为宿主-容器之间的通道。把临时文件落到 `/workspace` 会污染 git 状态——`git status` / review / commit 都被噪声打扰。本 PR 为沙箱新增一对独立的、与 git 无关的双向读写挂载点，让宿主和容器互相 drop 文件而不污染工作树。

设计要点严格遵循 #288 已对齐的方案：路径硬编码、不暴露 `.airc.json` 配置项、不引入软链接、容器 `devuser` 与宿主同 uid（无新增写权限面）、SELinux `:z` 与 WSL2 路径转换全部走既有 `volumeArg` 抽象。

## 📋 主要变更 / Brief Changelog

### 新挂载点（`lib/sandbox/{config,constants}.js` + `lib/sandbox/commands/create.js`）

- `loadConfig` 派生 `shareBase = ~/.agent-infra/share/<project>`，与 `worktreeBase` 同级。
- `constants.js` 新增 3 个 helper：`shareDir(config)`、`shareCommonDir(config)`、`shareBranchDir(config, branch)`；分支独占目录走 `branches/<sanitizeBranchName(branch)>` 中间层，避免分支名为 `common` 时与项目级 `common/` 冲突。
- `create.js` 在 `docker run` 之前 `fs.mkdirSync({recursive:true})` 创建宿主目录（避免 SELinux 主机上 docker 以 root 创建挂载源），并在 `-v` 列表中追加：
  - `/share/common` ← `~/.agent-infra/share/<project>/common/`（项目级共享，跨分支可见）
  - `/share/branch` ← `~/.agent-infra/share/<project>/branches/<sanitizedBranch>/`（分支独占）
- 终端输出在 `Container/Image/Worktree/Host aliases` 行后追加两行 `Share (common):` / `Share (branch):` 路径提示。

### 删除时清理（`lib/sandbox/commands/rm.js`）

- `ai sandbox rm <branch>`：删 worktree 后追加 "Remove share dir for branch '<branch>' (...)?" 默认 yes 确认；用 `assertManagedPath(config.shareBase, shareBranch)` 守护 `rmSync` 边界。
- `ai sandbox rm --all`：清理工具状态后追加 "Remove all share dirs for project (...)?" 默认 yes 确认；用 `assertManagedPath(path.dirname(config.shareBase), config.shareBase)` 守护，禁止越界至 `~/.agent-infra` 之外。
- 若 share 目录不存在则跳过提示（`fs.existsSync` 短路），UX 平滑兼容老沙箱。

### 文档（`README.md` + `README.zh-CN.md`）

- 在 "Sandbox aliases and GitHub CLI" 章节后新增 "Host-sandbox file exchange / 宿主-沙箱文件交换" 双语章节，说明语义、宿主路径、生命周期（创建自动、删除询问），以及"现有沙箱需先 `ai sandbox rm` + `create` 才能加载新挂载点"的升级提示。

### 测试（`tests/cli/sandbox.test.js`）

- 新增 `share helpers compose project share namespace under shareBase`：覆盖 `shareDir` / `shareCommonDir` / `shareBranchDir` 的纯函数路径拼接（含 `feat/foo` → `branches/feat..foo` sanitize）。
- 扩展 `loadConfig derives sandbox defaults from .agents/.airc.json`：增加 `shareBase` 字段断言。
- 仅做结构性断言，不绑文档措辞、不写反向删除断言（遵守 `CLAUDE.md` 测试规约）。

## 🧪 验证变更 / Verifying this Change

### 自动化测试

| 范围 | 命令 | 结果 |
|------|------|------|
| sandbox 单元 | `node --test tests/cli/sandbox.test.js`（Node 22） | **144/144** |
| smoke | `npm run test:smoke`（Node 22） | **74/74** |
| core（pre-commit hook） | `npm run test:core`（Node 22） | **284/284** |
| 全量 | `npm test`（Node 22） | **376/376** |

### 测试步骤 / Test Steps

CI 不复现 docker；以下为本机可选回归（reviewer 参考）：

1. `ai sandbox create test-share-mount` —— 验证容器内 `/share/common` `/share/branch` 存在；touch 文件后宿主 `~/.agent-infra/share/<project>/{common,branches/test-share-mount}/` 出现，uid 与宿主一致。
2. 在容器内 `touch /share/branch/hello`、宿主 `touch ~/.agent-infra/share/<project>/common/hi`：双向可读。
3. `ai sandbox rm test-share-mount` —— 验证 "Remove share dir for branch 'test-share-mount' (...)" 提示出现；回答 yes 后宿主目录被清理。
4. `ai sandbox create feat/foo` —— 验证宿主目录走 sanitize 后的路径 `branches/feat..foo`。
5. SELinux / WSL2 / macOS：参考 #285、#188 的多平台冒烟流程，确认 `:z` 与 `/mnt/c/...` 路径转换无回归。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing — 当前提交环境无 `docker` 命令，无法端到端复现；建议合入前在具备 OrbStack / Docker / Colima / WSL2 的机器上执行上述清单。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented complex code where applicable

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written unit-tests where applicable
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（README 双语）
- [x] 没有破坏性变更 / No breaking changes
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（老沙箱：`fs.existsSync` 短路跳过提示，UX 平滑）

## 📋 附加信息 / Additional Notes

- **零 image rebuild**：`-v` 是运行时挂载，不影响 image label / signature。
- **零新依赖**：复用 `hostJoin` / `volumeArg` / `assertManagedPath` / `sanitizeBranchName`。
- **零新权限面**：依赖既有 `HOST_UID` build-arg 与容器 `devuser` 同步。
- 已存在的容器升级方式：`ai sandbox rm <branch>` + `ai sandbox create <branch>`，与历史任何 mount 改动行为一致。

---

**审查者注意事项 / Reviewer Notes:**

- `lib/sandbox/commands/create.js` 中 share 目录创建顺序是否符合"挂载源必须先由宿主用户创建"的要求
- `lib/sandbox/commands/rm.js` 中 `assertManagedPath` 的 root 选择是否覆盖单分支 / 全项目两种清理边界
- README 双语章节是否清楚表达了硬编码路径、删除确认行为以及历史沙箱升级路径

---

Generated with AI assistance
