### PR TITLE
fix(sandbox): make 'ai sandbox ls' work under podman shim (#257 Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Linux uses native Docker on the host kernel, so there is no managed VM. `sandbox
 These configurations are not actively tested in this release:
 
 - **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
-- **Podman** instead of Docker: Experimental via the `podman-docker` shim on Fedora 40+ (`sudo dnf install podman podman-docker`). Most subcommands work, but `ai sandbox ls` silently shows "No sandbox containers" even when sandboxes exist because the underlying Go template is incompatible with podman. Workaround: list sandboxes with `docker ps -a --filter "label=<project>.sandbox" --format '{{.Names}} {{index .Labels "<project>.sandbox.branch"}}'` (replace `<project>` with your project name; leave the `{{.Names}}` and `{{index .Labels ...}}` Go template literals as-is). To suppress the per-command "Emulate Docker CLI using podman" stderr line, run `sudo touch /etc/containers/nodocker`. See [#257](https://github.com/fitlab-ai/agent-infra/issues/257) for the full pass/fail matrix.
+- **Podman** instead of Docker: Works on Fedora 40+ via the `podman-docker` shim (`sudo dnf install podman podman-docker`; optionally `sudo touch /etc/containers/nodocker` to silence its per-command notice).
 - **SELinux-enforcing** hosts (Fedora / RHEL): `ai sandbox create` automatically labels bind mounts with Docker's shared `:z` flag — no setup required. Set `AGENT_INFRA_SELINUX_DISABLE=1` to opt out for debugging.
 - `ai sandbox vm` is a no-op on Linux. Linux uses native Docker directly with no VM to manage; use `ai sandbox create`, `ai sandbox exec`, `ai sandbox refresh`, `ai sandbox ls`, `ai sandbox rebuild`, `ai sandbox rm` directly.
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Linux uses native Docker on the host kernel, so there is no managed VM. `sandbox
 These configurations are not actively tested in this release:
 
 - **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
-- **Podman** instead of Docker: Works on Fedora 40+ via the `podman-docker` shim (`sudo dnf install podman podman-docker`; optionally `sudo touch /etc/containers/nodocker` to silence its per-command notice).
+- **Podman** instead of Docker: Works on Fedora 40+ and other `dnf`-based RHEL family distros (RHEL, CentOS Stream, Rocky, Alma) via the `podman-docker` shim (`sudo dnf install podman podman-docker`; optionally `sudo touch /etc/containers/nodocker` to silence its per-command notice).
 - **SELinux-enforcing** hosts (Fedora / RHEL): `ai sandbox create` automatically labels bind mounts with Docker's shared `:z` flag — no setup required. Set `AGENT_INFRA_SELINUX_DISABLE=1` to opt out for debugging.
 - `ai sandbox vm` is a no-op on Linux. Linux uses native Docker directly with no VM to manage; use `ai sandbox create`, `ai sandbox exec`, `ai sandbox refresh`, `ai sandbox ls`, `ai sandbox rebuild`, `ai sandbox rm` directly.
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Linux uses native Docker on the host kernel, so there is no managed VM. `sandbox
 These configurations are not actively tested in this release:
 
 - **Rootless Docker**: Track [#256](https://github.com/fitlab-ai/agent-infra/issues/256).
-- **Podman** instead of Docker: Track [#257](https://github.com/fitlab-ai/agent-infra/issues/257).
+- **Podman** instead of Docker: Experimental via the `podman-docker` shim on Fedora 40+ (`sudo dnf install podman podman-docker`). Most subcommands work, but `ai sandbox ls` silently shows "No sandbox containers" even when sandboxes exist because the underlying Go template is incompatible with podman. Workaround: list sandboxes with `docker ps -a --filter "label=<project>.sandbox" --format '{{.Names}} {{index .Labels "<project>.sandbox.branch"}}'` (replace `<project>` with your project name; leave the `{{.Names}}` and `{{index .Labels ...}}` Go template literals as-is). To suppress the per-command "Emulate Docker CLI using podman" stderr line, run `sudo touch /etc/containers/nodocker`. See [#257](https://github.com/fitlab-ai/agent-infra/issues/257) for the full pass/fail matrix.
 - **SELinux-enforcing** hosts (Fedora / RHEL): `ai sandbox create` automatically labels bind mounts with Docker's shared `:z` flag — no setup required. Set `AGENT_INFRA_SELINUX_DISABLE=1` to opt out for debugging.
 - `ai sandbox vm` is a no-op on Linux. Linux uses native Docker directly with no VM to manage; use `ai sandbox create`, `ai sandbox exec`, `ai sandbox refresh`, `ai sandbox ls`, `ai sandbox rebuild`, `ai sandbox rm` directly.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,7 +295,7 @@ Linux 直接使用宿主内核上的原生 Docker，没有受管 VM。`sandbox.v
 下列场景在本期未做主动验证：
 
 - **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
-- 用 **Podman** 替代 Docker：Fedora 40+ 上通过 `podman-docker` shim 实验性支持（`sudo dnf install podman podman-docker`）。多数子命令可用，但 `ai sandbox ls` 在存在沙箱时仍会静默显示「No sandbox containers」——底层 Go 模板与 podman 不兼容。变通方式：用 `docker ps -a --filter "label=<project>.sandbox" --format '{{.Names}} {{index .Labels "<project>.sandbox.branch"}}'` 自行查询（将 `<project>` 替换为项目名；`{{.Names}}` 和 `{{index .Labels ...}}` 是 Go 模板字面量，请保持原样）。如需抑制每条命令前的「Emulate Docker CLI using podman」stderr 提示，运行 `sudo touch /etc/containers/nodocker`。完整的 pass/fail 矩阵见 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
+- 用 **Podman** 替代 Docker：Fedora 40+ 上通过 `podman-docker` shim 已可使用（`sudo dnf install podman podman-docker`；可选 `sudo touch /etc/containers/nodocker` 抑制 podman 在每条命令前打印的提示）。
 - **SELinux enforcing** 宿主机（Fedora / RHEL）：`ai sandbox create` 会自动给 bind mount 加 Docker 共享 `:z` 标签，无需手动准备。如需排障可设 `AGENT_INFRA_SELINUX_DISABLE=1` 关闭。
 - `ai sandbox vm` 在 Linux 上是空操作。Linux 直接使用 native Docker，没有 VM 需要管理；请直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox refresh`、`ai sandbox ls`、`ai sandbox rebuild`、`ai sandbox rm`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,7 +295,7 @@ Linux 直接使用宿主内核上的原生 Docker，没有受管 VM。`sandbox.v
 下列场景在本期未做主动验证：
 
 - **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
-- 用 **Podman** 替代 Docker：Fedora 40+ 上通过 `podman-docker` shim 已可使用（`sudo dnf install podman podman-docker`；可选 `sudo touch /etc/containers/nodocker` 抑制 podman 在每条命令前打印的提示）。
+- 用 **Podman** 替代 Docker：Fedora 40+ 及其他 `dnf` 系 RHEL 发行版（RHEL、CentOS Stream、Rocky、Alma）上通过 `podman-docker` shim 已可使用（`sudo dnf install podman podman-docker`；可选 `sudo touch /etc/containers/nodocker` 抑制 podman 在每条命令前打印的提示）。
 - **SELinux enforcing** 宿主机（Fedora / RHEL）：`ai sandbox create` 会自动给 bind mount 加 Docker 共享 `:z` 标签，无需手动准备。如需排障可设 `AGENT_INFRA_SELINUX_DISABLE=1` 关闭。
 - `ai sandbox vm` 在 Linux 上是空操作。Linux 直接使用 native Docker，没有 VM 需要管理；请直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox refresh`、`ai sandbox ls`、`ai sandbox rebuild`、`ai sandbox rm`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,7 +295,7 @@ Linux 直接使用宿主内核上的原生 Docker，没有受管 VM。`sandbox.v
 下列场景在本期未做主动验证：
 
 - **Rootless Docker**：后续跟踪 [#256](https://github.com/fitlab-ai/agent-infra/issues/256)。
-- 用 **Podman** 替代 Docker：后续跟踪 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
+- 用 **Podman** 替代 Docker：Fedora 40+ 上通过 `podman-docker` shim 实验性支持（`sudo dnf install podman podman-docker`）。多数子命令可用，但 `ai sandbox ls` 在存在沙箱时仍会静默显示「No sandbox containers」——底层 Go 模板与 podman 不兼容。变通方式：用 `docker ps -a --filter "label=<project>.sandbox" --format '{{.Names}} {{index .Labels "<project>.sandbox.branch"}}'` 自行查询（将 `<project>` 替换为项目名；`{{.Names}}` 和 `{{index .Labels ...}}` 是 Go 模板字面量，请保持原样）。如需抑制每条命令前的「Emulate Docker CLI using podman」stderr 提示，运行 `sudo touch /etc/containers/nodocker`。完整的 pass/fail 矩阵见 [#257](https://github.com/fitlab-ai/agent-infra/issues/257)。
 - **SELinux enforcing** 宿主机（Fedora / RHEL）：`ai sandbox create` 会自动给 bind mount 加 Docker 共享 `:z` 标签，无需手动准备。如需排障可设 `AGENT_INFRA_SELINUX_DISABLE=1` 关闭。
 - `ai sandbox vm` 在 Linux 上是空操作。Linux 直接使用 native Docker，没有 VM 需要管理；请直接使用 `ai sandbox create`、`ai sandbox exec`、`ai sandbox refresh`、`ai sandbox ls`、`ai sandbox rebuild`、`ai sandbox rm`。
 

--- a/lib/sandbox/commands/ls.js
+++ b/lib/sandbox/commands/ls.js
@@ -9,6 +9,12 @@ import { runSafeEngine } from '../shell.js';
 import { resolveTools, toolProjectDirCandidates } from '../tools.js';
 
 const USAGE = 'Usage: ai sandbox ls';
+const CONTAINER_LIST_HEADER = 'NAMES\tSTATUS\tBRANCH';
+
+// Exported to lock the docker/podman-compatible format in unit tests.
+export function containerListFormat(label) {
+  return `{{.Names}}\t{{.Status}}\t{{index .Labels "${label}.branch"}}`;
+}
 
 function listChildren(dir) {
   if (!fs.existsSync(dir)) {
@@ -34,15 +40,16 @@ export function ls(args = []) {
     '--filter',
     `label=${label}`,
     '--format',
-    'table {{.Names}}\t{{.Status}}\t{{.Label "' + `${label}.branch` + '"}}'
+    containerListFormat(label)
   ]);
 
   p.intro(pc.cyan(`Sandbox status for ${config.project}`));
 
   p.log.step('Containers');
-  if (!containers || containers.split('\n').length <= 1) {
+  if (!containers) {
     p.log.warn('  No sandbox containers');
   } else {
+    process.stdout.write(`  ${CONTAINER_LIST_HEADER}\n`);
     for (const line of containers.split('\n')) {
       process.stdout.write(`  ${line}\n`);
     }

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -4083,15 +4083,6 @@ test("resolveTaskBranch rejects missing task files and missing branch metadata",
   }
 });
 
-test("sandbox ls uses a docker/podman-compatible Go template", async () => {
-  const { containerListFormat } = await loadFreshEsm("lib/sandbox/commands/ls.js");
-  const fmt = containerListFormat("demo-project.sandbox");
-
-  assert.doesNotMatch(fmt, /\{\{\.Label\b/, "must not use the .Label method form");
-  assert.match(fmt, /\{\{index\s+\.Labels\s+"demo-project\.sandbox\.branch"\}\}/);
-  assert.doesNotMatch(fmt, /^table\s/, "must not use the table prefix");
-});
-
 test("sandbox ls format embeds Names and Status columns in stable order", async () => {
   const { containerListFormat } = await loadFreshEsm("lib/sandbox/commands/ls.js");
 

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -4082,3 +4082,21 @@ test("resolveTaskBranch rejects missing task files and missing branch metadata",
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test("sandbox ls uses a docker/podman-compatible Go template", async () => {
+  const { containerListFormat } = await loadFreshEsm("lib/sandbox/commands/ls.js");
+  const fmt = containerListFormat("demo-project.sandbox");
+
+  assert.doesNotMatch(fmt, /\{\{\.Label\b/, "must not use the .Label method form");
+  assert.match(fmt, /\{\{index\s+\.Labels\s+"demo-project\.sandbox\.branch"\}\}/);
+  assert.doesNotMatch(fmt, /^table\s/, "must not use the table prefix");
+});
+
+test("sandbox ls format embeds Names and Status columns in stable order", async () => {
+  const { containerListFormat } = await loadFreshEsm("lib/sandbox/commands/ls.js");
+
+  assert.equal(
+    containerListFormat("proj.sandbox"),
+    '{{.Names}}\t{{.Status}}\t{{index .Labels "proj.sandbox.branch"}}'
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #257

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue) — `ai sandbox ls` 在 podman 下静默失败
- [x] 📚 文档更新 / Documentation update — README "Known Linux limits" 中 podman 条目

## 📝 变更目的 / Purpose of the Change

完成 Issue #257 的 Phase 1 评估并交付配套修复。

**起因**：PR #260 落 Linux native Docker 支持时显式不做 podman，把评估留作 #257。本任务是该评估：装上 `podman-docker` shim 后 `ai sandbox *` 全套命令在 Fedora 上能不能用？

**评估结果**（在 Fedora 41 + podman 5.6.2 上跑过 lifecycle）：

- ✅ `docker info` / `docker version --format '{{.Server.Version}}'` 与 docker engine 行为兼容（`engines/native.js:22,26` 三态诊断不会误判）
- ✅ `docker image inspect --format '{{ index .Config.Labels "k" }}'` 与 docker engine 等价（`create.js:923-932` 镜像签名比对不会触发假 stale）
- ✅ `docker build` / `docker run -d -v -e --label` / `docker exec -it` / `docker rmi` / `docker stop` / `docker rm` / 简单 `{{.Names}}` 模板 —— 全部 PASS
- ❌ `ai sandbox ls` 在 podman 下**静默失败** —— `ls.js:37` 的 `'table {{.Names}}...{{.Label "k"}}'` Go 模板在 podman 5.x 上报 `Label is not a method but has arguments`，stdout 只剩表头，UI 误判为 "No sandbox containers"

本 PR 一次性闭环：修这个 silent bug + 文档落地。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/commands/ls.js`：模板从 `table {{.Label "k"}}` 改为 `{{.Names}}\t{{.Status}}\t{{index .Labels "k"}}`（去 `table` 前缀、`.Label` 方法形式换 `index .Labels`），两侧 docker / podman 均兼容；新增导出 `containerListFormat(label)` 函数便于测试 lock；空结果判断从 `length <= 1` 改为 `!containers`，并在非空分支手动打印 `NAMES\tSTATUS\tBRANCH` 列头
- `tests/cli/sandbox.test.js`：新增 1 条结构性单测 `sandbox ls format embeds Names and Status columns in stable order`，用 `assert.equal()` 字面锁定完整模板字符串，防止有人改回 podman 不兼容形态
- `README.md` / `README.zh-CN.md`：把 "Known Linux limits" 里 `Podman: Track #257` 升级为「Fedora 40+ 及其他 dnf 系 RHEL 发行版（RHEL/CentOS Stream/Rocky/Alma）通过 `podman-docker` shim 可用」并提示 `sudo touch /etc/containers/nodocker` 抑制每条命令前的 emulation 提示；不引用 #257
- 4 个 commit，逻辑切片清晰：评估 docs → 核心修复 → 受众扩展 → CLAUDE.md 测试合规清理

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 项目测试套件：`PATH=<node22>/bin:$PATH npm run test:core`（含新增的 `containerListFormat` 单测）—— 311/311 通过
2. **真实 Fedora 端到端复测**（Aliyun ECS / Fedora 41 / podman 5.6.2 / `podman-docker` 5.6.2）：
   ```
   docker run -d --name podman-eval-dev-test \
     --label podman-eval.sandbox \
     --label podman-eval.sandbox.branch=feature-x \
     ubuntu:22.04 sleep 60
   cd /tmp/podman-eval && ai sandbox ls
   ```
   修复前：`▲ No sandbox containers`（silent fail）  
   修复后：
   ```
   ◇  Containers
     NAMES   STATUS                       BRANCH
     podman-eval-dev-test  Up Less than a second  feature-x
   (exit=0)
   ```
3. docker engine 路径不变（CI `sandbox-linux-e2e.yml` 已在 PR 创建后自动跑一次回归）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（`tests/cli/sandbox.test.js` 新增 `containerListFormat` 锁定）
- [x] 所有现有测试都通过 / All existing tests pass（311/311）
- [x] 我已经进行了手动测试 / I have performed manual testing（Fedora 41 + podman 5.6.2 真实端到端复测）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas（`containerListFormat` 上方注释说明 export 用途仅供测试 lock）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（`loadFreshEsm` 加载模块、纯函数断言，无 docker 进程依赖）
- [x] 代码检查通过 / Lint checks pass（项目暂未配置 lint，npm scripts 中无 lint 任务）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（README 中英双语已同步）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them — 无破坏性变更
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（新模板字符串在 docker engine 下行为等价，列头从 docker 自动对齐变为固定字符串，无功能回退）

## 📋 附加信息 / Additional Notes

**显式不在本 PR 范围**（按 #257 Phase 1 评估的 scope 控制）：

- 不引入 `sandbox.containerEngine: docker | podman` schema（这是 Phase 2 的事，本评估结论 A 不需要触发 Phase 2）
- 不改 `validateSandboxEngine` / `detectEngine` 接受 podman 引擎（同上）
- 不为 podman 加 CI matrix（一次性评估不需要回归）
- 不动 `engines/native.js` 第二态错误文案对 podman 用户的措辞（属独立 UX issue，与本任务正交）
- 不处理 rootless docker (#256) / SELinux 强制 (#258，已合入) / root UID (#261)

**任务工作区产物**（不进本 PR；评估全过程的设计/审查档案保留在 `.agents/workspace/active/TASK-20260507-000449/`）：plan / plan-r2 / implementation / implementation-r2 / review / review-r2 / review-r3 / review-r4 / review-r5 / refinement / refinement-r2。Issue #257 评论里也有对应的同步评论。

---

**审查者注意事项 / Reviewer Notes:**

重点关注：

1. `lib/sandbox/commands/ls.js` 模板换语法后，docker engine 下输出从自动 `table` 列对齐变为裸 tab —— 是否接受这个 UX 折中
2. 单测 `assert.equal()` 把完整模板字符串字面锁死（含 `\t`、`{{index .Labels "..."}}`）；列顺序属于稳定 UX 契约
3. README 简化措辞（不引用 issue）—— 是否符合项目「能简单说完不再延伸」的风格倾向
4. 4 个 commit 是否需要 squash —— 推荐保留 4 个（评估 → 核心修 → 受众扩展 → 合规清理），故事完整

Generated with AI assistance
