### PR TITLE
refactor(sandbox): sandbox refresh 在 SSH 场景下的友好降级与 token 脱敏

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 `ai sandbox exec` and `ai sandbox refresh` reconcile Claude Code credentials in both directions across the host credential store and every sandbox project copy under `~/.agent-infra/credentials/*`. When a long-running sandbox refreshes OAuth tokens first, the next entry or refresh command writes the freshest valid copy back to the host Keychain or `~/.claude/.credentials.json`; when the host is fresher, it updates the project copies. If every copy is stale, `ai sandbox refresh` probes `claude /status` and asks you to log in only when the probe cannot recover credentials.
 
-On macOS over SSH, the login keychain may be locked and reject non-interactive reads or writes. Unlock it with `security unlock-keychain ~/Library/Keychains/login.keychain-db`, or bypass the keychain by setting `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` to an absolute credentials JSON path such as `$HOME/.claude/.credentials.json`; sandbox create, exec, and refresh will then use that file instead of the keychain.
-
 ### Host-sandbox file exchange
 
 `ai sandbox create` mounts two writable directories for dropping files between
@@ -277,6 +275,34 @@ agent-infra runs on macOS and Linux. The CLI itself only needs Node.js (>=22); c
 | Docker Desktop | warned | warned | warned | manual | Resources must be set in Docker Desktop GUI (Settings -> Resources). |
 
 `vm.memory` and `--memory` values are expressed in GiB.
+
+#### SSH / locked keychain
+
+On macOS over SSH, the login keychain may be locked and reject non-interactive reads or writes with `errSecInteractionNotAllowed`. You can unlock it on the host and re-run `ai sandbox refresh`:
+
+```bash
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+ai sandbox refresh
+```
+
+For long-lived SSH sessions or CI, bypass the keychain with `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE`. macOS stores Claude Code credentials in the keychain by default, so seed the override file once from a session where the keychain is unlocked:
+
+```bash
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+umask 077 && mkdir -p "$HOME/.agent-infra" && \
+  security find-generic-password -s "Claude Code-credentials" -w \
+  > "$HOME/.agent-infra/claude-credentials.json"
+chmod 600 "$HOME/.agent-infra/claude-credentials.json"
+```
+
+Then on the SSH / CI side:
+
+```bash
+export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE="$HOME/.agent-infra/claude-credentials.json"
+ai sandbox refresh
+```
+
+After that, sandbox create, exec, and refresh use the file instead of the keychain for Claude Code credential reads and writes.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 `ai sandbox exec` and `ai sandbox refresh` reconcile Claude Code credentials in both directions across the host credential store and every sandbox project copy under `~/.agent-infra/credentials/*`. When a long-running sandbox refreshes OAuth tokens first, the next entry or refresh command writes the freshest valid copy back to the host Keychain or `~/.claude/.credentials.json`; when the host is fresher, it updates the project copies. If every copy is stale, `ai sandbox refresh` probes `claude /status` and asks you to log in only when the probe cannot recover credentials.
 
+On macOS over SSH, the login keychain may be locked and reject non-interactive reads or writes. Unlock it with `security unlock-keychain ~/Library/Keychains/login.keychain-db`, or bypass the keychain by setting `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` to an absolute credentials JSON path such as `$HOME/.claude/.credentials.json`; sandbox create, exec, and refresh will then use that file instead of the keychain.
+
 ### Host-sandbox file exchange
 
 `ai sandbox create` mounts two writable directories for dropping files between

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,8 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 `ai sandbox exec` 和 `ai sandbox refresh` 会在宿主机凭证存储与 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本之间做双向 reconcile。长时间运行的沙箱如果先刷新了 OAuth token，下一次进入或刷新命令会把最新有效副本回写到宿主 Keychain 或 `~/.claude/.credentials.json`；宿主机更新时也会继续覆盖项目副本。如果所有副本都已失效，`ai sandbox refresh` 会尝试 `claude /status` 探活，只有探活无法恢复时才提示重新登录。
 
+在 macOS 上通过 SSH 使用时，login keychain 可能处于锁定状态并拒绝非交互式读写。可以运行 `security unlock-keychain ~/Library/Keychains/login.keychain-db` 解锁，或把 `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` 设置为绝对路径形式的凭据 JSON 文件（例如 `$HOME/.claude/.credentials.json`）；之后 sandbox create、exec、refresh 都会使用该文件而不是 keychain。
+
 ### 宿主-沙箱文件交换
 
 `ai sandbox create` 会自动挂载两个可读写目录，方便宿主与容器之间互相 drop 文件，不污染 git 工作树：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,8 +203,6 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 `ai sandbox exec` 和 `ai sandbox refresh` 会在宿主机凭证存储与 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本之间做双向 reconcile。长时间运行的沙箱如果先刷新了 OAuth token，下一次进入或刷新命令会把最新有效副本回写到宿主 Keychain 或 `~/.claude/.credentials.json`；宿主机更新时也会继续覆盖项目副本。如果所有副本都已失效，`ai sandbox refresh` 会尝试 `claude /status` 探活，只有探活无法恢复时才提示重新登录。
 
-在 macOS 上通过 SSH 使用时，login keychain 可能处于锁定状态并拒绝非交互式读写。可以运行 `security unlock-keychain ~/Library/Keychains/login.keychain-db` 解锁，或把 `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` 设置为绝对路径形式的凭据 JSON 文件（例如 `$HOME/.claude/.credentials.json`）；之后 sandbox create、exec、refresh 都会使用该文件而不是 keychain。
-
 ### 宿主-沙箱文件交换
 
 `ai sandbox create` 会自动挂载两个可读写目录，方便宿主与容器之间互相 drop 文件，不污染 git 工作树：
@@ -270,6 +268,34 @@ agent-infra 支持 macOS 和 Linux。CLI 本身只需要 Node.js (>=22)；容器
 | Docker Desktop | 警告 | 警告 | 警告 | 手动 | 资源必须在 Docker Desktop GUI（Settings -> Resources）中设置。 |
 
 `vm.memory` 和 `--memory` 的单位是 GiB。
+
+#### SSH / 锁定的 keychain
+
+在 macOS 上通过 SSH 使用时，login keychain 可能处于锁定状态，并以 `errSecInteractionNotAllowed` 拒绝非交互式读写。你可以在宿主机上解锁后重新运行 `ai sandbox refresh`：
+
+```bash
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+ai sandbox refresh
+```
+
+对于长期 SSH 会话或 CI，可以通过 `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` 绕过 keychain。macOS 默认把 Claude Code 凭据存进 keychain，所以需要先在 keychain 已解锁的会话中 seed 一次 override 文件：
+
+```bash
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+umask 077 && mkdir -p "$HOME/.agent-infra" && \
+  security find-generic-password -s "Claude Code-credentials" -w \
+  > "$HOME/.agent-infra/claude-credentials.json"
+chmod 600 "$HOME/.agent-infra/claude-credentials.json"
+```
+
+之后在 SSH / CI 侧设置：
+
+```bash
+export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE="$HOME/.agent-infra/claude-credentials.json"
+ai sandbox refresh
+```
+
+此后 sandbox create、exec、refresh 读取和写入 Claude Code 凭据时都会使用该文件，而不是 keychain。
 
 ### Linux
 

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
@@ -38,7 +39,11 @@ import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../to
 import { hostJoin, toEnginePath, volumeArg } from '../engines/wsl2-paths.js';
 import { validateSelinuxDisableEnv } from '../engines/selinux.js';
 import { resolveBuildUid } from '../engines/native.js';
-import { assertClaudeCredentialsAvailable } from '../credentials.js';
+import {
+  assertClaudeCredentialsAvailable,
+  redactCommandError,
+  validateClaudeCredentialsEnvOverride
+} from '../credentials.js';
 
 const OPENCODE_YOLO_PERMISSION = '{"*":"allow","read":"allow","bash":"allow","edit":"allow","webfetch":"allow","external_directory":"allow","doom_loop":"allow"}';
 const SANDBOX_ALIAS_BLOCK_BEGIN = '# >>> agent-infra managed aliases >>>';
@@ -511,15 +516,66 @@ export function syncGpgKeys(
   return true;
 }
 
