### PR TITLE
feat(sandbox): add user-level dotfiles channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,63 @@ yes) to clean up the corresponding share dirs alongside the worktrees.
 Existing sandboxes pick up these mounts after `ai sandbox rm <branch>` and
 `ai sandbox create <branch>`.
 
+### User-level dotfiles channel
+
+`ai sandbox create` also mounts an optional read-only channel for host user preferences:
+
+- `/dotfiles` <- `~/.agent-infra/dotfiles/` - read-only, host-owned source.
+
+The host tree mirrors the expected paths under the container `$HOME`, in the
+same style as GNU stow or chezmoi:
+
+```text
+~/.agent-infra/dotfiles/
+├── .tmux.conf
+└── .config/
+    ├── lazygit/config.yml
+    └── yazi/yazi.toml
+```
+
+On each sandbox entry, `sandbox-dotfiles-link` links every file to
+`$HOME/<relative-path>` with `ln -sfn`, overriding image defaults. If the host
+directory does not exist, the mount and link step are skipped.
+
+To add future preferences such as `starship.toml` or `.gitconfig.local`, put
+files in `~/.agent-infra/dotfiles/`; no Dockerfile or `ai sandbox create`
+changes are needed.
+
+> **Do not put secrets in `~/.agent-infra/dotfiles/`.** The mount is read-only
+> inside the container, but the full preference tree is linked into every
+> project sandbox. Do not place `.ssh/`, `.aws/credentials`, `.netrc`,
+> `.gnupg/`, `.npmrc` files containing `_authToken`, AI tool OAuth/access token
+> files, or `.gitconfig` there. Use the dedicated SSH and credential channels,
+> and prefer `.gitconfig.local` with `[include]` for local Git preferences.
+> Also avoid symlinks in this tree; the hook uses `find -type f` and does not
+> follow them.
+
+**Protected paths** are ignored by the hook even if they appear under
+`~/.agent-infra/dotfiles/`:
+
+| Path pattern | Reason |
+|---|---|
+| `.ssh/*` | Host SSH credentials are managed by the read-only SSH mount. |
+| `.gnupg/*` | GPG private material is managed by `gpg-agent`. |
+| `.claude/*`, `.codex/*`, `.gemini/*` | AI tool credentials use dedicated bind mounts. |
+| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode credentials and data use dedicated bind mounts. |
+| `.host-shell-config/*` | agent-infra managed shell and Git configuration. |
+| `.gitconfig`, `.gitignore_global`, `.stCommitMsg`, `.bash_aliases` | agent-infra symlinks these to `.host-shell-config/`, including `safe.directory` and GPG sync state. |
+
+Other existing real directories, such as `~/.config/` or `~/.cache/`, are not
+replaced by top-level dotfiles. If a file conflicts with one of those
+directories, the hook prints a warning and skips it:
+
+```text
+sandbox-dotfiles-link: skipping /home/devuser/.config (existing directory; use nested path like .config/<file> instead)
+```
+
+Use nested paths such as `~/.agent-infra/dotfiles/.config/lazygit/config.yml`
+instead of treating `.config` as a top-level file.
+
 <a id="architecture-overview"></a>
 
 ## Architecture Overview

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,6 +213,49 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；`ai sandbox rm <branch>` 与 `ai sandbox rm --all` 删除时会附带询问是否清理（默认 yes）。
 已有沙箱需要执行 `ai sandbox rm <branch>` 后再执行 `ai sandbox create <branch>`，才能加载新的挂载点。
 
