### PR TITLE
fix(sandbox): inherit Claude launch-pin unlock flag

### DIFF
--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -670,18 +670,10 @@ export function ensureClaudeOnboarding(toolDir, hostHomeDir) {
       data.model = hostClaudeJson.model;
       changed = true;
     }
-    // Claude Code 对每代新模型存在 launch-pin 机制：硬编码默认 effort
-    // (如 Opus 4.7 默认 xhigh)，需顶层布尔 flag `unpin*LaunchEffort: true`
-    // 才会尊重 settings.json 的 effortLevel。这里镜像这些配套 flag，
-    // 让 PR #291 的 effortLevel 继承在新沙箱中真正生效。
-    //
     // Claude Code launch-pins a default effort per model generation (for
     // example xhigh for Opus 4.7). The saved effortLevel is honored only after
     // a top-level boolean `unpin*LaunchEffort: true` flag unlocks it, so mirror
     // those flags here with the existing first-write semantics.
-    //
-    // 用正则而非硬编码：未来新模型可能继续使用同模式 flag；若 Anthropic
-    // 放弃 `unpin*LaunchEffort` 命名，本块会静默跳过，届时需要重新评估。
     //
     // Pattern matching avoids one patch per future model generation. If
     // Anthropic changes the naming convention, this block will no-op and should

--- a/lib/sandbox/commands/create.js
+++ b/lib/sandbox/commands/create.js
@@ -670,6 +670,34 @@ export function ensureClaudeOnboarding(toolDir, hostHomeDir) {
       data.model = hostClaudeJson.model;
       changed = true;
     }
+    // Claude Code 对每代新模型存在 launch-pin 机制：硬编码默认 effort
+    // (如 Opus 4.7 默认 xhigh)，需顶层布尔 flag `unpin*LaunchEffort: true`
+    // 才会尊重 settings.json 的 effortLevel。这里镜像这些配套 flag，
+    // 让 PR #291 的 effortLevel 继承在新沙箱中真正生效。
+    //
+    // Claude Code launch-pins a default effort per model generation (for
+    // example xhigh for Opus 4.7). The saved effortLevel is honored only after
+    // a top-level boolean `unpin*LaunchEffort: true` flag unlocks it, so mirror
+    // those flags here with the existing first-write semantics.
+    //
+    // 用正则而非硬编码：未来新模型可能继续使用同模式 flag；若 Anthropic
+    // 放弃 `unpin*LaunchEffort` 命名，本块会静默跳过，届时需要重新评估。
+    //
+    // Pattern matching avoids one patch per future model generation. If
+    // Anthropic changes the naming convention, this block will no-op and should
+    // be revisited.
+    if (hostClaudeJson) {
+      for (const key of Object.keys(hostClaudeJson)) {
+        if (
+          /^unpin.*LaunchEffort$/.test(key)
+          && hostClaudeJson[key] === true
+          && !Object.hasOwn(data, key)
+        ) {
+          data[key] = true;
+          changed = true;
+        }
+      }
+    }
   }
   if (changed) {
     fs.writeFileSync(claudeJsonPath, JSON.stringify(data, null, 4), 'utf8');

--- a/tests/cli/sandbox.test.js
+++ b/tests/cli/sandbox.test.js
@@ -1400,6 +1400,117 @@ test("ensureClaudeOnboarding ignores malformed host json", async () => {
   }
 });
 
