### PR TITLE
ci(brew): 为 Homebrew Formula 增加 bottle 支持

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -4,18 +4,31 @@ on:
   workflow_run:
     workflows: ["Release"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish to the Homebrew tap
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
-  update-formula:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  prepare-formula:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository at released commit
+        if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Checkout repository for manual dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -24,9 +37,18 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Read package version from released commit
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
-          VERSION=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${DISPATCH_VERSION#v}"
+          else
+            VERSION=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected version: $VERSION"
 
       - name: Wait for npm registry propagation
@@ -68,6 +90,7 @@ jobs:
             url "${TARBALL_URL}"
             sha256 "${SHA256}"
             license "MIT"
+            # __BOTTLE_BLOCK__
 
             depends_on "node"
 
@@ -91,3 +114,127 @@ jobs:
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "agent-infra ${VERSION}"
           git push
+
+  bake-bottle:
+    needs: prepare-formula
+    if: ${{ needs.prepare-formula.outputs.version != '' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-26
+            platform: arm64_tahoe
+          - os: macos-15
+            platform: arm64_sequoia
+          - os: macos-14
+            platform: arm64_sonoma
+          - os: macos-14-large
+            platform: sonoma
+    steps:
+      - name: Configure brew tap
+        run: brew tap fitlab-ai/tap
+
+      - name: Build bottle
+        env:
+          VERSION: ${{ needs.prepare-formula.outputs.version }}
+        run: |
+          ROOT_URL="https://github.com/fitlab-ai/agent-infra/releases/download/v${VERSION}"
+          brew install --build-bottle --formula --verbose agent-infra
+          brew bottle --json --no-rebuild --root-url="$ROOT_URL" agent-infra
+
+      - name: Verify bottle artifacts
+        env:
+          VERSION: ${{ needs.prepare-formula.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          ls -la *.bottle.tar.gz *.bottle.json
+          test -f "agent-infra--${VERSION}.${PLATFORM}.bottle.tar.gz"
+          test -f "agent-infra--${VERSION}.${PLATFORM}.bottle.json"
+
+      - name: Upload bottle to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare-formula.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          gh release upload "v${VERSION}" \
+            "agent-infra--${VERSION}.${PLATFORM}.bottle.tar.gz" \
+            --clobber --repo fitlab-ai/agent-infra
+
+      - name: Upload bottle JSON as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bottle-json-${{ matrix.platform }}
+          path: agent-infra--*.${{ matrix.platform }}.bottle.json
+          retention-days: 7
+
+  publish-bottle:
+    needs: [prepare-formula, bake-bottle]
+    if: ${{ always() && needs.prepare-formula.result == 'success' }}
+    runs-on: macos-15
+    steps:
+      - name: Download all bottle JSON artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bottle-json-*
+          path: ./bottles
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Determine bake outcome
+        id: outcome
+        run: |
+          SUCCESS_COUNT=$(find ./bottles -name '*.bottle.json' 2>/dev/null | wc -l | tr -d ' ')
+          echo "success_count=$SUCCESS_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$SUCCESS_COUNT" -eq 0 ]; then
+            echo "::warning::All bottle bake jobs failed; publishing Formula without bottle block"
+            echo "has_bottles=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Homebrew bottle publish"
+              echo ""
+              echo "No bottle artifacts were available for this version."
+              echo "The workflow will publish the Formula without a bottle block."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_bottles=true" >> "$GITHUB_OUTPUT"
+            echo "Found $SUCCESS_COUNT bottle JSON files (expected 4)"
+          fi
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v6
+        with:
+          repository: fitlab-ai/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Merge bottle block into Formula
+        if: steps.outcome.outputs.has_bottles == 'true'
+        working-directory: homebrew-tap
+        run: |
+          for json in ../bottles/*.bottle.json; do
+            [ -e "$json" ] || continue
+            brew bottle --merge --write --no-commit "$json"
+          done
+          sed -i.bak '/# __BOTTLE_BLOCK__/d' Formula/agent-infra.rb && rm Formula/agent-infra.rb.bak
+
+      - name: Strip placeholder when no bottles
+        if: steps.outcome.outputs.has_bottles == 'false'
+        working-directory: homebrew-tap
+        run: sed -i.bak '/# __BOTTLE_BLOCK__/d' Formula/agent-infra.rb && rm Formula/agent-infra.rb.bak
+
+      - name: Commit Formula with bottle block
+        working-directory: homebrew-tap
+        env:
+          VERSION: ${{ needs.prepare-formula.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/agent-infra.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit --amend --no-edit
+          git push --force-with-lease

--- a/tests/core/release.test.ts
+++ b/tests/core/release.test.ts
@@ -72,6 +72,23 @@ test("update-homebrew workflow syncs the tap after a successful release run", ()
   assert.match(workflow, /class AgentInfra < Formula/);
   assert.match(workflow, /name: Commit and push/);
   assert.match(workflow, /git commit -m "agent-infra \$\{VERSION\}"/);
+  assert.match(workflow, /workflow_dispatch:[\s\S]*inputs:[\s\S]*version:/);
+  assert.match(workflow, /prepare-formula:/);
+  assert.match(workflow, /bake-bottle:/);
+  assert.match(workflow, /publish-bottle:/);
+  assert.match(workflow, /outputs:[\s\S]*version: \$\{\{ steps\.version\.outputs\.version \}\}/);
+  assert.equal(workflow.match(/license "MIT"\n[ ]*# __BOTTLE_BLOCK__/g)?.length, 1);
+  assert.match(workflow, /os: macos-26[\s\S]*platform: arm64_tahoe/);
+  assert.match(workflow, /os: macos-15[\s\S]*platform: arm64_sequoia/);
+  assert.match(workflow, /os: macos-14[\s\S]*platform: arm64_sonoma/);
+  assert.match(workflow, /os: macos-14-large[\s\S]*platform: sonoma/);
+  assert.match(workflow, /brew install --build-bottle --formula --verbose agent-infra/);
+  assert.match(workflow, /brew bottle --json --no-rebuild --root-url="\$ROOT_URL" agent-infra/);
+  assert.match(workflow, /https:\/\/github\.com\/fitlab-ai\/agent-infra\/releases\/download\/v\$\{VERSION\}/);
+  assert.match(workflow, /gh release upload "v\$\{VERSION\}"/);
+  assert.match(workflow, /bake-bottle:[\s\S]*continue-on-error: true/);
+  assert.match(workflow, /publish-bottle:[\s\S]*if: \$\{\{ always\(\)/);
+  assert.match(workflow, /brew bottle --merge --write --no-commit "\$json"/);
 });
 
 test("CLI help advertises scoped npm install commands and Homebrew", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #157

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

v0.5.0 / v0.6.0 后用户首次 `brew install fitlab-ai/tap/agent-infra` 时撞到 macOS CLT 兼容性检查 —— 根因不是 agent-infra 本身需要编译，而是 Formula 的 `def install` 含 `system "npm", "install"` 调用，brew 将其识别为 source build 并强制做 Xcode/CLT 兼容性检查。macOS 升级或 CLT 跟不上的用户首装即被拦截。

本 PR 通过为 Formula 提供 **bottle（预编译产物）** 让 brew 走「解压 tarball」路径，跳过 source build 阶段的 CLT 检查，从根本上消除该问题。研究确认 `pnpm` 等 homebrew-core 同类 npm-based Formula 即采用此模式。

## 📋 主要变更 / Brief Changelog

- **重构 `.github/workflows/update-homebrew.yml`** 为三阶段流水线：`prepare-formula`（写初始 Formula） → `bake-bottle`（4 平台矩阵烤 bottle） → `publish-bottle`（合并 sha256 + amend push）
- **bottle 矩阵 4 条腿，与 pnpm/homebrew-core baseline 对齐**：
  - `macos-26` → `arm64_tahoe`
  - `macos-15` → `arm64_sequoia`
  - `macos-14` → `arm64_sonoma`
  - `macos-14-large` → `sonoma`（Intel；同时通过 brew 内置 ABI fallback 服务 Intel Sequoia / Tahoe 用户）
- **bottle 托管位置**：主仓 GitHub Release assets（`fitlab-ai/agent-infra` releases），timing 与 Release workflow 天然对齐；新增 `workflow_dispatch` 入口支持补烤
- **优雅降级**：任一 bake job 失败不阻塞整个发布；全失败时降级到「无 bottle 发布」（等价于今天的行为），并通过 `$GITHUB_STEP_SUMMARY` 在 Actions UI 显式标注
- **测试**：扩展 `tests/core/release.test.ts` 的 `update-homebrew workflow` 结构性断言（追加 17 行，未修改既有断言），覆盖新阶段、4 平台矩阵、bottle 命令、降级路径

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

**静态验证（已完成）**：

1. `npm test`（Node 22）— 全量 487 / 488 通过（1 平台守卫跳过）
2. `npm run test:core` — 359 测试全部通过
3. `tests/core/release.test.ts` 的 `update-homebrew workflow` 测试 — 6/6 通过

**动态验证（依赖下次真实 release 或 `workflow_dispatch`）**：

1. 合并本 PR 后下次发版（v0.6.1+）触发完整流水线
2. 验证清单：
   - [ ] 4 条 bottle bake job 均在 GitHub Actions 上成功
   - [ ] tap 仓 Formula 含 `bottle do ... end` 块且 sha256 行数为 4
   - [ ] 主仓 release 含 4 个 `.bottle.tar.gz` asset
   - [ ] `post-release-smoke.yml` 的 `brew-smoke` 全绿
   - [ ] 在没有 Xcode/CLT 的 macOS 环境 `brew install fitlab-ai/tap/agent-infra` 不再触发 CLT 报错

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（端到端验证依赖下次真实 release）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（review.md + review-r2.md）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（降级路径保持与今天等价）

## 📋 附加信息 / Additional Notes

### 设计取舍

- **bottle hosting → 主仓 release assets**：相比 tap 仓 release 或 GitHub Pages，主仓 release 在 `update-homebrew` 触发时已存在，token 简单（`GITHUB_TOKEN` 即可），timing 自然对齐
- **Intel 只烤 1 条腿（sonoma）**：与 pnpm 等 homebrew-core 同类 Formula 一致；Intel Sequoia/Tahoe 用户走 brew 的 ABI 兼容 fallback 自动复用 Sonoma bottle。Homebrew 计划 2026-09 把 Intel 整体推到 Tier 3，届时可直接删除该腿
- **Runner 锁定具体版本，禁用 `macos-latest` 与 `macos-13`**：`macos-13` 已在 2025-09 退役；`macos-latest` 将在 2026-06-15 起迁移到 `macos-26`，使用具体版本避免语义漂移

### 审查历程

| 轮次 | 实施者 | 结论 | 备注 |
|------|--------|------|------|
| Round 1 设计 | claude | 2 条腿矩阵 | 矩阵选择脱离实际可用 runner |
| Round 2 设计 | claude | 4 条腿矩阵 | 与 pnpm/homebrew-core 对齐 |
| Round 1 实现 | codex | 通过 | 487/488 测试通过 |
| Round 1 审查 | claude | 通过 | 4 条 minor |
| Round 1 修复 | codex | 完成 | 4 条 minor 全处理 |
| Round 2 审查 | claude | 通过 | 0 blocker / 0 major / 0 minor |

---

**审查者注意事项 / Reviewer Notes:**

- **动态验证依赖下次真实 release 才能完成**，请合并后跟踪 `post-release-smoke.brew-smoke` 与 Formula bottle 块的实际生成情况
- **不影响 v0.6.0 已发布产物**，仅影响下一次（及之后）release 的 brew 安装路径
- 详细分析、技术方案与审查记录归档在 `.agents/workspace/active/TASK-20260408-221134/`（analysis.md / plan-r2.md / implementation.md / review-r2.md / refinement.md）

Generated with AI assistance.