+#### 用户级 dotfiles 通道
+
+`ai sandbox create` 还会自动挂载一条可选的只读通道，用于把宿主机用户级偏好带进沙箱：
+
+- `/dotfiles` <- `~/.agent-infra/dotfiles/`：只读，host 作为单向源。
+
+host 端目录树镜像容器 `$HOME` 下的预期路径，风格类似 GNU stow 或 chezmoi：
+
+```text
+~/.agent-infra/dotfiles/
+├── .tmux.conf
+└── .config/
+    ├── lazygit/config.yml
+    └── yazi/yazi.toml
+```
+
+每次进入沙箱时，`sandbox-dotfiles-link` 会用 `ln -sfn` 把每个文件链接到
+`$HOME/<相对路径>`，覆盖镜像默认。host 端目录不存在时，会跳过挂载和链接步骤。
+
+未来要加 `starship.toml`、`.gitconfig.local` 等偏好，只需把文件放进
+`~/.agent-infra/dotfiles/`，无需修改 Dockerfile 或 `ai sandbox create`。
+
+> **不要往 `~/.agent-infra/dotfiles/` 放任何凭证。** 容器内是只读挂载，但整棵偏好树会链入所有项目沙箱。不要放 `.ssh/`、`.aws/credentials`、`.netrc`、`.gnupg/`、包含 `_authToken` 的 `.npmrc`、任何 AI 工具 OAuth/access token 文件，也不要放 `.gitconfig`。SSH 和工具凭证请使用专用通道；本地 Git 偏好建议用 `.gitconfig.local` 配合 `[include]`。也不要在这棵目录里放符号链接；钩子使用 `find -type f` 遍历，不会跟随符号链接。
+
+**受保护路径**即使出现在 `~/.agent-infra/dotfiles/` 下，也会被钩子忽略：
+
+| 路径模式 | 原因 |
+|---|---|
+| `.ssh/*` | host SSH 凭证由只读 SSH 挂载管理。 |
+| `.gnupg/*` | GPG 私钥由 `gpg-agent` 管理。 |
+| `.claude/*`, `.codex/*`, `.gemini/*` | AI 工具凭证使用专用 bind mount。 |
+| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode 凭证和数据使用专用 bind mount。 |
+| `.host-shell-config/*` | agent-infra 管理的 shell 和 Git 配置。 |
+| `.gitconfig`, `.gitignore_global`, `.stCommitMsg`, `.bash_aliases` | agent-infra 将这些路径软链到 `.host-shell-config/`，包含 `safe.directory` 和 GPG 同步状态。 |
+
+其他已经存在的真实目录（如 `~/.config/`、`~/.cache/`）不会被顶层 dotfile 替换。如果某个文件与这类目录冲突，钩子会打印警告并跳过：
+
+```text
+sandbox-dotfiles-link: skipping /home/devuser/.config (existing directory; use nested path like .config/<file> instead)
+```
+
+正确用法是嵌套路径，例如 `~/.agent-infra/dotfiles/.config/lazygit/config.yml`，不要把 `.config` 当成顶层文件。
+
 <a id="architecture-overview"></a>
 
 ## 架构概览

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -578,6 +578,13 @@ export function buildContainerEnvFile(
   }
 }
 
