### PR TITLE
fix(core): 修复平台同步校验网络重试缺口

### DIFF
--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -928,14 +928,14 @@ function computeExpectedInLabels(taskDir) {
     return { ok: true, labels: Array.from(labels).sort(), mode: "mapped" };
   }
 
-  const repoLabelsResult = ghJson([
+  const repoLabelsResult = withRetry(() => ghJson([
     "label",
     "list",
     "--limit",
     "200",
     "--json",
     "name"
-  ], taskDir);
+  ], taskDir));
   if (!repoLabelsResult.ok) {
     return repoLabelsResult;
   }
@@ -1015,10 +1015,10 @@ function resolveUpstreamRepo(taskDir) {
     return ownerRepo;
   }
 
-  const repoResult = ghJson([
+  const repoResult = withRetry(() => ghJson([
     "api",
     `repos/${ownerRepo.value}`
-  ], taskDir);
+  ], taskDir));
 
   if (!repoResult.ok) {
     return repoResult;
@@ -1053,12 +1053,12 @@ function resolveOwnerRepo(taskDir) {
 }
 
 function detectPermissions(upstreamRepo, taskDir) {
-  const permissionsResult = ghJson([
+  const permissionsResult = withRetry(() => ghJson([
     "api",
     `repos/${upstreamRepo}`,
     "--jq",
     ".permissions"
-  ], taskDir);
+  ], taskDir));
 
   if (!permissionsResult.ok) {
     return { hasTriage: false, hasPush: false };

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -928,14 +928,14 @@ function computeExpectedInLabels(taskDir) {
     return { ok: true, labels: Array.from(labels).sort(), mode: "mapped" };
   }
 
-  const repoLabelsResult = ghJson([
+  const repoLabelsResult = withRetry(() => ghJson([
     "label",
     "list",
     "--limit",
     "200",
     "--json",
     "name"
-  ], taskDir);
+  ], taskDir));
   if (!repoLabelsResult.ok) {
     return repoLabelsResult;
   }
@@ -1015,10 +1015,10 @@ function resolveUpstreamRepo(taskDir) {
     return ownerRepo;
   }
 
-  const repoResult = ghJson([
+  const repoResult = withRetry(() => ghJson([
     "api",
     `repos/${ownerRepo.value}`
-  ], taskDir);
+  ], taskDir));
 
   if (!repoResult.ok) {
     return repoResult;
@@ -1053,12 +1053,12 @@ function resolveOwnerRepo(taskDir) {
 }
 
 function detectPermissions(upstreamRepo, taskDir) {
-  const permissionsResult = ghJson([
+  const permissionsResult = withRetry(() => ghJson([
     "api",
     `repos/${upstreamRepo}`,
     "--jq",
     ".permissions"
-  ], taskDir);
+  ], taskDir));
 
   if (!permissionsResult.ok) {
     return { hasTriage: false, hasPush: false };

--- a/tests/core/validate-artifact.test.ts
+++ b/tests/core/validate-artifact.test.ts
@@ -805,6 +805,177 @@ test("validate-artifact platform-sync blocks after retry exhaustion on gh networ
   }
 });
 
+test("validate-artifact platform-sync retries upstream repo lookup on transient gh failure", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-retry-upstream-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const commentsPath = path.join(tempRoot, "comments.json");
+  const counterPath = path.join(tempRoot, "transient-upstream.count");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    writeFakeGh(ghPath);
+
+    const taskContent = buildTaskContent({ issue_number: "65" });
+    const artifactContent = loadFixture("valid-implementation.md");
+
+    write(path.join(taskDir, "task.md"), taskContent);
+    write(path.join(taskDir, "implementation.md"), artifactContent);
+    writeJson(issuePath, buildIssuePayload());
+    writeJson(commentsPath, [
+      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
+      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
+    ]);
+    write(counterPath, "1");
+
+    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        GH_FAKE_ISSUE_PATH: issuePath,
+        GH_FAKE_COMMENTS_PATH: commentsPath,
+        GH_FAKE_TRANSIENT_FAIL_MATCHER: "api repos/fitlab-ai/agent-infra",
+        GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
+        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+      }
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
+
+    const payload = parseValidatorPayload(result.stdout);
+    assert.equal(payload.gate, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync retries permission lookup on transient gh failure", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-retry-permissions-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const commentsPath = path.join(tempRoot, "comments.json");
+  const counterPath = path.join(tempRoot, "transient-permissions.count");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    writeFakeGh(ghPath);
+
+    const taskContent = buildTaskContent({ issue_number: "65" });
+    const artifactContent = loadFixture("valid-implementation.md");
+
+    write(path.join(taskDir, "task.md"), taskContent);
+    write(path.join(taskDir, "implementation.md"), artifactContent);
+    writeJson(issuePath, buildIssuePayload());
+    writeJson(commentsPath, [
+      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
+      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
+    ]);
+    write(counterPath, "1");
+
+    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        GH_FAKE_ISSUE_PATH: issuePath,
+        GH_FAKE_COMMENTS_PATH: commentsPath,
+        GH_FAKE_TRANSIENT_FAIL_MATCHER: ".permissions",
+        GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
+        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+      }
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
+
+    const payload = parseValidatorPayload(result.stdout);
+    assert.equal(payload.gate, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync retries label list fallback when in: label mapping is empty", () => {
+  const scratchRoot = filePath(".tmp");
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(scratchRoot, "agent-infra-platform-sync-retry-labels-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh.cjs");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const commentsPath = path.join(tempRoot, "comments.json");
+  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+  const labelsPath = path.join(tempRoot, "labels.json");
+  const counterPath = path.join(tempRoot, "transient-labels.count");
+  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+  const adapterCopy = path.join(tempRoot, ".agents/scripts/platform-adapters/platform-sync.js");
+  const verifyCopy = path.join(tempRoot, ".agents/skills/commit/config/verify.json");
+
+  try {
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
+    write(path.join(tempRoot, ".agents/.airc.json"), JSON.stringify({
+      project: "agent-infra",
+      labels: { in: {} }
+    }, null, 2));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
+    write(verifyCopy, read(".agents/skills/commit/config/verify.json"));
+
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    const headSha = createHeadCommit(tempRoot);
+    write(ghPath, loadFixture("fake-gh.js"));
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
+    writeJson(issuePath, buildIssuePayload({ labels: [] }));
+    writeJson(commentsPath, []);
+    writeJson(prCommentsPath, [
+      {
+        body: [
+          "<!-- sync-pr:TASK-20260328-000001:summary -->",
+          `<!-- last-commit: ${headSha} -->`,
+          "## Review Summary",
+          "",
+          "Looks good."
+        ].join("\n")
+      }
+    ]);
+    writeJson(labelsPath, [{ name: "in: tests" }]);
+    write(counterPath, "1");
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptCopy, "check", "platform-sync", taskDir, "--skill", "commit"],
+      {
+        encoding: "utf8",
+        cwd: tempRoot,
+        env: gitSafeEnv({
+          AGENT_INFRA_GH_BIN: process.execPath,
+          AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+          GH_FAKE_ISSUE_PATH: issuePath,
+          GH_FAKE_COMMENTS_PATH: commentsPath,
+          GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
+          GH_FAKE_LABELS_PATH: labelsPath,
+          GH_FAKE_ISSUE_NUMBER: "65",
+          GH_FAKE_PR_NUMBER: "77",
+          GH_FAKE_TRANSIENT_FAIL_MATCHER: "label list",
+          GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
+          VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+        })
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
+
+    const payload = parseValidatorPayload(result.stdout);
+    assert.equal(payload.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("validate-artifact platform-sync skips when no platform adapter is registered", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-skip-"));
   const taskDir = path.join(tempRoot, "TASK-20260328-000001");

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -3,6 +3,20 @@ const fs = require("node:fs");
 
 const args = process.argv.slice(2);
 
+const transientMatcher = process.env.GH_FAKE_TRANSIENT_FAIL_MATCHER;
+const transientCounterFile = process.env.GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE;
+if (transientMatcher && transientCounterFile && fs.existsSync(transientCounterFile)) {
+  const joined = args.join(" ");
+  if (joined.includes(transientMatcher)) {
+    const remaining = Number(fs.readFileSync(transientCounterFile, "utf8").trim() || "0");
+    if (remaining > 0) {
+      fs.writeFileSync(transientCounterFile, String(remaining - 1));
+      console.error("transient network error");
+      process.exit(1);
+    }
+  }
+}
+
 function readJson(envName) {
   const filePath = process.env[envName];
   return filePath ? JSON.parse(fs.readFileSync(filePath, "utf8")) : null;
@@ -35,6 +49,11 @@ if (args[0] === "issue" && args[1] === "view") {
 
 if (args[0] === "pr" && args[1] === "view") {
   process.stdout.write(JSON.stringify(readJson("GH_FAKE_PR_PATH")));
+  process.exit(0);
+}
+
+if (args[0] === "label" && args[1] === "list") {
+  process.stdout.write(JSON.stringify(readJson("GH_FAKE_LABELS_PATH") || []));
   process.exit(0);
 }
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #324 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`refine-task` 等技能在跑 `validate-artifact.js gate` 时，`platform-sync` adapter 偶发因 GitHub API 瞬时 EOF / TLS 握手超时返回 blocked（exit 2），AI 工作流随之停止。adapter 大部分远端查询已经走 `withRetry()`（issue view、comments、PR view 等），但 **三处** `ghJson()` 调用没有重试覆盖：

1. `resolveUpstreamRepo()` —— upstream 仓库探测（工作流首个外网调用）
2. `detectPermissions()` —— 仓库权限查询
3. `computeExpectedInLabels()` 的 `gh label list` fallback

只要其中任一调用碰上瞬时网络抖动，整轮校验立刻 blocked。本 PR 把这三处统一接入既有 `withRetry()`，让瞬时错误（EOF / connection reset / 5xx / TLS timeout 等）按现有 `[3000, 10000] ms` 重试策略再判定，仅在重试耗尽后才升级为 blocked，对工作流可见的停顿概率明显下降。

## 📋 主要变更 / Brief Changelog

- 在 `.agents/scripts/platform-adapters/platform-sync.js` 中给三处缺口包 `withRetry(() => ghJson(...))`；不改 `ghJson` / `withRetry` / `classifyGhFailure` 的语义。
- 同步镜像到 `templates/.agents/scripts/platform-adapters/platform-sync.github.js`，保持与正本字节一致。
- 在 `tests/fixtures/validate-artifact/fake-gh.js` 中加一对 env-gated 的 transient-fail counter（`GH_FAKE_TRANSIENT_FAIL_MATCHER` + `GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE`），未设置时对现有用例零影响；顺手补一条 `gh label list` 路由以支撑新增 label fallback 测试。
- 在 `tests/core/validate-artifact.test.ts` 新增 3 个 retry-success 回归用例，分别覆盖 `resolveUpstreamRepo` / `detectPermissions` / `computeExpectedInLabels` fallback；每条用例在 gate `pass` 之外还断言 counter 文件最终降到 `"0"`，确保 transient failure 真的被触发并被重试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build && node --experimental-strip-types --no-warnings --test tests/core/validate-artifact.test.ts`（要求 Node ≥ 22）
2. `grep -n withRetry .agents/scripts/platform-adapters/platform-sync.js` 应出现 12 处（既有 9 处 + 新 3 处）
3. `diff .agents/scripts/platform-adapters/platform-sync.js templates/.agents/scripts/platform-adapters/platform-sync.github.js` 应输出空

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（51/51 validate-artifact；360/360 + 1 skipped on `test:core`，pre-commit hook 已校验）
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（fake-gh fixture）
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（无文档面变更，行为完全向后兼容）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（仅扩大 `withRetry` 覆盖面，不改公共 API 与错误分类语义）

## 📋 附加信息 / Additional Notes

- `detectPermissions()` 的失败降级语义本轮保持不变：重试耗尽仍返回 `{hasTriage: false, hasPush: false}`。本 PR 只解决「瞬时网络错误立即 blocked」的痛点，不改变长时间 outage 下的静默降级行为。
- 默认重试间隔为 `[3000, 10000] ms`；测试通过 `VALIDATE_ARTIFACT_RETRY_DELAYS_MS="0,0"` 避免拖慢用例。

---

**审查者注意事项 / Reviewer Notes:**

- 重点核对：三处 `withRetry(() => ghJson(...))` 是否与其它 8 处既有调用点风格一致。
- 测试隔离：每个新测试使用独立 `mkdtempSync` 工作目录与独立 counter 文件，无跨用例污染。
- counter 断言（最终为 `"0"`）是验证强度的关键，避免「测试通过但 withRetry 实际未执行」的伪绿。

---

Generated with AI assistance
