### PR TITLE
fix(skills): drop redundant Activity Log writes in create-task cascade

### DIFF
--- a/.agents/rules/create-issue.md
+++ b/.agents/rules/create-issue.md
@@ -155,10 +155,8 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 
 - 把 `issue_number: {n}` 写入 frontmatter（已存在则替换；不存在则在 frontmatter 末尾追加）
 - 更新 `updated_at` 为当前时间（命令：`date "+%Y-%m-%d %H:%M:%S%:z"`）
-- 在 `## 活动日志` / `## Activity Log` 段落追加：
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Issue** by {agent} — Created GitHub Issue #{n}
-  ```
+
+> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Task Created`），由调用方 SKILL 步骤 3 写入。
 
 ### 8. 返回结果
 

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -109,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 处理结果：
 - 规则成功创建 Issue：`issue_number` 已按规则回写到 task.md；继续读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并按规则设置 `status: waiting-for-triage`
-- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；获取当前时间，追加 `Issue Creation Skipped` Activity Log，说明错误原因
+- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`，让用户决定后续是否手动重试或写入 `issue_number`
 - 规则为 no-op（自定义或空平台）：不创建评论，不阻塞后续工作流，不写 Activity Log
 - task.md 已存在 `issue_number`：规则中的前置检查会跳过；`create-task` 直接进入步骤 5
 

--- a/templates/.agents/rules/create-issue.github.en.md
+++ b/templates/.agents/rules/create-issue.github.en.md
@@ -155,10 +155,8 @@ Update task.md:
 
 - Write `issue_number: {n}` into the frontmatter (replace if it exists; append at the end of the frontmatter otherwise)
 - Update `updated_at` to the current time (command: `date "+%Y-%m-%d %H:%M:%S%:z"`)
-- Append to the `## 活动日志` / `## Activity Log` section:
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Issue** by {agent} — Created GitHub Issue #{n}
-  ```
+
+> Do NOT append an Activity Log entry here. The Issue creation event is already captured by the GitHub Issue itself and by the frontmatter `issue_number` field; the Activity Log only records the single `create-task` skill execution anchor (`Task Created`), written by the caller SKILL step 3.
 
 ### 8. Return the Result
 

--- a/templates/.agents/rules/create-issue.github.zh-CN.md
+++ b/templates/.agents/rules/create-issue.github.zh-CN.md
@@ -155,10 +155,8 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 
 - 把 `issue_number: {n}` 写入 frontmatter（已存在则替换；不存在则在 frontmatter 末尾追加）
 - 更新 `updated_at` 为当前时间（命令：`date "+%Y-%m-%d %H:%M:%S%:z"`）
-- 在 `## 活动日志` / `## Activity Log` 段落追加：
-  ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Issue** by {agent} — Created GitHub Issue #{n}
-  ```
+
+> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Task Created`），由调用方 SKILL 步骤 3 写入。
 
 ### 8. 返回结果
 

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -109,7 +109,7 @@ The rule's content is determined by the configured code platform:
 
 Handle the result:
 - Rule successfully created the Issue: `issue_number` has been written back to task.md per the rule; continue by reading `.agents/rules/issue-sync.md`, completing upstream repository and permission detection, then sync the task comment and set `status: waiting-for-triage` by rule
-- Rule failed (auth / network / template parse / etc.): do not roll back task.md; get the current time and append an `Issue Creation Skipped` Activity Log entry with the reason
+- Rule failed (auth / network / template parse / etc.): do not roll back task.md; do NOT append an extra Activity Log entry; follow "Scenario C: Issue creation failed" output to surface `error_code` and `error_message` to the user so they can decide whether to retry manually or write `issue_number` later
 - Rule was a no-op (custom or empty platform): do not create comments, do not block the workflow, and do not write an Activity Log entry
 - task.md already has `issue_number`: the rule's prerequisite check skips creation; `create-task` proceeds directly to step 5
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -109,7 +109,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 处理结果：
 - 规则成功创建 Issue：`issue_number` 已按规则回写到 task.md；继续读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并按规则设置 `status: waiting-for-triage`
-- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；获取当前时间，追加 `Issue Creation Skipped` Activity Log，说明错误原因
+- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`，让用户决定后续是否手动重试或写入 `issue_number`
 - 规则为 no-op（自定义或空平台）：不创建评论，不阻塞后续工作流，不写 Activity Log
 - task.md 已存在 `issue_number`：规则中的前置检查会跳过；`create-task` 直接进入步骤 5
 

--- a/tests/core/validate-artifact.test.js
+++ b/tests/core/validate-artifact.test.js
@@ -428,6 +428,94 @@ test("validate-artifact create-task task-meta rejects invalid branch naming", ()
   }
 });
 
+test("validate-artifact activity-log passes for create-task happy path with Issue created", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-activity-pass-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    const now = formatTimestamp(new Date());
+    write(path.join(taskDir, "task.md"), [
+      buildTaskFrontmatter({
+        branch: "agent-infra-refactor-create-task-gate",
+        current_step: "requirement-analysis",
+        issue_number: 296,
+        updated_at: now
+      }),
+      "",
+      "# 任务：创建任务",
+      "",
+      "## 活动日志",
+      "",
+      `- ${now} — **Task Created** by codex — Task created from description`
+    ].join("\n"));
+
+    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact activity-log fails for create-task when Create Issue entry is appended", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-create-issue-fail-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    const now = formatTimestamp(new Date());
+    write(path.join(taskDir, "task.md"), [
+      buildTaskFrontmatter({
+        branch: "agent-infra-refactor-create-task-gate",
+        current_step: "requirement-analysis",
+        issue_number: 296,
+        updated_at: now
+      }),
+      "",
+      "# 任务：创建任务",
+      "",
+      "## 活动日志",
+      "",
+      `- ${now} — **Task Created** by codex — Task created from description`,
+      `- ${now} — **Create Issue** by codex — Created GitHub Issue #296`
+    ].join("\n"));
+
+    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Latest action 'Create Issue' does not match/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact activity-log fails for create-task when Issue Creation Skipped entry is appended", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-skipped-fail-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    const now = formatTimestamp(new Date());
+    write(path.join(taskDir, "task.md"), [
+      buildTaskFrontmatter({
+        branch: "agent-infra-refactor-create-task-gate",
+        current_step: "requirement-analysis",
+        issue_number: "N/A",
+        updated_at: now
+      }),
+      "",
+      "# 任务：创建任务",
+      "",
+      "## 活动日志",
+      "",
+      `- ${now} — **Task Created** by codex — Task created from description`,
+      `- ${now} — **Issue Creation Skipped** by codex — GitHub Issue creation failed`
+    ].join("\n"));
+
+    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Latest action 'Issue Creation Skipped' does not match/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("validate-artifact artifact check fails when a required section is missing", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-fail-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #296

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #296

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`create-task` skill 的完成校验门 (`expected_action_pattern: "Task Created"`) 与它委托的 `.agents/rules/create-issue.md` 步骤 7 在「task.md 活动日志最后一条 entry 是什么」这件事上互相冲突——严格按 SKILL.md + create-issue.md 文档执行的 happy path 必然在第一次 gate 验证时失败：

```
Verification: fail | Skill: create-task
  [FAIL] activity-log - Latest action 'Create Issue' does not match 'Task Created'
```

且 `Command failed: ...` 错误信息会泄漏 access/refresh token（在原始 sandbox refresh 故障中观察到）。

实测复现于 TASK-20260509-151246 / Issue #295：成功创建 Issue 后追加 `Create Issue` entry，gate 立刻报错；只有人工删除 `Create Issue` entry，gate 才通过。

回归来源：commit `2bfe62f` (#274) 把独立的 create-issue skill 合并进 create-task 时扩展了 `platform-sync` 检查，但漏掉了同步 `expected_action_pattern`。

通读 SKILL.md 后还发现一个**同源同因但今天没在实测里触发**的隐藏写入点：`SKILL.md:112` 的失败分支会追加 `Issue Creation Skipped` entry，触发后同样会让 gate 报错。本 PR 一并修复。

## 📋 主要变更 / Brief Changelog

### 文档/规则修复（删除冗余 Activity Log 写入）

- **`.agents/rules/create-issue.md` 步骤 7**：删除"在 `## 活动日志` 段落追加 `Create Issue` entry"的整段（含代码块），改为说明短语：

  > 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Task Created`），由调用方 SKILL 步骤 3 写入。

- **`.agents/skills/create-task/SKILL.md:112` 失败分支**：从"获取当前时间，追加 `Issue Creation Skipped` Activity Log"改为"不追加额外 Activity Log；按场景 C 输出 `error_code` / `error_message`"。

  现在 create-task 流程的四种结果分支（成功 / 失败 / no-op / 已绑定）**全部**只产出一条 `Task Created` Activity Log，gate 强语义保留（`expected_action_pattern: "Task Created"` 不动）。

### 模板同步（`tests/templates/templates.test.js` 强制 byte-equivalent）

- `templates/.agents/rules/create-issue.github.{en,zh-CN}.md`：与项目 rule 同步
- `templates/.agents/skills/create-task/SKILL.{en,zh-CN}.md`：与项目 SKILL 同步

### 测试（`tests/core/validate-artifact.test.js`）

新增 3 个 gate-level 端到端测试，覆盖 `create-task` `activity-log` gate 的预期行为：

1. `activity-log passes for create-task happy path with Issue created` — happy path
2. `activity-log fails for create-task when Create Issue entry is appended` — 回归守卫 #1：未来谁不小心把 `create-issue.md` 的追加加回来 → CI 立刻报警
3. `activity-log fails for create-task when Issue Creation Skipped entry is appended` — 回归守卫 #2：守卫第三个写入点不被人为加回

## 🧪 验证变更 / Verifying this Change

### 自动化测试

| 范围 | 命令 | 结果 |
|------|------|------|
| 全量 | `npm test`（Node 22） | **426/426** |
| pre-commit hook (test:core) | `npm run test:core` | **310/310** |

新增 3 个测试位于 `tests/core/validate-artifact.test.js:431-516`，全部通过。

### 测试步骤 / Test Steps

1. `git checkout agent-infra-bugfix-create-task-gate-activity-log-mismatch`
2. `npm install && npm test` —— 验证 426/426 通过
3. （可选）实际跑一次 `/create-task ...` 并触发 Issue 创建：观察 task.md 活动日志只有一条 `Task Created`；gate 一次通过
4. （可选）人工把 `**Create Issue**` entry 追加回 task.md，再跑 gate：CI 测试用例会在这个回归出现时立即报错

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（开发本任务过程中实际触发了 bug，并验证 gate 通过）

## 📸 截图 / Screenshots

不适用 / N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（#296）
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（review.md / Round 1，Verdict: Approved，0 blocker / 0 major / 0 minor）
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试（3 个 gate 端到端测试）
- [x] 当存在跨模块依赖时，我尽量使用了 mock（沿用 `runValidator` + `buildTaskFrontmatter` fixture 模式）
- [x] 单元测试通过（426/426）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（.agents/rules + .agents/skills + 4 份模板）
- [x] 没有破坏性变更（gate 语义保持强一致；现存只剩 `Task Created` 一条的 task.md 仍向后兼容）
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

- **零侵入性**：`validate-artifact.js`、`verify.json`、其他 14 个 skill 的 verify 配置完全未动。本 PR 选择"不写第二条 Activity Log"，与已修复的 import-issue 同类 bug（TASK-20260426-124425）思路保持一致；显式拒绝了"放宽正则"（方案 A，会让 gate 形同虚设）/"步骤顺序重排"（方案 B，引入二次 gate 复杂度）/"加专门 gate"（方案 D，性价比最差）三个候选，决策可追溯到 `.agents/workspace/active/TASK-20260509-152511/plan.md`。
- **范围扩展**：分析阶段只识别 2 个写入点（`Create Issue`），plan 阶段通读 SKILL.md 后补上第 3 个（`Issue Creation Skipped`）。一并修复避免埋雷。
- **协作署名**：claude（分析/方案/审查）+ codex（实现）。

---

**审查者注意事项 / Reviewer Notes:**

- 关注 `.agents/rules/create-issue.md` 与两份 GitHub 平台模板的语义同步（`tests/templates/templates.test.js` 已有强制等价检查）
- 关注 3 个新增测试是否正确锁定"只允许 `Task Created` 作为 latest action"的 gate 语义

Generated with AI assistance
