### PR TITLE
feat(sandbox): 完成 #159 收尾——Debian e2e + 不支持平台错误信息

### DIFF
--- a/.github/workflows/sandbox-linux-e2e.yml
+++ b/.github/workflows/sandbox-linux-e2e.yml
@@ -149,3 +149,96 @@ jobs:
           git -C /tmp/test-repo worktree remove --force "$HOME/.agent-infra/worktrees/linux-e2e/test-branch" 2>/dev/null || true
           git -C /tmp/test-repo branch -D test-branch 2>/dev/null || true
           rm -rf "$HOME/.agent-infra/worktrees/linux-e2e" "$HOME/.agent-infra/sandboxes"
+
+  sandbox-linux-debian:
+    name: Linux native Docker sandbox lifecycle (debian-12)
+    runs-on: ubuntu-latest
+    # TODO(#159 follow-up): remove continue-on-error after 3+ green runs.
+    continue-on-error: true
+    timeout-minutes: 20
+    container:
+      image: debian:12-slim
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - /home/runner/work:/home/runner/work
+    env:
+      HOME: /home/runner/work/_temp/debian-home
+      DEBIAN_TEST_REPO: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/test-repo
+    permissions:
+      contents: read
+    steps:
+      - name: Install host prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git xz-utils docker.io
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Link local CLI
+        run: npm link
+
+      - name: Prepare host state
+        # Keep in sync with sandbox-linux job lifecycle.
+        run: |
+          mkdir -p "$HOME/.claude"
+          cat > "$HOME/.claude/.credentials.json" <<'JSON'
+          {
+            "accessToken": "stub-access-token",
+            "refreshToken": "stub-refresh-token",
+            "expiresAt": "2999-01-01T00:00:00.000Z",
+            "scopes": ["user:profile", "user:sessions:claude_code"]
+          }
+          JSON
+
+      - name: Prepare test repository
+        # Keep in sync with sandbox-linux job lifecycle.
+        run: |
+          mkdir -p "$DEBIAN_TEST_REPO/.agents"
+          cd "$DEBIAN_TEST_REPO"
+          git init
+          git config user.name "agent-infra CI"
+          git config user.email "agent-infra-ci@example.com"
+          git branch -M main
+          cat > .agents/.airc.json <<'JSON'
+          {
+            "project": "linux-e2e",
+            "org": "fitlab-ai",
+            "sandbox": {
+              "runtimes": ["node20"],
+              "tools": ["claude-code"]
+            }
+          }
+          JSON
+          printf '# linux e2e\n' > README.md
+          git add README.md .agents/.airc.json
+          git commit -m "chore: prepare linux sandbox e2e fixture"
+
+      - name: Run sandbox lifecycle
+        working-directory: ${{ env.DEBIAN_TEST_REPO }}
+        run: |
+          docker info
+          ai sandbox create test-branch main
+          ai sandbox ls
+          container="$(docker ps --filter "label=linux-e2e.sandbox.branch=test-branch" --format '{{.Names}}' | head -n 1)"
+          test -n "$container"
+          docker exec "$container" sh -lc 'echo hello && node --version'
+
+      - name: Cleanup sandbox artifacts
+        if: always()
+        run: |
+          docker ps -aq --filter "label=linux-e2e.sandbox" | xargs -r docker rm -f
+          docker images -q --filter "label=linux-e2e.sandbox" | xargs -r docker rmi -f
+          git -C "$DEBIAN_TEST_REPO" worktree remove --force "$HOME/.agent-infra/worktrees/linux-e2e/test-branch" 2>/dev/null || true
+          git -C "$DEBIAN_TEST_REPO" branch -D test-branch 2>/dev/null || true
+          rm -rf "$HOME/.agent-infra/worktrees/linux-e2e" "$HOME/.agent-infra/sandboxes"

--- a/lib/sandbox/engine.js
+++ b/lib/sandbox/engine.js
@@ -69,7 +69,12 @@ export function detectEngine(config = {}, { platformFn = platform } = {}) {
 
     return ENGINES.COLIMA;
   }
