### PR TITLE
ci(release): 新增发布产物端到端安装冒烟测试 workflow

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -1,0 +1,130 @@
+name: Post-Release Smoke
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to smoke-test (without leading v), e.g. 0.5.10"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: post-release-smoke-${{ github.event.release.id || inputs.version }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-version:
+    name: Resolve target version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.pick.outputs.version }}
+    steps:
+      - name: Pick version from event or input
+        id: pick
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
+          else
+            VERSION="${RELEASE_TAG#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve version"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+  npm-smoke:
+    name: npm install (${{ matrix.os }})
+    needs: resolve-version
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Wait for npm registry propagation
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          for i in $(seq 1 30); do
+            if npm view "@fitlab-ai/agent-infra@${VERSION}" version >/dev/null 2>&1; then
+              echo "Package @fitlab-ai/agent-infra@${VERSION} available on npm"
+              exit 0
+            fi
+            echo "Waiting for npm registry... (attempt $i/30)"
+            sleep 10
+          done
+          echo "::error::Package @fitlab-ai/agent-infra@${VERSION} not found on npm after 5 minutes"
+          exit 1
+
+      - name: Smoke test - agent-infra version
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          OUTPUT=$(npx -y "@fitlab-ai/agent-infra@${VERSION}" version)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -F "${VERSION}"
+
+      - name: Smoke test - sandbox --help
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          npx -y "@fitlab-ai/agent-infra@${VERSION}" sandbox --help
+
+  brew-smoke:
+    name: brew install (macos-latest)
+    needs: resolve-version
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Wait for Homebrew tap formula update
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          FORMULA_URL="https://raw.githubusercontent.com/fitlab-ai/homebrew-tap/main/Formula/agent-infra.rb"
+          for i in $(seq 1 60); do
+            BODY=$(curl -fsSL "$FORMULA_URL" 2>/dev/null || true)
+            if printf '%s' "$BODY" | grep -qF "agent-infra-${VERSION}.tgz"; then
+              echo "Formula updated to ${VERSION}"
+              exit 0
+            fi
+            echo "Waiting for tap formula update... (attempt $i/60)"
+            sleep 10
+          done
+          echo "::error::Tap formula not updated to ${VERSION} after 10 minutes"
+          exit 1
+
+      - name: brew install
+        shell: bash
+        run: brew install fitlab-ai/tap/agent-infra
+
+      - name: Smoke test - agent-infra version
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          OUTPUT=$(agent-infra version)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -F "${VERSION}"

--- a/tests/core/release.test.js
+++ b/tests/core/release.test.js
@@ -101,3 +101,39 @@ test("release documentation reflects CI-driven npm publishing", () => {
     assert.match(content, /Issues that we want to release in v/);
   });
 });