-export function buildContainerEnvArgs(resolvedTools, engine = detectEngine(), runSafeEngineFn = runSafeEngine) {
-  const envArgs = resolvedTools.flatMap(({ tool }) =>
-    Object.entries(tool.envVars ?? {}).flatMap(([key, value]) => ['-e', `${key}=${value}`])
-  );
+// Docker `--env-file` parsing has no quoting/escaping support and treats
+// leading '#' as a comment. Newlines split entries, so reject them outright.
+// Other shell metacharacters are safe because the values are not expanded.
+function formatEnvFileEntry(key, value) {
+  if (String(key).includes('\n') || String(value).includes('\n')) {
+    throw new Error(`Container environment variable ${key} must not contain newlines`);
+  }
+  return `${key}=${value}`;
+}
+
+export function buildContainerEnvFile(
+  resolvedTools,
+  engine = detectEngine(),
+  runSafeEngineFn = runSafeEngine,
+  options = {}
+) {
+  const {
+    mkdtempFn = fs.mkdtempSync,
+    writeFileFn = fs.writeFileSync,
+    chmodFn = fs.chmodSync,
+    rmFn = fs.rmSync,
+    tmpDir = os.tmpdir()
+  } = options;
+
+  const entries = resolvedTools.flatMap(({ tool }) => Object.entries(tool.envVars ?? {}));
   const ghToken = runSafeEngineFn(engine, 'gh', ['auth', 'token']);
   if (ghToken) {
-    envArgs.push('-e', `GH_TOKEN=${ghToken}`);
+    entries.push(['GH_TOKEN', ghToken]);
   }
-  return envArgs;
+
+  if (entries.length === 0) {
+    return { dockerArgs: [], cleanup: () => {} };
+  }
+
+  const dir = mkdtempFn(path.join(tmpDir, 'agent-infra-env-'));
+  try {
+    chmodFn(dir, 0o700);
+    const envPath = path.join(dir, 'env');
+    const content = `${entries.map(([key, value]) => formatEnvFileEntry(key, value)).join('\n')}\n`;
+    writeFileFn(envPath, content, { mode: 0o600 });
+    chmodFn(envPath, 0o600);
+
+    return {
+      dockerArgs: ['--env-file', toEnginePath(engine, envPath)],
+      cleanup: () => {
+        try {
+          rmFn(dir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup only.
+        }
+      }
+    };
+  } catch (error) {
+    try {
+      rmFn(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
+    throw error;
+  }
 }
 
 export function assertBranchAvailable(
@@ -814,7 +870,7 @@ export function ensureSandboxAliasesFile(home) {
 
 export function commandErrorMessage(error) {
   const stderr = error?.stderr?.toString().trim();
-  return stderr || error?.message || 'Command failed';
+  return redactCommandError(stderr || error?.message || 'Command failed');
 }
 
 function runTaskCommand(cmd, args, opts = {}) {
@@ -892,6 +948,7 @@ export async function create(args) {
   }
 
   validateSelinuxDisableEnv();
+  validateClaudeCredentialsEnvOverride();
 
   const config = loadConfig();
   const [branchOrTaskId, base] = positionals;
@@ -1092,91 +1149,96 @@ export async function create(args) {
               signingKey
             )
             : null;
-          const envArgs = buildContainerEnvArgs(resolvedTools, engine);
-          const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
-          if (claudeCodeEntry) {
-            ensureClaudeOnboarding(claudeCodeEntry.dir, effectiveConfig.home);
-            ensureClaudeSettings(claudeCodeEntry.dir, effectiveConfig.home);
-            // Credential availability is asserted up-front in create() so we
-            // know the shared credentials file already exists at this point.
-          }
-          const codexEntry = resolvedTools.find(({ tool }) => tool.id === 'codex');
-          if (codexEntry) {
-            ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home);
-            ensureCodexWorkspaceTrust(codexEntry.dir);
-          }
-          const geminiEntry = resolvedTools.find(({ tool }) => tool.id === 'gemini-cli');
-          if (geminiEntry) {
-            ensureGeminiWorkspaceTrust(geminiEntry.dir);
-          }
-          const opencodeEntry = resolvedTools.find(({ tool }) => tool.id === 'opencode');
-          if (opencodeEntry) {
-            // The TUI reads <toolDir>/opencode.json via OPENCODE_CONFIG pinned in tools.js.
-            ensureOpenCodeModelInheritance(opencodeEntry.dir, effectiveConfig.home);
-          }
-          const toolVolumes = resolvedTools.flatMap(({ tool, dir }) => [
-            '-v',
-            volumeArg(engine, dir, tool.containerMount)
-          ]);
-          const workspaceDir = path.join(effectiveConfig.repoRoot, '.agents', 'workspace');
-          const hostShellConfig = prepareHostShellConfig({
-            home: effectiveConfig.home,
-            project: effectiveConfig.project,
-            branch,
-            repoRoot: effectiveConfig.repoRoot
-          });
-          const shellConfigVolumes = hostShellConfig.mounts.flatMap(({ hostPath, containerPath }) => [
-            '-v',
-            volumeArg(engine, hostPath, containerPath, ':ro')
-          ]);
-          const liveMountVolumes = resolvedTools.flatMap(({ tool }) =>
-            (tool.hostLiveMounts ?? [])
-              .filter(({ hostPath }) => fs.existsSync(hostPath))
-              .flatMap(({ hostPath, containerSubpath }) => [
-                '-v',
-                volumeArg(engine, hostPath, path.posix.join(tool.containerMount, containerSubpath))
-              ])
-          );
+          const envFile = buildContainerEnvFile(resolvedTools, engine);
+          let hostShellConfig;
+          try {
+            const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
+            if (claudeCodeEntry) {
+              ensureClaudeOnboarding(claudeCodeEntry.dir, effectiveConfig.home);
+              ensureClaudeSettings(claudeCodeEntry.dir, effectiveConfig.home);
+              // Credential availability is asserted up-front in create() so we
+              // know the shared credentials file already exists at this point.
+            }
+            const codexEntry = resolvedTools.find(({ tool }) => tool.id === 'codex');
+            if (codexEntry) {
+              ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home);
+              ensureCodexWorkspaceTrust(codexEntry.dir);
+            }
+            const geminiEntry = resolvedTools.find(({ tool }) => tool.id === 'gemini-cli');
+            if (geminiEntry) {
+              ensureGeminiWorkspaceTrust(geminiEntry.dir);
+            }
+            const opencodeEntry = resolvedTools.find(({ tool }) => tool.id === 'opencode');
+            if (opencodeEntry) {
+              // The TUI reads <toolDir>/opencode.json via OPENCODE_CONFIG pinned in tools.js.
+              ensureOpenCodeModelInheritance(opencodeEntry.dir, effectiveConfig.home);
+            }
+            const toolVolumes = resolvedTools.flatMap(({ tool, dir }) => [
+              '-v',
+              volumeArg(engine, dir, tool.containerMount)
+            ]);
+            const workspaceDir = path.join(effectiveConfig.repoRoot, '.agents', 'workspace');
+            hostShellConfig = prepareHostShellConfig({
+              home: effectiveConfig.home,
+              project: effectiveConfig.project,
+              branch,
+              repoRoot: effectiveConfig.repoRoot
+            });
+            const shellConfigVolumes = hostShellConfig.mounts.flatMap(({ hostPath, containerPath }) => [
+              '-v',
+              volumeArg(engine, hostPath, containerPath, ':ro')
+            ]);
+            const liveMountVolumes = resolvedTools.flatMap(({ tool }) =>
+              (tool.hostLiveMounts ?? [])
+                .filter(({ hostPath }) => fs.existsSync(hostPath))
+                .flatMap(({ hostPath, containerSubpath }) => [
+                  '-v',
+                  volumeArg(engine, hostPath, path.posix.join(tool.containerMount, containerSubpath))
+                ])
+            );
 
-          fs.mkdirSync(workspaceDir, { recursive: true });
-          fs.mkdirSync(shareCommon, { recursive: true });
-          fs.mkdirSync(shareBranch, { recursive: true });
+            fs.mkdirSync(workspaceDir, { recursive: true });
+            fs.mkdirSync(shareCommon, { recursive: true });
+            fs.mkdirSync(shareBranch, { recursive: true });
 
-          runEngineTaskCommand(engine, 'docker', [
-            'run',
-            '-d',
-            '--name',
-            container,
-            '--hostname',
-            `${effectiveConfig.project}-sandbox`,
-            '--label',
-            sandboxLabel(effectiveConfig),
-            '--label',
-            `${sandboxBranchLabel(effectiveConfig)}=${branch}`,
-            '-v',
-            volumeArg(engine, worktree, '/workspace'),
-            '-v',
-            volumeArg(engine, workspaceDir, '/workspace/.agents/workspace'),
-            '-v',
-            volumeArg(engine, shareCommon, '/share/common'),
-            '-v',
-            volumeArg(engine, shareBranch, '/share/branch'),
-            '-v',
-            volumeArg(
-              engine,
-              path.join(effectiveConfig.repoRoot, '.git'),
-              `${toEnginePath(engine, effectiveConfig.repoRoot)}/.git`
-            ),
-            '-v',
-            volumeArg(engine, hostJoin(effectiveConfig.home, '.ssh'), '/home/devuser/.ssh', ':ro'),
-            ...toolVolumes,
-            ...liveMountVolumes,
-            ...shellConfigVolumes,
-            ...envArgs,
-            '-w',
-            '/workspace',
-            effectiveConfig.imageName
-          ]);
+            runEngineTaskCommand(engine, 'docker', [
+              'run',
+              '-d',
+              '--name',
+              container,
+              '--hostname',
+              `${effectiveConfig.project}-sandbox`,
+              '--label',
+              sandboxLabel(effectiveConfig),
+              '--label',
+              `${sandboxBranchLabel(effectiveConfig)}=${branch}`,
+              '-v',
+              volumeArg(engine, worktree, '/workspace'),
+              '-v',
+              volumeArg(engine, workspaceDir, '/workspace/.agents/workspace'),
+              '-v',
+              volumeArg(engine, shareCommon, '/share/common'),
+              '-v',
+              volumeArg(engine, shareBranch, '/share/branch'),
+              '-v',
+              volumeArg(
+                engine,
+                path.join(effectiveConfig.repoRoot, '.git'),
+                `${toEnginePath(engine, effectiveConfig.repoRoot)}/.git`
+              ),
+              '-v',
+              volumeArg(engine, hostJoin(effectiveConfig.home, '.ssh'), '/home/devuser/.ssh', ':ro'),
+              ...toolVolumes,
+              ...liveMountVolumes,
+              ...shellConfigVolumes,
+              ...envFile.dockerArgs,
+              '-w',
+              '/workspace',
+              effectiveConfig.imageName
+            ]);
+          } finally {
+            envFile.cleanup();
+          }
 
           // Belt-and-suspenders: re-create the four shell-config symlinks at
           // runtime so users with a custom `sandbox.dockerfile` (which won't

--- a/lib/sandbox/commands/enter.js
+++ b/lib/sandbox/commands/enter.js
@@ -1,7 +1,13 @@
 import { loadConfig } from '../config.js';
 import { assertValidBranchName, containerNameCandidates } from '../constants.js';
 import { detectEngine } from '../engine.js';
-import { formatRemaining, reconcileClaudeCredentials } from '../credentials.js';
+import {
+  formatCredentialWarnings,
+  formatRemaining,
+  reconcileClaudeCredentials,
+  redactCommandError,
+  validateClaudeCredentialsEnvOverride
+} from '../credentials.js';
 import { runInteractiveEngine, runSafeEngine } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
 
@@ -31,6 +37,30 @@ export function terminalEnvFlags(env = process.env) {
   return flags;
 }
 
+export function formatCredentialSyncStatus(result, isTTY = process.stderr.isTTY) {
+  if (result.status === 'STALE_ACCESS') {
+    return 'Warning: Claude Code credentials on host appear stale. Run "ai sandbox refresh" or "claude /login" to renew.\n';
+  }
+  if (result.status === 'MISSING') {
+    return 'Warning: Claude Code credentials missing on host. Run "claude /login" to authenticate.\n';
+  }
+  if (result.status === 'KEYCHAIN_WRITE_FAILED') {
+    return `Warning: A sandbox refresh produced newer credentials but host Keychain write failed (${formatCredentialWarnings(result.warnings)}). Run "ai sandbox refresh" again or "claude /status" on the host to retry.\n`;
+  }
+  if (result.status === 'KEYCHAIN_LOCKED' || result.status === 'KEYCHAIN_ERROR') {
+    return 'Warning: Host keychain is unavailable; Claude credential sync skipped. Run "ai sandbox refresh" for details.\n';
+  }
+  if (result.status === 'OK' && result.authoritative !== 'host') {
+    const message = `Synced Claude Code credentials from sandbox refresh back to host (expires in ${formatRemaining(result.expiresAt)})`;
+    return isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`;
+  }
+  if (result.status === 'OK' && result.filesWritten.length > 0) {
+    const message = `Synced Claude Code credentials from host Keychain (expires in ${formatRemaining(result.expiresAt)})`;
+    return isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`;
+  }
+  return null;
+}
+
 export function enter(args) {
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(`${USAGE}\n`);
@@ -41,6 +71,7 @@ export function enter(args) {
   }
 
   const config = loadConfig();
+  validateClaudeCredentialsEnvOverride();
   const engine = detectEngine();
   const [branchOrTaskId, ...cmd] = args;
   const branch = resolveTaskBranch(branchOrTaskId, config.repoRoot);
@@ -56,25 +87,12 @@ export function enter(args) {
     try {
       // Scan all projects so a refresh from a neighbouring sandbox can still flow back to the host.
       const result = reconcileClaudeCredentials(config.home);
-      if (result.status === 'STALE_ACCESS') {
-        process.stderr.write(
-          'Warning: Claude Code credentials on host appear stale. Run "ai sandbox refresh" or "claude /login" to renew.\n'
-        );
-      } else if (result.status === 'MISSING') {
-        process.stderr.write('Warning: Claude Code credentials missing on host. Run "claude /login" to authenticate.\n');
-      } else if (result.status === 'KEYCHAIN_WRITE_FAILED') {
-        process.stderr.write(
-          `Warning: A sandbox refresh produced newer credentials but host Keychain write failed (${result.warnings.join('; ')}). Run "ai sandbox refresh" again or "claude /status" on the host to retry.\n`
-        );
-      } else if (result.status === 'OK' && result.authoritative !== 'host') {
-        const message = `Synced Claude Code credentials from sandbox refresh back to host (expires in ${formatRemaining(result.expiresAt)})`;
-        process.stderr.write(process.stderr.isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`);
-      } else if (result.status === 'OK' && result.filesWritten.length > 0) {
-        const message = `Synced Claude Code credentials from host Keychain (expires in ${formatRemaining(result.expiresAt)})`;
-        process.stderr.write(process.stderr.isTTY ? `\x1b[2m${message}\x1b[0m\n` : `${message}\n`);
+      const message = formatCredentialSyncStatus(result);
+      if (message) {
+        process.stderr.write(message);
       }
     } catch (error) {
-      process.stderr.write(`Warning: Failed to sync Claude Code credentials: ${error.message}\n`);
+      process.stderr.write(`Warning: Failed to sync Claude Code credentials: ${redactCommandError(error?.message ?? 'unknown error')}\n`);
     }
   }
 

--- a/lib/sandbox/commands/refresh.js
+++ b/lib/sandbox/commands/refresh.js
@@ -1,9 +1,13 @@
 import { homedir } from 'node:os';
 import { parseArgs } from 'node:util';
 import {
+  buildLockedGuidance,
   discoverProjects,
+  formatCredentialWarnings,
   formatRemaining,
-  reconcileClaudeCredentials
+  reconcileClaudeCredentials,
+  redactCommandError,
+  validateClaudeCredentialsEnvOverride
 } from '../credentials.js';
 import { runProbe } from '../shell.js';
 
@@ -44,6 +48,7 @@ export async function refresh(args, deps = {}) {
   if (positionals.length > 0) {
     throw new Error(USAGE);
   }
+  validateClaudeCredentialsEnvOverride();
 
   const home = homedir();
   if (!home) {
@@ -62,7 +67,7 @@ export async function refresh(args, deps = {}) {
     writeStdout('Host credentials appear stale; probing claude /status to trigger refresh...\n');
     const probe = probeClaudeStatus(spawnFn);
     if (!probe.ok) {
-      writeStderr(`Probe failed: ${probe.stderr || probe.error || 'unknown error'}\n`);
+      writeStderr(`Probe failed: ${redactCommandError(probe.stderr || probe.error || 'unknown error')}\n`);
       writeStderr('Run "claude /login" on the host to renew credentials.\n');
       return 1;
     }
@@ -76,8 +81,19 @@ export async function refresh(args, deps = {}) {
     return 1;
   }
 
+  if (result.status === 'KEYCHAIN_LOCKED') {
+    writeStderr(`${buildLockedGuidance()}\n`);
+    return 1;
+  }
+
+  if (result.status === 'KEYCHAIN_ERROR') {
+    writeStderr(`Host keychain error: ${redactCommandError(result.detail || 'unknown error')}\n`);
+    writeStderr(`${buildLockedGuidance()}\n`);
+    return 1;
+  }
+
   if (result.status === 'KEYCHAIN_WRITE_FAILED') {
-    writeStderr(`[host] keychain write failed: ${result.warnings.join('; ') || 'unknown error'}\n`);
+    writeStderr(`[host] keychain write failed: ${formatCredentialWarnings(result.warnings) || 'unknown error'}\n`);
     return 1;
   }
 

--- a/lib/sandbox/credentials.js
+++ b/lib/sandbox/credentials.js
@@ -4,6 +4,102 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { hostJoin } from './engines/wsl2-paths.js';
 
+const LOCKED_PATTERN = /errSecInteractionNotAllowed|User interaction is not allowed/i;
+const NOT_FOUND_PATTERN = /errSecItemNotFound|specified item could not be found/i;
+const REDACTION_PATTERNS = [
+  { pattern: /\{[^{}]*"claudeAiOauth"[\s\S]*?\}\s*\}/g, replacement: '[REDACTED credentials blob]' },
+  { pattern: /sk-ant-[A-Za-z0-9_-]{20,}/g, replacement: '[REDACTED claude token]' },
+  { pattern: /gh[psoru]_[A-Za-z0-9]{30,}/g, replacement: '[REDACTED github token]' },
+  { pattern: /Bearer\s+[A-Za-z0-9._~+/=-]{20,}/gi, replacement: 'Bearer [REDACTED]' }
+];
+
+export function redactCommandError(text) {
+  if (!text || typeof text !== 'string') {
+    return '';
+  }
+
+  return REDACTION_PATTERNS.reduce(
+    (result, { pattern, replacement }) => result.replace(pattern, replacement),
+    text
+  );
+}
+
+export const redactSecurityOutput = redactCommandError;
+
+function extractStderrSafely(error) {
+  const stderr = error?.stderr;
+  if (Buffer.isBuffer(stderr)) {
+    return stderr.toString('utf8');
+  }
+  if (typeof stderr === 'string') {
+    return stderr;
+  }
+  return '';
+}
+
+function classifySecurityFailure(text) {
+  if (LOCKED_PATTERN.test(text)) {
+    return 'LOCKED';
+  }
+  if (NOT_FOUND_PATTERN.test(text)) {
+    return 'NOT_FOUND';
+  }
+  return 'OTHER';
+}
+
+function runSecurity(args, options = {}, execFn = execFileSync) {
+  try {
+    const stdout = execFn('security', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...options
+    });
+    const text = typeof stdout === 'string' ? stdout : (stdout?.toString?.('utf8') ?? '');
+    return { ok: true, stdout: text, stderr: '', classification: 'OK' };
+  } catch (error) {
+    const stderr = redactCommandError(extractStderrSafely(error));
+    return {
+      ok: false,
+      stdout: '',
+      stderr,
+      classification: classifySecurityFailure(stderr)
+    };
+  }
+}
+
+export function buildLockedGuidance() {
+  return [
+    'macOS keychain is locked (errSecInteractionNotAllowed).',
+    'Options to recover:',
+    '  1. Unlock the keychain on the host:',
+    '       security unlock-keychain ~/Library/Keychains/login.keychain-db',
+    '     Then re-run "ai sandbox refresh".',
+    '  2. Bypass the keychain via an environment variable (recommended for SSH / CI):',
+    '       export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE="$HOME/.claude/.credentials.json"',
+    '     Then re-run "ai sandbox refresh". Subsequent reads/writes will use the file instead of the keychain.'
+  ].join('\n');
+}
+
+export function claudeCredentialsEnvOverride(env = process.env) {
+  const raw = env?.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE;
+  if (!raw || typeof raw !== 'string') {
+    return null;
+  }
+  return { path: raw, source: 'AGENT_INFRA_CLAUDE_CREDENTIALS_FILE' };
+}
+
+export function validateClaudeCredentialsEnvOverride(env = process.env) {
+  const raw = env?.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE;
+  if (raw === undefined || raw === '') {
+    return;
+  }
+  if (typeof raw !== 'string' || !path.isAbsolute(raw)) {
+    throw new Error(
+      'Invalid AGENT_INFRA_CLAUDE_CREDENTIALS_FILE value. Expected an absolute file path.'
+    );
+  }
+}
+
 // Reconcile treats the freshest valid endpoint as authoritative so sandbox
 // token rotations can flow back to the host credential store.
 function validateClaudeCredentialsBlob(raw, blob = null) {
@@ -48,28 +144,41 @@ export function readClaudeCredentialsFile(filePath, readFn = (targetPath) => fs.
 }
 
 export function inspectClaudeKeychainStatus(home, execFn = execFileSync, options = {}) {
+  const {
+    readFn,
+    existsFn,
+    envFn = () => process.env
+  } = options;
+  const override = claudeCredentialsEnvOverride(envFn());
+  if (override) {
+    return readClaudeCredentialsFile(override.path, readFn, existsFn);
+  }
+
   if (process.platform === 'darwin') {
-    try {
-      const keychainAccount = path.basename(home);
-      const credentials = execFn('security', [
-        'find-generic-password',
-        '-a',
-        keychainAccount,
-        '-s',
-        'Claude Code-credentials',
-        '-w'
-      ], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe']
-      });
-      return validateClaudeCredentialsBlob(credentials);
-    } catch {
+    const result = runSecurity([
+      'find-generic-password',
+      '-a',
+      path.basename(home),
+      '-s',
+      'Claude Code-credentials',
+      '-w'
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    }, execFn);
+    if (result.ok) {
+      return validateClaudeCredentialsBlob(result.stdout);
+    }
+    if (result.classification === 'NOT_FOUND') {
       return { status: 'MISSING' };
     }
+    if (result.classification === 'LOCKED') {
+      return { status: 'KEYCHAIN_LOCKED', detail: result.stderr };
+    }
+    return { status: 'KEYCHAIN_ERROR', detail: result.stderr };
   }
 
   const credentialsPath = path.join(home, '.claude', '.credentials.json');
-  return readClaudeCredentialsFile(credentialsPath, options.readFn, options.existsFn);
+  return readClaudeCredentialsFile(credentialsPath, readFn, existsFn);
 }
 
 export function inspectClaudeMountFile(home, project, options = {}) {
@@ -123,48 +232,67 @@ export function writeClaudeCredentialsToHost(home, blob, options = {}) {
     writeFileFn = fs.writeFileSync,
     renameFn = fs.renameSync,
     rmFn = fs.rmSync,
-    randomFn = () => randomBytes(6).toString('hex')
+    randomFn = () => randomBytes(6).toString('hex'),
+    envFn = () => process.env
   } = options;
+  const override = claudeCredentialsEnvOverride(envFn());
+
+  if (!override && process.platform === 'darwin') {
+    const result = runSecurity([
+      'add-generic-password',
+      '-U',
+      '-a',
+      path.basename(home),
+      '-s',
+      'Claude Code-credentials',
+      '-w',
+      blob
+    ], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    }, execFn);
+    if (result.ok) {
+      return { ok: true };
+    }
+    if (result.classification === 'LOCKED') {
+      return { ok: false, classification: 'LOCKED', error: buildLockedGuidance() };
+    }
+    return {
+      ok: false,
+      classification: result.classification,
+      error: `security command failed: ${result.stderr || 'unknown error'}`
+    };
+  }
+
+  const targetPath = override?.path ?? path.join(home, '.claude', '.credentials.json');
+  const dir = path.dirname(targetPath);
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${randomFn()}`;
 
   try {
-    if (process.platform === 'darwin') {
-      execFn('security', [
-        'add-generic-password',
-        '-U',
-        '-a',
-        path.basename(home),
-        '-s',
-        'Claude Code-credentials',
-        '-w',
-        blob
-      ], {
-        stdio: ['ignore', 'ignore', 'pipe']
-      });
-      return { ok: true };
-    }
-
-    const dir = path.join(home, '.claude');
-    const targetPath = path.join(dir, '.credentials.json');
-    const tmpPath = `${targetPath}.tmp.${process.pid}.${randomFn()}`;
-
-    try {
-      mkdirFn(dir, { recursive: true, mode: 0o700 });
-      chmodFn(dir, 0o700);
-      writeFileFn(tmpPath, blob, { mode: 0o600 });
-      chmodFn(tmpPath, 0o600);
-      renameFn(tmpPath, targetPath);
-      return { ok: true };
-    } catch (error) {
-      try {
-        rmFn(tmpPath, { force: true });
-      } catch {
-        // Best-effort cleanup only.
-      }
-      return { ok: false, error: error.message };
-    }
+    mkdirFn(dir, { recursive: true, mode: 0o700 });
+    chmodFn(dir, 0o700);
+    writeFileFn(tmpPath, blob, { mode: 0o600 });
+    chmodFn(tmpPath, 0o600);
+    renameFn(tmpPath, targetPath);
+    return { ok: true };
   } catch (error) {
-    return { ok: false, error: error.message };
+    try {
+      rmFn(tmpPath, { force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
+    return {
+      ok: false,
+      classification: 'OTHER',
+      error: redactCommandError(error?.message ?? 'unknown error')
+    };
   }
+}
+
+export function formatCredentialWarnings(warnings = []) {
+  return warnings
+    .map((warning) => (typeof warning === 'string' ? warning : warning?.message))
+    .filter(Boolean)
+    .join('; ');
 }
 
 function endpointNameForFile(project) {
@@ -219,13 +347,14 @@ export function reconcileClaudeCredentials(home, options = {}) {
     discoverFn = discoverProjects,
     projects = null,
     singleProject = null,
-    inspection = null
+    inspection = null,
+    envFn = () => process.env
   } = options;
 
   const effectiveProjects = singleProject
     ? [singleProject]
     : (projects ?? discoverFn(home));
-  const hostInspection = inspection ?? inspectClaudeKeychainStatus(home, execFn, { readFn, existsFn });
+  const hostInspection = inspection ?? inspectClaudeKeychainStatus(home, execFn, { readFn, existsFn, envFn });
   const hostEndpoint = { name: 'host', ...hostInspection };
   const fileEndpoints = effectiveProjects.map((project) => ({
     name: endpointNameForFile(project),
@@ -237,14 +366,18 @@ export function reconcileClaudeCredentials(home, options = {}) {
 
   if (!authoritative) {
     const hasStaleEndpoint = endpoints.some((endpoint) => endpoint.status === 'STALE_ACCESS');
+    const unavailableStatus = ['KEYCHAIN_LOCKED', 'KEYCHAIN_ERROR'].includes(hostEndpoint.status)
+      ? hostEndpoint.status
+      : null;
     return {
-      status: hasStaleEndpoint ? 'STALE_ACCESS' : 'MISSING',
+      status: unavailableStatus ?? (hasStaleEndpoint ? 'STALE_ACCESS' : 'MISSING'),
       authoritative: null,
       expiresAt: null,
       hostWritten: false,
       filesWritten: [],
       fileErrors: [],
-      warnings: []
+      warnings: [],
+      detail: hostEndpoint.detail ?? null
     };
   }
 
@@ -255,12 +388,16 @@ export function reconcileClaudeCredentials(home, options = {}) {
   let hostWriteFailed = false;
 
   if (authoritative.name !== 'host' && shouldWriteEndpoint(authoritative, hostEndpoint)) {
-    const result = writeHostFn(home, authoritative.blob, { execFn });
+    const result = writeHostFn(home, authoritative.blob, { execFn, envFn });
     if (result?.ok) {
       hostWritten = true;
     } else {
       hostWriteFailed = true;
-      warnings.push(result?.error ?? 'unknown error');
+      warnings.push({
+        source: 'host-keychain',
+        classification: result?.classification ?? 'OTHER',
+        message: result?.error ?? 'unknown error'
+      });
     }
   }
 
@@ -328,14 +465,31 @@ export function assertClaudeCredentialsAvailable(
   project,
   resolvedTools,
   extractFn = extractClaudeCredentialsBlob,
-  writeFn = writeClaudeCredentialsFile
+  writeFn = writeClaudeCredentialsFile,
+  inspectFn = inspectClaudeKeychainStatus
 ) {
   const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
   if (!claudeCodeEntry) {
     return;
   }
 
-  const blob = extractFn(home);
+  let blob = null;
+  const hasCustomInspectFn = inspectFn !== inspectClaudeKeychainStatus;
+  const hasCustomExtractFn = extractFn !== extractClaudeCredentialsBlob;
+  if (hasCustomInspectFn || !hasCustomExtractFn) {
+    const inspection = inspectFn(home);
+    if (inspection.status === 'KEYCHAIN_LOCKED') {
+      throw new Error([
+        'Claude Code credentials are stored in the macOS keychain, but the keychain is locked.',
+        '',
+        buildLockedGuidance()
+      ].join('\n'));
+    }
+    blob = inspection.status === 'OK' ? inspection.blob : null;
+  } else {
+    blob = extractFn(home);
+  }
+
   if (!blob) {
     throw new Error([
       'Claude Code credentials not found on host.',

--- a/lib/sandbox/credentials.js
+++ b/lib/sandbox/credentials.js
@@ -75,8 +75,18 @@ export function buildLockedGuidance() {
     '       security unlock-keychain ~/Library/Keychains/login.keychain-db',
     '     Then re-run "ai sandbox refresh".',
     '  2. Bypass the keychain via an environment variable (recommended for SSH / CI):',
-    '       export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE="$HOME/.claude/.credentials.json"',
-    '     Then re-run "ai sandbox refresh". Subsequent reads/writes will use the file instead of the keychain.'
+    '     macOS stores Claude Code credentials in the keychain by default, so',
+    '     the env-override file must be seeded once before use.',
+    '     On a session where the keychain is unlocked, run:',
+    '       security unlock-keychain ~/Library/Keychains/login.keychain-db',
+    '       umask 077 && mkdir -p "$HOME/.agent-infra" && \\',
+    '         security find-generic-password -s "Claude Code-credentials" -w \\',
+    '         > "$HOME/.agent-infra/claude-credentials.json"',
+    '       chmod 600 "$HOME/.agent-infra/claude-credentials.json"',
+    '     Then on the SSH / CI side:',
+    '       export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE="$HOME/.agent-infra/claude-credentials.json"',
+    '       ai sandbox refresh',
+    '     Subsequent reads/writes use that file instead of the keychain.'
   ].join('\n');
 }
 

--- a/lib/sandbox/shell.js
+++ b/lib/sandbox/shell.js
@@ -106,9 +106,9 @@ export function runVerbose(cmd, args, opts = {}) {
 
   if (result.status !== 0) {
     if (result.signal === 'SIGTERM') {
-      throw new Error(`Command timed out after ${opts.timeout ?? DEFAULT_TIMEOUT_MS}ms: ${cmd} ${args.join(' ')}`);
+      throw new Error(`Command timed out after ${opts.timeout ?? DEFAULT_TIMEOUT_MS}ms: ${cmd}`);
     }
-    throw new Error(`Command failed with exit code ${result.status}: ${cmd} ${args.join(' ')}`);
+    throw new Error(`Command failed with exit code ${result.status}: ${cmd}`);
   }
 }
 

--- a/tests/cli/sandbox-credentials.test.js
+++ b/tests/cli/sandbox-credentials.test.js
@@ -30,6 +30,62 @@ function validBlob(overrides = {}) {
   }, null, 2);
 }
 
+function taintedSecurityError(stderr = "") {
+  const error = new Error(
+    'Command failed: security add-generic-password -w {"claudeAiOauth":{"accessToken":"sk-ant-oat01-123456789012345678901234567890","refreshToken":"sk-ant-ort01-123456789012345678901234567890"}}'
+  );
+  error.stderr = Buffer.from(stderr);
+  return error;
+}
+
+test("redactCommandError strips credential-shaped tokens", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  const redacted = credentials.redactCommandError([
+    'oauth={"claudeAiOauth":{"accessToken":"sk-ant-oat01-123456789012345678901234567890"}}',
+    "github=ghp_123456789012345678901234567890123456",
+    "installation=ghs_123456789012345678901234567890123456",
+    "header=Bearer abcdefghijklmnopqrstuvwxyz1234567890"
+  ].join("\n"));
+
+  assert.doesNotMatch(redacted, /sk-ant-oat01/);
+  assert.doesNotMatch(redacted, /claudeAiOauth/);
+  assert.doesNotMatch(redacted, /ghp_123456789012345678901234567890123456/);
+  assert.doesNotMatch(redacted, /ghs_123456789012345678901234567890123456/);
+  assert.match(redacted, /\[REDACTED credentials blob\]/);
+  assert.match(redacted, /\[REDACTED github token\]/);
+  assert.match(redacted, /Bearer \[REDACTED\]/);
+});
+
+test("redactCommandError preserves benign short lookalikes", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  assert.equal(
+    credentials.redactCommandError("image sha256:abc123 and token-ish ghp_short"),
+    "image sha256:abc123 and token-ish ghp_short"
+  );
+});
+
+test("env override helpers validate absolute credential file paths", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  assert.equal(credentials.claudeCredentialsEnvOverride({}), null);
+  assert.deepEqual(
+    credentials.claudeCredentialsEnvOverride({ AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: "/tmp/creds.json" }),
+    { path: "/tmp/creds.json", source: "AGENT_INFRA_CLAUDE_CREDENTIALS_FILE" }
+  );
+  assert.doesNotThrow(() => credentials.validateClaudeCredentialsEnvOverride({}));
+  assert.doesNotThrow(() => credentials.validateClaudeCredentialsEnvOverride({
+    AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: "/tmp/creds.json"
+  }));
+  assert.throws(
+    () => credentials.validateClaudeCredentialsEnvOverride({
+      AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: "relative/creds.json"
+    }),
+    /absolute file path/
+  );
+});
+
 test("extractClaudeCredentialsBlob reads the full Claude Code credentials blob from macOS Keychain", async () => {
   const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
   const rawBlob = validBlob();
@@ -229,19 +285,68 @@ test("assertClaudeCredentialsAvailable throws a readable error when credentials 
   ), /Claude Code credentials not found on host/);
 });
 
+test("assertClaudeCredentialsAvailable reports keychain locked guidance", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  assert.throws(() => credentials.assertClaudeCredentialsAvailable(
+    "/Users/demo",
+    "agent-infra",
+    [{ tool: { id: "claude-code" }, dir: "/tmp/claude" }],
+    () => null,
+    () => {},
+    () => ({ status: "KEYCHAIN_LOCKED", detail: "security: User interaction is not allowed." })
+  ), (error) => {
+    assert.match(error.message, /keychain is locked/);
+    assert.match(error.message, /security unlock-keychain/);
+    assert.match(error.message, /AGENT_INFRA_CLAUDE_CREDENTIALS_FILE/);
+    return true;
+  });
+});
+
 test("inspectClaudeKeychainStatus reports macOS credential states", async () => {
   const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
 
   withPlatform("darwin", () => {
     assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => validBlob()).status, "OK");
     assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => {
-      throw new Error("missing");
+      throw Object.assign(new Error("missing"), {
+        stderr: Buffer.from("security: SecKeychainSearchCopyNext: The specified item could not be found.")
+      });
     }).status, "MISSING");
+    assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => {
+      throw taintedSecurityError("security: errSecInteractionNotAllowed: User interaction is not allowed.");
+    }).status, "KEYCHAIN_LOCKED");
+    assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => {
+      throw taintedSecurityError("security: arbitrary failure");
+    }).status, "KEYCHAIN_ERROR");
     assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => "not-json").status, "STALE_ACCESS");
     assert.equal(credentials.inspectClaudeKeychainStatus("/Users/demo", () => JSON.stringify({
       claudeAiOauth: { accessToken: "token" }
     })).status, "STALE_ACCESS");
   });
+});
+
+test("inspectClaudeKeychainStatus reads env override without touching keychain", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-env-inspect-"));
+  const overridePath = path.join(tmpDir, "credentials.json");
+
+  try {
+    fs.writeFileSync(overridePath, validBlob({ expiresAt: 123456 }), "utf8");
+    withPlatform("darwin", () => {
+      assert.deepEqual(credentials.inspectClaudeKeychainStatus("/Users/demo", () => {
+        assert.fail("security should not be called when env override is set");
+      }, {
+        envFn: () => ({ AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: overridePath })
+      }), {
+        status: "OK",
+        blob: validBlob({ expiresAt: 123456 }),
+        expiresAt: 123456
+      });
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("inspectClaudeKeychainStatus reports Linux credential states", async () => {
@@ -332,6 +437,7 @@ test("writeClaudeCredentialsToHost updates macOS Keychain credentials", async ()
           rawBlob
         ]);
         assert.deepEqual(options, {
+          encoding: "utf8",
           stdio: ["ignore", "ignore", "pipe"]
         });
       }
@@ -345,12 +451,59 @@ test("writeClaudeCredentialsToHost returns a soft failure when macOS Keychain wr
   withPlatform("darwin", () => {
     const result = credentials.writeClaudeCredentialsToHost("/Users/demo", validBlob(), {
       execFn: () => {
-        throw new Error("keychain locked");
+        throw taintedSecurityError("security: arbitrary failure");
       }
     });
 
-    assert.deepEqual(result, { ok: false, error: "keychain locked" });
+    assert.equal(result.ok, false);
+    assert.equal(result.classification, "OTHER");
+    assert.match(result.error, /^security command failed:/);
+    assert.doesNotMatch(result.error, /sk-ant-oat01/);
+    assert.doesNotMatch(result.error, /claudeAiOauth/);
   });
+});
+
+test("writeClaudeCredentialsToHost returns locked guidance without leaking OAuth data", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  withPlatform("darwin", () => {
+    const result = credentials.writeClaudeCredentialsToHost("/Users/demo", validBlob(), {
+      execFn: () => {
+        throw taintedSecurityError("security: errSecInteractionNotAllowed: User interaction is not allowed.");
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.classification, "LOCKED");
+    assert.match(result.error, /security unlock-keychain/);
+    assert.match(result.error, /AGENT_INFRA_CLAUDE_CREDENTIALS_FILE/);
+    assert.doesNotMatch(result.error, /sk-ant-oat01/);
+    assert.doesNotMatch(result.error, /claudeAiOauth/);
+    assert.doesNotMatch(result.error, /Command failed/);
+  });
+});
+
+test("writeClaudeCredentialsToHost writes env override file without touching keychain", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-env-write-"));
+  const overridePath = path.join(tmpDir, "credentials.json");
+  const rawBlob = validBlob();
+
+  try {
+    withPlatform("darwin", () => {
+      assert.deepEqual(credentials.writeClaudeCredentialsToHost("/Users/demo", rawBlob, {
+        envFn: () => ({ AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: overridePath }),
+        execFn: () => {
+          assert.fail("security should not be called when env override is set");
+        },
+        randomFn: () => "fixed"
+      }), { ok: true });
+    });
+    assert.equal(fs.readFileSync(overridePath, "utf8"), rawBlob);
+    assertModeBits(overridePath, 0o600);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("writeClaudeCredentialsToHost atomically replaces Linux host credentials", async () => {
@@ -392,7 +545,7 @@ test("writeClaudeCredentialsToHost preserves Linux host credentials when rename 
         }
       });
 
-      assert.deepEqual(result, { ok: false, error: "rename failed" });
+      assert.deepEqual(result, { ok: false, classification: "OTHER", error: "rename failed" });
     });
 
     assert.equal(fs.readFileSync(targetPath, "utf8"), "original");
@@ -443,7 +596,9 @@ test("syncClaudeCredentialsFromKeychain and formatRemaining handle unavailable o
     withPlatform("darwin", () => {
       assert.deepEqual(credentials.syncClaudeCredentialsFromKeychain("/Users/demo", "agent-infra", {
         execFn: () => {
-          throw new Error("missing");
+          throw Object.assign(new Error("missing"), {
+            stderr: Buffer.from("security: SecKeychainSearchCopyNext: The specified item could not be found.")
+          });
         },
         writeFn: () => {
           writeCalled = true;
@@ -589,7 +744,9 @@ test("reconcileClaudeCredentials reports KEYCHAIN_WRITE_FAILED when host write f
     const result = credentials.reconcileClaudeCredentials("/Users/demo", {
       projects: ["demo"],
       execFn: () => {
-        throw new Error("missing");
+        throw Object.assign(new Error("missing"), {
+          stderr: Buffer.from("security: SecKeychainSearchCopyNext: The specified item could not be found.")
+        });
       },
       readFn: () => fileBlob,
       existsFn: () => true,
@@ -598,7 +755,28 @@ test("reconcileClaudeCredentials reports KEYCHAIN_WRITE_FAILED when host write f
 
     assert.equal(result.status, "KEYCHAIN_WRITE_FAILED");
     assert.equal(result.authoritative, "file:demo");
-    assert.deepEqual(result.warnings, ["keychain locked"]);
+    assert.deepEqual(result.warnings, [{
+      source: "host-keychain",
+      classification: "OTHER",
+      message: "keychain locked"
+    }]);
+  });
+});
+
+test("reconcileClaudeCredentials reports KEYCHAIN_LOCKED when host is locked and no file is usable", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+
+  withPlatform("darwin", () => {
+    const result = credentials.reconcileClaudeCredentials("/Users/demo", {
+      projects: [],
+      inspection: {
+        status: "KEYCHAIN_LOCKED",
+        detail: "security: User interaction is not allowed."
+      }
+    });
+
+    assert.equal(result.status, "KEYCHAIN_LOCKED");
+    assert.equal(result.detail, "security: User interaction is not allowed.");
   });
 });
 

--- a/tests/cli/sandbox-credentials.test.js
+++ b/tests/cli/sandbox-credentials.test.js
@@ -86,6 +86,17 @@ test("env override helpers validate absolute credential file paths", async () =>
   );
 });
 
+test("buildLockedGuidance includes macOS env override seed instructions", async () => {
+  const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
+  const guidance = credentials.buildLockedGuidance();
+
+  assert.match(guidance, /security unlock-keychain/);
+  assert.match(guidance, /security find-generic-password -s "Claude Code-credentials" -w/);
+  assert.match(guidance, /\$HOME\/\.agent-infra\/claude-credentials\.json/);
+  assert.match(guidance, /AGENT_INFRA_CLAUDE_CREDENTIALS_FILE/);
+  assert.doesNotMatch(guidance, /\$HOME\/\.claude\/\.credentials\.json/);
+});
+
 test("extractClaudeCredentialsBlob reads the full Claude Code credentials blob from macOS Keychain", async () => {
   const credentials = await loadFreshEsm("lib/sandbox/credentials.js");
   const rawBlob = validBlob();

--- a/tests/cli/sandbox-refresh.test.js
+++ b/tests/cli/sandbox-refresh.test.js
@@ -200,7 +200,9 @@ test("refresh exits 1 with login prompt when host credentials are missing", asyn
     const code = await withHome(tmpDir, () => withPlatform("darwin", () => refresh([], {
       discoverFn: () => ["agent-infra"],
       execFn: () => {
-        throw new Error("missing");
+        throw Object.assign(new Error("missing"), {
+          stderr: Buffer.from("security: SecKeychainSearchCopyNext: The specified item could not be found.")
+        });
       },
       writeStdout: () => {},
       writeStderr: (chunk) => stderr.push(chunk)
@@ -229,6 +231,31 @@ test("refresh exits 1 when probe fails after stale host credentials", async () =
 
     assert.equal(code, 1);
     assert.match(stderr.join(""), /claude \/login/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("refresh redacts tokens from failed probe stderr", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-refresh-probe-redact-"));
+  const stderr = [];
+
+  try {
+    const code = await withHome(tmpDir, () => withPlatform("darwin", () => refresh([], {
+      discoverFn: () => ["agent-infra"],
+      execFn: () => "not-json",
+      spawnFn: () => ({
+        status: 1,
+        stderr: "Authentication failed: ghp_123456789012345678901234567890123456"
+      }),
+      writeStdout: () => {},
+      writeStderr: (chunk) => stderr.push(chunk)
+    })));
+
+    assert.equal(code, 1);
+    assert.match(stderr.join(""), /\[REDACTED github token\]/);
+    assert.doesNotMatch(stderr.join(""), /ghp_123456789012345678901234567890123456/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -325,7 +352,9 @@ test("refresh exits 1 when newer sandbox credentials cannot be written to host",
   const code = await withPlatform("darwin", () => refresh([], {
     discoverFn: () => ["agent-infra"],
     execFn: () => {
-      throw new Error("missing");
+      throw Object.assign(new Error("missing"), {
+        stderr: Buffer.from("security: SecKeychainSearchCopyNext: The specified item could not be found.")
+      });
     },
     readFn: () => validBlob(200),
     existsFn: () => true,
@@ -336,6 +365,89 @@ test("refresh exits 1 when newer sandbox credentials cannot be written to host",
 
   assert.equal(code, 1);
   assert.match(stderr.join(""), /keychain write failed: keychain locked/);
+});
+
+test("refresh emits keychain guidance when host keychain is locked", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const stderr = [];
+
+  const code = await withPlatform("darwin", () => refresh([], {
+    discoverFn: () => ["agent-infra"],
+    execFn: () => {
+      const error = new Error(
+        'Command failed: security find-generic-password {"claudeAiOauth":{"accessToken":"sk-ant-oat01-123456789012345678901234567890"}}'
+      );
+      error.stderr = Buffer.from("security: errSecInteractionNotAllowed: User interaction is not allowed.");
+      throw error;
+    },
+    writeStdout: () => {},
+    writeStderr: (chunk) => stderr.push(chunk)
+  }));
+
+  assert.equal(code, 1);
+  assert.match(stderr.join(""), /security unlock-keychain/);
+  assert.match(stderr.join(""), /AGENT_INFRA_CLAUDE_CREDENTIALS_FILE/);
+  assert.doesNotMatch(stderr.join(""), /sk-ant-oat01/);
+  assert.doesNotMatch(stderr.join(""), /claudeAiOauth/);
+});
+
+test("refresh emits keychain error detail and guidance for non-locked failures", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const stderr = [];
+
+  const code = await withPlatform("darwin", () => refresh([], {
+    discoverFn: () => ["agent-infra"],
+    execFn: () => {
+      const error = new Error(
+        'Command failed: security find-generic-password {"claudeAiOauth":{"accessToken":"sk-ant-oat01-123456789012345678901234567890"}}'
+      );
+      error.stderr = Buffer.from("security: errSecAuthFailed: Authorization failed.");
+      throw error;
+    },
+    writeStdout: () => {},
+    writeStderr: (chunk) => stderr.push(chunk)
+  }));
+
+  assert.equal(code, 1);
+  assert.match(stderr.join(""), /Host keychain error: security: errSecAuthFailed/);
+  assert.match(stderr.join(""), /security unlock-keychain/);
+  assert.match(stderr.join(""), /AGENT_INFRA_CLAUDE_CREDENTIALS_FILE/);
+  assert.doesNotMatch(stderr.join(""), /sk-ant-oat01/);
+  assert.doesNotMatch(stderr.join(""), /claudeAiOauth/);
+  assert.doesNotMatch(stderr.join(""), /Command failed/);
+});
+
+test("refresh uses env override credentials without touching keychain", async () => {
+  const { refresh } = await loadFreshEsm("lib/sandbox/commands/refresh.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-refresh-env-"));
+  const overridePath = path.join(tmpDir, "credentials.json");
+  const targetDir = path.join(tmpDir, ".agent-infra", "credentials", "agent-infra", "claude-code");
+  const previousOverride = process.env.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE;
+
+  try {
+    fs.writeFileSync(overridePath, validBlob(), "utf8");
+    fs.mkdirSync(targetDir, { recursive: true });
+    process.env.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE = overridePath;
+
+    const code = await withHome(tmpDir, () => withPlatform("darwin", () => refresh([], {
+      discoverFn: () => ["agent-infra"],
+      execFn: () => {
+        assert.fail("security should not be called when env override is set");
+      },
+      writeStdout: () => {},
+      writeStderr: () => {}
+    })));
+
+    assert.equal(code, 0);
+    assert.ok(fs.existsSync(path.join(targetDir, ".credentials.json")));
+  } finally {
+    if (previousOverride === undefined) {
+      delete process.env.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE;
+    } else {
+      process.env.AGENT_INFRA_CLAUDE_CREDENTIALS_FILE = previousOverride;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("refresh continues on per-project sync failure and exits 1 at end", async () => {

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -16,7 +16,7 @@ import {
   onPlatforms,
   withGitSafeProcessEnv
 } from "../helpers.js";
-import { restoreTerminal, runInteractive } from "../../lib/sandbox/shell.js";
+import { restoreTerminal, runInteractive, runVerbose } from "../../lib/sandbox/shell.js";
 
 function restoreDockerContext(previousValue) {
   if (previousValue === undefined) {
@@ -645,55 +645,105 @@ test("composeDockerfile configures tmux extended keys and terminal env forwardin
   }
 });
 
-test("buildContainerEnvArgs injects GH_TOKEN when available", async () => {
+test("buildContainerEnvFile writes tool env vars to a private env file", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-"));
 
-  const envArgs = sandboxCreate.buildContainerEnvArgs([
-    { tool: { envVars: { FOO: "bar" } } },
-    { tool: { envVars: { BAZ: "qux" } } }
-  ], "native", (engine, cmd, args) => {
-    assert.equal(engine, "native");
-    assert.equal(cmd, "gh");
-    assert.deepEqual(args, ["auth", "token"]);
-    return "token-123";
-  });
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([
+      { tool: { envVars: { FOO: "bar" } } },
+      { tool: { envVars: { BAZ: "qux" } } }
+    ], "native", () => "", { tmpDir });
 
-  assert.deepEqual(envArgs, [
-    "-e", "FOO=bar",
-    "-e", "BAZ=qux",
-    "-e", "GH_TOKEN=token-123"
-  ]);
+    assert.equal(envFile.dockerArgs[0], "--env-file");
+    assert.equal(path.dirname(path.dirname(envFile.dockerArgs[1])), tmpDir);
+    assert.equal(fs.readFileSync(envFile.dockerArgs[1], "utf8"), "FOO=bar\nBAZ=qux\n");
+    assertModeBits(path.dirname(envFile.dockerArgs[1]), 0o700);
+    assertModeBits(envFile.dockerArgs[1], 0o600);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
-test("buildContainerEnvArgs skips GH_TOKEN when auth token is unavailable", async () => {
+test("buildContainerEnvFile stores GH_TOKEN in the env file but not docker argv", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-token-"));
+
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([
+      { tool: { envVars: { FOO: "bar" } } }
+    ], "native", (engine, cmd, args) => {
+      assert.equal(engine, "native");
+      assert.equal(cmd, "gh");
+      assert.deepEqual(args, ["auth", "token"]);
+      return "ghp_123456789012345678901234567890123456";
+    }, { tmpDir });
+
+    assert.deepEqual(envFile.dockerArgs, ["--env-file", envFile.dockerArgs[1]]);
+    assert.ok(!envFile.dockerArgs.some((arg) => arg.includes("ghp_123456789012345678901234567890123456")));
+    assert.match(fs.readFileSync(envFile.dockerArgs[1], "utf8"), /GH_TOKEN=ghp_123456789012345678901234567890123456/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvFile returns empty docker args when there are no env vars", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
 
-  const envArgs = sandboxCreate.buildContainerEnvArgs([
-    { tool: { envVars: { FOO: "bar" } } }
+  const envFile = sandboxCreate.buildContainerEnvFile([
+    { tool: { envVars: {} } }
   ], "native", () => "");
 
-  assert.deepEqual(envArgs, ["-e", "FOO=bar"]);
+  assert.deepEqual(envFile.dockerArgs, []);
+  assert.doesNotThrow(() => envFile.cleanup());
 });
 
-test("buildContainerEnvArgs uses engine-aware gh", async () => {
+test("buildContainerEnvFile cleanup removes the temporary directory", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-cleanup-"));
 
-  const envArgs = sandboxCreate.buildContainerEnvArgs([
-    { tool: { envVars: { FOO: "bar" } } }
-  ], "wsl2", () => "");
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([
+      { tool: { envVars: { FOO: "bar" } } }
+    ], "native", () => "", { tmpDir });
+    const envDir = path.dirname(envFile.dockerArgs[1]);
 
-  assert.ok(envArgs.includes("-e"), "env args include -e flag");
-  assert.deepEqual(envArgs, ["-e", "FOO=bar"]);
+    assert.ok(fs.existsSync(envDir));
+    envFile.cleanup();
+    assert.equal(fs.existsSync(envDir), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
-test("buildContainerEnvArgs includes GH_TOKEN from engine-aware runSafeEngine", async () => {
+test("buildContainerEnvFile rejects newlines and removes the temporary directory", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-newline-"));
+
+  try {
+    assert.throws(() => sandboxCreate.buildContainerEnvFile([
+      { tool: { envVars: { FOO: "bar\nbaz" } } }
+    ], "native", () => "", { tmpDir }), /must not contain newlines/);
+    assert.deepEqual(fs.readdirSync(tmpDir), []);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvFile uses engine-aware env-file paths for WSL2", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
 
-  const envArgs = sandboxCreate.buildContainerEnvArgs([
+  const envFile = sandboxCreate.buildContainerEnvFile([
     { tool: { envVars: { FOO: "bar" } } }
-  ], "wsl2", () => "ghp_testtoken123");
+  ], "wsl2", () => "", {
+    tmpDir: "F:\\tmp",
+    mkdtempFn: () => "F:\\tmp\\agent-infra-env-fixed",
+    writeFileFn: () => {},
+    chmodFn: () => {},
+    rmFn: () => {}
+  });
 
-  assert.deepEqual(envArgs, ["-e", "FOO=bar", "-e", "GH_TOKEN=ghp_testtoken123"]);
+  assert.deepEqual(envFile.dockerArgs, ["--env-file", "/mnt/f/tmp/agent-infra-env-fixed/env"]);
 });
 
 test("terminalEnvFlags forwards iTerm2 detection variables for Shift+Enter support", async () => {
@@ -725,6 +775,19 @@ test("terminalEnvFlags omits unset variables instead of forwarding empty values"
   });
 
   assert.deepEqual(flags, ["-e", "TERM_PROGRAM=iTerm.app"]);
+});
+
+test("sandbox exec formats host keychain unavailable credential sync warnings", async () => {
+  const sandboxEnter = await loadFreshEsm("lib/sandbox/commands/enter.js");
+
+  assert.equal(
+    sandboxEnter.formatCredentialSyncStatus({ status: "KEYCHAIN_LOCKED" }),
+    'Warning: Host keychain is unavailable; Claude credential sync skipped. Run "ai sandbox refresh" for details.\n'
+  );
+  assert.equal(
+    sandboxEnter.formatCredentialSyncStatus({ status: "KEYCHAIN_ERROR" }),
+    'Warning: Host keychain is unavailable; Claude credential sync skipped. Run "ai sandbox refresh" for details.\n'
+  );
 });
 
 // On Windows, `lib/sandbox/engine.js` detectEngine forces the engine to wsl2,
@@ -2179,6 +2242,41 @@ test("commandErrorMessage prefers stderr over the generic execFileSync message",
   });
 
   assert.equal(message, "fatal: invalid reference: missing-branch");
+});
+
+test("commandErrorMessage redacts tokens from fallback error messages", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  const message = sandboxCreate.commandErrorMessage({
+    message: "Command failed: docker run -e GH_TOKEN=ghp_123456789012345678901234567890123456"
+  });
+
+  assert.doesNotMatch(message, /ghp_123456789012345678901234567890123456/);
+  assert.match(message, /\[REDACTED github token\]/);
+});
+
+test("runVerbose error messages do not include argv", () => {
+  assert.throws(
+    () => runVerbose(process.execPath, ["-e", "process.exit(1)", "SECRET_ARG_VALUE"]),
+    (error) => {
+      assert.match(error.message, /^Command failed with exit code 1:/);
+      assert.doesNotMatch(error.message, /SECRET_ARG_VALUE/);
+      return true;
+    }
+  );
+});
+
+test("runVerbose timeout messages do not include argv", () => {
+  assert.throws(
+    () => runVerbose(process.execPath, ["-e", "setTimeout(() => {}, 10_000)", "SECRET_TIMEOUT_VALUE"], {
+      timeout: 1
+    }),
+    (error) => {
+      assert.match(error.message, /^Command timed out after 1ms:/);
+      assert.doesNotMatch(error.message, /SECRET_TIMEOUT_VALUE/);
+      return true;
+    }
+  );
 });
 
 test("ensureSandboxAliasesFile creates the default aliases once", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #295

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🚀 功能增强 / Feature enhancement — `sandbox refresh` 在 SSH + 锁定 keychain 场景下的友好降级
- [x] 🐛 Bug 修复 / Bug fix — 修复 `security` / `docker run` 子进程错误消息中泄漏 OAuth / GitHub token 的安全缺陷
- [x] 🔧 重构 / Refactoring — 把 macOS `security` 调用与所有 subprocess argv 泄漏面集中到单点防御边界
- [x] 📚 文档更新 / Documentation update — README 双语补 macOS SSH / locked keychain 章节

## 📝 变更目的 / Purpose of the Change

`node bin/cli.js sandbox refresh` 在 SSH 远程到 macOS 且 login keychain 锁定时存在三个问题：

1. **错误信息泄漏 Claude OAuth 凭据**：`execFileSync('security', [..., '-w', blob])` 失败时 Node 抛出的 `Error.message` 含完整 argv，包括 `claudeAiOauth` blob（含 `accessToken` / `refreshToken`）。CI 收集 stderr / 共享日志服务 / 远程开发机 shell history 都可能持久化这些 token。
2. **错误信息不可读**：直接抛出 `errSecInteractionNotAllowed` 原文，普通用户无法判断这是 keychain 锁屏导致。
3. **失败后无恢复路径**：命令退出后用户无引导。

经过两轮 analyze（Round 2 扩展跨平台审计），还发现一处**同根**的泄漏：

4. **`docker run -e GH_TOKEN=...` argv 泄漏**：`buildContainerEnvArgs` 把 GitHub token 拼进 docker run argv，失败时 `commandErrorMessage` fallback 到 `error.message` 会泄漏；token 也对同主机其他 user 通过 `ps -ef` 可见。**这是所有平台**（不限 macOS / SSH）都会触发的缺陷。

本 PR 用**结构性消除 + 多层防御**两条主线一并修复：argv 中绝不放 secret（macOS 用 `runSecurity` 边界丢弃 Error 实例；docker 用 `--env-file`；`runVerbose` 去 `args.join`），所有错误消息走通用 `redactCommandError` 兜底（Claude OAuth blob / `sk-ant-*` / `gh[psoru]_*` / `Bearer ...`）。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/credentials.js` — 新增 `runSecurity()` 单点封装所有 `/usr/bin/security` 调用，**绝不**把 `execFileSync` 抛出的 Error 跨边界传播，只读 `err.stderr` 并经 `redactCommandError` 脱敏；新增 status 值 `KEYCHAIN_LOCKED` / `KEYCHAIN_ERROR`；新增 `AGENT_INFRA_CLAUDE_CREDENTIALS_FILE` env override（绝对路径校验）；新增 `redactCommandError` 通用脱敏 helper（patterns：`claudeAiOauth` blob / `sk-ant-` / `gh[psoru]_` / `Bearer`）；新增 `buildLockedGuidance()` 多行可操作引导（含 macOS keychain seed 步骤）；`reconcileClaudeCredentials.warnings` 升级为结构化对象数组；`assertClaudeCredentialsAvailable` 在 LOCKED 状态下抛 guidance。
- `lib/sandbox/commands/refresh.js` — 入口校验 env override 值；KEYCHAIN_LOCKED / KEYCHAIN_ERROR 分支输出 guidance；`claude /status` 探针 stderr 也走 `redactCommandError`（第三方传染防御）。
- `lib/sandbox/commands/enter.js` — 抽 `formatCredentialSyncStatus()` 纯函数，凭据同步状态渲染可单测；KEYCHAIN_LOCKED / KEYCHAIN_ERROR 静默路径补 hint。
- `lib/sandbox/commands/create.js` — 入口校验 env override 值；旧 `buildContainerEnvArgs` 删除导出，改为 `buildContainerEnvFile()`：把所有容器 env（含 `GH_TOKEN`）写到 0o600 临时文件，docker run 只接 `--env-file <path>`，`finally` 清理。**docker run argv 不再含 token**，根除 `Error.message` 和 `ps -ef` 两条侧信道；`commandErrorMessage` 经 redact 兜底。
- `lib/sandbox/shell.js` — `runVerbose` 不再 `args.join(' ')` 拼接到 Error.message，结构性消除"未来调用者踩坑就泄漏"埋雷。
- `tests/cli/sandbox-credentials.test.js` — 新增 21 个用例覆盖 redactor patterns / env override / `runSecurity` 边界 / `KEYCHAIN_LOCKED` 状态 / write 路径 LOCKED 引导 / `buildLockedGuidance` 包含 macOS seed 指令的 regression guard
- `tests/cli/sandbox-refresh.test.js` — 新增 4 个用例覆盖 probe stderr redact / KEYCHAIN_LOCKED 引导 / KEYCHAIN_ERROR 引导 / env override 端到端
- `tests/cli/sandbox.test.js` — 6 个旧 `buildContainerEnvArgs` 测试改造为 `buildContainerEnvFile` 测试 + `commandErrorMessage` redact 测试 + 2 个 `runVerbose` 不含 argv 测试 + `sandbox exec formats host keychain unavailable credential sync warnings`
- `README.md` / `README.zh-CN.md` — `### macOS` 子章节下新增 `#### SSH / locked keychain`（双语），含 seed env-override 文件的两阶段流程；推荐路径 `$HOME/.agent-infra/claude-credentials.json`（避免与 Claude Code Linux 默认路径冲突）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/cli/sandbox-credentials.test.js tests/cli/sandbox-refresh.test.js tests/cli/sandbox.test.js` — 250 通过 / 1 跳过 / 0 失败
2. `npm run test:core`（Node 22）— 328 通过 / 1 跳过 / 0 失败（pre-commit hook 已经跑过）
3. `npm test`（full，Node 22）— 457 通过 / 1 跳过 / 0 失败
4. 手动冒烟（建议 reviewer 在 macOS 上跑）：
   - `security lock-keychain ~/Library/Keychains/login.keychain-db && ai sandbox refresh` — 断言 stderr 含 `errSecInteractionNotAllowed` 引导和 `security unlock-keychain` 命令，**不**含 `sk-ant-` 任何形态 token
   - 按 README `#### SSH / locked keychain` 步骤 seed `~/.agent-infra/claude-credentials.json` 后 `export AGENT_INFRA_CLAUDE_CREDENTIALS_FILE=... && ai sandbox refresh` — 断言成功无 `security` 子进程调用
   - 故意制造 docker run 失败（image 不存在等）— 断言 stderr **不**含 `ghp_*` 或 `GH_TOKEN=...` 字面量

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（+33 新增用例）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing — mock 形态完整覆盖，真实 macOS 端到端建议 reviewer 验证

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（5 轮 review + 3 轮 refinement）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas（`runSecurity` 边界约束、docker `--env-file` 解析假设、redaction patterns 设计动机均有 why 注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（`execFn` / `envFn` / `fsImpl` / `runSafeEngineFn` 全部注入）
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（README 双语 `#### SSH / locked keychain` 章节）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / 见下方"破坏性变更说明"
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

### 破坏性变更说明 / Breaking Changes

- **`buildContainerEnvArgs` 删除导出**：仓库内仅 `create.js:1095` 一处 caller，本 PR 内一并改为 `buildContainerEnvFile`。无外部消费者（非公共 API）。
- **`reconcileClaudeCredentials.warnings` 结构变化**：从 `string[]` 改为 `{ source, classification, message }[]`。仓库内消费方（`refresh.js` / `enter.js`）已同步迁移，全部用 `formatCredentialWarnings` helper 渲染。无导出 API 改动。
- **新增 status 值 `KEYCHAIN_LOCKED` / `KEYCHAIN_ERROR`**：所有 status switch 点（`reconcile` / `extract` / `refresh` / `enter` / `assertClaudeCredentialsAvailable`）本 PR 内全部更新。
- **`runVerbose` Error.message 缩短**：不再含 args。调用方若依赖 args 文本做日志匹配会受影响——但仓库内没有这种依赖；docker / git 等命令自身 stderr 包含完整诊断信息。
- **`commandErrorMessage` 走 redact**：成功路径不变（无 token 时 redact 是 noop）；失败路径含 token 时形态变化（`ghp_xxx` → `[REDACTED github token]`）。

### 未覆盖范围 / Out of Scope

- **P1：TTY 下交互式自动解锁**（按用户在 stdin 是 TTY 时询问是否自动 `security unlock-keychain` 后重试）—— 与本 PR 的"脱敏 + 旁路"主线正交，留作后续 issue。本 PR 已经在 `buildLockedGuidance` / README 里给出"手动 unlock + seed env-override 文件"两条可操作路径覆盖核心痛点。
- **Linux/Windows 凭据文件存储后端不变**：`fs.writeFileSync(path, blob)` 的 Error.message 不含 data，结构性安全，本 PR 不动。

---

**审查者注意事项 / Reviewer Notes:**

1. **`runSecurity` 边界约束**（`credentials.js:50-68`）—— 关键安全准则：return 对象内**绝不**放 Error 实例、不挂 `.cause`、不挂 `.original`；`extractStderrSafely` 显式拒绝读 `err.message`。这是消除 macOS keychain 写路径 token 泄漏的核心
2. **`--env-file` 替代 `-e GH_TOKEN=...` argv**（`create.js:526-579 / 1140 / 1192-1226`）—— 临时目录走 `mkdtempSync(prefix='agent-infra-env-')` + `chmod 0o700`，env 文件 mode `0o600`，docker run 在 `finally` 中调 `envFile.cleanup()` 删除整个临时目录；`mkdtemp` 之后用 try/catch 兜底，formatEnvFileEntry 抛错时也会清理
3. **`redactCommandError` patterns 设计**（`credentials.js:9-14`）—— 4 层 pattern 互相兜底（claudeAiOauth blob / sk-ant- bare token / GitHub PAT 全系列 / Bearer header），长度下界 ≥20 避免误命中短 hash
4. **`buildLockedGuidance` macOS seed 流程**（`credentials.js:70-92` + README 双语 `#### SSH / locked keychain`）—— Claude Code 在 macOS 默认只往 keychain 写凭据，所以 env-override 文件需要先从已解锁 keychain seed 一次。文案与 README 内容字句一致
5. **5 轮 review + 3 轮 refinement 全程跟踪**：见 Issue #295 评论区的 `task` / `analysis` / `analysis-r2` / `plan` / `plan-r2` / `implementation` / `review` / `refinement` / `review-r2` / `refinement-r2` / `review-r3` / `review-r4` / `refinement-r3` / `review-r5` 评论

Generated with AI assistance
