### PR TITLE
feat(sandbox): dereference dotfiles symlinks on host

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,6 @@ nested directories beyond 32 levels are also skipped with a warning. Symlinks
 pointing outside `$HOME` are accepted as long as the host user can read the
 target.
 
-Existing sandboxes created before this feature need `ai sandbox rm <branch>`
-and `ai sandbox create <branch>` once to pick up the new snapshot bind mount.
-`ai sandbox refresh` does not rebuild the snapshot.
-
 > **Do not put secrets in `~/.agent-infra/dotfiles/`.** The mount is read-only
 > inside the container, but the full preference tree is linked into every
 > project sandbox. Do not place `.ssh/`, `.aws/credentials`, `.netrc`,

--- a/README.md
+++ b/README.md
@@ -245,14 +245,37 @@ To add future preferences such as `starship.toml` or `.gitconfig.local`, put
 files in `~/.agent-infra/dotfiles/`; no Dockerfile or `ai sandbox create`
 changes are needed.
 
+#### Symlinks as pointers to host files
+
+You can place symlinks inside `~/.agent-infra/dotfiles/` to point at real files
+on your host:
+
+```bash
+ln -s ~/.tmux.conf ~/.agent-infra/dotfiles/.tmux.conf
+ln -s ~/.config/lazygit ~/.agent-infra/dotfiles/.config/lazygit
+```
+
+Before each `ai sandbox create` and `ai sandbox enter`, agent-infra
+dereferences the dotfiles tree into
+`~/.agent-infra/.cache/dotfiles-resolved/<project>/` and mounts that snapshot
+into the container. Editing the host source file, then re-entering the sandbox,
+is enough to pick up the latest content.
+
+Dangling symlinks are skipped with a stderr warning. Symlink cycles and deeply
+nested directories beyond 32 levels are also skipped with a warning. Symlinks
+pointing outside `$HOME` are accepted as long as the host user can read the
+target.
+
+Existing sandboxes created before this feature need `ai sandbox rm <branch>`
+and `ai sandbox create <branch>` once to pick up the new snapshot bind mount.
+`ai sandbox refresh` does not rebuild the snapshot.
+
 > **Do not put secrets in `~/.agent-infra/dotfiles/`.** The mount is read-only
 > inside the container, but the full preference tree is linked into every
 > project sandbox. Do not place `.ssh/`, `.aws/credentials`, `.netrc`,
 > `.gnupg/`, `.npmrc` files containing `_authToken`, AI tool OAuth/access token
 > files, or `.gitconfig` there. Use the dedicated SSH and credential channels,
 > and prefer `.gitconfig.local` with `[include]` for local Git preferences.
-> Also avoid symlinks in this tree; the hook uses `find -type f` and does not
-> follow them.
 
 **Protected paths** are ignored by the hook even if they appear under
 `~/.agent-infra/dotfiles/`:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,7 +235,27 @@ host 端目录树镜像容器 `$HOME` 下的预期路径，风格类似 GNU stow
 未来要加 `starship.toml`、`.gitconfig.local` 等偏好，只需把文件放进
 `~/.agent-infra/dotfiles/`，无需修改 Dockerfile 或 `ai sandbox create`。
 