+
+test("post-release-smoke workflow verifies npm and brew install channels", () => {
+  const workflow = read(".github/workflows/post-release-smoke.yml");
+
+  assert.match(workflow, /name: Post-Release Smoke/);
+  assert.match(workflow, /release:[\s\S]*types: \[published\]/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /inputs:[\s\S]*version:/);
+  assert.match(workflow, /permissions: \{\}/);
+  assert.match(workflow, /concurrency:/);
+  assert.match(workflow, /cancel-in-progress: true/);
+
+  assert.match(workflow, /resolve-version:/);
+  assert.match(workflow, /timeout-minutes: 5/);
+  assert.match(workflow, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
+  assert.match(workflow, /DISPATCH_VERSION: \$\{\{ inputs\.version \}\}/);
+  assert.match(workflow, /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \}\}/);
+  assert.match(workflow, /outputs:[\s\S]*version:/);
+
+  assert.match(workflow, /npm-smoke:/);
+  assert.match(workflow, /needs: resolve-version/);
+  assert.match(workflow, /timeout-minutes: 15/);
+  assert.match(workflow, /matrix:[\s\S]*os: \[ubuntu-latest, macos-latest, windows-latest\]/);
+  assert.match(workflow, /fail-fast: false/);
+  assert.match(workflow, /npm view "@fitlab-ai\/agent-infra@\$\{VERSION\}" version/);
+  assert.match(workflow, /npx -y "@fitlab-ai\/agent-infra@\$\{VERSION\}" version/);
+  assert.match(workflow, /npx -y "@fitlab-ai\/agent-infra@\$\{VERSION\}" sandbox --help/);
+
+  assert.match(workflow, /brew-smoke:/);
+  assert.match(workflow, /runs-on: macos-latest/);
+  assert.match(workflow, /timeout-minutes: 20/);
+  assert.match(workflow, /raw\.githubusercontent\.com\/fitlab-ai\/homebrew-tap\/main\/Formula\/agent-infra\.rb/);
+  assert.match(workflow, /name: brew install\s*\n\s*shell: bash/);
+  assert.match(workflow, /brew install fitlab-ai\/tap\/agent-infra/);
+  assert.match(workflow, /agent-infra version/);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #156

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement (CI / release pipeline)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

v0.5.0 发布过程中暴露了发布质量门的盲区：CI 全绿但用户首装 brew 时翻车。现有 `tests/core/release.test.js` 仅做 YAML 结构与 CLI help 文案的字符串断言，未在真实 OS / 包管理器上执行 `npm install` 与 `brew install`。

本 PR 新增一道**发布后端到端安装冒烟门**：每次 GitHub Release 正式发布后自动尝试用户视角的两种安装方式（`npx` 与 `brew`），在 ~5–8 分钟内给出"用户能不能装上"的明确结论；失败时 job 名称直接定位是 npm/Linux / npm/macOS / npm/Windows / brew/macOS 哪条通道挂了，方便发布者决定是否立即出 patch。

The v0.5.0 release exposed a blind spot: CI was green but first-time `brew install` failed for users. The existing `tests/core/release.test.js` only asserts YAML shape and CLI help text — it never executes a real `npm install` or `brew install`. This PR adds an end-to-end install smoke gate that fires on `release.published`, exercising both channels on real GitHub-hosted runners so the maintainer learns within ~5–8 minutes whether the published artifacts are actually installable.

## 📋 主要变更 / Brief Changelog

- **`.github/workflows/post-release-smoke.yml`**（新增）—— 双触发（`release.published` + `workflow_dispatch(version)`），3 个 job：
  - `resolve-version`：把 release tag 或手动入参规范化为统一的无 `v` 前缀版本号，注入下游 outputs；通过 `env:` 透传 `github.event.release.tag_name` / `inputs.version` 等表达式，规避 GHA 脚本注入。
  - `npm-smoke`：`ubuntu-latest` / `macos-latest` / `windows-latest` 三平台并行（`fail-fast: false`），先以 `npm view ...` 轮询 30×10s 等 npm registry 传播，再用 `npx -y @fitlab-ai/agent-infra@${VERSION}` 真实跑 `version` 与 `sandbox --help`，并用 `grep -F "${VERSION}"` 子串校验避免静默放过空输出/降级版本。
  - `brew-smoke`：仅 `macos-latest`，轮询 60×10s 直到 `fitlab-ai/homebrew-tap` 的 `Formula/agent-infra.rb` 包含 `agent-infra-${VERSION}.tgz`（即 `update-homebrew.yml` 已推完 tap commit），再 `brew install fitlab-ai/tap/agent-infra` 并校验 `agent-infra version` 输出。
  - workflow-level `concurrency: post-release-smoke-${{ github.event.release.id || inputs.version }}` + `cancel-in-progress`；每个 job 设 `timeout-minutes`（5 / 15 / 20）；`permissions: {}`（公共通道无需 secret）；所有 step 显式 `shell: bash` 统一跨平台行为。
- **`tests/core/release.test.js`**（追加 `test("post-release-smoke workflow verifies npm and brew install channels", ...)`）—— 结构性断言新 workflow 的触发器键、`inputs.version`、`permissions: {}`、`concurrency` / `cancel-in-progress`、三个 `timeout-minutes`、三个 env 键、`needs: resolve-version`、矩阵 OS 列表、`fail-fast: false`、关键命令（`npm view` / `npx ... version` / `npx ... sandbox --help` / `brew install fitlab-ai/tap/agent-infra` / `agent-infra version`）、tap raw URL 与 `brew install` step 紧随 `shell: bash`。全部仅断言 workflow 结构，不绑定 echo/log/注释文案（符合 `.claude/CLAUDE.md` "禁止关键词语义断言" 规则）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. **本地静态校验**：`actionlint -color .github/workflows/post-release-smoke.yml`（v1.7.7，含 shellcheck v0.10.0 启用）→ exit 0，0 finding。
2. **本地结构测试**：`node --test tests/core/release.test.js`（Node v22.22.3）→ 6/6 passed，其中新增 `post-release-smoke workflow verifies npm and brew install channels` 通过。
3. **全量测试**：`npm run test:core`（pre-commit hook 实跑）→ 359 tests / 358 passed / 1 skipped / 0 failed。
4. **合入后首跑（建议）**：合并到 `main` 后，用一个**已存在**于 npm + tap 的历史版本做 `workflow_dispatch` dry run：
   ```bash
   gh workflow run post-release-smoke.yml -R fitlab-ai/agent-infra -f version=0.5.9
   ```
   观察 4 个 job（`Resolve target version` / `npm install (ubuntu-latest)` / `npm install (macos-latest)` / `npm install (windows-latest)` / `brew install (macos-latest)`）全绿即可。
5. **下一次真实发布**：观察 `release.published` 自动触发 + 5–8 分钟内拿到结论。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（结构性断言覆盖新 workflow 的关键约束）
- [x] 所有现有测试都通过 / All existing tests pass（pre-commit hook 全绿）
- [x] 我已经进行了手动测试 / I have performed manual testing（actionlint + shellcheck 静态校验通过；workflow 本体的真实触发依赖合入 main 后下次 release 或 `workflow_dispatch`，平台硬性约束）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（#156）/ Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject/body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / Code follows project standards
- [x] 我已经进行了自我代码审查 / Self-review performed（2 轮：`review.md` / `review-r2.md`，最终 0 blocker / 0 major / 0 minor）
- [x] 我已经为复杂的代码添加了必要的注释 / Comments added where non-obvious（workflow 内通过 step name + `::error::` 文案表达意图，无需额外注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / Unit tests written（`tests/core/release.test.js` 追加 26 行结构性断言）
- [N/A] 当存在跨模块依赖时，我尽量使用了 mock / Mocks used where applicable（workflow 测试无跨模块依赖）
- [N/A] 代码检查通过 / Lint checks pass（项目暂未配置 lint 工具；workflow 已用 actionlint + shellcheck 校验通过）
- [x] 单元测试通过 / Unit tests pass（Node v22.22.3 下 359 tests / 358 passed / 1 skipped / 0 failed）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / Documentation updated（task workspace 工件）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered（新增独立 workflow，不改动 `release.yml` / `update-homebrew.yml`）

## 📋 附加信息 / Additional Notes

### 设计要点

1. **触发器双轨**：`release.published` 走"GitHub Release 正式发布"语义，与"用户能看到这个版本"对齐；`workflow_dispatch` 提供手动重跑入口，供历史版本回测或故障重跑使用。
2. **不进 `templates/`**：post-release-smoke 是本仓库自身发布产物的质量门，不是初始化模板的一部分；`templates/.github/workflows/` 当前也只镜像 `metadata-sync` / `pr-label` / `status-label`，未镜像 release/homebrew 类发布流水线，保持一致。
3. **GHA 表达式注入防御**：所有用户可控表达式（`inputs.version`、`github.event.release.tag_name`、`github.event_name`）先通过 `env:` 注入 step 环境，再以 `"$VAR"` 引用，遵循 GitHub Security Hardening 推荐。
4. **失败定位粒度到通道 × 平台**：job `name` 显式标注 `npm install (ubuntu-latest)` / `brew install (macos-latest)`，GitHub UI 与邮件通知一眼可定位故障通道。
5. **brew tap 时序解耦**：`update-homebrew.yml` 由 `workflow_run` 触发（独立于 `release.published`），smoke 不通过 `workflow_run` 显式依赖，而是轮询 `raw.githubusercontent.com/fitlab-ai/homebrew-tap/main/Formula/agent-infra.rb` 自行判断 formula 是否切换到目标版本（最长 10 分钟窗口）。

### 已知约束 / Known Constraints

- **首次端到端验证依赖合入 `main`**：`workflow_dispatch` 只能在默认分支调用，新 workflow 没合入 main 前无法手动 dispatch（GitHub Actions 平台硬约束）。本 PR 合入前的"档位 1"静态校验已经覆盖 actionlint 能识别的全部表达式 / shell 错误；运行时验证留给合入后的首次 dry run。
- **真实 `release.published` 信号**：要等下一次 v0.5.x 发布；建议合入后立刻用 `gh workflow run post-release-smoke.yml -f version=0.5.9` 验证管道本身能跑通。

### 任务跟踪

- 任务 ID: `TASK-20260408-221028`
- 工作流：analyze → plan → implement (codex) → review → refine (codex) → review-r2 → commit → create-pr
- 工件：`.agents/workspace/active/TASK-20260408-221028/` 下 `analysis.md` / `plan.md` / `implementation.md` / `refinement.md` / `review.md` / `review-r2.md`

---

**审查者注意事项 / Reviewer Notes:**

- workflow 体在合入 `main` 之前**无法**端到端执行；本 PR 静态校验（actionlint + shellcheck）通过，结构性测试在 CI 也会跑过，但"真实安装得上吗"的信号要等合入后 dry run 或下次发布。
- brew 等待窗口 10 分钟的设定依据：`update-homebrew.yml` 自身要先等 npm 5 分钟传播 + 推 tap commit，smoke 需要覆盖这段累计延迟。如果觉得过保守，可后续调短到 8 分钟。
- 测试断言用了 `[\s\S]*` 跨行结构匹配（不锁定 YAML 空白），权衡是稍微放宽了相邻性约束，但目的就是允许未来 reformatting 不误报。

Generated with AI assistance.