### PR TITLE
fix(sandbox): 用目录 bind + symlink 修复 .gitconfig //deleted 回归

### DIFF
--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -64,11 +64,14 @@ alias xy='codex --yolo; tput ed'
 alias gy='gemini --yolo; tput ed'
 `;
 const CONTAINER_HOME = '/home/devuser';
+const CONTAINER_SHELL_CONFIG_MOUNT = `${CONTAINER_HOME}/.host-shell-config`;
 const USAGE = `Usage: ai sandbox create <branch> [base] [--cpu <n>] [--memory <n>]
 
 Host aliases:
-  ${'~'}/.agent-infra/aliases/sandbox.sh is auto-created on first run and mounted at
-  ${CONTAINER_HOME}/.bash_aliases inside the sandbox container.`;
+  ${'~'}/.agent-infra/aliases/sandbox.sh is auto-created on first run and exposed
+  as ${CONTAINER_HOME}/.bash_aliases inside the sandbox container (the host
+  shell-config directory is bind-mounted at ${CONTAINER_SHELL_CONFIG_MOUNT} and
+  symlinked into $HOME).`;
 
 function buildSignature(preparedDockerfile, tools) {
   return createHash('sha256')
@@ -238,18 +241,32 @@ export function hostHasGpgKeys(home, execFn = execFileSync) {
 
 export function writeSanitizedGitconfig({ home, hostConfigDir, stripGpg, repoRoot }) {
   const gitconfigPath = hostJoin(home, '.gitconfig');
-  if (!fs.existsSync(gitconfigPath)) {
-    return null;
-  }
+  // Always emit a sanitized .gitconfig, even when the host has none. The
+  // container ~/.gitconfig is a symlink into the bound shell-config directory;
+  // a missing file would leave the symlink dangling and drop the default
+  // safe.directory entries the image relies on.
+  const sourceContent = fs.existsSync(gitconfigPath)
+    ? fs.readFileSync(gitconfigPath, 'utf8')
+    : '';
 
   fs.mkdirSync(hostConfigDir, { recursive: true });
   const targetPath = path.join(hostConfigDir, '.gitconfig');
-  const gitconfig = sanitizeGitConfig(fs.readFileSync(gitconfigPath, 'utf8'), home, {
-    stripGpg,
-    repoRoot
-  });
+  const gitconfig = sanitizeGitConfig(sourceContent, home, { stripGpg, repoRoot });
   fs.writeFileSync(targetPath, gitconfig, 'utf8');
   return targetPath;
+}
+
+// Files inside the host shell-config bind that need to be exposed in $HOME.
+// Keep in sync with the symlink block in lib/sandbox/runtimes/ai-tools.dockerfile.
+const SHELL_CONFIG_SYMLINKS = ['.gitconfig', '.gitignore_global', '.stCommitMsg', '.bash_aliases'];
+
+export function ensureShellConfigSymlinks(engine, container, execFn = execEngine) {
+  // Idempotent symlink setup. Runs against a started container so it also
+  // covers custom Dockerfiles that don't bake the symlinks into the image.
+  const script = SHELL_CONFIG_SYMLINKS
+    .map((file) => `ln -sf .host-shell-config/${file} ${CONTAINER_HOME}/${file}`)
+    .join(' && ');
+  execFn(engine, 'docker', ['exec', container, 'bash', '-lc', script], { stdio: 'ignore' });
 }
 
 export function prepareHostShellConfig({ home, project, branch, repoRoot }) {
@@ -257,17 +274,12 @@ export function prepareHostShellConfig({ home, project, branch, repoRoot }) {
   fs.rmSync(hostDir, { recursive: true, force: true });
   fs.mkdirSync(hostDir, { recursive: true });
 
-  /** @type {Array<{ hostPath: string, containerPath: string }>} */
-  const mounts = [];
-  const gitconfigPath = writeSanitizedGitconfig({
+  writeSanitizedGitconfig({
     home,
     hostConfigDir: hostDir,
     stripGpg: true,
     repoRoot
   });
-  if (gitconfigPath) {
-    mounts.push({ hostPath: gitconfigPath, containerPath: `${CONTAINER_HOME}/.gitconfig` });
-  }
 
   for (const file of ['.gitignore_global', '.stCommitMsg']) {
     const hostPath = hostJoin(home, file);
@@ -275,17 +287,17 @@ export function prepareHostShellConfig({ home, project, branch, repoRoot }) {
       continue;
     }
 
-    const targetPath = path.join(hostDir, file);
-    fs.copyFileSync(hostPath, targetPath);
-    mounts.push({ hostPath: targetPath, containerPath: `${CONTAINER_HOME}/${file}` });
+    fs.copyFileSync(hostPath, path.join(hostDir, file));
   }
 
   const aliasesPath = sandboxAliasesPath(home);
   if (fs.existsSync(aliasesPath)) {
-    const targetPath = path.join(hostDir, '.bash_aliases');
-    fs.copyFileSync(aliasesPath, targetPath);
-    mounts.push({ hostPath: targetPath, containerPath: `${CONTAINER_HOME}/.bash_aliases` });
+    fs.copyFileSync(aliasesPath, path.join(hostDir, '.bash_aliases'));
   }
+
+  // Single directory bind keeps virtiofs happy: per-file rewrites inside no
+  // longer race the bind layer like individual single-file binds do.
+  const mounts = [{ hostPath: hostDir, containerPath: CONTAINER_SHELL_CONFIG_MOUNT }];
 
   return { hostDir, mounts };
 }
@@ -1166,6 +1178,13 @@ export async function create(args) {
             effectiveConfig.imageName
           ]);
 
+          // Belt-and-suspenders: re-create the four shell-config symlinks at
+          // runtime so users with a custom `sandbox.dockerfile` (which won't
+          // include the ai-tools.dockerfile symlink fragment) still get
+          // ~/.gitconfig and friends pointing into the host bind-mount.
+          // `ln -sf` is idempotent for the default image.
+          ensureShellConfigSymlinks(engine, container);
+
           if (needsGpg) {
             message(
               cachedGpg
@@ -1275,7 +1294,7 @@ Management:
   ai sandbox rm ${branch}
 
 Sandbox aliases:
-  Edit the host aliases file to customize shortcuts mounted at ${CONTAINER_HOME}/.bash_aliases.
+  Edit the host aliases file to customize shortcuts exposed at ${CONTAINER_HOME}/.bash_aliases inside the sandbox container.
 
 Tool notes:
 ${toolHints}

--- a/lib/sandbox/runtimes/ai-tools.dockerfile
+++ b/lib/sandbox/runtimes/ai-tools.dockerfile
@@ -18,6 +18,16 @@ RUN mkdir -p /home/devuser/.local/share /home/devuser/.local/state
 
 RUN git config --global --add safe.directory /workspace
 
+# Host shell-config is bind-mounted as a directory at this path; the four files
+# inside (.gitconfig, .gitignore_global, .stCommitMsg, .bash_aliases) are exposed
+# via symlinks in $HOME. Directory binds avoid the //deleted invalidation that
+# single-file binds suffer when their source is rewritten on macOS/virtiofs.
+RUN mkdir -p /home/devuser/.host-shell-config && \
+    ln -sf .host-shell-config/.gitconfig        /home/devuser/.gitconfig && \
+    ln -sf .host-shell-config/.gitignore_global /home/devuser/.gitignore_global && \
+    ln -sf .host-shell-config/.stCommitMsg      /home/devuser/.stCommitMsg && \
+    ln -sf .host-shell-config/.bash_aliases     /home/devuser/.bash_aliases
+
 RUN echo 'export NPM_CONFIG_PREFIX=/home/devuser/.npm-global' >> /home/devuser/.bashrc && \
     echo 'export PATH="/home/devuser/.npm-global/bin:${PATH}"' >> /home/devuser/.bashrc && \
     echo 'export GIT_CONFIG_GLOBAL=/home/devuser/.gitconfig' >> /home/devuser/.bashrc && \

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -3045,6 +3045,35 @@ test("hostHasGpgKeys reports whether the host keyring is available", async () =>
   }), false);
 });
 
+test("ensureShellConfigSymlinks runs a single docker exec wiring all four $HOME entries", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const calls = [];
+  const fakeExec = (engine, cmd, args) => {
+    calls.push({ engine, cmd, args });
+    return "";
+  };
+
+  sandboxCreate.ensureShellConfigSymlinks("docker", "agent-infra-dev-demo", fakeExec);
+
+  assert.equal(calls.length, 1, "single docker exec");
+  assert.equal(calls[0].engine, "docker");
+  assert.equal(calls[0].cmd, "docker");
+  assert.deepEqual(calls[0].args.slice(0, 4), [
+    "exec",
+    "agent-infra-dev-demo",
+    "bash",
+    "-lc"
+  ]);
+  const script = calls[0].args[4];
+  for (const file of [".gitconfig", ".gitignore_global", ".stCommitMsg", ".bash_aliases"]) {
+    assert.match(
+      script,
+      new RegExp(`ln -sf \\.host-shell-config/${file.replace(".", "\\.")} /home/devuser/${file.replace(".", "\\.")}`),
+      `script wires ${file}`
+    );
+  }
+});
+
 test("prepareHostShellConfig writes sanitized config files and returns read-only mount metadata", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-host-shell-config-"));
@@ -3078,22 +3107,17 @@ test("prepareHostShellConfig writes sanitized config files and returns read-only
     );
     assert.deepEqual(prepared.mounts, [
       {
-        hostPath: path.join(prepared.hostDir, ".gitconfig"),
-        containerPath: "/home/devuser/.gitconfig"
-      },
-      {
-        hostPath: path.join(prepared.hostDir, ".gitignore_global"),
-        containerPath: "/home/devuser/.gitignore_global"
-      },
-      {
-        hostPath: path.join(prepared.hostDir, ".stCommitMsg"),
-        containerPath: "/home/devuser/.stCommitMsg"
-      },
-      {
-        hostPath: path.join(prepared.hostDir, ".bash_aliases"),
-        containerPath: "/home/devuser/.bash_aliases"
+        hostPath: prepared.hostDir,
+        containerPath: "/home/devuser/.host-shell-config"
       }
     ]);
+    for (const file of [".gitconfig", ".gitignore_global", ".stCommitMsg", ".bash_aliases"]) {
+      assert.equal(
+        fs.existsSync(path.join(prepared.hostDir, file)),
+        true,
+        `${file} present in host dir`
+      );
+    }
     assert.deepEqual(
       fs.readFileSync(path.join(prepared.hostDir, ".gitconfig"), "utf8").split("\n").filter(Boolean),
       [
@@ -3110,6 +3134,38 @@ test("prepareHostShellConfig writes sanitized config files and returns read-only
       fs.readFileSync(path.join(prepared.hostDir, ".bash_aliases"), "utf8"),
       fs.readFileSync(aliases.path, "utf8")
     );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("prepareHostShellConfig writes a minimal .gitconfig with safe.directory entries when the host has none", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-host-shell-config-no-gitconfig-"));
+
+  try {
+    // Intentionally do NOT create tmpDir/.gitconfig — simulate a host without one.
+    sandboxCreate.ensureSandboxAliasesFile(tmpDir);
+
+    const prepared = sandboxCreate.prepareHostShellConfig({
+      home: tmpDir,
+      project: "demo",
+      branch: "feature/demo",
+      repoRoot: "/repo"
+    });
+
+    const gitconfigPath = path.join(prepared.hostDir, ".gitconfig");
+    assert.equal(
+      fs.existsSync(gitconfigPath),
+      true,
+      "sandbox .gitconfig is produced even without a host .gitconfig"
+    );
+    const lines = fs.readFileSync(gitconfigPath, "utf8").split("\n").filter(Boolean);
+    assert.deepEqual(lines, [
+      "[safe]",
+      "\tdirectory = /workspace",
+      "\tdirectory = /repo"
+    ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -3134,10 +3190,6 @@ test("prepareHostShellConfig removes stale files from the previous host config s
     });
 
     assert.equal(fs.existsSync(path.join(prepared.hostDir, ".stCommitMsg")), false);
-    assert.equal(
-      prepared.mounts.some(({ hostPath }) => hostPath.endsWith(".stCommitMsg")),
-      false
-    );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #304

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix — 修复 macOS / OrbStack 下 sandbox 容器长跑后 `.gitconfig` bind 变 `//deleted` 的回归

## 📝 变更目的 / Purpose of the Change

macOS / OrbStack 上 sandbox 容器长跑（3 小时以上）后，`/proc/self/mountinfo` 中 `.gitconfig`
的 bind 源会被标成 `//deleted`，容器内 `ls /home/devuser/.gitconfig` 报 *No such file*。
v0.5.9 brew 包不复现，HEAD（v0.5.10-alpha.0）复现。

经过 250+ 次脚本级密集探针 + 50 次 reconcile 驱动 exec 的复现尝试，**bug 非确定性触发**，
无法在分钟级稳定复现，但根因机制清晰：

> macOS + OrbStack virtiofs 下，单文件 bind 在源文件被反复修改（in-place 写、邻近文件
> 原子重写等）后，会非确定性地积累 `//deleted` 失效。

本 PR 采用**结构性修复**（plan-task 中标记的 A2 方案），从挂载结构上消除"单文件 bind 在
virtiofs 上的脆弱面"，**不依赖能否复现具体回归提交**。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/commands/create.js` — `prepareHostShellConfig` 把 4 个单文件 bind（`.gitconfig` / `.gitignore_global` / `.stCommitMsg` / `.bash_aliases`）合并成**单个目录 bind**：host 侧 `~/.agent-infra/config/<project>/<branch>/` → 容器内 `/home/devuser/.host-shell-config`。新增 `CONTAINER_SHELL_CONFIG_MOUNT` 常量与 `ensureShellConfigSymlinks` 运行时兜底函数。`writeSanitizedGitconfig` 现在即使 host 无 `~/.gitconfig` 也会落地最小版（含 `safe.directory` 条目）。USAGE 帮助文案同步更新。
- `lib/sandbox/runtimes/ai-tools.dockerfile` — 新增镜像层 `mkdir /home/devuser/.host-shell-config` + 4 个相对 symlink（`.gitconfig` → `.host-shell-config/.gitconfig` 等），容器内 `$HOME` 下 4 个文件名保持不变。
- `tests/cli/sandbox.test.js` — `prepareHostShellConfig` 两个旧测试断言更新（单条目录 mount + 4 个文件落地）；新增两个测试：`ensureShellConfigSymlinks runs a single docker exec wiring all four $HOME entries`、`prepareHostShellConfig writes a minimal .gitconfig with safe.directory entries when the host has none`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/sandbox.test.js` — sandbox 全套通过（182 tests / 181 pass / 1 skipped）
2. `npm run test:core` — 322 tests / 321 pass / 1 skipped（pre-commit hook 已跑过）
3. `npm test`（full）— 438 tests / 437 pass / 1 skipped
4. 端到端冒烟（macOS + OrbStack）：
   - `ai sandbox create` 后 `mountinfo` 显示单条目录 bind：`... /Users/.../config/agent-infra/<branch> /home/devuser/.host-shell-config ro,relatime - virtiofs mac rw`
   - 容器内 `ls -la ~/.gitconfig ~/.bash_aliases ~/.gitignore_global ~/.stCommitMsg` 全部是 `lrwxrwxrwx → .host-shell-config/...`
   - `git config --global --list` 读取到 host 同步的配置
   - 200 次密集 in-place 重写 `.gitconfig` 源后，`mountinfo` 始终干净，**无 `//deleted`**

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（+2 新增覆盖修复点）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（macOS + OrbStack 端到端冒烟）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed（Dockerfile symlink 块、`ensureShellConfigSymlinks` 函数、`writeSanitizedGitconfig` 改动均有 why 注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（`ensureShellConfigSymlinks` 通过注入 `execFn` 单测）
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（CLI USAGE 帮助文案已对齐新结构）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / 见下方"破坏性变更说明"
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

### 破坏性变更说明 / Breaking Changes

- **现有运行中的 sandbox 容器**：仍然挂着旧的 4 个单文件 bind，本次改动**不会自动迁移**。用户需 `ai sandbox rebuild` 或下次 `ai sandbox create` 才能切换到新结构。旧容器**不引入新 bug**（仅保留原状），是可接受的。
- **镜像签名变更**：`ai-tools.dockerfile` 改动会改变 `dockerfileSignature`，触发用户首次 `sandbox create` 时**自动 rebuild**（~1–2 min）。这是预期行为。
- **自定义 `sandbox.dockerfile`**：codex review Round 1 提的 Major 问题，本 PR 在 `docker run` 后增加运行时 `ensureShellConfigSymlinks` 兼容层，**自定义 Dockerfile 用户也能正确获得 4 个 symlink，零迁移成本**。

### 未覆盖范围 / Out of Scope

- 容器内还有另外 4 个**单文件 bind**（claude/codex/opencode/gemini 的 credentials/auth 文件，来自 `lib/sandbox/tools.js` 的 `hostLiveMounts`），理论上有同样的 virtiofs 脆弱面，但实测未观察到 `//deleted`，且 host 路径分散（部分直接在 `~/` 下），无法用同一目录 bind 统一处理。**留作后续 issue**，本 PR 保持聚焦。

---

**审查者注意事项 / Reviewer Notes:**

1. **Dockerfile 相对 symlink 写法**（`ai-tools.dockerfile:26-29`）—— 相对 `/home/devuser` 解析；故意不写绝对路径以便 image 移植时更稳健
2. **`prepareHostShellConfig` 的 `mounts` 数组从 4 项变 1 项** —— 已确认仓库内只有 `create.js:1128` 和单测调用，全部更新到位
3. **`writeSanitizedGitconfig` 现在永远落地**（即使 host 没 `~/.gitconfig`） —— Blocker 修复，保留容器内 `~/.gitconfig` symlink 不悬空 + 镜像默认 `safe.directory` 配置
4. **`ensureShellConfigSymlinks` 运行时层** —— `ln -sf` 幂等，默认 Dockerfile 重复执行是 no-op，自定义 Dockerfile 凭此获得兼容
5. 完整需求/设计/审查/修复全程跟踪：见 Issue #304 评论区的 `task` / `analysis` / `plan` / `implementation` / `review` / `refinement` / `review-r2` 评论

Generated with AI assistance.