-> **不要往 `~/.agent-infra/dotfiles/` 放任何凭证。** 容器内是只读挂载，但整棵偏好树会链入所有项目沙箱。不要放 `.ssh/`、`.aws/credentials`、`.netrc`、`.gnupg/`、包含 `_authToken` 的 `.npmrc`、任何 AI 工具 OAuth/access token 文件，也不要放 `.gitconfig`。SSH 和工具凭证请使用专用通道；本地 Git 偏好建议用 `.gitconfig.local` 配合 `[include]`。也不要在这棵目录里放符号链接；钩子使用 `find -type f` 遍历，不会跟随符号链接。
+##### 符号链接作为指向 host 文件的指针
+
+你可以在 `~/.agent-infra/dotfiles/` 里放符号链接，让它们指向 host 上的真实文件：
+
+```bash
+ln -s ~/.tmux.conf ~/.agent-infra/dotfiles/.tmux.conf
+ln -s ~/.config/lazygit ~/.agent-infra/dotfiles/.config/lazygit
+```
+
+每次执行 `ai sandbox create` 和 `ai sandbox enter` 前，agent-infra 会先把
+dotfiles 树解引用到
+`~/.agent-infra/.cache/dotfiles-resolved/<project>/`，再把这份快照挂载进容器。
+因此修改 host 源文件后，重新进入沙箱即可看到最新内容。
+
+悬空符号链接会被跳过并在 stderr 输出警告。符号链接循环以及超过 32 层的深层目录也会被跳过并输出警告。指向 `$HOME` 之外的符号链接可以使用，只要 host 用户能读取目标。
+
+此功能发布前已创建的沙箱，需要先执行一次 `ai sandbox rm <branch>`，再执行
+`ai sandbox create <branch>`，才能切换到新的快照 bind mount。`ai sandbox refresh`
+不会重建快照。
+
+> **不要往 `~/.agent-infra/dotfiles/` 放任何凭证。** 容器内是只读挂载，但整棵偏好树会链入所有项目沙箱。不要放 `.ssh/`、`.aws/credentials`、`.netrc`、`.gnupg/`、包含 `_authToken` 的 `.npmrc`、任何 AI 工具 OAuth/access token 文件，也不要放 `.gitconfig`。SSH 和工具凭证请使用专用通道；本地 Git 偏好建议用 `.gitconfig.local` 配合 `[include]`。
 
 **受保护路径**即使出现在 `~/.agent-infra/dotfiles/` 下，也会被钩子忽略：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -251,10 +251,6 @@ dotfiles 树解引用到
 
 悬空符号链接会被跳过并在 stderr 输出警告。符号链接循环以及超过 32 层的深层目录也会被跳过并输出警告。指向 `$HOME` 之外的符号链接可以使用，只要 host 用户能读取目标。
 
-此功能发布前已创建的沙箱，需要先执行一次 `ai sandbox rm <branch>`，再执行
-`ai sandbox create <branch>`，才能切换到新的快照 bind mount。`ai sandbox refresh`
-不会重建快照。
-
 > **不要往 `~/.agent-infra/dotfiles/` 放任何凭证。** 容器内是只读挂载，但整棵偏好树会链入所有项目沙箱。不要放 `.ssh/`、`.aws/credentials`、`.netrc`、`.gnupg/`、包含 `_authToken` 的 `.npmrc`、任何 AI 工具 OAuth/access token 文件，也不要放 `.gitconfig`。SSH 和工具凭证请使用专用通道；本地 Git 偏好建议用 `.gitconfig.local` 配合 `[include]`。
 
 **受保护路径**即使出现在 `~/.agent-infra/dotfiles/` 下，也会被钩子忽略：

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -39,6 +39,7 @@ import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../to
 import { hostJoin, toEnginePath, volumeArg } from '../engines/wsl2-paths.js';
 import { validateSelinuxDisableEnv } from '../engines/selinux.js';
 import { resolveBuildUid } from '../engines/native.js';
+import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.js';
 import {
   assertClaudeCredentialsAvailable,
   redactCommandError,
@@ -578,11 +579,11 @@ export function buildContainerEnvFile(
   }
 }
 
