### PR TITLE
ci(sandbox): always run e2e workflow with internal path guard

### DIFF
--- a/.github/workflows/sandbox-linux-e2e.yml
+++ b/.github/workflows/sandbox-linux-e2e.yml
@@ -2,27 +2,44 @@ name: Sandbox Linux E2E
 
 on:
   pull_request:
-    paths:
-      - "bin/cli.ts"
-      - "lib/sandbox/**"
-      - "install.sh"
-      - "package.json"
-      - "package-lock.json"
-      - ".github/workflows/sandbox-linux-e2e.yml"
   push:
     branches:
       - main
-    paths:
-      - "bin/cli.ts"
-      - "lib/sandbox/**"
-      - "install.sh"
-      - "package.json"
-      - "package-lock.json"
-      - ".github/workflows/sandbox-linux-e2e.yml"
   workflow_dispatch:
 
+# The workflow runs on every PR / push so its required status checks can
+# always report. A `detect-changes` job decides whether the real sandbox
+# lifecycle should execute; downstream jobs gate every step on its output
+# but never job-level skip, so each required check still reports success.
+
 jobs:
+  detect-changes:
+    name: Detect sandbox-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      sandbox: ${{ steps.changed.outputs.sandbox }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Filter changed paths
+        id: changed
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            sandbox:
+              - 'bin/cli.ts'
+              - 'lib/sandbox/**'
+              - 'install.sh'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/sandbox-linux-e2e.yml'
+
   sandbox-linux:
+    needs: detect-changes
     name: Linux native Docker sandbox lifecycle (${{ matrix.mode }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -33,26 +50,35 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Skip when sandbox paths unchanged
+        if: needs.detect-changes.outputs.sandbox != 'true'
+        run: echo "No sandbox-relevant changes; reporting success without running the full lifecycle."
+
       - name: Checkout repository
+        if: needs.detect-changes.outputs.sandbox == 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node.js
+        if: needs.detect-changes.outputs.sandbox == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
 
       - name: Install dependencies
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm ci
 
       - name: Build
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm run build
 
       - name: Link local CLI
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm link
 
       - name: Setup rootless Docker
-        if: matrix.mode == 'rootless'
+        if: needs.detect-changes.outputs.sandbox == 'true' && matrix.mode == 'rootless'
         run: |
           set -euxo pipefail
           sudo apt-get update
@@ -100,6 +126,7 @@ jobs:
           docker info
 
       - name: Prepare host state
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: |
           mkdir -p "$HOME/.claude"
           cat > "$HOME/.claude/.credentials.json" <<'JSON'
@@ -112,6 +139,7 @@ jobs:
           JSON
 
       - name: Prepare test repository
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: |
           mkdir -p /tmp/test-repo/.agents
           cd /tmp/test-repo
@@ -134,6 +162,7 @@ jobs:
           git commit -m "chore: prepare linux sandbox e2e fixture"
 
       - name: Run sandbox lifecycle
+        if: needs.detect-changes.outputs.sandbox == 'true'
         working-directory: /tmp/test-repo
         run: |
           docker info
@@ -144,7 +173,7 @@ jobs:
           docker exec "$container" sh -lc 'echo hello && node --version'
 
       - name: Cleanup sandbox artifacts
-        if: always()
+        if: always() && needs.detect-changes.outputs.sandbox == 'true'
         run: |
           docker ps -aq --filter "label=linux-e2e.sandbox" | xargs -r docker rm -f
           docker images -q --filter "label=linux-e2e.sandbox" | xargs -r docker rmi -f
@@ -153,6 +182,7 @@ jobs:
           rm -rf "$HOME/.agent-infra/worktrees/linux-e2e" "$HOME/.agent-infra/sandboxes"
 
   sandbox-linux-debian:
+    needs: detect-changes
     name: Linux native Docker sandbox lifecycle (debian-12)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -167,31 +197,42 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Skip when sandbox paths unchanged
+        if: needs.detect-changes.outputs.sandbox != 'true'
+        run: echo "No sandbox-relevant changes; reporting success without running the full lifecycle."
+
       - name: Install host prerequisites
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
             ca-certificates curl git xz-utils docker.io
 
       - name: Checkout repository
+        if: needs.detect-changes.outputs.sandbox == 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node.js
+        if: needs.detect-changes.outputs.sandbox == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
 
       - name: Install dependencies
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm ci
 
       - name: Build
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm run build
 
       - name: Link local CLI
+        if: needs.detect-changes.outputs.sandbox == 'true'
         run: npm link
 
       - name: Prepare host state
+        if: needs.detect-changes.outputs.sandbox == 'true'
         # Keep in sync with sandbox-linux job lifecycle.
         run: |
           mkdir -p "$HOME/.claude"
@@ -205,6 +246,7 @@ jobs:
           JSON
 
       - name: Prepare test repository
+        if: needs.detect-changes.outputs.sandbox == 'true'
         # Keep in sync with sandbox-linux job lifecycle.
         run: |
           mkdir -p "$DEBIAN_TEST_REPO/.agents"
@@ -228,6 +270,7 @@ jobs:
           git commit -m "chore: prepare linux sandbox e2e fixture"
 
       - name: Run sandbox lifecycle
+        if: needs.detect-changes.outputs.sandbox == 'true'
         working-directory: ${{ env.DEBIAN_TEST_REPO }}
         run: |
           docker info
@@ -238,7 +281,7 @@ jobs:
           docker exec "$container" sh -lc 'echo hello && node --version'
 
       - name: Cleanup sandbox artifacts
-        if: always()
+        if: always() && needs.detect-changes.outputs.sandbox == 'true'
         run: |
           docker ps -aq --filter "label=linux-e2e.sandbox" | xargs -r docker rm -f
           docker images -q --filter "label=linux-e2e.sandbox" | xargs -r docker rmi -f


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** N/A（无关联 Issue；属于仓库 CI 治理修补）

- [ ] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [x] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement（CI / required-check 修补）
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`sandbox-linux-e2e.yml` 之前用 `on.pull_request.paths` 限制只在以下 6 个路径之一改动时才跑：

```yaml
- "bin/cli.ts"
- "lib/sandbox/**"
- "install.sh"
- "package.json"
- "package-lock.json"
- ".github/workflows/sandbox-linux-e2e.yml"
```

但 branch protection 把这 3 个 job（`Linux native Docker sandbox lifecycle (rootful) / (rootless) / (debian-12)`）列为 **Required status checks**。结果：任何不触碰上述路径的 PR（例如 #325 这种只动 `release.yml` + 发布文档 + test）会出现死锁——`Expected — Waiting for status to be reported`，merge 按钮永远不亮。

本 PR 用业内标准的 **"always-run + internal path guard"** 模式解决：workflow 在每个 PR / push 都触发，但内部用一个 detect-changes 前置 job 决定是否真跑后续 lifecycle；不真跑时每个 required job 仍然执行一个简单的 echo step，向 GitHub 报告 success。required-check 列表无需改动，job 名称完整保留。

## 📋 主要变更 / Brief Changelog

- **删除 `on.pull_request.paths` 和 `on.push.paths` 过滤**：workflow 现在在所有 PR / push 上触发。
- **新增 `detect-changes` 前置 job**（runs-on: ubuntu-latest, 5min timeout）：用 [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) 输出 `sandbox: true|false`，保留原来的 6 条路径作为命中条件。
- **`sandbox-linux`（rootful / rootless 矩阵）与 `sandbox-linux-debian` 都 `needs: detect-changes`**：job 名字一字不改，跟现有 required-check 注册完全兼容。
- **每个 job 第一步是 `Skip when sandbox paths unchanged`**（始终运行，`if: needs.detect-changes.outputs.sandbox != 'true'`）：未命中路径时 echo 一句话；保证 job 至少跑一个 step，结论为 `success`（关键 —— 否则 job-level skip 报告的是 `skipped`，branch protection 还是会卡）。
- **现有所有 step 加 `if: needs.detect-changes.outputs.sandbox == 'true'`**：命中路径时按原流程跑完，未命中时全跳过；`Setup rootless Docker` 上既有的 `if: matrix.mode == 'rootless'` 与 `Cleanup sandbox artifacts` 的 `if: always()` 都正确组合（前者 `&& matrix.mode == 'rootless'`，后者 `always() && needs.detect-changes...`）。

净变化：`+60 / -17`，文件 247 → 290 行。无业务代码改动。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. **YAML 语法校验**（避免 GitHub Actions 在 push 后报 invalid workflow file）：
   ```text
   $ npx --yes -p js-yaml -- js-yaml .github/workflows/sandbox-linux-e2e.yml > /dev/null && echo OK
   OK
   ```
2. **job 名称未漂移**（required-check 列表按名称登记，名字一个字母都不能动）：
   ```text
   $ grep -n "Linux native Docker sandbox lifecycle" .github/workflows/sandbox-linux-e2e.yml
   43:    name: Linux native Docker sandbox lifecycle (${{ matrix.mode }})
   186:    name: Linux native Docker sandbox lifecycle (debian-12)
   ```
3. **本仓库测试套件全绿**（Node 22 下）：
   ```text
   $ NODE22_DIR=$(dirname "$(npm exec --yes --package=node@22 -- which node)")
   $ PATH="$NODE22_DIR:$PATH" npm test
   1..488
   # pass 487
   # fail 0
   # skipped 1
   ```
4. **本 PR 自验证**：本 PR 改动的路径恰好包含 `.github/workflows/sandbox-linux-e2e.yml`，命中 detect-changes 输出 `true`。本 PR 上 sandbox e2e workflow 会**真跑**完整流程（rootful / rootless / debian-12），相当于原地体检——既验证了改造前的旧行为依然能跑，也验证了 detect-changes job 本身没问题。
5. **跨 PR 验证**（合入后第一个不动 sandbox 路径的 PR，例如 #325 在 rebase 后）：detect-changes 输出 `false`；三个 required job 各自跑 `Skip when sandbox paths unchanged` echo step；branch protection 收到 success；merge 按钮恢复可用。

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / Unit tests added（workflow 本身的"是否在某 PR 命中"在 CI 上自然观测，结构性单测如果加，建议另开 PR；本 PR 范围窄）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / Manual testing performed（YAML 解析 + 名字 grep + npm test）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 这是 CI 治理性修补，不对应业务 Issue（参考 GitHub 的 "Required status checks with path filters" 已知死锁场景）
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / PR 范围严格只在 `.github/workflows/sandbox-linux-e2e.yml`
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释（顶部加了 4 行 comment 解释为什么 always-run + internal guard）

**测试要求 / Testing Requirements:**

- [N/A] 我已经编写了必要的单元测试（workflow 改动主要靠 CI 真跑验证；结构性单测可在后续 PR 加）
- [N/A] 当存在跨模块依赖时，我尽量使用了 mock
- [N/A] 代码检查通过（项目暂未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（workflow 文件顶部加了 comment 说明设计）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（**无破坏性变更**；job 名称完整保留 → required-check 注册不动）
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

- 这是为了 unblock PR #325 的 follow-up；本 PR 合入后，所有不动 sandbox / install / package 文件的 PR 都不再需要 admin override merge。
- 本 PR 自己也是触发条件之一（修改了 `sandbox-linux-e2e.yml`），所以 sandbox e2e 这次会真跑。

---

**审查者注意事项 / Reviewer Notes:**

- 关注点 1：**job 名称是否一字不改**（grep 结果在上面）。
- 关注点 2：**leading skip step 是否真的让 job 报 success**——这是这个 pattern 的 load-bearing 假设；如果你想本地验证，可以临时把 path filter 文件名拼错触发"不命中"路径看 actions 页报 success。
- 关注点 3：detect-changes job 选了 `dorny/paths-filter@v3`（公认 maintained，~2.5k stars）；如果团队偏好其它实现可以指出。

Generated with AI assistance