### PR TITLE
feat(core): 在 task 与同步元数据中记录 agent-infra 版本号

### DIFF
--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -13,16 +13,24 @@
 ## 任务状态管理
 
 - 每次执行工作流命令后，必须立即更新对应任务的 `task.md`
-- 至少同步 `current_step`、`updated_at`、`assigned_to`，以及本轮产物引用
+- 至少同步 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`，以及本轮产物引用
+- 更新 `agent_infra_version` 前，先读取 `.agents/rules/version-stamp.md`
 - Activity Log 只能追加，不能覆盖历史记录
 
 ## 常见命令的状态更新要求
 
-- `import-issue`：更新 `current_step`、`updated_at`、`assigned_to`
-- `analyze-task`：更新 `current_step`、`updated_at`、`assigned_to`
-- `plan-task`：更新 `current_step`、`updated_at`
-- `implement-task`：更新 `current_step`、`updated_at`
-- `review-task`：更新 `current_step`、`updated_at`
-- `refine-task`：更新 `current_step`、`updated_at`
-- `complete-task`：更新 `status`、`completed_at`、`updated_at`
-- `block-task`：更新 `status`、`blocked_at`、`blocked_reason`
+- `create-task`：创建 `branch`、`workflow`、`status`、`created_at`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-issue`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-codescan`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-dependabot`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `restore-task`：更新 `status`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `analyze-task`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `plan-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `implement-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `review-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `refine-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `create-pr`：更新 `pr_number`、`updated_at`、`agent_infra_version`
+- `commit`：更新 `updated_at`、`agent_infra_version`；必要时更新 `current_step`（详见 `commit/reference/task-status-update.md`）
+- `complete-task`：更新 `status`、`current_step`、`completed_at`、`updated_at`、`agent_infra_version`
+- `block-task`：更新 `status`、`blocked_at`、`blocked_reason`、`updated_at`、`agent_infra_version`
+- `cancel-task`：更新 `status`、`cancelled_at`、`cancel_reason`、`updated_at`、`agent_infra_version`

--- a/.agents/rules/version-stamp.md
+++ b/.agents/rules/version-stamp.md
@@ -1,0 +1,29 @@
+# 通用规则 - agent-infra 版本戳
+
+## 写入时机
+
+每次创建或更新 `task.md` frontmatter 时，同步写入 `agent_infra_version`。
+
+该字段表示最后一次写入该任务元数据的 `agent-infra` CLI 版本，与 `updated_at` 同步刷新。
+
+## 取值命令
+
+```bash
+agent_infra_version=$(ai version --raw 2>/dev/null || echo "unknown")
+```
+
+- 命令成功时，值必须直接使用输出结果，例如 `vX.Y.Z` 或 `vX.Y.Z-alpha.0`
+- 不要在写入端自行拼接 `v` 前缀
+- 命令失败时写入 `unknown`
+
+## frontmatter 字段
+
+```yaml
+agent_infra_version: {agent_infra_version}
+```
+
+## 兼容性
+
+- 历史任务可能缺少该字段；读取或恢复任务时不得因此阻塞
+- 字段存在时，值必须是 `vX.Y.Z`、`vX.Y.Z-prerelease`、带 SemVer build 元数据的版本，或 `unknown`
+- 同步 Issue / PR 评论时无需额外处理；frontmatter 镜像会自然包含该字段

--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -22,12 +22,14 @@ const DEFAULT_REQUIRED_FIELDS = [
   "status",
   "created_at",
   "updated_at",
+  "agent_infra_version",
   "current_step",
   "assigned_to"
 ];
 
 const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