-  return 'unsupported';
+  throw new Error(
+    `sandbox: platform "${os}" is not supported. `
+    + 'Supported platforms: linux (native), darwin (colima/orbstack/docker-desktop), win32 (wsl2). '
+    + 'Please open an issue at https://github.com/fitlab-ai/agent-infra/issues/new '
+    + 'with your platform details if you need this added.'
+  );
 }
 
 export function hasUserVmConfig(vm = {}) {
@@ -116,8 +121,16 @@ export async function ensureDocker(config, onMessage, dependencies = {}) {
 }
 
 export function isVmManaged(config = {}, dependencies = {}) {
-  const engine = detectEngine(config, dependencies);
-  return isManagedEngine(engine);
+  try {
+    const engine = detectEngine(config, dependencies);
+    return isManagedEngine(engine);
+  } catch (error) {
+    if (error?.message?.startsWith('sandbox: platform "')) {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 export function isManagedEngine(engine) {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -2373,6 +2373,37 @@ test("detectEngine rejects unsupported configured sandbox engines early", async 
   );
 });
 
+test("detectEngine throws an actionable error on unsupported platforms", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.throws(
+    () => sandboxEngine.detectEngine({}, { platformFn: () => "freebsd" }),
+    (error) => {
+      assert.match(error.message, /freebsd/);
+      assert.match(error.message, /linux \(native\)/);
+      assert.match(error.message, /darwin \(colima/);
+      assert.match(error.message, /win32 \(wsl2\)/);
+      assert.match(error.message, /agent-infra\/issues\/new/);
+      return true;
+    }
+  );
+});
+
+test("isVmManaged returns false on unsupported platforms instead of throwing", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.equal(sandboxEngine.isVmManaged({}, { platformFn: () => "freebsd" }), false);
+});
+
+test("isVmManaged keeps invalid sandbox engine config errors actionable", async () => {
+  const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
+
+  assert.throws(
+    () => sandboxEngine.isVmManaged({ engine: "podman" }, { platformFn: () => "darwin" }),
+    /Expected one of: null, colima, orbstack, docker-desktop.*only affects macOS/s
+  );
+});
+
 test("detectEngine returns Colima on macOS when no engine is configured", async () => {
   const sandboxEngine = await loadFreshEsm("lib/sandbox/engine.js");
   const dependencies = {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #159

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature — Debian 12 sandbox e2e 覆盖
- [x] 🐛 Bug 修复 / Bug fix — `detectEngine` 在不支持平台返回的技术性错误改为面向用户的可操作错误

## 📝 变更目的 / Purpose of the Change

Issue #159 的 Windows (WSL2) / Linux (native) 主体已经通过 #184/#188、#199/#260、#287、#299 等子任务陆续落地，本任务收尾两个剩余项，完成后即可关闭 #159：

1. **Debian e2e 矩阵覆盖**：把 Ubuntu 之外最主流的 Debian 系发行版纳入 sandbox lifecycle CI，给 release-side 兜底信心。Fedora / Arch 按需后续再补，不在本次范围。
2. **不支持平台错误信息**：用户在 freebsd / sunos / aix 等平台跑 `ai sandbox ...` 时，下游 `getAdapter('unsupported')` 会抛出技术性的 `No adapter registered for engine 'unsupported'`。这条错误对终端用户无可操作引导，改成在 `detectEngine` 直接抛出包含平台名、已支持平台清单和 `issues/new` 链接的英文错误。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/engine.js` — `detectEngine` 删除 `'unsupported'` 哨兵字符串，直接抛出自包含错误；`isVmManaged` 仅在错误来源于平台分支（前缀 `sandbox: platform "`）时返回 `false`，配置非法的错误（来自 `validateSandboxEngine`）继续向上冒泡保持可操作。
- `tests/cli/sandbox.test.js` — 新增 3 条单测：错误信息 token 断言、`isVmManaged` 平台兜底、`isVmManaged` 不吞配置错误。
- `.github/workflows/sandbox-linux-e2e.yml` — 新增 `sandbox-linux-debian` job，在 `debian:12-slim` 容器内通过 host docker socket 跑 rootful sandbox lifecycle（create / ls / exec / cleanup）。
  - `container.volumes` 额外挂 `/home/runner/work` 到容器内同名路径，让 host docker daemon 收到的 bind-mount 路径在 host 上真实存在；`HOME` 与 `DEBIAN_TEST_REPO` 都固定在 `/home/runner/work/...` 下。
  - 标 `continue-on-error: true` + `TODO(#159 follow-up)`，沿用 rootless matrix 的观察窗口模式。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/sandbox.test.js` — 全套 sandbox 测试通过（180 tests / 179 pass / 1 skipped）
2. `npm run test:core` — 320 tests / 319 pass / 1 skipped（pre-commit hook 也跑这一档）
3. CI：本 PR push 后观察新加的 `sandbox-linux-debian` job 在 `sandbox-linux-e2e.yml` 上的实际结果；现有 `sandbox-linux` (rootful + rootless) 必须保持绿色

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed（Debian job 的 "Keep in sync with sandbox-linux job lifecycle" 注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（无文档面变更）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / 无破坏性变更
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（错误信息变化对自动化消费者属语义升级而非破坏；`detectEngine` 不支持平台的行为从"返回字符串再被下游抛错"变为"自己抛错"，调用链异常路径与之前一致）

## 📋 附加信息 / Additional Notes

**Follow-up checklist（留底，因为 #159 在本 PR 合并后会关闭）：**

- [ ] `sandbox-linux-debian` job 在 main 上稳定绿色 3 次以上后，移除 `.github/workflows/sandbox-linux-e2e.yml` 中该 job 的 `continue-on-error: true` 与对应 TODO 行
- [ ] （可选 refactor）把 `sandbox-linux` 与 `sandbox-linux-debian` 共用的 lifecycle 步骤抽到 composite action / shared shell script，消除当前 ~50 行复制
- [ ] 视后续诉求决定是否补 Fedora / Arch e2e 覆盖

**审查者注意事项 / Reviewer Notes:**

- 本 PR 含 2 个 commit，按低风险到高风险排序：先 `fix(sandbox)`（engine error path）后 `ci(sandbox)`（CI matrix），可分别独立 review。
- Round 1 审查（`review.md`）指出过 Debian job 的 host/container 路径不一致风险；Round 2（`review-r2.md`）确认已通过 `/home/runner/work` 同名 mount + `DEBIAN_TEST_REPO` 锁定 host-visible 路径修复。
- 详细审查对话见任务工作区 `.agents/workspace/active/TASK-20260409-102632/`（analysis.md / plan.md / implementation.md / review.md / refinement.md / review-r2.md）。

---

Generated with AI assistance