-export function buildDotfilesVolumeArgs(engine, dotfilesDir, existsFn = fs.existsSync) {
-  if (!dotfilesDir || !existsFn(dotfilesDir)) {
+export function buildDotfilesVolumeArgs(engine, snapshotDir, existsFn = fs.existsSync) {
+  if (!snapshotDir || !existsFn(snapshotDir)) {
     return [];
   }
-  return ['-v', volumeArg(engine, dotfilesDir, '/dotfiles', ':ro')];
+  return ['-v', volumeArg(engine, snapshotDir, '/dotfiles', ':ro')];
 }
 
 export function assertBranchAvailable(
@@ -1208,6 +1209,14 @@ export async function create(args) {
             fs.mkdirSync(shareCommon, { recursive: true });
             fs.mkdirSync(shareBranch, { recursive: true });
 
+            const dotfilesSnapshot = materializeDotfiles(
+              effectiveConfig.dotfilesDir,
+              dotfilesCacheDir(effectiveConfig.home, effectiveConfig.project)
+            );
+            const dotfilesMount = dotfilesSnapshot
+              ? buildDotfilesVolumeArgs(engine, dotfilesSnapshot.cacheDir)
+              : [];
+
             runEngineTaskCommand(engine, 'docker', [
               'run',
               '-d',
@@ -1235,7 +1244,7 @@ export async function create(args) {
               ),
               '-v',
               volumeArg(engine, hostJoin(effectiveConfig.home, '.ssh'), '/home/devuser/.ssh', ':ro'),
-              ...buildDotfilesVolumeArgs(engine, effectiveConfig.dotfilesDir),
+              ...dotfilesMount,
               ...toolVolumes,
               ...liveMountVolumes,
               ...shellConfigVolumes,

--- a/lib/sandbox/commands/enter.js
+++ b/lib/sandbox/commands/enter.js
@@ -10,6 +10,7 @@ import {
 } from '../credentials.js';
 import { runInteractiveEngine, runSafeEngine } from '../shell.js';
 import { resolveTaskBranch } from '../task-resolver.js';
+import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.js';
 
 const USAGE = `Usage: ai sandbox exec <branch> [cmd...]`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
@@ -98,6 +99,12 @@ export function enter(args) {
 
   const envFlags = terminalEnvFlags();
   if (cmd.length === 0) {
+    try {
+      materializeDotfiles(config.dotfilesDir, dotfilesCacheDir(config.home, config.project));
+    } catch (error) {
+      process.stderr.write(`Warning: dotfiles snapshot rebuild failed: ${redactCommandError(error?.message ?? 'unknown error')}\n`);
+    }
+
     return runInteractiveEngine(engine, 'docker', ['exec', '-it', ...envFlags, container, 'bash', TMUX_ENTRY_PATH]);
   }
 

--- a/lib/sandbox/dotfiles.js
+++ b/lib/sandbox/dotfiles.js
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { hostJoin } from './engines/wsl2-paths.js';
+
+export function dotfilesCacheDir(home, project) {
+  return hostJoin(home, '.agent-infra', '.cache', 'dotfiles-resolved', project);
+}
+
+function dotfilesWarning(warnings, writeStderr, relPath, reason, detail = '') {
+  const warning = { rel: relPath, reason };
+  if (detail) {
+    warning.detail = detail;
+  }
+  warnings.push(warning);
+
+  const suffix = detail ? `: ${detail}` : '';
+  writeStderr(`sandbox-dotfiles (host): skipping ${relPath} (${reason}${suffix})\n`);
+}
+
+function copyDotfile(srcPath, dstPath, context) {
+  const { fsModule, relPath, warnings, writeStderr } = context;
+  try {
+    fsModule.mkdirSync(path.dirname(dstPath), { recursive: true });
+    fsModule.copyFileSync(srcPath, dstPath);
+  } catch (error) {
+    dotfilesWarning(warnings, writeStderr, relPath, 'copy failed', error?.code ?? error?.message ?? 'unknown error');
+  }
+}
+
+function walkAndMaterializeDotfiles(context) {
+  const {
+    srcDir,
+    dstDir,
+    relParts,
+    depth,
+    maxDepth,
+    activeDirs,
+    warnings,
+    writeStderr,
+    fsModule
+  } = context;
+  const relPath = relParts.length > 0 ? relParts.join('/') : '.';
+
+  if (depth > maxDepth) {
+    dotfilesWarning(warnings, writeStderr, relPath, 'depth exceeds limit', String(maxDepth));
+    return;
+  }
+
+  let entries;
+  try {
+    entries = fsModule.readdirSync(srcDir, { withFileTypes: true });
+  } catch (error) {
+    dotfilesWarning(warnings, writeStderr, relPath, 'read failed', error?.code ?? error?.message ?? 'unknown error');
+    return;
+  }
+
+  for (const entry of entries) {
+    const childSrc = path.join(srcDir, entry.name);
+    const childDst = path.join(dstDir, entry.name);
+    const childRelParts = [...relParts, entry.name];
+    const childRelPath = childRelParts.join('/');
+
+    if (entry.isSymbolicLink()) {
+      let resolvedTarget;
+      try {
+        resolvedTarget = fsModule.realpathSync(childSrc);
+      } catch (error) {
+        const reason = error?.code === 'ELOOP' ? 'symlink loop' : 'dangling symlink';
+        dotfilesWarning(warnings, writeStderr, childRelPath, reason, error?.code ?? 'unresolved');
+        continue;
+      }
+
+      let targetStat;
+      try {
+        targetStat = fsModule.statSync(resolvedTarget);
+      } catch (error) {
+        dotfilesWarning(warnings, writeStderr, childRelPath, 'target stat failed', error?.code ?? error?.message ?? 'unknown error');
+        continue;
+      }
+
+      if (targetStat.isDirectory()) {
+        if (activeDirs.has(resolvedTarget)) {
+          dotfilesWarning(warnings, writeStderr, childRelPath, 'symlink loop');
+          continue;
+        }
+
+        activeDirs.add(resolvedTarget);
+        walkAndMaterializeDotfiles({
+          srcDir: resolvedTarget,
+          dstDir: childDst,
+          relParts: childRelParts,
+          depth: depth + 1,
+          maxDepth,
+          activeDirs,
+          warnings,
+          writeStderr,
+          fsModule
+        });
+        activeDirs.delete(resolvedTarget);
+        continue;
+      }
+
+      if (targetStat.isFile()) {
+        copyDotfile(resolvedTarget, childDst, {
+          fsModule,
+          relPath: childRelPath,
+          warnings,
+          writeStderr
+        });
+      }
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      let childRealPath = null;
+      try {
+        childRealPath = fsModule.realpathSync(childSrc);
+      } catch {
+        // A real directory may disappear during traversal; readdir will warn below.
+      }
+      if (childRealPath) {
+        activeDirs.add(childRealPath);
+      }
+      walkAndMaterializeDotfiles({
+        srcDir: childSrc,
+        dstDir: childDst,
+        relParts: childRelParts,
+        depth: depth + 1,
+        maxDepth,
+        activeDirs,
+        warnings,
+        writeStderr,
+        fsModule
+      });
+      if (childRealPath) {
+        activeDirs.delete(childRealPath);
+      }
+      continue;
+    }
+
+    if (entry.isFile()) {
+      copyDotfile(childSrc, childDst, {
+        fsModule,
+        relPath: childRelPath,
+        warnings,
+        writeStderr
+      });
+    }
+  }
+}
+
+export function materializeDotfiles(srcDir, cacheDir, options = {}) {
+  const {
+    writeStderr = (message) => process.stderr.write(message),
+    maxDepth = 32,
+    fsModule = fs
+  } = options;
+
+  if (!srcDir || !fsModule.existsSync(srcDir)) {
+    return null;
+  }
+
+  fsModule.mkdirSync(cacheDir, { recursive: true });
+  for (const entry of fsModule.readdirSync(cacheDir)) {
+    fsModule.rmSync(path.join(cacheDir, entry), { recursive: true, force: true });
+  }
+
+  const warnings = [];
+  const activeDirs = new Set();
+  try {
+    activeDirs.add(fsModule.realpathSync(srcDir));
+  } catch {
+    activeDirs.add(srcDir);
+  }
+
+  walkAndMaterializeDotfiles({
+    srcDir,
+    dstDir: cacheDir,
+    relParts: [],
+    depth: 0,
+    maxDepth,
+    activeDirs,
+    warnings,
+    writeStderr,
+    fsModule
+  });
+
+  return { cacheDir, warnings };
+}

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -59,6 +59,44 @@ function captureStdoutWrite(fn) {
   }
 }
 
+function makeDotfilesFixture(prefix = "agent-infra-materialize-dotfiles-") {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const srcDir = path.join(tmpDir, "src");
+  const cacheDir = path.join(tmpDir, "cache");
+  const externalDir = path.join(tmpDir, "external");
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.mkdirSync(externalDir, { recursive: true });
+  return { tmpDir, srcDir, cacheDir, externalDir };
+}
+
+function trySymlink(target, linkPath, type) {
+  try {
+    fs.symlinkSync(target, linkPath, type);
+    return true;
+  } catch (error) {
+    if (["EPERM", "EACCES", "ENOTSUP"].includes(error?.code)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function symlinkType(type) {
+  if (type === "dir" && process.platform === "win32") {
+    return "junction";
+  }
+  return type;
+}
+
+function readMaterializeResult(sandboxDotfiles, srcDir, cacheDir, options = {}) {
+  const stderrChunks = [];
+  const result = sandboxDotfiles.materializeDotfiles(srcDir, cacheDir, {
+    writeStderr: (chunk) => stderrChunks.push(chunk),
+    ...options
+  });
+  return { result, stderr: stderrChunks.join("") };
+}
+
 function withFakeStty(exitCode, fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-fake-stty-"));
   const sttyPath = path.join(tmpDir, "stty");
@@ -349,6 +387,15 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     process.chdir(previousCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+});
+
+test("dotfilesCacheDir returns project-scoped cache path under .agent-infra cache", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+
+  assert.equal(
+    sandboxDotfiles.dotfilesCacheDir("/home/u", "demo"),
+    "/home/u/.agent-infra/.cache/dotfiles-resolved/demo"
+  );
 });
 
 test("loadConfig preserves configured sandbox engine", async () => {
@@ -824,6 +871,226 @@ test("buildDotfilesVolumeArgs applies engine-aware path on wsl2", async () => {
   );
 
   assert.deepEqual(args, ["-v", "/mnt/c/Users/u/.agent-infra/dotfiles:/dotfiles:ro"]);
+});
+
+test("materializeDotfiles returns null when source directory is missing", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    fs.rmSync(srcDir, { recursive: true, force: true });
+
+    const result = sandboxDotfiles.materializeDotfiles(srcDir, cacheDir);
+
+    assert.equal(result, null);
+    assert.equal(fs.existsSync(cacheDir), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles dereferences a regular file symlink", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir, externalDir } = makeDotfilesFixture();
+
+  try {
+    const realFile = path.join(externalDir, ".tmux.conf");
+    fs.writeFileSync(realFile, "set -g mouse on\n", "utf8");
+    const symlinkCreated = trySymlink(realFile, path.join(srcDir, ".tmux.conf"), "file");
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(srcDir, ".tmux.conf")), false);
+      return;
+    }
+
+    const { result, stderr } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.equal(result.cacheDir, cacheDir);
+    assert.deepEqual(result.warnings, []);
+    assert.equal(stderr, "");
+    assert.equal(fs.lstatSync(path.join(cacheDir, ".tmux.conf")).isFile(), true);
+    assert.equal(fs.readFileSync(path.join(cacheDir, ".tmux.conf"), "utf8"), "set -g mouse on\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles dereferences a directory symlink", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir, externalDir } = makeDotfilesFixture();
+
+  try {
+    const realConfigDir = path.join(externalDir, "config");
+    fs.mkdirSync(path.join(realConfigDir, "lazygit"), { recursive: true });
+    fs.writeFileSync(path.join(realConfigDir, "lazygit", "config.yml"), "gui:\n  nerdFontsVersion: \"3\"\n", "utf8");
+    const symlinkCreated = trySymlink(realConfigDir, path.join(srcDir, ".config"), symlinkType("dir"));
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(srcDir, ".config")), false);
+      return;
+    }
+
+    const { result } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(
+      fs.readFileSync(path.join(cacheDir, ".config", "lazygit", "config.yml"), "utf8"),
+      "gui:\n  nerdFontsVersion: \"3\"\n"
+    );
+    assert.equal(fs.lstatSync(path.join(cacheDir, ".config")).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles warns on dangling symlink and continues", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    fs.writeFileSync(path.join(srcDir, "regular"), "kept\n", "utf8");
+    const symlinkCreated = trySymlink(path.join(tmpDir, "missing"), path.join(srcDir, "broken"), "file");
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(srcDir, "broken")), false);
+      return;
+    }
+
+    const { result, stderr } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.equal(result.warnings.some((warning) => warning.rel === "broken" && warning.reason === "dangling symlink"), true);
+    assert.match(stderr, /sandbox-dotfiles \(host\): skipping broken \(dangling symlink:/);
+    assert.equal(fs.existsSync(path.join(cacheDir, "broken")), false);
+    assert.equal(fs.readFileSync(path.join(cacheDir, "regular"), "utf8"), "kept\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles breaks symlink cycles via active realpath set", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    const realDir = path.join(srcDir, "dir");
+    fs.mkdirSync(realDir, { recursive: true });
+    fs.writeFileSync(path.join(realDir, "kept"), "kept\n", "utf8");
+    const symlinkCreated = trySymlink(srcDir, path.join(realDir, "back"), symlinkType("dir"));
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(realDir, "back")), false);
+      return;
+    }
+
+    const { result, stderr } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.equal(result.warnings.some((warning) => warning.rel === "dir/back" && warning.reason === "symlink loop"), true);
+    assert.match(stderr, /sandbox-dotfiles \(host\): skipping dir\/back \(symlink loop\)/);
+    assert.equal(fs.readFileSync(path.join(cacheDir, "dir", "kept"), "utf8"), "kept\n");
+    assert.equal(fs.existsSync(path.join(cacheDir, "dir", "back", "dir", "back")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles caps recursion at maxDepth", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    const deepDir = path.join(srcDir, "one", "two", "three");
+    fs.mkdirSync(deepDir, { recursive: true });
+    fs.writeFileSync(path.join(deepDir, "too-deep"), "hidden\n", "utf8");
+
+    const { result, stderr } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir, { maxDepth: 2 });
+
+    assert.equal(result.warnings.some((warning) => warning.rel === "one/two/three" && warning.reason === "depth exceeds limit"), true);
+    assert.match(stderr, /sandbox-dotfiles \(host\): skipping one\/two\/three \(depth exceeds limit: 2\)/);
+    assert.equal(fs.existsSync(path.join(cacheDir, "one", "two", "three", "too-deep")), false);
+    assert.equal(fs.existsSync(path.join(cacheDir, "one", "two", "three")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles dereferences symlinks pointing outside the source tree", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir, externalDir } = makeDotfilesFixture();
+
+  try {
+    const hostFile = path.join(externalDir, "host-tmux.conf");
+    fs.writeFileSync(hostFile, "set -g status-position top\n", "utf8");
+    const symlinkCreated = trySymlink(hostFile, path.join(srcDir, ".tmux.conf"), "file");
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(srcDir, ".tmux.conf")), false);
+      return;
+    }
+
+    const { result } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(fs.readFileSync(path.join(cacheDir, ".tmux.conf"), "utf8"), "set -g status-position top\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles empties cacheDir contents without removing cacheDir itself", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, "old"), "old\n", "utf8");
+    const before = fs.statSync(cacheDir);
+    fs.writeFileSync(path.join(srcDir, "new"), "new\n", "utf8");
+
+    readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    const after = fs.statSync(cacheDir);
+    assert.equal(after.ino, before.ino);
+    assert.equal(fs.existsSync(path.join(cacheDir, "old")), false);
+    assert.equal(fs.readFileSync(path.join(cacheDir, "new"), "utf8"), "new\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles preserves regular files alongside symlinks", async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir, externalDir } = makeDotfilesFixture();
+
+  try {
+    fs.writeFileSync(path.join(srcDir, ".inputrc"), "set editing-mode vi\n", "utf8");
+    const hostFile = path.join(externalDir, ".tmux.conf");
+    fs.writeFileSync(hostFile, "set -g history-limit 100000\n", "utf8");
+    const symlinkCreated = trySymlink(hostFile, path.join(srcDir, ".tmux.conf"), "file");
+    if (!symlinkCreated) {
+      assert.equal(fs.existsSync(path.join(srcDir, ".tmux.conf")), false);
+      return;
+    }
+
+    const { result } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(fs.readFileSync(path.join(cacheDir, ".inputrc"), "utf8"), "set editing-mode vi\n");
+    assert.equal(fs.readFileSync(path.join(cacheDir, ".tmux.conf"), "utf8"), "set -g history-limit 100000\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("materializeDotfiles skips fifos silently", onPlatforms("linux", "darwin"), async () => {
+  const sandboxDotfiles = await loadFreshEsm("lib/sandbox/dotfiles.js");
+  const { tmpDir, srcDir, cacheDir } = makeDotfilesFixture();
+
+  try {
+    execFileSync("mkfifo", [path.join(srcDir, "pipe")]);
+
+    const { result, stderr } = readMaterializeResult(sandboxDotfiles, srcDir, cacheDir);
+
+    assert.deepEqual(result.warnings, []);
+    assert.equal(stderr, "");
+    assert.equal(fs.existsSync(path.join(cacheDir, "pipe")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("terminalEnvFlags forwards iTerm2 detection variables for Shift+Enter support", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #310

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

PR #309 引入的 user-level dotfiles 通道（`~/.agent-infra/dotfiles/` → 容器
`/dotfiles:ro`）无法支持用户的"指针式工作流"：

```bash
ln -s ~/.tmux.conf ~/.agent-infra/dotfiles/.tmux.conf
```

Docker bind mount 把 symlink 文本原样搬进容器，目标路径（`/Users/.../.tmux.conf`）
在容器里不存在 → 悬空；`sandbox-dotfiles-link` 又用 `find . -type f` 把 symlink
静默跳过。最终 `$HOME/.tmux.conf` 完全没建，用户没有任何提示。

本 PR 在 host 侧、bind mount 之前对 symlink 做解引用：把
`~/.agent-infra/dotfiles/` 物化成一份"扁平的真实内容"快照，再挂这份快照。
容器内 `sandbox-dotfiles-link` 一行不动。

## 📋 主要变更 / Brief Changelog

- 新增 `lib/sandbox/dotfiles.js`：`materializeDotfiles(srcDir, cacheDir)`
  自递归遍历，用 `realpathSync` + `copyFileSync` 把 dotfiles 树解引用到
  `~/.agent-infra/.cache/dotfiles-resolved/<project>/`。悬空 symlink、循环、
  超过 32 层的深度、HOME 外目标，每一类都有显式 stderr warning 并跳过，
  绝不让单个坏 link 中断 `ai sandbox create`。
- 缓存目录 inode 稳定（in-place 清空内容、不 rename 目录本身），这样
  `ai sandbox enter` 在已运行容器上重建快照后，bind mount 能实时看到新内容
  —— 用户改 host 配置后 `exit` 重进 tmux 即可生效。
- `lib/sandbox/commands/create.js` 与 `lib/sandbox/commands/enter.js` 都接入
  `materializeDotfiles`：`create` 在 `docker run` 前必跑；`enter` 在交互
  入口（`cmd.length === 0`）前 best-effort 跑（失败只 warn，不阻断进入）。
- `buildDotfilesVolumeArgs` 参数从 `dotfilesDir` 重命名为 `snapshotDir`，
  语义反映挂载源已经是物化后的快照。
- 双语 README 新增 "Symlinks as pointers to host files" 章节，给出使用示例
  和已知限制。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run test:core`（在 Node 22 下运行）—— 344 tests 全绿
2. 手动 E2E：
   - `ln -s ~/.tmux.conf ~/.agent-infra/dotfiles/.tmux.conf`
   - `ai sandbox create test-symlink`
   - `ai sandbox exec test-symlink -- cat $HOME/.tmux.conf` → 应等于 host
     `~/.tmux.conf` 内容
   - host 端 `echo "# new line" >> ~/.tmux.conf` → `ai sandbox exec test-symlink`
     重进 tmux 后即可看到新内容
   - 悬空 link：`ln -s /nonexistent ~/.agent-infra/dotfiles/.broken`，再 enter
     应在 stderr 看到 `sandbox-dotfiles (host): skipping .broken (dangling symlink: ENOENT)`
3. `tests/cli/sandbox.test.js` 中新增 10 个 `materializeDotfiles` 用例 + 1 个
   `dotfilesCacheDir` 用例，覆盖：常规 symlink、目录 symlink、悬空 + 警告、
  symlink 循环、深度上限、HOME 外目标、cacheDir inode 稳定性、混合文件、
  fifo 静默跳过（`onPlatforms("linux", "darwin")` 守卫）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

**升级提示**（不属于长期文档，记录在此供 reviewer / changelog 使用）：
此 PR 合并前已创建的沙箱挂载的是旧路径 `~/.agent-infra/dotfiles/`，需要执行
一次 `ai sandbox rm <branch>` + `ai sandbox create <branch>` 才能切换到新的
快照 bind mount。`ai sandbox refresh` 不触发快照重建（refresh 只处理 Claude
凭证）。

**保留项**：缓存路径 `~/.agent-infra/.cache/dotfiles-resolved/<project>/` 与
项目中其他缓存（`gpg-cache/`、`share/`、`worktrees/`）的"直接挂在
`.agent-infra/` 下"风格不一致。该路径在 Issue #310 描述里硬指定，本 PR 保留
原样，如有反对意见可在后续 PR 中重命名（host 侧迁移成本仅是用户手动 `rm -rf`
一次旧 cache 即可）。

Closes #310
Refs #309 #298

---

Generated with AI assistance