+export function buildDotfilesVolumeArgs(engine, dotfilesDir, existsFn = fs.existsSync) {
+  if (!dotfilesDir || !existsFn(dotfilesDir)) {
+    return [];
+  }
+  return ['-v', volumeArg(engine, dotfilesDir, '/dotfiles', ':ro')];
+}
+
 export function assertBranchAvailable(
   repoRoot,
   branch,
@@ -1228,6 +1235,7 @@ export async function create(args) {
               ),
               '-v',
               volumeArg(engine, hostJoin(effectiveConfig.home, '.ssh'), '/home/devuser/.ssh', ':ro'),
+              ...buildDotfilesVolumeArgs(engine, effectiveConfig.dotfilesDir),
               ...toolVolumes,
               ...liveMountVolumes,
               ...shellConfigVolumes,

--- a/lib/sandbox/config.js
+++ b/lib/sandbox/config.js
@@ -71,6 +71,7 @@ export function loadConfig() {
     imageName: `${project}-sandbox:latest`,
     worktreeBase: hostJoin(home, '.agent-infra', 'worktrees', project),
     shareBase: hostJoin(home, '.agent-infra', 'share', project),
+    dotfilesDir: hostJoin(home, '.agent-infra', 'dotfiles'),
     engine,
     runtimes: Array.isArray(sandbox.runtimes) && sandbox.runtimes.length > 0
       ? [...sandbox.runtimes]

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -105,9 +105,48 @@ else
 fi
 SCRIPT
 
+RUN cat > /usr/local/bin/sandbox-dotfiles-link <<'SCRIPT' && chmod +x /usr/local/bin/sandbox-dotfiles-link
+#!/bin/sh
+# Mirror /dotfiles/ tree as symlinks under $HOME/, overwriting any image-baked
+# defaults. Future preferences only need to land in the host directory.
+set -eu
+
+DOTFILES_SRC=/dotfiles
+[ -d "$DOTFILES_SRC" ] || exit 0
+
+cd "$DOTFILES_SRC"
+find . -type f -print | while IFS= read -r rel; do
+  rel=${rel#./}
+  target="$HOME/$rel"
+  case "$rel" in
+    .ssh|.ssh/*|\
+    .gnupg|.gnupg/*|\
+    .claude|.claude/*|\
+    .codex|.codex/*|\
+    .gemini|.gemini/*|\
+    .config/opencode|.config/opencode/*|\
+    .local/share/opencode|.local/share/opencode/*|\
+    .host-shell-config|.host-shell-config/*|\
+    .gitconfig|.gitignore_global|.stCommitMsg|.bash_aliases)
+      continue ;;
+  esac
+
+  mkdir -p "$(dirname "$target")"
+  if [ -d "$target" ] && [ ! -L "$target" ]; then
+    printf 'sandbox-dotfiles-link: skipping %s (existing directory; use nested path like %s/<file> instead)\n' "$target" "$rel" >&2
+    continue
+  fi
+
+  ln -sfn "$DOTFILES_SRC/$rel" "$target" 2>/dev/null \
+    || printf 'sandbox-dotfiles-link: failed to link %s\n' "$target" >&2
+done
+SCRIPT
+
 RUN cat > /usr/local/bin/sandbox-tmux-entry <<'SCRIPT' && chmod +x /usr/local/bin/sandbox-tmux-entry
 #!/bin/sh
 set -eu
+
+sandbox-dotfiles-link >/dev/null || true
 
 SESSION=work
 

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -344,6 +344,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME, ".agent-infra", "worktrees", "demo"));
     assert.equal(config.shareBase, path.join(process.env.HOME, ".agent-infra", "share", "demo"));
+    assert.equal(config.dotfilesDir, path.join(process.env.HOME, ".agent-infra", "dotfiles"));
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -616,6 +617,57 @@ test("composeDockerfile bakes sandbox-tmux-entry script", async () => {
   }
 });
 
+test("composeDockerfile bakes sandbox-dotfiles-link script", async () => {
+  const sandboxDockerfile = await loadFreshEsm("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-dotfiles-link-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /cat > \/usr\/local\/bin\/sandbox-dotfiles-link <<'SCRIPT'/);
+    assert.match(content, /chmod \+x \/usr\/local\/bin\/sandbox-dotfiles-link/);
+    assert.match(content, /DOTFILES_SRC=\/dotfiles/);
+    assert.match(content, /\[ -d "\$DOTFILES_SRC" \] \|\| exit 0/);
+    assert.match(content, /find \. -type f -print/);
+    assert.match(content, /\.ssh\|\.ssh\/\*/);
+    assert.match(content, /\.gnupg\|\.gnupg\/\*/);
+    assert.match(content, /\.config\/opencode\|\.config\/opencode\/\*/);
+    assert.match(content, /\.gitconfig\|\.gitignore_global\|\.stCommitMsg\|\.bash_aliases/);
+    assert.match(content, /mkdir -p "\$\(dirname "\$target"\)"/);
+    assert.match(content, /\[ -d "\$target" \] && \[ ! -L "\$target" \]/);
+    assert.match(content, /skipping %s \(existing directory; use nested path like %s\/<file> instead\)/);
+    assert.match(content, /ln -sfn "\$DOTFILES_SRC\/\$rel" "\$target"/);
+    assert.match(content, /printf 'sandbox-dotfiles-link: failed to link %s\\n' "\$target" >&2/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("composeDockerfile invokes sandbox-dotfiles-link from sandbox-tmux-entry", async () => {
+  const sandboxDockerfile = await loadFreshEsm("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-dotfiles-entry-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /sandbox-dotfiles-link >\/dev\/null \|\| true/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("composeDockerfile configures tmux extended keys and terminal env forwarding", async () => {
   const sandboxDockerfile = await loadFreshEsm("lib/sandbox/dockerfile.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmux-config-"));
@@ -744,6 +796,34 @@ test("buildContainerEnvFile uses engine-aware env-file paths for WSL2", async ()
   });
 
   assert.deepEqual(envFile.dockerArgs, ["--env-file", "/mnt/f/tmp/agent-infra-env-fixed/env"]);
+});
+
+test("buildDotfilesVolumeArgs returns volume args when host dir exists", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  const args = sandboxCreate.buildDotfilesVolumeArgs("native", "/host/dotfiles", () => true);
+
+  assert.deepEqual(args, ["-v", "/host/dotfiles:/dotfiles:ro"]);
+});
+
+test("buildDotfilesVolumeArgs returns empty when host dir is missing or falsy", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  assert.deepEqual(sandboxCreate.buildDotfilesVolumeArgs("native", "/host/dotfiles", () => false), []);
+  assert.deepEqual(sandboxCreate.buildDotfilesVolumeArgs("native", null), []);
+  assert.deepEqual(sandboxCreate.buildDotfilesVolumeArgs("native", ""), []);
+});
+
+test("buildDotfilesVolumeArgs applies engine-aware path on wsl2", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+
+  const args = sandboxCreate.buildDotfilesVolumeArgs(
+    "wsl2",
+    "C:\\Users\\u\\.agent-infra\\dotfiles",
+    () => true
+  );
+
+  assert.deepEqual(args, ["-v", "/mnt/c/Users/u/.agent-infra/dotfiles:/dotfiles:ro"]);
 });
 
 test("terminalEnvFlags forwards iTerm2 detection variables for Shift+Enter support", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #298

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

为沙箱新增**第四类挂载语义层**：用户级偏好 dotfiles 通道，与现有的项目级 `/share`、SSH 凭证 `~/.ssh`、AI 工具凭证目录三类在作用域与读写语义上正交。

在此之前，沙箱里 tmux、lazygit、yazi 等 TUI 工具只能依赖镜像内置默认（`/etc/tmux.conf` 等），用户无法把习惯的偏好带进沙箱。临时方案只能进沙箱后手工 `vim ~/.tmux.conf`，沙箱重建即丢失。

This PR introduces a **fourth mount-semantics layer** for the sandbox: a user-level dotfiles channel that is orthogonal to existing project-level `/share`, SSH credentials, and AI-tool credential mounts. Previously TUI tools (tmux, lazygit, yazi, ...) inside the sandbox could only fall back to image-baked defaults; user preferences now persist across sandbox rebuilds via a host directory `~/.agent-infra/dotfiles/`.

## 📋 主要变更 / Brief Changelog

- 新增 host 端约定目录 `~/.agent-infra/dotfiles/`，目录树镜像容器 `$HOME`（GNU stow / chezmoi 风格）；通过 `volumeArg(engine, dotfilesDir, '/dotfiles', ':ro')` 仅在 host 端存在时挂载为 ro `/dotfiles`，host 缺失即跳过（`fs.existsSync` 在 JS 侧拦截）。
- 镜像内置 `/usr/local/bin/sandbox-dotfiles-link` 钩子：`find /dotfiles -type f` 遍历，对每个文件 `mkdir -p $(dirname target)` + `ln -sfn /dotfiles/<rel> $HOME/<rel>`；只链文件、不动目录；`sandbox-tmux-entry` 起首调用钩子（`>/dev/null || true` 屏蔽 stdout 噪音、保留 stderr 警告、退出码兜底）。
- 钩子内置**双层守卫**：
  - **Layer 1（硬白名单 silently skip）**：`.ssh`、`.gnupg`、`.claude`、`.codex`、`.gemini`、`.config/opencode`、`.local/share/opencode`、`.host-shell-config` 及 4 个 agent-infra 管理软链（`.gitconfig`、`.gitignore_global`、`.stCommitMsg`、`.bash_aliases`），保护框架强绑定凭证 / 配置不被 dotfiles 覆盖；
  - **Layer 2（dir-collision warn + hint）**：target 已是真实目录（非软链）时打印含嵌套路径建议的 stderr 警告并跳过，避免 `ln -sfn` 在目录里静默创建嵌套链接（runtime 测试发现的真实漏洞）。
- 抽出导出函数 `buildDotfilesVolumeArgs(engine, dotfilesDir, existsFn)`（紧邻 `buildContainerEnvArgs` 同一模式），便于单测覆盖"存在 / 缺失 / null 边界 / wsl2 路径"全分支。
- 双语 README 新增「用户级 dotfiles 通道」小节，含目录示例、行为说明、**受保护路径表**、**冲突告警示例**与凭证禁放清单。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

**自动化（unit）**：

```bash
npx -y node@22 --test tests/cli/sandbox.test.js          # 187 / 186 pass / 1 skipped
npx -y node@22 --test tests/cli/*.test.js tests/templates/*.test.js \
  tests/core/*.test.js tests/scripts/*.test.js           # 443 / 442 pass / 1 skipped
```

**Docker 端到端（maintainer 本地，已跑过 11/11 PASS）**：

1. `mkdir -p ~/.agent-infra/dotfiles/.config/lazygit && echo 'set -g status-bg red' > ~/.agent-infra/dotfiles/.tmux.conf && echo 'gui: { theme: red }' > ~/.agent-infra/dotfiles/.config/lazygit/config.yml`
2. `git branch agent-infra-feature-dotfiles-verify HEAD && node bin/cli.js sandbox create agent-infra-feature-dotfiles-verify`
3. `node bin/cli.js sandbox exec agent-infra-feature-dotfiles-verify` 进 sandbox 后：
   - `test -x /usr/local/bin/sandbox-dotfiles-link` ✅
   - `ls /dotfiles` 看到 host 文件 ✅
   - `grep sandbox-dotfiles-link /usr/local/bin/sandbox-tmux-entry` ✅
   - `readlink ~/.tmux.conf` → `/dotfiles/.tmux.conf` ✅
   - `readlink ~/.config/lazygit/config.yml` → `/dotfiles/.config/lazygit/config.yml` ✅
   - `tmux show-options -g status-bg` → `status-bg red` ✅
4. host 端 `rm -rf ~/.agent-infra/dotfiles && node bin/cli.js sandbox rm/create/exec` → 沙箱内 `ls /dotfiles` 报 `No such file or directory`（`fs.existsSync` 拦截 -v 生效）✅

**钩子算法层 sandbox-runtime 测试（21/21 PASS）**：

- Layer 1：12 类白名单条目 silently skip + 3 个控制组（`.tmux.conf` / `.config/lazygit/config.yml` / `.bashrc`）正常链接、stderr 零噪音
- Layer 2：`.cache` 撞已存在目录 → warn + hint + 不破坏既有目录 + 嵌套保留

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更：新增挂载、host 缺失即跳过，对老 sandbox 无影响）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

**镜像层签名变化**：本 PR 修改了 `lib/sandbox/runtimes/base.dockerfile`，dockerfile signature 变更会让所有现存沙箱在下次 `ai sandbox create` 时自动触发一次 rebuild（既有逻辑，无新工作）。从 layer 6（`sandbox-dotfiles-link`）开始的所有层重建，约 5–7 分钟，之后回归 layer cache。

**未来扩展**：往沙箱里塞任何新偏好（`starship.toml`、`lazygit/`、`yazi/` 等），**只需把文件放到 host 端 `~/.agent-infra/dotfiles/`**，永远不再改 Dockerfile / `create.js`——这是本 PR 设计的核心卖点。

**受保护路径**与**冲突告警**已写入双语 README，避免凭证泄漏与静默走形。

---

**审查者注意事项 / Reviewer Notes:**

- `lib/sandbox/runtimes/base.dockerfile` 的钩子脚本是 PR 核心，关注 Layer 1 case 与 Layer 2 if 守卫顺序（`Layer 1 case → mkdir -p → Layer 2 if → ln -sfn → printf fallback`）
- `tests/cli/sandbox.test.js` 新增的 9 条 assertion 均为结构性 token 匹配，遵循 CLAUDE.md "禁止关键词语义断言" 规约
- 钩子在 `sandbox-tmux-entry` 起首调用（不在 `ai sandbox exec <branch> <cmd>` 自定义命令路径触发），是有意设计：一次性命令不应隐式应用用户偏好

Closes #298.

Generated with AI assistance.