+const AGENT_INFRA_VERSION_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
 const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -212,8 +214,24 @@ function checkTaskMeta({ taskDir, config }) {
   const metadata = task.metadata;
   const requiredFields = config.required_fields || DEFAULT_REQUIRED_FIELDS;
   const missingFields = requiredFields.filter((field) => isBlank(metadata[field]));
-  if (missingFields.length > 0) {
-    return failResult("task-meta", `Missing required fields: ${missingFields.join(", ")}`);
+  const blockingMissingFields = missingFields.filter((field) => field !== "agent_infra_version");
+  const warnings = [];
+  if (missingFields.includes("agent_infra_version")) {
+    warnings.push("field 'agent_infra_version' missing — historical task or skipped version stamp");
+  }
+  if (blockingMissingFields.length > 0) {
+    return failResult("task-meta", `Missing required fields: ${blockingMissingFields.join(", ")}`);
+  }
+
+  if (
+    !isBlank(metadata.agent_infra_version) &&
+    metadata.agent_infra_version !== "unknown" &&
+    !AGENT_INFRA_VERSION_PATTERN.test(metadata.agent_infra_version)
+  ) {
+    return failResult(
+      "task-meta",
+      `Invalid agent_infra_version: ${metadata.agent_infra_version}`
+    );
   }
 
   const invalidDates = ["created_at", "updated_at", "completed_at", "blocked_at", "cancelled_at"]
@@ -272,7 +290,12 @@ function checkTaskMeta({ taskDir, config }) {
     }
   }
 
-  return passResult("task-meta", `Task metadata valid (${requiredFields.length} required fields checked)`);
+  const warningSuffix = warnings.length > 0 ? `; warnings: ${warnings.join("; ")}` : "";
+  return passResult(
+    "task-meta",
+    `Task metadata valid (${requiredFields.length} required fields checked${warningSuffix})`,
+    warnings
+  );
 }
 
 function validateTaskBranch(metadata) {
@@ -683,8 +706,12 @@ function buildSingleCheckSummary(status) {
   return "0 passed, 1 failed";
 }
 
-function passResult(type, message) {
-  return { type, status: "pass", message };
+function passResult(type, message, warnings = []) {
+  const result = { type, status: "pass", message };
+  if (warnings.length > 0) {
+    result.warnings = warnings;
+  }
+  return result;
 }
 
 function failResult(type, message, failType = "check_failed") {

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -11,6 +11,8 @@ description: "分析任务并输出需求分析文档"
 - 严格基于 `task.md` 中已有的需求、上下文和来源信息展开分析
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -110,6 +112,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 记录本轮分析产物：`{analysis-artifact}`（Round `{analysis-round}`）
 - 如任务模板包含 `## 分析` 段落，更新为指向 `{analysis-artifact}` 的链接
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -17,6 +17,8 @@ description: "标记任务为阻塞状态并记录原因"
 - **资源问题**：缺少访问权限、等待外部团队、被其他任务阻塞
 - **需要决策**：待定的架构决策、需要利益相关者批准
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -47,6 +49,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：blocked
 - `blocked_at`：{当前时间戳}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}

--- a/.agents/skills/block-task/config/verify.json
+++ b/.agents/skills/block-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "blocked_at"

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -11,6 +11,8 @@ description: "取消不再需要的任务并转移"
 - 只有在确认该任务无需继续实现、审查或修复时才可取消
 - 有效 `issue_number` 存在时，Issue 同步属于必做项
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -48,6 +50,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `cancelled_at`：{当前时间戳}
 - `cancel_reason`：{取消原因}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}

--- a/.agents/skills/cancel-task/config/verify.json
+++ b/.agents/skills/cancel-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "cancelled_at",

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -7,6 +7,8 @@ description: "提交当前变更到 Git"
 
 在不覆盖用户本地工作的前提下创建 Git commit，并在需要时更新关联任务状态。
 
+更新关联 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 1. 检查本地修改（关键）
 
 在任何编辑前先检查：

--- a/.agents/skills/commit/config/verify.json
+++ b/.agents/skills/commit/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/.agents/skills/commit/reference/task-status-update.md
+++ b/.agents/skills/commit/reference/task-status-update.md
@@ -2,6 +2,8 @@
 
 在选择提交后的任务状态分支之前先读取本文件。
 
+更新任务元数据前，先读取 `.agents/rules/version-stamp.md`，并随 `updated_at` 一起刷新 `agent_infra_version`。
+
 ## 更新关联任务状态
 
 先获取当前时间：
@@ -53,6 +55,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果仍有工作待完成：
 - 更新 `task.md` 中的 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 记录这次提交完成了什么
 - 记录下一位人类或 agent 需要继续做什么
 
@@ -61,6 +64,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果这次提交把工作移交给代码审查：
 - 将 `current_step` 更新为 `code-review`
 - 更新 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 在工作流状态中标记实现阶段已完成
 
 必带下一步命令：
@@ -76,6 +80,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果下一步是创建 Pull Request：
 - 更新 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 在 `task.md` 中记录 PR 计划
 
 必带下一步命令：

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -10,6 +10,8 @@ description: "标记任务完成并归档"
 - 本命令更新任务元数据并物理移动任务目录
 - 除非强制执行，不要转移有未完成工作流步骤的任务
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -58,8 +60,10 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
 - `status`：completed
+- `current_step`：completed
 - `completed_at`：{当前时间戳}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 标记所有工作流步骤为已完成
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "completed_at"

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -7,6 +7,10 @@ description: "创建 Pull Request 到目标分支"
 
 创建 Pull Request，并在与任务关联时立即补齐核心元数据和 reviewer 摘要。
 
+## 行为边界 / 关键规则
+
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行流程
 
 ### 1. 解析命令参数
@@ -72,7 +76,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -20,6 +20,8 @@ description: "根据自然语言描述创建任务"
 
 执行本技能后，你**必须**立即更新 task.md 中的任务状态。
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 解析用户描述
@@ -74,6 +76,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -93,6 +96,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```

--- a/.agents/skills/create-task/config/verify.json
+++ b/.agents/skills/create-task/config/verify.json
@@ -10,6 +10,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -14,6 +14,8 @@ description: "根据技术方案实施任务并输出报告"
 - 每轮实现都创建新的实现产物，不覆盖旧文件
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -88,6 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：implementation
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：

--- a/.agents/skills/implement-task/config/verify.json
+++ b/.agents/skills/implement-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/import-codescan/config/verify.json
+++ b/.agents/skills/import-codescan/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/import-dependabot/config/verify.json
+++ b/.agents/skills/import-dependabot/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -69,6 +69,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -91,6 +92,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
@@ -161,6 +163,8 @@ Issue #{number} 已导入。
 ## 停止
 
 完成检查清单后，**立即停止**。不要继续执行后续步骤。
+
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
 ## 注意事项
 

--- a/.agents/skills/import-issue/config/verify.json
+++ b/.agents/skills/import-issue/config/verify.json
@@ -10,6 +10,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -11,6 +11,8 @@ description: "为任务设计技术方案和实施计划"
 - 这是一个**强制性的人工审查检查点** —— 不要自动进入实现阶段
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -88,6 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：technical-design
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 记录本轮方案产物：`{plan-artifact}`（Round `{plan-round}`）
 - 如任务模板包含 `## 设计` 段落，更新为指向 `{plan-artifact}` 的链接
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -13,6 +13,8 @@ description: "处理代码审查反馈并修复问题"
 - 绝不自动执行 `git add` 或 `git commit`
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件

--- a/.agents/skills/refine-task/config/verify.json
+++ b/.agents/skills/refine-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -14,6 +14,8 @@ description: "从平台 Issue 评论还原本地任务文件"
 - 如果目标目录已存在，立即停止并提示用户先处理目录冲突
 - 执行本技能后，你**必须**立即更新恢复出的 `task.md`
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证输入与环境
@@ -83,6 +85,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：`active`
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 
 追加 Activity Log，说明任务已从平台 Issue 还原。
 

--- a/.agents/skills/restore-task/config/verify.json
+++ b/.agents/skills/restore-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/.agents/skills/review-task/SKILL.md
+++ b/.agents/skills/review-task/SKILL.md
@@ -12,6 +12,8 @@ description: "审查任务实现并输出代码审查报告"
 - 本技能只审查代码并写报告，不修改业务代码
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件

--- a/.agents/skills/review-task/config/verify.json
+++ b/.agents/skills/review-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -6,7 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
-agent_infra_version: v0.0.0      # 当前 agent-infra 版本；由工作流命令刷新
+agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -6,6 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+agent_infra_version: v0.0.0      # 当前 agent-infra 版本；由工作流命令刷新
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -97,7 +97,11 @@ switch (command) {
     break;
   }
   case 'version': {
-    console.log(`agent-infra ${VERSION}`);
+    if (process.argv[3] === '--raw') {
+      console.log(VERSION);
+    } else {
+      console.log(`agent-infra ${VERSION}`);
+    }
     break;
   }
   case 'help':

--- a/templates/.agents/rules/task-management.en.md
+++ b/templates/.agents/rules/task-management.en.md
@@ -13,16 +13,24 @@ Map user intent to the corresponding workflow command:
 ## Task State Management
 
 - Update the corresponding `task.md` immediately after every workflow command
-- At minimum, synchronize `current_step`, `updated_at`, `assigned_to`, and the current-round artifact reference
+- At minimum, synchronize `current_step`, `updated_at`, `assigned_to`, `agent_infra_version`, and the current-round artifact reference
+- Before updating `agent_infra_version`, read `.agents/rules/version-stamp.md`
 - Activity Log entries are append-only and must never overwrite history
 
 ## Required State Updates by Command
 
-- `import-issue`: update `current_step`, `updated_at`, `assigned_to`
-- `analyze-task`: update `current_step`, `updated_at`, `assigned_to`
-- `plan-task`: update `current_step`, `updated_at`
-- `implement-task`: update `current_step`, `updated_at`
-- `review-task`: update `current_step`, `updated_at`
-- `refine-task`: update `current_step`, `updated_at`
-- `complete-task`: update `status`, `completed_at`, `updated_at`
-- `block-task`: update `status`, `blocked_at`, `blocked_reason`
+- `create-task`: create `branch`, `workflow`, `status`, `created_at`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `import-issue`: update `current_step`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `import-codescan`: update `current_step`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `import-dependabot`: update `current_step`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `restore-task`: update `status`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `analyze-task`: update `current_step`, `updated_at`, `assigned_to`, `agent_infra_version`
+- `plan-task`: update `current_step`, `updated_at`, `agent_infra_version`
+- `implement-task`: update `current_step`, `updated_at`, `agent_infra_version`
+- `review-task`: update `current_step`, `updated_at`, `agent_infra_version`
+- `refine-task`: update `current_step`, `updated_at`, `agent_infra_version`
+- `create-pr`: update `pr_number`, `updated_at`, `agent_infra_version`
+- `commit`: update `updated_at`, `agent_infra_version`; update `current_step` when needed (see `commit/reference/task-status-update.md`)
+- `complete-task`: update `status`, `current_step`, `completed_at`, `updated_at`, `agent_infra_version`
+- `block-task`: update `status`, `blocked_at`, `blocked_reason`, `updated_at`, `agent_infra_version`
+- `cancel-task`: update `status`, `cancelled_at`, `cancel_reason`, `updated_at`, `agent_infra_version`

--- a/templates/.agents/rules/task-management.zh-CN.md
+++ b/templates/.agents/rules/task-management.zh-CN.md
@@ -13,16 +13,24 @@
 ## 任务状态管理
 
 - 每次执行工作流命令后，必须立即更新对应任务的 `task.md`
-- 至少同步 `current_step`、`updated_at`、`assigned_to`，以及本轮产物引用
+- 至少同步 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`，以及本轮产物引用
+- 更新 `agent_infra_version` 前，先读取 `.agents/rules/version-stamp.md`
 - Activity Log 只能追加，不能覆盖历史记录
 
 ## 常见命令的状态更新要求
 
-- `import-issue`：更新 `current_step`、`updated_at`、`assigned_to`
-- `analyze-task`：更新 `current_step`、`updated_at`、`assigned_to`
-- `plan-task`：更新 `current_step`、`updated_at`
-- `implement-task`：更新 `current_step`、`updated_at`
-- `review-task`：更新 `current_step`、`updated_at`
-- `refine-task`：更新 `current_step`、`updated_at`
-- `complete-task`：更新 `status`、`completed_at`、`updated_at`
-- `block-task`：更新 `status`、`blocked_at`、`blocked_reason`
+- `create-task`：创建 `branch`、`workflow`、`status`、`created_at`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-issue`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-codescan`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `import-dependabot`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `restore-task`：更新 `status`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `analyze-task`：更新 `current_step`、`updated_at`、`assigned_to`、`agent_infra_version`
+- `plan-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `implement-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `review-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `refine-task`：更新 `current_step`、`updated_at`、`agent_infra_version`
+- `create-pr`：更新 `pr_number`、`updated_at`、`agent_infra_version`
+- `commit`：更新 `updated_at`、`agent_infra_version`；必要时更新 `current_step`（详见 `commit/reference/task-status-update.md`）
+- `complete-task`：更新 `status`、`current_step`、`completed_at`、`updated_at`、`agent_infra_version`
+- `block-task`：更新 `status`、`blocked_at`、`blocked_reason`、`updated_at`、`agent_infra_version`
+- `cancel-task`：更新 `status`、`cancelled_at`、`cancel_reason`、`updated_at`、`agent_infra_version`

--- a/templates/.agents/rules/version-stamp.en.md
+++ b/templates/.agents/rules/version-stamp.en.md
@@ -1,0 +1,29 @@
+# General Rule - agent-infra Version Stamp
+
+## When to Write
+
+Every time a workflow creates or updates `task.md` frontmatter, also write `agent_infra_version`.
+
+This field records the `agent-infra` CLI version that last wrote the task metadata, and is refreshed together with `updated_at`.
+
+## Value Command
+
+```bash
+agent_infra_version=$(ai version --raw 2>/dev/null || echo "unknown")
+```
+
+- On success, write the command output directly, for example `vX.Y.Z` or `vX.Y.Z-alpha.0`
+- Do not add the `v` prefix in the writer
+- If the command fails, write `unknown`
+
+## Frontmatter Field
+
+```yaml
+agent_infra_version: {agent_infra_version}
+```
+
+## Compatibility
+
+- Historical tasks may not have this field; reading or restoring tasks must not block on that alone
+- When present, the value must be `vX.Y.Z`, `vX.Y.Z-prerelease`, a version with SemVer build metadata, or `unknown`
+- Issue / PR comment sync does not need special handling; frontmatter mirroring naturally includes this field

--- a/templates/.agents/rules/version-stamp.zh-CN.md
+++ b/templates/.agents/rules/version-stamp.zh-CN.md
@@ -1,0 +1,29 @@
+# 通用规则 - agent-infra 版本戳
+
+## 写入时机
+
+每次创建或更新 `task.md` frontmatter 时，同步写入 `agent_infra_version`。
+
+该字段表示最后一次写入该任务元数据的 `agent-infra` CLI 版本，与 `updated_at` 同步刷新。
+
+## 取值命令
+
+```bash
+agent_infra_version=$(ai version --raw 2>/dev/null || echo "unknown")
+```
+
+- 命令成功时，值必须直接使用输出结果，例如 `vX.Y.Z` 或 `vX.Y.Z-alpha.0`
+- 不要在写入端自行拼接 `v` 前缀
+- 命令失败时写入 `unknown`
+
+## frontmatter 字段
+
+```yaml
+agent_infra_version: {agent_infra_version}
+```
+
+## 兼容性
+
+- 历史任务可能缺少该字段；读取或恢复任务时不得因此阻塞
+- 字段存在时，值必须是 `vX.Y.Z`、`vX.Y.Z-prerelease`、带 SemVer build 元数据的版本，或 `unknown`
+- 同步 Issue / PR 评论时无需额外处理；frontmatter 镜像会自然包含该字段

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -22,12 +22,14 @@ const DEFAULT_REQUIRED_FIELDS = [
   "status",
   "created_at",
   "updated_at",
+  "agent_infra_version",
   "current_step",
   "assigned_to"
 ];
 
 const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
+const AGENT_INFRA_VERSION_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
 const BRANCH_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -212,8 +214,24 @@ function checkTaskMeta({ taskDir, config }) {
   const metadata = task.metadata;
   const requiredFields = config.required_fields || DEFAULT_REQUIRED_FIELDS;
   const missingFields = requiredFields.filter((field) => isBlank(metadata[field]));
-  if (missingFields.length > 0) {
-    return failResult("task-meta", `Missing required fields: ${missingFields.join(", ")}`);
+  const blockingMissingFields = missingFields.filter((field) => field !== "agent_infra_version");
+  const warnings = [];
+  if (missingFields.includes("agent_infra_version")) {
+    warnings.push("field 'agent_infra_version' missing — historical task or skipped version stamp");
+  }
+  if (blockingMissingFields.length > 0) {
+    return failResult("task-meta", `Missing required fields: ${blockingMissingFields.join(", ")}`);
+  }
+
+  if (
+    !isBlank(metadata.agent_infra_version) &&
+    metadata.agent_infra_version !== "unknown" &&
+    !AGENT_INFRA_VERSION_PATTERN.test(metadata.agent_infra_version)
+  ) {
+    return failResult(
+      "task-meta",
+      `Invalid agent_infra_version: ${metadata.agent_infra_version}`
+    );
   }
 
   const invalidDates = ["created_at", "updated_at", "completed_at", "blocked_at", "cancelled_at"]
@@ -272,7 +290,12 @@ function checkTaskMeta({ taskDir, config }) {
     }
   }
 
-  return passResult("task-meta", `Task metadata valid (${requiredFields.length} required fields checked)`);
+  const warningSuffix = warnings.length > 0 ? `; warnings: ${warnings.join("; ")}` : "";
+  return passResult(
+    "task-meta",
+    `Task metadata valid (${requiredFields.length} required fields checked${warningSuffix})`,
+    warnings
+  );
 }
 
 function validateTaskBranch(metadata) {
@@ -683,8 +706,12 @@ function buildSingleCheckSummary(status) {
   return "0 passed, 1 failed";
 }
 
-function passResult(type, message) {
-  return { type, status: "pass", message };
+function passResult(type, message, warnings = []) {
+  const result = { type, status: "pass", message };
+  if (warnings.length > 0) {
+    result.warnings = warnings;
+  }
+  return result;
 }
 
 function failResult(type, message, failType = "check_failed") {

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -11,6 +11,8 @@ description: "Analyze a task and produce a requirements document"
 - Base the analysis strictly on the existing requirements, context, and source information in `task.md`
 - After executing this skill, you **must** immediately update task status in task.md
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Prerequisites
@@ -110,6 +112,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: requirement-analysis
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - Record the analysis artifact for this round: `{analysis-artifact}` (Round `{analysis-round}`)
 - If the task template contains a `## Analysis` section, update it to link to `{analysis-artifact}`
 - Mark requirement-analysis as complete in workflow progress and include the actual round when the task template supports it

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -11,6 +11,8 @@ description: "分析任务并输出需求分析文档"
 - 严格基于 `task.md` 中已有的需求、上下文和来源信息展开分析
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -110,6 +112,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 记录本轮分析产物：`{analysis-artifact}`（Round `{analysis-round}`）
 - 如任务模板包含 `## 分析` 段落，更新为指向 `{analysis-artifact}` 的链接
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）

--- a/templates/.agents/skills/analyze-task/config/verify.json
+++ b/templates/.agents/skills/analyze-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -17,6 +17,8 @@ description: "Mark a task as blocked and record the reason"
 - **Resource issues**: Missing access, waiting for external team, blocked by another task
 - **Decision needed**: Architecture decision pending, stakeholder approval required
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -47,6 +49,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `status`: blocked
 - `blocked_at`: {current timestamp}
 - `updated_at`: {current timestamp}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {one-line reason}

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -17,6 +17,8 @@ description: "标记任务为阻塞状态并记录原因"
 - **资源问题**：缺少访问权限、等待外部团队、被其他任务阻塞
 - **需要决策**：待定的架构决策、需要利益相关者批准
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -47,6 +49,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：blocked
 - `blocked_at`：{当前时间戳}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}

--- a/templates/.agents/skills/block-task/config/verify.json
+++ b/templates/.agents/skills/block-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "blocked_at"

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -11,6 +11,8 @@ description: "Cancel an unneeded task and move it"
 - Cancel only when the task no longer needs implementation, review, or follow-up work
 - When a valid `issue_number` exists, Issue sync is required
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -48,6 +50,7 @@ Update `task.md` in the task directory:
 - `cancelled_at`: {current timestamp}
 - `cancel_reason`: {cancellation reason}
 - `updated_at`: {current timestamp}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {one-line cancellation reason}

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -11,6 +11,8 @@ description: "取消不再需要的任务并转移"
 - 只有在确认该任务无需继续实现、审查或修复时才可取消
 - 有效 `issue_number` 存在时，Issue 同步属于必做项
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -48,6 +50,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `cancelled_at`：{当前时间戳}
 - `cancel_reason`：{取消原因}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}

--- a/templates/.agents/skills/cancel-task/config/verify.json
+++ b/templates/.agents/skills/cancel-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "cancelled_at",

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -7,6 +7,8 @@ description: "Commit the current changes to Git"
 
 Create a Git commit without overwriting user work and update the related task state when needed.
 
+When updating related `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## 1. Check Local Modifications (CRITICAL)
 
 Before any edit, inspect:

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -7,6 +7,8 @@ description: "提交当前变更到 Git"
 
 在不覆盖用户本地工作的前提下创建 Git commit，并在需要时更新关联任务状态。
 
+更新关联 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 1. 检查本地修改（关键）
 
 在任何编辑前先检查：

--- a/templates/.agents/skills/commit/config/verify.json
+++ b/templates/.agents/skills/commit/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/templates/.agents/skills/commit/reference/task-status-update.en.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.en.md
@@ -2,6 +2,8 @@
 
 Read this file before choosing the post-commit task-state branch.
 
+Before updating task metadata, read `.agents/rules/version-stamp.md` and refresh `agent_infra_version` together with `updated_at`.
+
 ## Update the Related Task State
 
 Get the current time first:
@@ -53,6 +55,7 @@ Next step - complete and archive the task:
 
 If more work is still pending:
 - update `updated_at` in `task.md`
+- update `agent_infra_version` from `.agents/rules/version-stamp.md`
 - record what this commit finished
 - record what the next human or agent action is
 
@@ -61,6 +64,7 @@ If more work is still pending:
 If this commit hands work over to code review:
 - update `current_step` to `code-review`
 - update `updated_at`
+- update `agent_infra_version` from `.agents/rules/version-stamp.md`
 - mark implementation as finished in the workflow state
 
 Required next-step commands:
@@ -76,6 +80,7 @@ Next step - code review:
 
 If the next step is Pull Request creation:
 - update `updated_at`
+- update `agent_infra_version` from `.agents/rules/version-stamp.md`
 - record the PR plan in `task.md`
 
 Required next-step commands:

--- a/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
@@ -2,6 +2,8 @@
 
 在选择提交后的任务状态分支之前先读取本文件。
 
+更新任务元数据前，先读取 `.agents/rules/version-stamp.md`，并随 `updated_at` 一起刷新 `agent_infra_version`。
+
 ## 更新关联任务状态
 
 先获取当前时间：
@@ -53,6 +55,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果仍有工作待完成：
 - 更新 `task.md` 中的 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 记录这次提交完成了什么
 - 记录下一位人类或 agent 需要继续做什么
 
@@ -61,6 +64,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 如果这次提交把工作移交给代码审查：
 - 将 `current_step` 更新为 `code-review`
 - 更新 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 在工作流状态中标记实现阶段已完成
 
 必带下一步命令：
@@ -76,6 +80,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 如果下一步是创建 Pull Request：
 - 更新 `updated_at`
+- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
 - 在 `task.md` 中记录 PR 计划
 
 必带下一步命令：

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -10,6 +10,8 @@ description: "Mark a task as completed and archive it"
 - This command updates task metadata AND physically moves the task directory
 - Do not move a task that has incomplete workflow steps unless forced
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -58,8 +60,10 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 Update `.agents/workspace/active/{task-id}/task.md`:
 - `status`: completed
+- `current_step`: completed
 - `completed_at`: {current timestamp}
 - `updated_at`: {current timestamp}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - Mark all workflow steps as complete
 - Verify and check off all items in `## Completion Checklist` (change `- [ ]` to `- [x]`)
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -10,6 +10,8 @@ description: "标记任务完成并归档"
 - 本命令更新任务元数据并物理移动任务目录
 - 除非强制执行，不要转移有未完成工作流步骤的任务
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证任务存在
@@ -58,8 +60,10 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
 - `status`：completed
+- `current_step`：completed
 - `completed_at`：{当前时间戳}
 - `updated_at`：{当前时间戳}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 标记所有工作流步骤为已完成
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：

--- a/templates/.agents/skills/complete-task/config/verify.json
+++ b/templates/.agents/skills/complete-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to",
         "completed_at"

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -7,6 +7,10 @@ description: "Create a Pull Request to a target branch"
 
 Create a Pull Request and, when task-related, sync the essential metadata and reviewer summary immediately.
 
+## Boundary / Critical Rules
+
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Execution Flow
 
 ### 1. Parse Command Arguments
@@ -72,7 +76,7 @@ Get the current time:
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, and append the PR Created Activity Log entry including metadata-sync and summary results.
+If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, `agent_infra_version`, and append the PR Created Activity Log entry including metadata-sync and summary results.
 
 ### 9. Verification Gate
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -7,6 +7,10 @@ description: "创建 Pull Request 到目标分支"
 
 创建 Pull Request，并在与任务关联时立即补齐核心元数据和 reviewer 摘要。
 
+## 行为边界 / 关键规则
+
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行流程
 
 ### 1. 解析命令参数
@@ -72,7 +76,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -20,6 +20,8 @@ The user's description is a **work item**, not an **instruction to execute immed
 
 After executing this skill, you **must** immediately update task status in task.md.
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Parse the User Description
@@ -74,6 +76,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {current AI agent}
@@ -93,6 +96,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: requirement-analysis
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - `## Context` -> `- **Branch**:`: update it to the generated branch name
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -20,6 +20,8 @@ description: "根据自然语言描述创建任务"
 
 执行本技能后，你**必须**立即更新 task.md 中的任务状态。
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 解析用户描述
@@ -74,6 +76,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -93,6 +96,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```

--- a/templates/.agents/skills/create-task/config/verify.json
+++ b/templates/.agents/skills/create-task/config/verify.json
@@ -10,6 +10,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/implement-task/SKILL.en.md
+++ b/templates/.agents/skills/implement-task/SKILL.en.md
@@ -14,6 +14,8 @@ Implement the approved task and produce `implementation.md` or `implementation-r
 - Create a new implementation artifact for each round and never overwrite an older one
 - After executing this skill, you **must** immediately update task.md
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Prerequisites
@@ -88,6 +90,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: implementation
 - `assigned_to`: {current agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are clearly satisfied by this round's implemented code and passing tests
 - record `{implementation-artifact}` for Round `{implementation-round}`
 - append:

--- a/templates/.agents/skills/implement-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/implement-task/SKILL.zh-CN.md
@@ -14,6 +14,8 @@ description: "根据技术方案实施任务并输出报告"
 - 每轮实现都创建新的实现产物，不覆盖旧文件
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -88,6 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：implementation
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{implementation-round}` 的 `{implementation-artifact}`
 - 追加：

--- a/templates/.agents/skills/implement-task/config/verify.json
+++ b/templates/.agents/skills/implement-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/import-codescan/config/verify.json
+++ b/templates/.agents/skills/import-codescan/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/import-dependabot/config/verify.json
+++ b/templates/.agents/skills/import-dependabot/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -69,6 +69,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {current AI agent}
@@ -91,6 +92,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: requirement-analysis
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - `## Context` -> `- **Branch**:`: update it to the generated branch name
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
@@ -161,6 +163,8 @@ Next step - run requirements analysis:
 ## STOP
 
 After completing the checklist, **stop immediately**. Do not continue to later steps.
+
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
 ## Notes
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -69,6 +69,7 @@ workflow: feature-development|bug-fix|refactoring
 status: active
 created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
+agent_infra_version: {agent_infra_version}
 created_by: human
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
@@ -91,6 +92,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：requirement-analysis
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
@@ -161,6 +163,8 @@ Issue #{number} 已导入。
 ## 停止
 
 完成检查清单后，**立即停止**。不要继续执行后续步骤。
+
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
 ## 注意事项
 

--- a/templates/.agents/skills/import-issue/config/verify.json
+++ b/templates/.agents/skills/import-issue/config/verify.json
@@ -10,6 +10,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -11,6 +11,8 @@ description: "Design a technical plan for a task"
 - This is a **mandatory human review checkpoint**; do not automatically proceed to implementation
 - After executing this skill, you **must** immediately update task status in task.md
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Prerequisites
@@ -88,6 +90,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `current_step`: technical-design
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - Record the plan artifact for this round: `{plan-artifact}` (Round `{plan-round}`)
 - If the task template contains a `## Design` section, update it to link to `{plan-artifact}`
 - Mark technical-design as complete in workflow progress and include the actual round when the task template supports it

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -11,6 +11,8 @@ description: "为任务设计技术方案和实施计划"
 - 这是一个**强制性的人工审查检查点** —— 不要自动进入实现阶段
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件
@@ -88,6 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `current_step`：technical-design
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 记录本轮方案产物：`{plan-artifact}`（Round `{plan-round}`）
 - 如任务模板包含 `## 设计` 段落，更新为指向 `{plan-artifact}` 的链接
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）

--- a/templates/.agents/skills/plan-task/config/verify.json
+++ b/templates/.agents/skills/plan-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -13,6 +13,8 @@ Fix review findings and produce `refinement.md` or `refinement-r{N}.md`.
 - Never auto-run `git add` or `git commit`
 - After executing this skill, you **must** immediately update task.md
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -13,6 +13,8 @@ description: "处理代码审查反馈并修复问题"
 - 绝不自动执行 `git add` 或 `git commit`
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件

--- a/templates/.agents/skills/refine-task/config/verify.json
+++ b/templates/.agents/skills/refine-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -14,6 +14,8 @@ Restore local task workspace files from platform Issue comments that contain syn
 - Stop immediately if the target directory already exists and ask the user to resolve the conflict first
 - After executing this skill, you **must** immediately update the restored `task.md`
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Input and Environment
@@ -83,6 +85,7 @@ Update the restored `task.md`:
 - `status`: `active`
 - `assigned_to`: {current AI agent}
 - `updated_at`: {current time}
+- `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 
 Append an Activity Log entry indicating the task was restored from the platform Issue.
 

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -14,6 +14,8 @@ description: "从平台 Issue 评论还原本地任务文件"
 - 如果目标目录已存在，立即停止并提示用户先处理目录冲突
 - 执行本技能后，你**必须**立即更新恢复出的 `task.md`
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证输入与环境
@@ -83,6 +85,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `status`：`active`
 - `assigned_to`：{当前 AI 代理}
 - `updated_at`：{当前时间}
+- `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 
 追加 Activity Log，说明任务已从平台 Issue 还原。
 

--- a/templates/.agents/skills/restore-task/config/verify.json
+++ b/templates/.agents/skills/restore-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ],

--- a/templates/.agents/skills/review-task/SKILL.en.md
+++ b/templates/.agents/skills/review-task/SKILL.en.md
@@ -12,6 +12,8 @@ Review the latest implementation round and produce `review.md` or `review-r{N}.m
 - This skill reviews code and writes a report; it does not modify product code
 - After executing this skill, you **must** immediately update task.md
 
+Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/review-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-task/SKILL.zh-CN.md
@@ -12,6 +12,8 @@ description: "审查任务实现并输出代码审查报告"
 - 本技能只审查代码并写报告，不修改业务代码
 - 执行本技能后，你**必须**立即更新 task.md
 
+版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
+
 ## 执行步骤
 
 ### 1. 验证前置条件

--- a/templates/.agents/skills/review-task/config/verify.json
+++ b/templates/.agents/skills/review-task/config/verify.json
@@ -9,6 +9,7 @@
         "status",
         "created_at",
         "updated_at",
+        "agent_infra_version",
         "current_step",
         "assigned_to"
       ]

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -6,7 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
-agent_infra_version: v0.0.0      # Current agent-infra version; refreshed by workflow commands
+agent_infra_version: v0.0.0    # Current agent-infra version; refreshed by workflow commands
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -6,6 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+agent_infra_version: v0.0.0      # Current agent-infra version; refreshed by workflow commands
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -6,7 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
-agent_infra_version: v0.0.0      # 当前 agent-infra 版本；由工作流命令刷新
+agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -6,6 +6,7 @@ workflow: feature-development  # feature-development | bug-fix | code-review | r
 status: open                   # open | in-progress | review | blocked | completed
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
+agent_infra_version: v0.0.0      # 当前 agent-infra 版本；由工作流命令刷新
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -48,6 +48,15 @@ test("cli version output stays in sync with package.json", () => {
   assert.equal(output.trim(), `agent-infra v${pkg.version}`);
 });
 
+test("cli version raw output returns the bare version string", () => {
+  const pkg = JSON.parse(read("package.json"));
+  const output = execFileSync(process.execPath, cliArgs("version", "--raw"), {
+    encoding: "utf8"
+  });
+
+  assert.equal(output.trim(), `v${pkg.version}`);
+});
+
 test("agent-infra init generates seed files in a temp directory", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-test-"));
   const cli = CLI_PATH;

--- a/tests/core/validate-artifact.test.ts
+++ b/tests/core/validate-artifact.test.ts
@@ -34,6 +34,7 @@ type ValidatorCheck = {
   type: string;
   status: string;
   fail_type?: string;
+  warnings?: string[];
 };
 type ValidatorPayload = {
   gate: string;
@@ -41,6 +42,7 @@ type ValidatorPayload = {
   type: string;
   status: string;
   message: string;
+  warnings?: string[];
 };
 
 function parseValidatorPayload(stdout: string): ValidatorPayload {
@@ -451,6 +453,94 @@ test("validate-artifact create-task task-meta rejects invalid branch naming", ()
     const result = runValidator(["check", "task-meta", taskDir, "--skill", "create-task"]);
     assert.equal(result.status, 1);
     assert.match(result.stdout, /Invalid branch/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact task-meta warns without blocking when agent_infra_version is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-missing-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    write(path.join(taskDir, "task.md"), buildTaskContent());
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /agent_infra_version.*missing/);
+
+    const payload = parseValidatorPayload(result.stdout);
+    assert.deepEqual(payload.warnings, [
+      "field 'agent_infra_version' missing — historical task or skipped version stamp"
+    ]);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact task-meta rejects malformed agent_infra_version", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-invalid-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      agent_infra_version: "0.6.1"
+    }));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Invalid agent_infra_version/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact task-meta accepts unknown agent_infra_version fallback", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-unknown-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      agent_infra_version: "unknown"
+    }));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact task-meta accepts SemVer build metadata in agent_infra_version", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-build-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      agent_infra_version: "v0.6.1-alpha.0+build.7"
+    }));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /Invalid agent_infra_version/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact task-meta accepts stamped agent_infra_version", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-valid-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+
+  try {
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      agent_infra_version: "v0.6.1-alpha.0"
+    }));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/templates/templates.test.ts
+++ b/tests/templates/templates.test.ts
@@ -61,6 +61,8 @@ test("required template files were migrated into templates/", () => {
   const requiredFiles = [
     "templates/.agents/workflows/feature-development.en.yaml",
     "templates/.agents/templates/task.en.md",
+    "templates/.agents/rules/version-stamp.en.md",
+    "templates/.agents/rules/version-stamp.zh-CN.md",
     "templates/.agents/README.en.md",
     "templates/.agents/QUICKSTART.en.md",
     "templates/.agents/skills/archive-tasks/SKILL.en.md",
@@ -135,6 +137,17 @@ test("root and template gitignore both ignore node_modules", () => {
 
   assert.match(rootGitignore, /^node_modules\/$/m);
   assert.match(templateGitignore, /^node_modules\/$/m);
+});
+
+test("task templates include agent-infra version metadata", () => {
+  for (const relativePath of [
+    ".agents/templates/task.md",
+    "templates/.agents/templates/task.en.md",
+    "templates/.agents/templates/task.zh-CN.md"
+  ]) {
+    const content = read(relativePath);
+    assert.match(content, /^agent_infra_version: v0\.0\.0\b/m, `${relativePath} should stamp the CLI version field`);
+  }
 });
 
 test("update-agent-infra template copies stay in sync with working files", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #282

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

任意一份历史 `task.md` 都对外暴露了 `id`、`workflow`、`created_at`、`updated_at`、`current_step` 等元数据，但**唯独没有记录写入它的 `agent-infra` CLI 版本**。一旦后续出现产物格式异常、行为回归、同步失败等问题，排查链路就必须靠 `git log` + 经验回忆来反推写入版本，是一条不可靠的人工降级路径。

本 PR 在工作流的关键产物（task frontmatter、Issue/PR 同步评论的元数据块、状态更新链路）上持久化 `agent-infra` 自身的版本号，使得任何一份历史产物都能被一眼反查到写入它的 CLI 版本。

**关键澄清**：本 PR 关注的是 `agent-infra` 自身的版本号（来自 `package.json` / `lib/version.ts`），不是底层各 TUI（Claude Code / Codex / Gemini CLI / OpenCode）的版本号。

## 📋 主要变更 / Brief Changelog

- **新增 frontmatter 字段 `agent_infra_version`**：写入 `task.md`，并在每次更新 frontmatter 时随 `updated_at` 一起刷新（last-writer-wins）。frontmatter 通过 Issue/PR 同步评论的 `<details>` 块自然镜像，无需修改 sync 规则
- **新增共享规则 `.agents/rules/version-stamp.md`**（含 zh-CN / en 模板镜像）：单点定义字段命名、取值命令、缺失字段容错策略。15 个会写入 frontmatter 的 SKILL.md 与对应 `config/verify.json` 全部引用该规则
- **新增 CLI 输出契约 `ai version --raw`**：直接打印 `v0.6.1-alpha.0` 形式的纯版本号，作为 SKILL 取值的稳定通道；既有 `ai version` 行为不变
- **扩展 `validate-artifact.js`**：把 `agent_infra_version` 纳入 task-meta 校验；缺失字段降级为**结构化 warning**（不阻塞 gate，避免历史任务回归），值格式校验支持完整 SemVer（含 `+build` 元数据）与 `unknown` 兜底
- **`.agents/rules/task-management.md`**（含双语模板）整理为 15 条命令的字段集合权威清单
- **测试**：新增 `ai version --raw` 用例、`agent_infra_version` 的 missing / invalid / unknown / 含 build / 正常版本 五条用例、双语模板存在性用例。共 495 用例，494 pass，1 skipped

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

```bash
NODE22_DIR=$(dirname "$(npx -y node@22 -p 'process.execPath')")
PATH="$NODE22_DIR:$PATH" npm test
```

预期：

```text
# tests 495
# pass 494
# skipped 1
# fail 0
```

> 备注：本仓库 `package.json#engines.node` 要求 `>=22`（`--experimental-strip-types`）；如果开发机默认 Node 是 20.x，按上述命令把 Node 22 临时置于 `PATH` 前即可。本 PR 的 pre-commit hook 已在 Node 22 下复跑 `npm run test:core` 验证通过。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（本任务自身的 task.md 即 backfill 了新字段，全 6 次 gate 校验通过）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（4 轮 review + 3 轮 refinement，最终 0 blocker / 0 major / 0 minor）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（缺失字段降级为非阻塞 warning，历史 task / archive 不受影响；`import-issue` Recovered 场景在远端缺字段时自动注入当前版本，不阻塞导入）

## 📋 附加信息 / Additional Notes

### 设计取舍

- **方案 B：last-writer-wins**（vs 创建时定格 / Activity Log 行级版本）—— 用户在任务推进中升级 CLI 后，下次写入的产物即对应当时版本，正面解决问题；额外的步骤级历史可由 `git log task.md` 兜底
- **字段命名 `agent_infra_version`**（vs `cli_version` / `tool_version` / `ai_version`）—— 与项目名一致，不与潜在的 TUI/template 版本字段命名冲突
- **取值通道 `ai version --raw`**（vs 解析 `ai version` 字符串）—— 给 SKILL 的 shell 取值一条稳定可测的契约，避免输出格式漂移
- **缺失字段为 warning 而非 fail** —— 已有 active / archive 任务零回归；新流程一旦触碰任务即完成 backfill

### 审查历程

| 轮次 | 实施者 | 结论 | 备注 |
|------|--------|------|------|
| Round 1 实现 | codex | 完成 | 87 文件，493 用例通过 |
| Round 1 审查 | claude | 通过（有 2 major / 7 minor） | 渲染回归、规则不自洽等 |
| Round 1 修复 | codex | 完成 | 9 条全处理 |
| Round 2 审查 | claude | 通过（2 minor） | 实现报告与精修态漂移、规则字段不对称 |
| Round 2 修复 | codex | 完成 | 2 条全处理 |
| Round 3 审查 | claude | 通过（1 minor） | complete-task 规则 vs SKILL 漂移 |
| Round 3 修复 | codex | 完成 | 1 条全处理 |
| Round 4 审查 | claude | 通过（0 / 0 / 0） | — |
| Style fix | claude | 完成 | 任务模板 frontmatter 注释列对齐（人工评审）|

详细分析、技术方案与审查记录归档在 `.agents/workspace/active/TASK-20260505-101253/`（analysis.md / plan.md / implementation.md / review[-rN].md / refinement[-rN].md）。

---

**审查者注意事项 / Reviewer Notes:**

- 本任务自身的 `task.md` 是「按新规则生成的第一个真实样本」，可以直接拉到 PR 仓库本地观察 frontmatter 与 Issue #282 的 task 评论 `<details>` 块中的 `agent_infra_version` 字段。
- 测试需用 Node 22 复跑（见上方命令）。pre-commit hook 已自动在 Node 22 下跑 `test:core`。

Generated with AI assistance.