+test("ensureClaudeOnboarding inherits host launch-pin flag when sandbox is absent", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-inherit-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-host-"));
+
+  try {
+    fs.writeFileSync(
+      path.join(hostHome, ".claude.json"),
+      JSON.stringify({ unpinOpus47LaunchEffort: true }),
+      "utf8"
+    );
+    sandboxCreate.ensureClaudeOnboarding(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".claude.json"), "utf8"));
+    assert.equal(data.unpinOpus47LaunchEffort, true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeOnboarding preserves existing sandbox launch-pin flag value", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-preserve-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-host-preserve-"));
+
+  try {
+    fs.writeFileSync(
+      path.join(hostHome, ".claude.json"),
+      JSON.stringify({ unpinOpus47LaunchEffort: true }),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, ".claude.json"),
+      JSON.stringify({ unpinOpus47LaunchEffort: false }),
+      "utf8"
+    );
+    sandboxCreate.ensureClaudeOnboarding(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".claude.json"), "utf8"));
+    assert.equal(data.unpinOpus47LaunchEffort, false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeOnboarding skips launch-pin flag when host omits it", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-omit-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-host-omit-"));
+
+  try {
+    fs.writeFileSync(path.join(hostHome, ".claude.json"), JSON.stringify({ theme: "dark" }), "utf8");
+    sandboxCreate.ensureClaudeOnboarding(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".claude.json"), "utf8"));
+    assert.equal(Object.hasOwn(data, "unpinOpus47LaunchEffort"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeOnboarding inherits all matching launch-pin flags for future models", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-future-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-host-future-"));
+
+  try {
+    fs.writeFileSync(
+      path.join(hostHome, ".claude.json"),
+      JSON.stringify({
+        unpinOpus47LaunchEffort: true,
+        unpinOpus48LaunchEffort: true
+      }),
+      "utf8"
+    );
+    sandboxCreate.ensureClaudeOnboarding(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".claude.json"), "utf8"));
+    assert.equal(data.unpinOpus47LaunchEffort, true);
+    assert.equal(data.unpinOpus48LaunchEffort, true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeOnboarding skips launch-pin flag values that are not strictly true", async () => {
+  const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-nonboolean-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-launchpin-host-nonboolean-"));
+
+  try {
+    fs.writeFileSync(
+      path.join(hostHome, ".claude.json"),
+      JSON.stringify({
+        unpinOpus47LaunchEffort: "true",
+        unpinOpus48LaunchEffort: 1,
+        unpinOpus49LaunchEffort: false
+      }),
+      "utf8"
+    );
+    sandboxCreate.ensureClaudeOnboarding(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".claude.json"), "utf8"));
+    assert.equal(Object.hasOwn(data, "unpinOpus47LaunchEffort"), false);
+    assert.equal(Object.hasOwn(data, "unpinOpus48LaunchEffort"), false);
+    assert.equal(Object.hasOwn(data, "unpinOpus49LaunchEffort"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
 test("ensureClaudeSettings creates settings.json with skipDangerousModePermissionPrompt", async () => {
   const sandboxCreate = await loadFreshEsm("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-"));


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #311

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

PR #291（commit 4d4cd42）声明的「宿主默认自动继承到沙箱」语义在 Claude Code Opus 4.7 上失效：

- 宿主 `~/.claude/settings.json` 设置 `effortLevel: "high"`、宿主 CC 显示 `opus high`；
- PR #291 已经把宿主的 `effortLevel` 复制进沙箱 `settings.json`，但沙箱 CC 仍然显示 `opus xhigh`。

**根因**：Claude Code v2.1.x 对每代新模型存在「launch effort 钉扎」机制——硬编码该模型的默认 effort（Opus 4.7 默认 `xhigh`），由 `~/.claude.json` 顶层的配套布尔 flag（当前命名为 `unpinOpus47LaunchEffort: true`）解锁；只有该 flag 为 true 时，保存的 `effortLevel` 才会被尊重。

PR #291 的继承只复制了 `settings.json` 的 `effortLevel`，没有复制 `.claude.json` 的 `unpin*LaunchEffort` 配套 flag，因此沙箱即便拿到 `effortLevel: "high"` 也会被 launch-pin 覆盖回 `xhigh`，继承表现为静默失效。

The host-default-inheritance semantics introduced by PR #291 silently regress on Claude Code Opus 4.7 because that release launch-pins `xhigh` until a top-level boolean flag in `.claude.json` unlocks the saved `effortLevel`. Only the `settings.json` half was being mirrored, so this PR completes the inheritance by also mirroring the matching unlock flag.

## 📋 主要变更 / Brief Changelog

- 在 `ensureClaudeOnboarding`（`lib/sandbox/commands/create.js`）的 `if (hostHomeDir)` 块尾部追加一段字段级继承：遍历宿主 `~/.claude.json` 顶层键，按正则 `/^unpin.*LaunchEffort$/` + 严格 `=== true` + `!Object.hasOwn(data, key)` 守卫，把所有匹配的布尔解锁 flag 镜像到沙箱 `.claude.json`，沿用 PR #291 的「字段级 + 首次写入 + 不覆盖已有」语义。
- 用正则而非硬编码 `unpinOpus47LaunchEffort`，让继承自动覆盖未来同命名模式的新模型 flag（如 `unpinOpus48LaunchEffort`），避免每代发一次修复 PR 的技术债；并在英文注释里明确写明 launch-pin 机制、正则动机、以及一旦 Anthropic 改命名该块会静默失效需要重新评估的风险。
- 在 `tests/cli/sandbox.test.js` 追加 5 个 `ensureClaudeOnboarding` 场景，覆盖：宿主有沙箱无、沙箱已有保留原值、宿主无、未来多模型同时匹配、非严格 `true` 值（含字符串、数字、布尔 `false`）全部跳过。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（或在 Node 22 下：`npx -y -p node@22 -c 'npm test'`），全量 467 用例应 466 通过 / 1 跳过 / 0 失败。
2. 定向：`node --test --test-name-pattern "ensureClaudeOnboarding" tests/cli/sandbox.test.js`，应 14 / 14 通过（含 5 个新增）。
3. 手动验证：宿主 `~/.claude/settings.json` 含 `"effortLevel": "high"`，宿主 `~/.claude.json` 含 `"unpinOpus47LaunchEffort": true`；执行 `ai sandbox create test-launch-pin`，进入沙箱启动 `claude`，顶部应显示 `opus high`（修复前为 `xhigh`）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（建议在维护者宿主环境上跑一次以闭环）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject/body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范（注释纯英文，与 `.claude/CLAUDE.md` 「代码标识符 / JSDoc -> 英文」对齐）
- [x] 我已经进行了自我代码审查 / Self-review performed (3 轮自动审查 + 1 轮人工审查)
- [x] 我已经为复杂的代码添加了必要的注释 / Comments added (launch-pin 机制、正则动机、未来失效风险 三段英文)

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / Unit tests written
- [x] 当存在跨模块依赖时，我尽量使用了 mock / Mocks used where applicable（本变更纯文件 IO，直接走 `mkdtempSync` 隔离）
- [N/A] 代码检查通过 / Lint checks pass（项目暂未配置 lint 工具）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / Documentation updated（双语 inline 注释 + task workspace 工件）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered（`!Object.hasOwn` 守卫确保不覆盖已有沙箱字段）

## 📋 附加信息 / Additional Notes

**范围声明 / Scope statement**：

本 PR 只修复 Claude Code 的 launch-pin flag 继承。以下作为独立后续任务处理：

- 存量沙箱回填：让 `ai sandbox refresh` 也跑一次继承
- Codex / OpenCode 是否存在类似 launch-pin 机制的排查

**已知风险 / Known risk**：一旦 Anthropic 弃用 `unpin*LaunchEffort` 命名模式，本继承块会静默失效；新模式上线时需要回到 `ensureClaudeOnboarding` 重新评估正则。该风险已在源码英文注释中显式声明。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注：

1. `^unpin.*LaunchEffort$` 的匹配范围是否符合当前对未来 Claude Code launch-pin flag 的前向兼容预期。
2. 只继承严格 `=== true` 且不覆盖沙箱已有值，是否与 PR #291 的首次写入语义一致。
3. 注释覆盖是否充分（launch-pin 机制、正则动机、未来失效风险三点都在 `lib/sandbox/commands/create.js:673-680` 范围内）。

Generated with AI assistance