### PR TITLE
refactor(cli): GitHub Actions 跨平台测试规范化与 Windows 测试补齐

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -82,6 +82,8 @@
       "**/post-release.*",
       ".agents/skills/post-release/SKILL.*"
     ],
-    "ejected": []
+    "ejected": [
+      ".agents/rules/cross-platform-tests.md"
+    ]
   }
 }

--- a/.agents/rules/cross-platform-tests.md
+++ b/.agents/rules/cross-platform-tests.md
@@ -27,9 +27,9 @@ test("restoreTerminal does not throw when stty is unavailable", () => {
 
 不要再新增 `e2eOnPlatforms()`、`unitOnly()`、`skipOnWindows()` 等别名。`onPlatforms()` 是唯一的整条测试平台守卫 helper。
 
-## 2. 同一条测试覆盖多平台行为差异
+## 2. 同一条测试覆盖多平台行为差异（含其调用的 helper）
 
-同一条测试需要在多个平台运行，并断言不同平台的不同结果时，可以在测试体内读取 `process.platform`。这种分支必须用于断言或 fixture 构造，不得用于跳过整条测试。
+同一条测试需要在多个平台运行，并断言不同平台的不同结果时，可以在测试体内或其调用的共享 helper / fixture 函数内部读取 `process.platform`。这种分支必须用于断言、构造或资源 setup，不得用于跳过整条测试。
 
 ✅ 推荐：
 
@@ -38,6 +38,18 @@ if (process.platform === "darwin") {
   assert.equal(readKeychain(), expected);
 } else {
   assert.equal(fs.readFileSync(credentialsPath, "utf8"), expected);
+}
+```
+
+✅ helper / fixture 内的合法分支：
+
+```js
+function writeFakeGh(filePathname) {
+  if (process.platform === "win32") {
+    writeNodeCommandShim(filePathname, filePathname);
+    return;
+  }
+  fs.chmodSync(filePathname, 0o755);
 }
 ```
 

--- a/.agents/rules/cross-platform-tests.md
+++ b/.agents/rules/cross-platform-tests.md
@@ -1,0 +1,67 @@
+# 跨平台测试守卫规范
+
+本规则用于新增或修改跨平台测试时统一表达「整条测试在哪些真实平台运行」。目标是让平台跳过语义集中到 `tests/helpers.js` 的 `onPlatforms()`，避免在测试体内散落早返回。
+
+## 1. 整条测试的平台守卫
+
+整条测试只适用于部分真实平台时，必须使用 `onPlatforms()` 作为 `node:test` 的 options 参数。
+
+✅ 推荐：
+
+```js
+test("restoreTerminal does not throw when stty is unavailable", onPlatforms("linux", "darwin"), () => {
+  // ...
+});
+```
+
+❌ 禁止：
+
+```js
+test("restoreTerminal does not throw when stty is unavailable", () => {
+  if (process.platform === "win32") {
+    return;
+  }
+  // ...
+});
+```
+
+不要再新增 `e2eOnPlatforms()`、`unitOnly()`、`skipOnWindows()` 等别名。`onPlatforms()` 是唯一的整条测试平台守卫 helper。
+
+## 2. 同一条测试覆盖多平台行为差异
+
+同一条测试需要在多个平台运行，并断言不同平台的不同结果时，可以在测试体内读取 `process.platform`。这种分支必须用于断言或 fixture 构造，不得用于跳过整条测试。
+
+✅ 推荐：
+
+```js
+if (process.platform === "darwin") {
+  assert.equal(readKeychain(), expected);
+} else {
+  assert.equal(fs.readFileSync(credentialsPath, "utf8"), expected);
+}
+```
+
+## 3. 运行时回退
+
+某些平台的系统能力会在运行时失败，例如 Windows 无管理员权限创建 symlink 时可能抛出 `EPERM`。这类分支属于运行时回退，可以保留在测试体内，但必须只处理已知错误，不得吞掉无关失败。
+
+✅ 推荐：
+
+```js
+try {
+  createSymlink();
+} catch (error) {
+  if (process.platform !== "win32" || error.code !== "EPERM") {
+    throw error;
+  }
+}
+```
+
+## 4. 已知未启用的 Windows sandbox e2e
+
+`tests/cli/sandbox.test.js` 中的 sandbox exec e2e 当前仍限制在 Linux 和 macOS：
+
+- `sandbox exec enters tmux automatically for interactive shells`
+- `sandbox exec reconciles newer Claude credentials from a neighbouring project`
+
+原因是 Windows 上 `lib/sandbox/engine.js` 会自动选择 `wsl2`，docker 调用经由 `wsl.exe -- docker ...`，测试中的 `docker.cmd` shim 无法命中。后续如为 sandbox engine 增加测试用 override，再启用这些 Windows e2e。跟踪 Issue：[#294](https://github.com/fitlab-ai/agent-infra/issues/294)。

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,7 @@ npm test
 
 1. **禁止关键词语义断言**：不要通过匹配自然语言措辞来验证 skill 文档内容（如 `assert.match(content, /某段具体描述/)`）。SKILL.md 的文案会频繁调整，绑定措辞的测试极其脆弱。只做结构性检查：frontmatter 合法性、步骤编号连续、引用完整性、体积阈值等。
 2. **禁止反向删除断言**：已删除的功能不需要断言其不存在（如 `assert.doesNotMatch(content, /removedField/)`）。删除即彻底删除，不要用测试永久记住一个不再存在的概念，否则会形成无止境的测试债务。
+3. **平台守卫只走 helper**：跨平台测试的「整条是否运行」判定必须通过 `tests/helpers.js` 的 `onPlatforms()` 表达，不得在测试体内写 `if (process.platform === ...) return;` 早返回。同测试体内覆盖多平台行为差异（断言/构造分支）、运行时回退（如 EPERM）属于合法用例。详见 `.agents/rules/cross-platform-tests.md`。
 
 ## 提交与 PR 规范
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ node --test tests/cli/*.test.js tests/templates/*.test.js tests/core/*.test.js t
 
 1. **禁止关键词语义断言**：不要通过匹配自然语言措辞来验证 skill 文档内容（如 `assert.match(content, /某段具体描述/)`）。SKILL.md 的文案会频繁调整，绑定措辞的测试极其脆弱。只做结构性检查：frontmatter 合法性、步骤编号连续、引用完整性、体积阈值等。
 2. **禁止反向删除断言**：已删除的功能不需要断言其不存在（如 `assert.doesNotMatch(content, /removedField/)`）。删除即彻底删除，不要用测试永久记住一个不再存在的概念，否则会形成无止境的测试债务。
+3. **平台守卫只走 helper**：跨平台测试的「整条是否运行」判定必须通过 `tests/helpers.js` 的 `onPlatforms()` 表达，不得在测试体内写 `if (process.platform === ...) return;` 早返回。同测试体内覆盖多平台行为差异（断言/构造分支）、运行时回退（如 EPERM）属于合法用例。详见 `.agents/rules/cross-platform-tests.md`。
 
 ## 提交与 PR 规范
 

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -148,7 +148,7 @@ test("restoreTerminal is a no-op when stdout is not a TTY", () => {
   assert.equal(output, "");
 });
 
-test("restoreTerminal does not throw when stty is unavailable", { skip: process.platform === "win32" }, () => {
+test("restoreTerminal does not throw when stty is unavailable", onPlatforms("linux", "darwin"), () => {
   const output = withFakeStty(1, () => withTTY(true, () => captureStdoutWrite(() => {
     assert.doesNotThrow(() => restoreTerminal());
   })));
@@ -427,11 +427,7 @@ test("loadConfig fails when .agents/.airc.json is missing", async () => {
   }
 });
 
-test("loadConfig uses os.homedir on Windows when HOME is unset", async () => {
-  if (process.platform !== 'win32') {
-    return;
-  }
-
+test("loadConfig uses os.homedir on Windows when HOME is unset", onPlatforms("win32"), async () => {
   const sandboxConfig = await loadFreshEsm("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-userprofile-"));
   const previousCwd = process.cwd();
@@ -671,15 +667,11 @@ test("terminalEnvFlags omits unset variables instead of forwarding empty values"
   assert.deepEqual(flags, ["-e", "TERM_PROGRAM=iTerm.app"]);
 });
 
-test("sandbox exec enters tmux automatically for interactive shells", () => {
-  // On Windows, the engine is auto-detected as wsl2, so docker calls are
-  // routed through `wsl.exe -- docker ...` and bypass this test's docker.cmd
-  // shim. The wsl2 argv shape is covered separately by the commandForEngine
-  // wrapping test below.
-  if (process.platform === "win32") {
-    return;
-  }
-
+// On Windows, `lib/sandbox/engine.js` detectEngine forces the engine to wsl2,
+// so docker calls are routed through `wsl.exe -- docker ...` and bypass this
+// test's docker.cmd shim. Keep the shim for future enablement; commandForEngine
+// covers wsl2.
+test("sandbox exec enters tmux automatically for interactive shells", onPlatforms("linux", "darwin"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-"));
   const repoDir = path.join(tmpDir, "repo");
   const binDir = path.join(tmpDir, "bin");
@@ -762,11 +754,10 @@ node -e 'require("fs").appendFileSync(process.argv[1], JSON.stringify(process.ar
   }
 });
 
-test("sandbox exec reconciles newer Claude credentials from a neighbouring project", () => {
-  if (process.platform === "win32") {
-    return;
-  }
-
+// Windows currently routes docker calls through the wsl2 engine, so this test's
+// docker shim is bypassed. Non-darwin credential writes use the same file path
+// on Linux and Windows once the sandbox engine can be overridden in tests.
+test("sandbox exec reconciles newer Claude credentials from a neighbouring project", onPlatforms("linux", "darwin"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-credentials-"));
   const repoDir = path.join(tmpDir, "repo");
   const binDir = path.join(tmpDir, "bin");

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -121,6 +121,16 @@ function assertModeBits(filePathname, expectedMode) {
   assertEqual(actualMode, expectedMode);
 }
 
+/**
+ * Restrict a node:test case to the listed Node.js process.platform values.
+ *
+ * Use this as the test options argument: test(name, onPlatforms("linux", "darwin"), fn).
+ * Allowed values are "linux", "darwin", and "win32". Do not use early returns
+ * such as `if (process.platform === "...") return;` to skip a whole test body.
+ *
+ * Branching on process.platform inside a test remains valid when the same test
+ * intentionally covers platform-specific assertions or fixture construction.
+ */
 function onPlatforms(...allowed) {
   return {
     skip: allowed.includes(process.platform)


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #290

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

Closes #290

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring（跨平台测试守卫风格收敛到 `onPlatforms()` 单一 helper）
- [x] 📚 文档更新 / Documentation update（新增 `.agents/rules/cross-platform-tests.md` 规范、`CLAUDE.md` / `AGENTS.md` 测试规约第 3 条）
- [x] 🧹 代码清理 / Code cleanup（删除 sandbox.test.js 中 4 处早返回 / 内联 skip 守卫）

## 📝 变更目的 / Purpose of the Change

`.github/workflows/unit-tests.yml` 用 `os: [ubuntu-latest, windows-latest, macos-latest]` × `node: [22]` 矩阵跑同一份 `npm test`，所有平台差异化**完全靠测试代码内**的 `if (process.platform === "...") return;` 等早返回式守卫做。这套写法两个问题：

1. **守卫散落、易漏写、易出 bug**——PR #289 新增的 `sandbox.test.js:754 sandbox exec reconciles ...` 漏掉 darwin 守卫，CLI 子进程在 macOS GH Actions runner 上调用真实 `/usr/bin/security add-generic-password` 触发 Keychain ACL prompt 挂死，整个 macOS job 15 分钟超时被 cancel（最终通过 fake `security` shim `a9ec441` 绕过；根因——「守卫风格散乱」——没有解决）。
2. **Windows 默认全部跳过**，`sandbox.test.js` 已经备好 `docker.cmd` 包装器但 `if (win32) return;` 直接跳过，windows-latest runner 当前主要在跑单测，e2e 几乎裸奔。

本 PR 把多种并存的守卫风格（`{ skip: ... }` / `if (...) return;` / `if (...) ...`）收敛到 `tests/helpers.js` 现有的 `onPlatforms()` helper（**单一规范、单一名字**——不引入 `e2eOnPlatforms`/`unitOnly`/`skipOnWindows` 等冗余别名）。同时把规范以文档形式固化到 `.agents/rules/cross-platform-tests.md`，并在 `.claude/CLAUDE.md` / `AGENTS.md` 测试规约段落追加第 3 条「平台守卫只走 helper」，对 Claude Code / Codex / Gemini CLI / OpenCode 用户都可见。

**关于 Windows e2e 启用范围的诚实交代**：本 PR 启用了 1 条之前静默 skip 的 Windows 专属测试（`loadConfig uses os.homedir on Windows when HOME is unset`）。但 `sandbox.test.js:670/760` 的两条 sandbox-exec e2e 仍维持 `linux/darwin`——根因是 `lib/sandbox/engine.js:detectEngine` 在 win32 上**强制返回** `wsl2`，没有 env override 通道；docker 调用经由 `wsl.exe -- docker ...` 路由，绕过测试 `docker.cmd` shim。这是 Issue #290 标题里「Windows 测试补齐」目标的真正剩余部分，由 follow-up Issue #294 跟踪。

## 📋 主要变更 / Brief Changelog

### Commit `f7c7204` `refactor(tests): unify platform guards via onPlatforms helper`

- 迁移 `sandbox.test.js` 4 处守卫到 `onPlatforms()`：
  - L151 `restoreTerminal does not throw when stty is unavailable`（A → helper）
  - L430 `loadConfig uses os.homedir on Windows when HOME is unset`（B → helper，**Windows runner 上从静默 return 升级为真实运行**）
  - L670 `sandbox exec enters tmux automatically for interactive shells`（B → helper）
  - L760 `sandbox exec reconciles newer Claude credentials from a neighbouring project`（B → helper）
- `tests/helpers.js` 给 `onPlatforms()` 加 JSDoc，把它标记为唯一规范的跨平台守卫 helper，明确允许的测试体内分支用例
- 测试体内同测试覆盖多平台行为差异的 `if (process.platform === "darwin") ...` 断言/构造分支保留不动（830-882 行的 reconcile darwin shim 注入与断言分支）
- `.claude/CLAUDE.md` 「测试编写规约」追加第 3 条「平台守卫只走 helper」
- 新建 `.agents/rules/cross-platform-tests.md`，三类合法场景对照清晰：守卫 / 同测试多平台分支 / 运行时回退

### Commit `5144694` `docs(tests): close platform-guard rule coverage gaps`

后续 review 发现两个 round 1 没扫到的覆盖漏洞，本 commit 补：

- 把 `平台守卫只走 helper` 第 3 条**字节级镜像**到 `AGENTS.md`，确保 Codex / Gemini CLI / OpenCode 用户在主指南里也能看到（不止 Claude Code）
- `.agents/rules/cross-platform-tests.md` 第 2 节标题与措辞扩展为「同一条测试覆盖多平台行为差异（含其调用的 helper）」，新增 `writeFakeGh` 风格的 helper-internal ✅ 例子，明确容纳 `withHome` / `writeFakeGh` / `linkNodeModules` / `writeNodeCommandShim` 这类 helper 内的合法平台分支

### Commit `96b3dc9` `chore: eject cross-platform-tests rule from sync`

后续 review 又发现：因为 `.agents/rules/` 在 `.airc.json:files.managed` 列表里，`sync-templates.js` 的孤儿删除逻辑（行 1112-1124）会把没有 templates 源的 rule 文件**直接 `fs.unlinkSync`**。`cross-platform-tests.md` 是项目自有规则（深度引用 `tests/helpers.js`、`onPlatforms()`、`sandbox.test.js`、`lib/sandbox/engine.js`），不应进 templates 推送给下游项目。

修复：在 `.agents/.airc.json:files.ejected` 数组中登记本文件，让 sync-templates 跳过覆盖 + 删除逻辑——这是 `ejected` 清单从空到非空的首个条目。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 本地（Node 22）跑 `npm run test:smoke` —— 74 pass / 0 fail / 0 skipped
2. 本地（Node 22）跑 `npm run test:core` —— 309 pass / 0 fail / 1 skipped（`loadConfig uses os.homedir on Windows when HOME is unset` 在非 win32 上正确跳过）
3. 本地（Node 22）跑 `node --test tests/cli/sandbox.test.js` —— 169 pass / 0 fail / 1 skipped
4. 干跑 `syncTemplates(process.cwd(), './templates')` 验证 ejected 保护：`ejected.skipped` 包含 `cross-platform-tests.md`、`managed.removed` 为空
5. CI 矩阵观察 `ubuntu-latest` / `macos-latest` / `windows-latest` 三个 job：重点核对 Windows runner 上 `loadConfig` 测试**真实运行**（之前是静默 return）

### 测试覆盖 / Test Coverage

- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing
- [ ] 我已经添加了单元测试 / I have added unit tests（本 PR 是测试基础设施重构，不需要新增测试；helpers.js 的 `onPlatforms` 通过其使用方间接覆盖）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（7 轮 review，详见 task workspace）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 代码检查通过 / Lint checks pass（暂无 lint 配置）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 没有破坏性变更 / No breaking changes
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（`onPlatforms` 已有的 `sandbox.test.js:262` 调用签名不变）

## 📋 附加信息 / Additional Notes

**Follow-up Issue**：#294 `refactor(cli): detectEngine 增加 sandbox engine env override`——为本 PR 因 wsl2 engine 阻塞而未启用的两条 sandbox-exec e2e（`sandbox.test.js:670/760`）在 Windows 上铺路。

**关联 PR**：#289（双向凭证同步；macOS 测试 fix `a9ec441` 是触发本任务的导火索）

---

**审查者注意事项 / Reviewer Notes:**

本 PR 的 review history 比较长（7 轮），但每一轮都是补漏不返工：
- Round 1（4 minor）→ Refinement 1：cross-platform-tests.md 引用 #294、注释 detectEngine 锚点、JSDoc 措辞、注释位置统一
- Round 3（1 major + 1 minor）→ Refinement 2：AGENTS.md 镜像、cross-platform-tests.md 第 2 节范围扩展
- Round 5（1 major）→ Refinement 3：airc.json files.ejected 登记
- Round 6（1 blocker）→ Refinement 4：templateVersion 还原（sync-templates 副作用回退）

每轮 review 都在 Issue #290 评论里有完整记录，可对照核查。

---

Generated with AI assistance
