### PR TITLE
feat(templates): 在工作流中同步 Issue Type 自定义字段

### DIFF
--- a/.agents/rules/create-issue.md
+++ b/.agents/rules/create-issue.md
@@ -149,6 +149,12 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 
 设置失败不阻断流程。
 
+### 6.5 设置 Issue 字段（可选）
+
+如果 `has_push=true`，读取 `.agents/rules/issue-fields.md`，按流程 A 写入 `task.md` 中适用且非空的 `priority`、`effort`、`start_date` 和 `target_date`。
+
+字段写入失败不阻断流程。
+
 ### 7. 回写 task.md
 
 更新 task.md：

--- a/.agents/rules/issue-fields.md
+++ b/.agents/rules/issue-fields.md
@@ -1,0 +1,155 @@
+# Issue 字段
+
+写入或校验 Issue Type pinned custom fields 前先读取本文件。
+
+## 边界
+
+- 仅在已知 `upstream_repo`、`has_push` 和 Issue 编号后使用本规则。
+- 如果 `has_push=false`，跳过直接字段写入并继续流程。
+- 每次写入前都读取组织当前 Issue Type schema；不要硬编码字段集合。
+- 缺失、空值或无法解析的值直接跳过。字段写入是 best-effort，不应阻断工作流。
+
+## 支持的 task.md frontmatter
+
+所有字段均可选：
+
+| task.md 字段 | Issue 字段 | 值格式 |
+|---|---|---|
+| `priority` | `Priority` | `Urgent`、`High`、`Medium` 或 `Low` |
+| `effort` | `Effort` | `High`、`Medium` 或 `Low` |
+| `start_date` | `Start date` | `YYYY-MM-DD` |
+| `target_date` | `Target date` | `YYYY-MM-DD` |
+
+写入前可规范化本地化选项：
+
+| 输入 | 写入选项 |
+|---|---|
+| `紧急` | `Urgent` |
+| `高` | `High` |
+| `中` | `Medium` |
+| `低` | `Low` |
+
+AI agent 在创建或修订任务时可根据标题与描述推断 `priority` 和 `effort`，但除非用户或来源 Issue 明确提供日期，否则必须保持日期字段为空。`task.md` 中人工填写的值优先。
+
+## GraphQL 参考
+
+读取 Issue Type pinned fields：
+
+```graphql
+query($owner:String!){
+  organization(login:$owner){ issueTypes(first:20){ nodes{
+    id name
+    pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    }
+  } } }
+}
+```
+
+读取单个 Issue 的当前 type 与字段值：
+
+```graphql
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){ issue(number:$number){
+    id
+    issueType{ name pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    } }
+    issueFieldValues(first:50){ nodes{
+      __typename
+      ... on IssueFieldSingleSelectValue{ name optionId field{ ... on IssueFieldSingleSelect{ name } } }
+      ... on IssueFieldDateValue{ value field{ ... on IssueFieldDate{ name } } }
+      ... on IssueFieldTextValue{ value field{ ... on IssueFieldText{ name } } }
+      ... on IssueFieldNumberValue{ value field{ ... on IssueFieldNumber{ name } } }
+    } }
+  } }
+}
+```
+
+写入或清空字段，以及更新 Issue Type：
+
+```graphql
+mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){
+  setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){ issue{ id } }
+}
+
+mutation($issueId:ID!,$issueTypeId:ID){
+  updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){ issue{ id } }
+}
+```
+
+`IssueFieldCreateOrUpdateInput` 支持 `fieldId`、`singleSelectOptionId`、`dateValue`、`textValue`、`numberValue` 和 `delete`。
+
+最小命令壳：
+
+```bash
+gh api graphql \
+  -f query='query($owner:String!){organization(login:$owner){issueTypes(first:20){nodes{id name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}}}}}' \
+  -F owner="{owner}"
+
+gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){id issueType{name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}} issueFieldValues(first:50){nodes{__typename ... on IssueFieldSingleSelectValue{name optionId field{... on IssueFieldSingleSelect{name}}} ... on IssueFieldDateValue{value field{... on IssueFieldDate{name}}} ... on IssueFieldTextValue{value field{... on IssueFieldText{name}}} ... on IssueFieldNumberValue{value field{... on IssueFieldNumber{name}}}}}}}}' \
+  -F owner="{owner}" -F name="{repo}" -F number="{issue-number}"
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueFields": [
+      { "fieldId": "{field-id}", "singleSelectOptionId": "{option-id}" },
+      { "fieldId": "{date-field-id}", "dateValue": "YYYY-MM-DD" },
+      { "fieldId": "{old-field-id}", "delete": true }
+    ]
+  }
+}
+JSON
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueTypeId:ID){updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueTypeId": "{issue-type-id}"
+  }
+}
+JSON
+```
+
+未列入本地化映射表的值会按字面量 option name 处理；这是为了支持规范英文输入。
+
+## 流程 A：创建 Issue 后写入字段
+
+1. 如果 `has_push` 不是 `true`，停止本流程。
+2. 从 `$upstream_repo` 解析 `{owner}`，查询 `organization.issueTypes`。
+3. 选择目标 Issue Type 的 `pinnedFields`。
+4. 从 `task.md` 读取非空的 `priority`、`effort`、`start_date` 和 `target_date`。
+5. 对每个值：
+   - 目标 type 未 pin 同名字段时跳过。
+   - single-select 字段先规范化本地化输入，再按 option name 匹配。
+   - date 字段只写入 `YYYY-MM-DD` 值。
+6. 用所有已解析 input 一次性提交 `setIssueFieldValue` mutation。没有 input 时跳过。
+
+## 流程 B：设置 Type 并迁移字段
+
+现有 Issue Type 发生变更时使用本流程。
+
+1. 如果 `has_push` 不是 `true`，停止本流程。
+2. 读取 Issue id、当前 Issue Type、pinned fields 和当前字段值。
+3. 查询组织 Issue Type 列表，解析目标 Issue Type id。
+4. 用目标 Issue Type id 执行 `updateIssueIssueType`。
+5. 解析目标 type 的 pinned fields。
+6. 对每个旧字段值：
+   - 目标 type 有同名字段时重新写入该值。single-select 值按 option name 在目标 type 中重新解析 option id。
+   - 目标 type 没有同名字段时，对旧字段发送 `{ fieldId, delete: true }`。
+7. 用所有迁移 input 一次性提交 `setIssueFieldValue` mutation。迁移 input 为空时跳过。
+
+两个流程均应保持幂等。重复写入未变化的值或删除已为空字段都是可接受的。

--- a/.agents/rules/issue-pr-commands.md
+++ b/.agents/rules/issue-pr-commands.md
@@ -88,6 +88,7 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-typ
 ```
 
 - 仅当 `has_push=true` 时执行 Issue Type 设置；否则跳过并继续
+- 变更现有 Issue Type 时，先读取 `.agents/rules/issue-fields.md` 并使用流程 B，确保同名 pinned fields 迁移，且新 type 不包含的字段被清空
 
 ## Issue 更新
 

--- a/.agents/rules/issue-sync.md
+++ b/.agents/rules/issue-sync.md
@@ -48,6 +48,7 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 | 设置/移除 milestone | `has_triage` | 同上 |
 | 编辑 Issue body | `has_triage` | 需求复选框同步使用 |
 | 设置 Issue Type | `has_push` | 需要 write 权限 |
+| 设置 Issue 字段 | `has_push` | pinned custom fields；失败不阻断 |
 | 设置 assignee | 不检测 | 无权限时直接跳过 |
 | 发布/更新评论 | 无需检测 | 公开仓库中认证用户可执行 |
 
@@ -55,7 +56,7 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 
 | 层级 | 操作类型 | 有权限 | 无权限 |
 |------|---------|--------|--------|
-| 静默降级 | label / milestone / Issue Type | 直接执行 `gh` 命令，同时更新 task 留言 | 跳过 `gh` 直接操作，仅更新 task 留言，由 bot 补位 |
+| 静默降级 | label / milestone / Issue Type / Issue 字段 | 直接执行 `gh` 命令，同时更新 task 留言 | 跳过 `gh` 直接操作，仅更新 task 留言，由 bot 补位 |
 | 直接跳过 | assignee | 直接执行 `gh` 命令 | 不做任何替代 |
 | 正常执行 | 评论 | 正常执行 | 正常执行 |
 

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -5,6 +5,18 @@ import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+const FRONTMATTER_FIELD_MAP = {
+  priority: "Priority",
+  effort: "Effort",
+  start_date: "Start date",
+  target_date: "Target date"
+};
+const OPTION_LOCALIZATION = {
+  "紧急": "Urgent",
+  "高": "High",
+  "中": "Medium",
+  "低": "Low"
+};
 
 let activeShared = null;
 let repoRoot = "";
@@ -107,6 +119,7 @@ export function check({ taskDir, config, artifactFile }, shared) {
     checkPrAssignee,
     checkSyncedRequirements,
     checkIssueType,
+    checkIssueFields,
     checkMilestone
   ];
 
@@ -326,6 +339,27 @@ function fetchRemoteData(context) {
     }
   }
 
+  let issueFields;
+  if (context.config.verify_issue_fields && context.hasPush) {
+    const [owner, name] = context.upstreamRepo.split("/");
+    const issueFieldsResult = withRetry(() => ghJson([
+      "api",
+      "graphql",
+      "-f",
+      `query=${ISSUE_FIELDS_QUERY}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-F",
+      `number=${context.issueNumber}`
+    ], context.taskDir));
+
+    if (issueFieldsResult.ok) {
+      issueFields = normalizeIssueFields(issueFieldsResult.value);
+    }
+  }
+
   let prLabels = null;
   let prMilestone;
   let prAssignees;
@@ -377,6 +411,7 @@ function fetchRemoteData(context) {
     prComments,
     prLabels,
     issueType,
+    issueFields,
     prMilestone,
     prAssignees
   };
@@ -703,6 +738,45 @@ function checkIssueType(context, remoteData) {
   return null;
 }
 
+function checkIssueFields(context, remoteData) {
+  if (!context.config.verify_issue_fields || !context.hasPush) {
+    return null;
+  }
+
+  if (remoteData.issueFields === undefined) {
+    return null;
+  }
+
+  for (const [metadataKey, fieldName] of Object.entries(FRONTMATTER_FIELD_MAP)) {
+    const expectedRaw = context.task.metadata[metadataKey];
+    if (isBlank(expectedRaw) || !remoteData.issueFields.pinnedNames.has(fieldName)) {
+      continue;
+    }
+
+    const actual = remoteData.issueFields.values.get(fieldName);
+    const expected = normalizeExpectedIssueField(metadataKey, expectedRaw);
+    if (!expected) {
+      continue;
+    }
+
+    if (!actual) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} field '${fieldName}' is missing, expected '${expected.value}'`,
+        "check_failed"
+      );
+    }
+
+    if (actual.kind !== expected.kind || actual.value !== expected.value) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} field '${fieldName}' is '${actual.value}', expected '${expected.value}'`,
+        "check_failed"
+      );
+    }
+  }
+
+  return null;
+}
+
 function checkPrAssignee(context, remoteData) {
   if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
     return null;
@@ -884,6 +958,69 @@ function mapTaskTypeToIssueType(taskType) {
   };
 
   return mapping[taskType] || "Task";
+}
+
+const ISSUE_FIELDS_QUERY = `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){issueType{name pinnedFields{__typename ... on IssueFieldSingleSelect{id name} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}} issueFieldValues(first:50){nodes{__typename ... on IssueFieldSingleSelectValue{name optionId field{... on IssueFieldSingleSelect{name}}} ... on IssueFieldDateValue{value field{... on IssueFieldDate{name}}} ... on IssueFieldTextValue{value field{... on IssueFieldText{name}}} ... on IssueFieldNumberValue{value field{... on IssueFieldNumber{name}}}}}}}}`;
+
+function normalizeIssueFields(payload) {
+  const issue = payload?.data?.repository?.issue;
+  const pinnedFields = Array.isArray(issue?.issueType?.pinnedFields)
+    ? issue.issueType.pinnedFields
+    : [];
+  const values = Array.isArray(issue?.issueFieldValues?.nodes)
+    ? issue.issueFieldValues.nodes
+    : [];
+  const pinnedNames = new Set(
+    pinnedFields
+      .map((field) => typeof field?.name === "string" ? field.name : "")
+      .filter(Boolean)
+  );
+  const normalizedValues = new Map();
+
+  for (const value of values) {
+    const fieldName = value?.field?.name;
+    if (!fieldName) {
+      continue;
+    }
+
+    if (value.__typename === "IssueFieldSingleSelectValue") {
+      normalizedValues.set(fieldName, {
+        kind: "single-select",
+        value: normalizeOptionName(value.name)
+      });
+    } else if (value.__typename === "IssueFieldDateValue") {
+      normalizedValues.set(fieldName, {
+        kind: "date",
+        value: normalizeDateValue(value.value)
+      });
+    }
+  }
+
+  return { pinnedNames, values: normalizedValues };
+}
+
+function normalizeExpectedIssueField(metadataKey, rawValue) {
+  const value = String(rawValue || "").trim();
+  if (!value) {
+    return null;
+  }
+
+  if (metadataKey === "start_date" || metadataKey === "target_date") {
+    return { kind: "date", value: normalizeDateValue(value) };
+  }
+
+  return { kind: "single-select", value: normalizeOptionName(value) };
+}
+
+function normalizeOptionName(value) {
+  const normalized = String(value || "").trim();
+  return OPTION_LOCALIZATION[normalized] || normalized;
+}
+
+function normalizeDateValue(value) {
+  const normalized = String(value || "").trim();
+  const match = normalized.match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : normalized;
 }
 
 function arraysEqual(left, right) {

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -38,6 +38,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "pendingDesignWork",
       "expected_comment_marker_key": "artifact"

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -30,6 +30,7 @@
       "verify_task_comment_content": true,
       "sync_checked_requirements": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_comment_marker_key": "summary"
     }

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -78,11 +78,16 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # 可选；Urgent | High | Medium | Low
+effort:                    # 可选；High | Medium | Low
+start_date:                # 可选；YYYY-MM-DD
+target_date:               # 可选；YYYY-MM-DD
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
 
 注意：`created_by` 为 `human`，因为任务来源于用户的描述。
+可选 Issue 字段元数据在创建任务时可留空；不要臆测日期。
 
 ### 3. 更新任务状态
 

--- a/.agents/skills/implement-task/config/verify.json
+++ b/.agents/skills/implement-task/config/verify.json
@@ -37,6 +37,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -71,9 +71,15 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # 可选；有来源/frontmatter 值时保留
+effort:                    # 可选；有来源/frontmatter 值时保留
+start_date:                # 可选；有明确 YYYY-MM-DD 时保留
+target_date:               # 可选；有明确 YYYY-MM-DD 时保留
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
+
+可选 Issue 字段元数据应保留恢复得到或来源中明确给出的值。缺失时留空；不要臆测日期。
 
 3.3 追加 Activity Log。
 

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -39,6 +39,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "pendingDesignWork",
       "expected_comment_marker_key": "artifact"

--- a/.agents/skills/refine-task/SKILL.md
+++ b/.agents/skills/refine-task/SKILL.md
@@ -59,6 +59,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 更新 task.md：
 - 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
+- 保留明确填写的可选 Issue 字段元数据（`priority`、`effort`、`start_date`、`target_date`）；仅在审查上下文非常明确时推断 `priority` 或 `effort`，不要臆测日期
 - 追加：
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {refinement-artifact}`
 

--- a/.agents/skills/refine-task/config/verify.json
+++ b/.agents/skills/refine-task/config/verify.json
@@ -33,6 +33,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/.agents/skills/review-task/config/verify.json
+++ b/.agents/skills/review-task/config/verify.json
@@ -38,6 +38,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -7,6 +7,10 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
+priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
+effort:                         # 可选 Issue 字段：High | Medium | Low
+start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD
+target_date:                    # Feature 可选 Issue 字段：YYYY-MM-DD
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/templates/.agents/rules/create-issue.github.en.md
+++ b/templates/.agents/rules/create-issue.github.en.md
@@ -149,6 +149,12 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 
 Failure is non-blocking.
 
+### 6.5 Set Issue Fields (Optional)
+
+If `has_push=true`, read `.agents/rules/issue-fields.md` and follow Flow A to write any applicable non-empty `priority`, `effort`, `start_date`, and `target_date` values from `task.md`.
+
+Field write failures are non-blocking.
+
 ### 7. Write Back task.md
 
 Update task.md:

--- a/templates/.agents/rules/create-issue.github.zh-CN.md
+++ b/templates/.agents/rules/create-issue.github.zh-CN.md
@@ -149,6 +149,12 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 
 设置失败不阻断流程。
 
+### 6.5 设置 Issue 字段（可选）
+
+如果 `has_push=true`，读取 `.agents/rules/issue-fields.md`，按流程 A 写入 `task.md` 中适用且非空的 `priority`、`effort`、`start_date` 和 `target_date`。
+
+字段写入失败不阻断流程。
+
 ### 7. 回写 task.md
 
 更新 task.md：

--- a/templates/.agents/rules/issue-fields.github.en.md
+++ b/templates/.agents/rules/issue-fields.github.en.md
@@ -1,0 +1,155 @@
+# Issue Fields
+
+Read this file before writing or verifying Issue Type pinned custom fields.
+
+## Boundary
+
+- Use this rule only after `upstream_repo`, `has_push`, and the Issue number are known.
+- If `has_push=false`, skip direct field writes and continue.
+- Fetch the organization's current Issue Type schema before each write; do not hard-code the field set.
+- Missing, empty, or unresolvable values are skipped. Field writes are best-effort and must not block the workflow.
+
+## Supported Task Frontmatter
+
+All fields are optional:
+
+| task.md field | Issue field | Value format |
+|---|---|---|
+| `priority` | `Priority` | `Urgent`, `High`, `Medium`, or `Low` |
+| `effort` | `Effort` | `High`, `Medium`, or `Low` |
+| `start_date` | `Start date` | `YYYY-MM-DD` |
+| `target_date` | `Target date` | `YYYY-MM-DD` |
+
+Localized option input may be normalized before writing:
+
+| Input | Stored option |
+|---|---|
+| `紧急` | `Urgent` |
+| `高` | `High` |
+| `中` | `Medium` |
+| `低` | `Low` |
+
+AI agents may infer `priority` and `effort` from the title and description when creating or refining tasks, but must keep date fields empty unless the user or source Issue provides explicit dates. Human edits in `task.md` take precedence.
+
+## GraphQL Reference
+
+Read Issue Type pinned fields:
+
+```graphql
+query($owner:String!){
+  organization(login:$owner){ issueTypes(first:20){ nodes{
+    id name
+    pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    }
+  } } }
+}
+```
+
+Read one Issue's current type and field values:
+
+```graphql
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){ issue(number:$number){
+    id
+    issueType{ name pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    } }
+    issueFieldValues(first:50){ nodes{
+      __typename
+      ... on IssueFieldSingleSelectValue{ name optionId field{ ... on IssueFieldSingleSelect{ name } } }
+      ... on IssueFieldDateValue{ value field{ ... on IssueFieldDate{ name } } }
+      ... on IssueFieldTextValue{ value field{ ... on IssueFieldText{ name } } }
+      ... on IssueFieldNumberValue{ value field{ ... on IssueFieldNumber{ name } } }
+    } }
+  } }
+}
+```
+
+Write or clear fields and update Issue Type:
+
+```graphql
+mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){
+  setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){ issue{ id } }
+}
+
+mutation($issueId:ID!,$issueTypeId:ID){
+  updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){ issue{ id } }
+}
+```
+
+`IssueFieldCreateOrUpdateInput` supports `fieldId`, `singleSelectOptionId`, `dateValue`, `textValue`, `numberValue`, and `delete`.
+
+Minimal command shells:
+
+```bash
+gh api graphql \
+  -f query='query($owner:String!){organization(login:$owner){issueTypes(first:20){nodes{id name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}}}}}' \
+  -F owner="{owner}"
+
+gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){id issueType{name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}} issueFieldValues(first:50){nodes{__typename ... on IssueFieldSingleSelectValue{name optionId field{... on IssueFieldSingleSelect{name}}} ... on IssueFieldDateValue{value field{... on IssueFieldDate{name}}} ... on IssueFieldTextValue{value field{... on IssueFieldText{name}}} ... on IssueFieldNumberValue{value field{... on IssueFieldNumber{name}}}}}}}}' \
+  -F owner="{owner}" -F name="{repo}" -F number="{issue-number}"
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueFields": [
+      { "fieldId": "{field-id}", "singleSelectOptionId": "{option-id}" },
+      { "fieldId": "{date-field-id}", "dateValue": "YYYY-MM-DD" },
+      { "fieldId": "{old-field-id}", "delete": true }
+    ]
+  }
+}
+JSON
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueTypeId:ID){updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueTypeId": "{issue-type-id}"
+  }
+}
+JSON
+```
+
+Values not listed in the localization table are treated as literal option names, which is intended for canonical English input.
+
+## Flow A: Write Fields After Issue Creation
+
+1. Stop if `has_push` is not `true`.
+2. Resolve `{owner}` from `$upstream_repo` and query `organization.issueTypes`.
+3. Select the target Issue Type's `pinnedFields`.
+4. Read non-empty `priority`, `effort`, `start_date`, and `target_date` values from `task.md`.
+5. For each value:
+   - Skip it when the target type does not pin a same-name field.
+   - For single-select fields, normalize localized input and match the option by name.
+   - For date fields, write only `YYYY-MM-DD` values.
+6. Submit one `setIssueFieldValue` mutation with all resolved inputs. If no input remains, skip.
+
+## Flow B: Set Type And Migrate Fields
+
+Use this flow whenever an existing Issue Type is changed.
+
+1. Stop if `has_push` is not `true`.
+2. Read the Issue id, current Issue Type, pinned fields, and current field values.
+3. Query the organization Issue Type list and resolve the target Issue Type id.
+4. Run `updateIssueIssueType` with the target Issue Type id.
+5. Resolve the target type's pinned fields.
+6. For each old field value:
+   - If the target type has a same-name field, write the value again. For single-select values, resolve the target option id by option name.
+   - If the target type does not have a same-name field, send `{ fieldId, delete: true }` for the old field.
+7. Submit one `setIssueFieldValue` mutation with all migration inputs. Empty migrations are skipped.
+
+Both flows are idempotent. Rewriting an unchanged value or deleting an already empty field is acceptable.

--- a/templates/.agents/rules/issue-fields.github.zh-CN.md
+++ b/templates/.agents/rules/issue-fields.github.zh-CN.md
@@ -1,0 +1,155 @@
+# Issue 字段
+
+写入或校验 Issue Type pinned custom fields 前先读取本文件。
+
+## 边界
+
+- 仅在已知 `upstream_repo`、`has_push` 和 Issue 编号后使用本规则。
+- 如果 `has_push=false`，跳过直接字段写入并继续流程。
+- 每次写入前都读取组织当前 Issue Type schema；不要硬编码字段集合。
+- 缺失、空值或无法解析的值直接跳过。字段写入是 best-effort，不应阻断工作流。
+
+## 支持的 task.md frontmatter
+
+所有字段均可选：
+
+| task.md 字段 | Issue 字段 | 值格式 |
+|---|---|---|
+| `priority` | `Priority` | `Urgent`、`High`、`Medium` 或 `Low` |
+| `effort` | `Effort` | `High`、`Medium` 或 `Low` |
+| `start_date` | `Start date` | `YYYY-MM-DD` |
+| `target_date` | `Target date` | `YYYY-MM-DD` |
+
+写入前可规范化本地化选项：
+
+| 输入 | 写入选项 |
+|---|---|
+| `紧急` | `Urgent` |
+| `高` | `High` |
+| `中` | `Medium` |
+| `低` | `Low` |
+
+AI agent 在创建或修订任务时可根据标题与描述推断 `priority` 和 `effort`，但除非用户或来源 Issue 明确提供日期，否则必须保持日期字段为空。`task.md` 中人工填写的值优先。
+
+## GraphQL 参考
+
+读取 Issue Type pinned fields：
+
+```graphql
+query($owner:String!){
+  organization(login:$owner){ issueTypes(first:20){ nodes{
+    id name
+    pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    }
+  } } }
+}
+```
+
+读取单个 Issue 的当前 type 与字段值：
+
+```graphql
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){ issue(number:$number){
+    id
+    issueType{ name pinnedFields{
+      __typename
+      ... on IssueFieldSingleSelect{ id name options{ id name } }
+      ... on IssueFieldDate{ id name }
+      ... on IssueFieldText{ id name }
+      ... on IssueFieldNumber{ id name }
+    } }
+    issueFieldValues(first:50){ nodes{
+      __typename
+      ... on IssueFieldSingleSelectValue{ name optionId field{ ... on IssueFieldSingleSelect{ name } } }
+      ... on IssueFieldDateValue{ value field{ ... on IssueFieldDate{ name } } }
+      ... on IssueFieldTextValue{ value field{ ... on IssueFieldText{ name } } }
+      ... on IssueFieldNumberValue{ value field{ ... on IssueFieldNumber{ name } } }
+    } }
+  } }
+}
+```
+
+写入或清空字段，以及更新 Issue Type：
+
+```graphql
+mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){
+  setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){ issue{ id } }
+}
+
+mutation($issueId:ID!,$issueTypeId:ID){
+  updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){ issue{ id } }
+}
+```
+
+`IssueFieldCreateOrUpdateInput` 支持 `fieldId`、`singleSelectOptionId`、`dateValue`、`textValue`、`numberValue` 和 `delete`。
+
+最小命令壳：
+
+```bash
+gh api graphql \
+  -f query='query($owner:String!){organization(login:$owner){issueTypes(first:20){nodes{id name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}}}}}' \
+  -F owner="{owner}"
+
+gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){id issueType{name pinnedFields{__typename ... on IssueFieldSingleSelect{id name options{id name}} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}} issueFieldValues(first:50){nodes{__typename ... on IssueFieldSingleSelectValue{name optionId field{... on IssueFieldSingleSelect{name}}} ... on IssueFieldDateValue{value field{... on IssueFieldDate{name}}} ... on IssueFieldTextValue{value field{... on IssueFieldText{name}}} ... on IssueFieldNumberValue{value field{... on IssueFieldNumber{name}}}}}}}}' \
+  -F owner="{owner}" -F name="{repo}" -F number="{issue-number}"
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueFields:[IssueFieldCreateOrUpdateInput!]!){setIssueFieldValue(input:{issueId:$issueId,issueFields:$issueFields}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueFields": [
+      { "fieldId": "{field-id}", "singleSelectOptionId": "{option-id}" },
+      { "fieldId": "{date-field-id}", "dateValue": "YYYY-MM-DD" },
+      { "fieldId": "{old-field-id}", "delete": true }
+    ]
+  }
+}
+JSON
+
+gh api graphql --input - <<'JSON'
+{
+  "query": "mutation($issueId:ID!,$issueTypeId:ID){updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){issue{id}}}",
+  "variables": {
+    "issueId": "{issue-id}",
+    "issueTypeId": "{issue-type-id}"
+  }
+}
+JSON
+```
+
+未列入本地化映射表的值会按字面量 option name 处理；这是为了支持规范英文输入。
+
+## 流程 A：创建 Issue 后写入字段
+
+1. 如果 `has_push` 不是 `true`，停止本流程。
+2. 从 `$upstream_repo` 解析 `{owner}`，查询 `organization.issueTypes`。
+3. 选择目标 Issue Type 的 `pinnedFields`。
+4. 从 `task.md` 读取非空的 `priority`、`effort`、`start_date` 和 `target_date`。
+5. 对每个值：
+   - 目标 type 未 pin 同名字段时跳过。
+   - single-select 字段先规范化本地化输入，再按 option name 匹配。
+   - date 字段只写入 `YYYY-MM-DD` 值。
+6. 用所有已解析 input 一次性提交 `setIssueFieldValue` mutation。没有 input 时跳过。
+
+## 流程 B：设置 Type 并迁移字段
+
+现有 Issue Type 发生变更时使用本流程。
+
+1. 如果 `has_push` 不是 `true`，停止本流程。
+2. 读取 Issue id、当前 Issue Type、pinned fields 和当前字段值。
+3. 查询组织 Issue Type 列表，解析目标 Issue Type id。
+4. 用目标 Issue Type id 执行 `updateIssueIssueType`。
+5. 解析目标 type 的 pinned fields。
+6. 对每个旧字段值：
+   - 目标 type 有同名字段时重新写入该值。single-select 值按 option name 在目标 type 中重新解析 option id。
+   - 目标 type 没有同名字段时，对旧字段发送 `{ fieldId, delete: true }`。
+7. 用所有迁移 input 一次性提交 `setIssueFieldValue` mutation。迁移 input 为空时跳过。
+
+两个流程均应保持幂等。重复写入未变化的值或删除已为空字段都是可接受的。

--- a/templates/.agents/rules/issue-pr-commands.github.en.md
+++ b/templates/.agents/rules/issue-pr-commands.github.en.md
@@ -88,6 +88,7 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-typ
 ```
 
 - set the Issue Type only when `has_push=true`; otherwise skip and continue
+- when changing an existing Issue Type, read `.agents/rules/issue-fields.md` and use Flow B so same-name pinned fields are migrated and fields absent from the new type are cleared
 
 ## Update Issues
 

--- a/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
+++ b/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
@@ -88,6 +88,7 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-typ
 ```
 
 - 仅当 `has_push=true` 时执行 Issue Type 设置；否则跳过并继续
+- 变更现有 Issue Type 时，先读取 `.agents/rules/issue-fields.md` 并使用流程 B，确保同名 pinned fields 迁移，且新 type 不包含的字段被清空
 
 ## Issue 更新
 

--- a/templates/.agents/rules/issue-sync.github.en.md
+++ b/templates/.agents/rules/issue-sync.github.en.md
@@ -48,6 +48,7 @@ Operation-to-permission mapping:
 | add/remove milestones | `has_triage` | same as above |
 | edit Issue body | `has_triage` | used by requirement checkbox sync |
 | set Issue Type | `has_push` | requires write permission |
+| set Issue fields | `has_push` | pinned custom fields; failures are non-blocking |
 | set assignee | no check | skip directly when it fails |
 | publish/update comments | no check | allowed for authenticated users in public repositories |
 
@@ -55,7 +56,7 @@ Operation-to-permission mapping:
 
 | Level | Operation type | With permission | Without permission |
 |------|---------|--------|--------|
-| silent degradation | label / milestone / Issue Type | run the `gh` command directly and also update the task comment | skip direct `gh` writes, update only the task comment, let the bot backfill |
+| silent degradation | label / milestone / Issue Type / Issue fields | run the `gh` command directly and also update the task comment | skip direct `gh` writes, update only the task comment, let the bot backfill |
 | direct skip | assignee | run the `gh` command directly | do nothing else |
 | normal execution | comments | run normally | run normally |
 

--- a/templates/.agents/rules/issue-sync.github.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.github.zh-CN.md
@@ -48,6 +48,7 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 | 设置/移除 milestone | `has_triage` | 同上 |
 | 编辑 Issue body | `has_triage` | 需求复选框同步使用 |
 | 设置 Issue Type | `has_push` | 需要 write 权限 |
+| 设置 Issue 字段 | `has_push` | pinned custom fields；失败不阻断 |
 | 设置 assignee | 不检测 | 无权限时直接跳过 |
 | 发布/更新评论 | 无需检测 | 公开仓库中认证用户可执行 |
 
@@ -55,7 +56,7 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 
 | 层级 | 操作类型 | 有权限 | 无权限 |
 |------|---------|--------|--------|
-| 静默降级 | label / milestone / Issue Type | 直接执行 `gh` 命令，同时更新 task 留言 | 跳过 `gh` 直接操作，仅更新 task 留言，由 bot 补位 |
+| 静默降级 | label / milestone / Issue Type / Issue 字段 | 直接执行 `gh` 命令，同时更新 task 留言 | 跳过 `gh` 直接操作，仅更新 task 留言，由 bot 补位 |
 | 直接跳过 | assignee | 直接执行 `gh` 命令 | 不做任何替代 |
 | 正常执行 | 评论 | 正常执行 | 正常执行 |
 

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -5,6 +5,18 @@ import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+const FRONTMATTER_FIELD_MAP = {
+  priority: "Priority",
+  effort: "Effort",
+  start_date: "Start date",
+  target_date: "Target date"
+};
+const OPTION_LOCALIZATION = {
+  "紧急": "Urgent",
+  "高": "High",
+  "中": "Medium",
+  "低": "Low"
+};
 
 let activeShared = null;
 let repoRoot = "";
@@ -107,6 +119,7 @@ export function check({ taskDir, config, artifactFile }, shared) {
     checkPrAssignee,
     checkSyncedRequirements,
     checkIssueType,
+    checkIssueFields,
     checkMilestone
   ];
 
@@ -326,6 +339,27 @@ function fetchRemoteData(context) {
     }
   }
 
+  let issueFields;
+  if (context.config.verify_issue_fields && context.hasPush) {
+    const [owner, name] = context.upstreamRepo.split("/");
+    const issueFieldsResult = withRetry(() => ghJson([
+      "api",
+      "graphql",
+      "-f",
+      `query=${ISSUE_FIELDS_QUERY}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-F",
+      `number=${context.issueNumber}`
+    ], context.taskDir));
+
+    if (issueFieldsResult.ok) {
+      issueFields = normalizeIssueFields(issueFieldsResult.value);
+    }
+  }
+
   let prLabels = null;
   let prMilestone;
   let prAssignees;
@@ -377,6 +411,7 @@ function fetchRemoteData(context) {
     prComments,
     prLabels,
     issueType,
+    issueFields,
     prMilestone,
     prAssignees
   };
@@ -703,6 +738,45 @@ function checkIssueType(context, remoteData) {
   return null;
 }
 
+function checkIssueFields(context, remoteData) {
+  if (!context.config.verify_issue_fields || !context.hasPush) {
+    return null;
+  }
+
+  if (remoteData.issueFields === undefined) {
+    return null;
+  }
+
+  for (const [metadataKey, fieldName] of Object.entries(FRONTMATTER_FIELD_MAP)) {
+    const expectedRaw = context.task.metadata[metadataKey];
+    if (isBlank(expectedRaw) || !remoteData.issueFields.pinnedNames.has(fieldName)) {
+      continue;
+    }
+
+    const actual = remoteData.issueFields.values.get(fieldName);
+    const expected = normalizeExpectedIssueField(metadataKey, expectedRaw);
+    if (!expected) {
+      continue;
+    }
+
+    if (!actual) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} field '${fieldName}' is missing, expected '${expected.value}'`,
+        "check_failed"
+      );
+    }
+
+    if (actual.kind !== expected.kind || actual.value !== expected.value) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} field '${fieldName}' is '${actual.value}', expected '${expected.value}'`,
+        "check_failed"
+      );
+    }
+  }
+
+  return null;
+}
+
 function checkPrAssignee(context, remoteData) {
   if (!context.config.verify_pr_assignee || !context.hasPush || !context.prNumber) {
     return null;
@@ -884,6 +958,69 @@ function mapTaskTypeToIssueType(taskType) {
   };
 
   return mapping[taskType] || "Task";
+}
+
+const ISSUE_FIELDS_QUERY = `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){issueType{name pinnedFields{__typename ... on IssueFieldSingleSelect{id name} ... on IssueFieldDate{id name} ... on IssueFieldText{id name} ... on IssueFieldNumber{id name}}} issueFieldValues(first:50){nodes{__typename ... on IssueFieldSingleSelectValue{name optionId field{... on IssueFieldSingleSelect{name}}} ... on IssueFieldDateValue{value field{... on IssueFieldDate{name}}} ... on IssueFieldTextValue{value field{... on IssueFieldText{name}}} ... on IssueFieldNumberValue{value field{... on IssueFieldNumber{name}}}}}}}}`;
+
+function normalizeIssueFields(payload) {
+  const issue = payload?.data?.repository?.issue;
+  const pinnedFields = Array.isArray(issue?.issueType?.pinnedFields)
+    ? issue.issueType.pinnedFields
+    : [];
+  const values = Array.isArray(issue?.issueFieldValues?.nodes)
+    ? issue.issueFieldValues.nodes
+    : [];
+  const pinnedNames = new Set(
+    pinnedFields
+      .map((field) => typeof field?.name === "string" ? field.name : "")
+      .filter(Boolean)
+  );
+  const normalizedValues = new Map();
+
+  for (const value of values) {
+    const fieldName = value?.field?.name;
+    if (!fieldName) {
+      continue;
+    }
+
+    if (value.__typename === "IssueFieldSingleSelectValue") {
+      normalizedValues.set(fieldName, {
+        kind: "single-select",
+        value: normalizeOptionName(value.name)
+      });
+    } else if (value.__typename === "IssueFieldDateValue") {
+      normalizedValues.set(fieldName, {
+        kind: "date",
+        value: normalizeDateValue(value.value)
+      });
+    }
+  }
+
+  return { pinnedNames, values: normalizedValues };
+}
+
+function normalizeExpectedIssueField(metadataKey, rawValue) {
+  const value = String(rawValue || "").trim();
+  if (!value) {
+    return null;
+  }
+
+  if (metadataKey === "start_date" || metadataKey === "target_date") {
+    return { kind: "date", value: normalizeDateValue(value) };
+  }
+
+  return { kind: "single-select", value: normalizeOptionName(value) };
+}
+
+function normalizeOptionName(value) {
+  const normalized = String(value || "").trim();
+  return OPTION_LOCALIZATION[normalized] || normalized;
+}
+
+function normalizeDateValue(value) {
+  const normalized = String(value || "").trim();
+  const match = normalized.match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : normalized;
 }
 
 function arraysEqual(left, right) {

--- a/templates/.agents/skills/analyze-task/config/verify.json
+++ b/templates/.agents/skills/analyze-task/config/verify.json
@@ -38,6 +38,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "pendingDesignWork",
       "expected_comment_marker_key": "artifact"

--- a/templates/.agents/skills/complete-task/config/verify.json
+++ b/templates/.agents/skills/complete-task/config/verify.json
@@ -30,6 +30,7 @@
       "verify_task_comment_content": true,
       "sync_checked_requirements": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_comment_marker_key": "summary"
     }

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -78,11 +78,16 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # optional; Urgent | High | Medium | Low
+effort:                    # optional; High | Medium | Low
+start_date:                # optional; YYYY-MM-DD
+target_date:               # optional; YYYY-MM-DD
 current_step: requirement-analysis
 assigned_to: {current AI agent}
 ```
 
 Note: `created_by` is `human` because the task comes from the user's description.
+Optional Issue field metadata may be left empty at task creation; do not invent dates.
 
 ### 3. Update Task Status
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -78,11 +78,16 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # 可选；Urgent | High | Medium | Low
+effort:                    # 可选；High | Medium | Low
+start_date:                # 可选；YYYY-MM-DD
+target_date:               # 可选；YYYY-MM-DD
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
 
 注意：`created_by` 为 `human`，因为任务来源于用户的描述。
+可选 Issue 字段元数据在创建任务时可留空；不要臆测日期。
 
 ### 3. 更新任务状态
 

--- a/templates/.agents/skills/implement-task/config/verify.json
+++ b/templates/.agents/skills/implement-task/config/verify.json
@@ -37,6 +37,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -71,9 +71,15 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # optional; preserve source/frontmatter value when available
+effort:                    # optional; preserve source/frontmatter value when available
+start_date:                # optional; preserve explicit YYYY-MM-DD when available
+target_date:               # optional; preserve explicit YYYY-MM-DD when available
 current_step: requirement-analysis
 assigned_to: {current AI agent}
 ```
+
+Optional Issue field metadata should preserve recovered or explicit source values. If absent, leave it empty; do not invent dates.
 
 3.3 Append Activity Log entries.
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -71,9 +71,15 @@ created_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 updated_at: {YYYY-MM-DD HH:mm:ss±HH:MM}
 agent_infra_version: {agent_infra_version}
 created_by: human
+priority:                  # 可选；有来源/frontmatter 值时保留
+effort:                    # 可选；有来源/frontmatter 值时保留
+start_date:                # 可选；有明确 YYYY-MM-DD 时保留
+target_date:               # 可选；有明确 YYYY-MM-DD 时保留
 current_step: requirement-analysis
 assigned_to: {当前 AI 代理}
 ```
+
+可选 Issue 字段元数据应保留恢复得到或来源中明确给出的值。缺失时留空；不要臆测日期。
 
 3.3 追加 Activity Log。
 

--- a/templates/.agents/skills/plan-task/config/verify.json
+++ b/templates/.agents/skills/plan-task/config/verify.json
@@ -39,6 +39,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "pendingDesignWork",
       "expected_comment_marker_key": "artifact"

--- a/templates/.agents/skills/refine-task/SKILL.en.md
+++ b/templates/.agents/skills/refine-task/SKILL.en.md
@@ -59,6 +59,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 Update task.md:
 - review the `## Requirements` section and only change items from `- [ ]` to `- [x]` when they are newly satisfied by this round's fixes and passing tests
+- preserve explicit optional Issue field metadata (`priority`, `effort`, `start_date`, `target_date`); only infer `priority` or `effort` from clear review context, and do not invent dates
 - append:
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {refinement-artifact}`
 

--- a/templates/.agents/skills/refine-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/refine-task/SKILL.zh-CN.md
@@ -59,6 +59,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 更新 task.md：
 - 审查 `## 需求` 段落，仅把因本轮修复而新满足且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
+- 保留明确填写的可选 Issue 字段元数据（`priority`、`effort`、`start_date`、`target_date`）；仅在审查上下文非常明确时推断 `priority` 或 `effort`，不要臆测日期
 - 追加：
   `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Refinement (Round {N}, for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {refinement-artifact}`
 

--- a/templates/.agents/skills/refine-task/config/verify.json
+++ b/templates/.agents/skills/refine-task/config/verify.json
@@ -33,6 +33,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/templates/.agents/skills/review-task/config/verify.json
+++ b/templates/.agents/skills/review-task/config/verify.json
@@ -38,6 +38,7 @@
       "verify_comment_content": true,
       "verify_task_comment_content": true,
       "verify_issue_type": true,
+      "verify_issue_fields": false,
       "verify_milestone": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -7,6 +7,10 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # Current agent-infra version; refreshed by workflow commands
+priority:                       # Optional Issue field: Urgent | High | Medium | Low
+effort:                         # Optional Issue field: High | Medium | Low
+start_date:                     # Optional Issue field for Feature: YYYY-MM-DD
+target_date:                    # Optional Issue field for Feature: YYYY-MM-DD
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -7,6 +7,10 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
+priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
+effort:                         # 可选 Issue 字段：High | Medium | Low
+start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD
+target_date:                    # Feature 可选 Issue 字段：YYYY-MM-DD
 current_step: analysis         # analysis | design | implementation | review | fix | commit
 assigned_to:                   # claude | codex | gemini | opencode | human
 ---

--- a/tests/core/validate-artifact.test.ts
+++ b/tests/core/validate-artifact.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import type { SpawnSyncReturns } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 import {
   filePath,
@@ -30,6 +31,7 @@ type TaskCommentOptions = {
   rawBody?: boolean;
 };
 type IssuePayloadOverrides = Record<string, unknown>;
+type PlatformSyncConfig = Record<string, unknown>;
 type ValidatorCheck = {
   type: string;
   status: string;
@@ -256,6 +258,51 @@ function buildIssueType(name: string = "Task") {
   return { name };
 }
 
+function buildIssueFieldsPayload({
+  pinnedFields = [
+    { typename: "IssueFieldSingleSelect", name: "Priority" },
+    { typename: "IssueFieldSingleSelect", name: "Effort" }
+  ],
+  values = [
+    { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
+    { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" }
+  ]
+}: {
+  pinnedFields?: Array<{ typename: string; name: string }>;
+  values?: Array<{ typename: string; fieldName: string; value: string }>;
+} = {}) {
+  return {
+    data: {
+      repository: {
+        issue: {
+          issueType: {
+            name: "Feature",
+            pinnedFields: pinnedFields.map((field) => ({
+              __typename: field.typename,
+              id: `field-${field.name}`,
+              name: field.name
+            }))
+          },
+          issueFieldValues: {
+            nodes: values.map((value) => value.typename === "IssueFieldDateValue"
+              ? {
+                  __typename: value.typename,
+                  value: value.value,
+                  field: { name: value.fieldName }
+                }
+              : {
+                  __typename: value.typename,
+                  name: value.value,
+                  optionId: `option-${value.value}`,
+                  field: { name: value.fieldName }
+                })
+          }
+        }
+      }
+    }
+  };
+}
+
 function buildIssuePayload(overrides: IssuePayloadOverrides = {}) {
   return {
     state: "OPEN",
@@ -265,6 +312,95 @@ function buildIssuePayload(overrides: IssuePayloadOverrides = {}) {
     type: buildIssueType(),
     ...overrides
   };
+}
+
+function parseTestFrontmatter(content: string) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return null;
+  }
+
+  const metadata: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (field) {
+      metadata[field[1]] = field[2].trim();
+    }
+  }
+
+  return metadata;
+}
+
+async function runPlatformSyncAdapter(taskDir: string, config: PlatformSyncConfig, env: NodeJS.ProcessEnv = {}) {
+  const oldEnv: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    oldEnv[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    const adapter = await import(pathToFileURL(filePath(".agents/scripts/platform-adapters/platform-sync.js")).href);
+    return adapter.check({ taskDir, config, artifactFile: undefined }, {
+      repoRoot: filePath("."),
+      loadTask(dir: string) {
+        const taskPath = path.join(dir, "task.md");
+        const content = fs.readFileSync(taskPath, "utf8");
+        const metadata = parseTestFrontmatter(content);
+        if (!metadata) {
+          return { ok: false, message: "task.md frontmatter not found or invalid" };
+        }
+        return { ok: true, content, metadata };
+      },
+      getCheckedRequirements() {
+        return [];
+      },
+      normalizeContent(value: string) {
+        return String(value || "").replace(/\r\n/g, "\n").trim();
+      },
+      isBlank(value: unknown) {
+        return value === undefined || value === null || String(value).trim() === "";
+      },
+      escapeRegExp(value: string) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      },
+      passResult(type: string, message: string) {
+        return { type, status: "pass", message };
+      },
+      failResult(type: string, message: string, failType = "check_failed") {
+        return { type, status: "fail", message, fail_type: failType };
+      },
+      blockedResult(type: string, message: string, failType = "network_error") {
+        return { type, status: "blocked", message, fail_type: failType };
+      },
+      safeStat(filePathname: string) {
+        try {
+          return fs.statSync(filePathname);
+        } catch {
+          return null;
+        }
+      },
+      parseIssueNumber(value: unknown) {
+        const number = Number(value);
+        return Number.isInteger(number) && number > 0 ? number : null;
+      },
+      parsePrNumber(value: unknown) {
+        const number = Number(value);
+        return Number.isInteger(number) && number > 0 ? number : null;
+      }
+    });
+  } finally {
+    for (const [key, value] of Object.entries(oldEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 function buildPrPayload(overrides: IssuePayloadOverrides = {}) {
@@ -1250,6 +1386,151 @@ test("validate-artifact platform-sync skips Issue Type verification when the RES
     const payload = parseValidatorPayload(result.stdout);
     assert.equal(payload.type, "platform-sync");
     assert.equal(payload.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync passes when Issue fields match task frontmatter", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-pass-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      type: "feature",
+      priority: "高",
+      effort: "Medium",
+      start_date: "2026-06-01"
+    }));
+    writeJson(issuePath, buildIssuePayload());
+    writeJson(issueFieldsPath, buildIssueFieldsPayload({
+      pinnedFields: [
+        { typename: "IssueFieldSingleSelect", name: "Priority" },
+        { typename: "IssueFieldDate", name: "Start date" },
+        { typename: "IssueFieldSingleSelect", name: "Effort" }
+      ],
+      values: [
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" },
+        { typename: "IssueFieldDateValue", fieldName: "Start date", value: "2026-06-01" }
+      ]
+    }));
+
+    const result = await runPlatformSyncAdapter(taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+      GH_FAKE_ISSUE_PATH: issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
+    });
+
+    assert.equal(result.status, "pass");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync fails when an Issue field differs from task frontmatter", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-fail-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      priority: "High"
+    }));
+    writeJson(issuePath, buildIssuePayload());
+    writeJson(issueFieldsPath, buildIssueFieldsPayload({
+      values: [
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "Low" }
+      ]
+    }));
+
+    const result = await runPlatformSyncAdapter(taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+      GH_FAKE_ISSUE_PATH: issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
+    });
+
+    assert.equal(result.status, "fail");
+    assert.match(result.message, /field 'Priority' is 'Low', expected 'High'/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("validate-artifact platform-sync skips Issue field verification when fields are inapplicable or unavailable", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-skip-"));
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = path.join(binDir, "gh");
+  const issuePath = path.join(tempRoot, "issue.json");
+  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
+
+  try {
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    writeFakeGh(ghPath);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      target_date: "2026-06-30"
+    }));
+    writeJson(issuePath, buildIssuePayload());
+    writeJson(issueFieldsPath, buildIssueFieldsPayload({
+      pinnedFields: [
+        { typename: "IssueFieldSingleSelect", name: "Priority" },
+        { typename: "IssueFieldSingleSelect", name: "Effort" }
+      ],
+      values: []
+    }));
+
+    const inapplicableResult = await runPlatformSyncAdapter(taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+      GH_FAKE_ISSUE_PATH: issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
+    });
+    assert.equal(inapplicableResult.status, "pass");
+
+    const unavailableResult = await runPlatformSyncAdapter(taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+      GH_FAKE_ISSUE_PATH: issuePath,
+      GH_FAKE_ISSUE_FIELDS_FAIL: "Issue fields are unavailable",
+      VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+    });
+    assert.equal(unavailableResult.status, "pass");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -97,6 +97,16 @@ if (args[0] === "api" && args[1] && /repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(arg
   process.exit(0);
 }
 
+if (args[0] === "api" && args[1] === "graphql") {
+  if (process.env.GH_FAKE_ISSUE_FIELDS_FAIL) {
+    console.error(process.env.GH_FAKE_ISSUE_FIELDS_FAIL);
+    process.exit(1);
+  }
+
+  process.stdout.write(JSON.stringify(readJson("GH_FAKE_ISSUE_FIELDS_PATH")));
+  process.exit(0);
+}
+
 if (args[0] === "api" && args.some((arg) => /\/issues\/\d+\/comments\?per_page=100$/.test(arg))) {
   const requestPath = args.find((arg) => /\/issues\/\d+\/comments\?per_page=100$/.test(arg)) || "";
   const match = requestPath.match(/\/issues\/(\d+)\/comments\?per_page=100$/);


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #337 👈👈

Closes #337

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

GitHub Issue Type 支持 pinned custom fields（`fitlab-ai` org：Task/Bug 挂 Priority+Effort；Feature 额外挂 Start date / Target date），但此前工作流只设置/校验 Issue Type 本身，未处理其挂载的自定义字段：创建 Issue 时字段为空、type 变更时旧字段值不迁移、多 AI 协作缺少一致的字段读写约定。本次把字段写入、迁移与可选一致性校验纳入既有同步机制。

## 📋 主要变更 / Brief Changelog

- 新增写入侧规则 `issue-fields.github.{en,zh-CN}.md`（+ 渲染副本）：Flow A「创建后写入字段」、Flow B「set-type-and-migrate」（同名迁移、目标 type 无对应字段则 `delete:true` 清空）、`gh api graphql` 命令壳与中英 option 本地化映射、AI 启发式推断指引。
- 校验侧在 `platform-sync` adapter 新增**默认关闭**的 `verify_issue_fields`（GraphQL 读取当前 type pinnedFields + 字段值，按白名单比较 frontmatter，取数失败优雅跳过，与 `verify_issue_type` 同构），6 个工作流技能 `verify.json` 默认 `false`。
- `task.md` frontmatter 新增可选 `priority` / `effort` / `start_date` / `target_date`，并在 `create-issue` / `issue-pr-commands` / `issue-sync` 三个规则中以短引用接线（含 `has_push` 权限降级）。
- 模板与已部署 `.agents/` 副本三联同步；新增 fake-gh GraphQL 路由与一致/不一致/跳过三态测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npx -y -p node@22 npm test` —— 全量 501 tests，500 pass / 1 skipped（平台条件跳过）。
2. 校验器与模板专项：validator + platform-coupling + adapter-defaults + templates = 87/87 pass。
3. 真实 GraphQL 端到端冒烟（在 #337 上执行后已恢复原状）：Flow A 写入 4 字段成功；Feature→Task 迁移保留 Priority/Effort、`delete:true` 清空两个 date 字段成功；date 回读格式确认为 `YYYY-MM-DD`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时使用了 mock（fake-gh） / I have used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（规则文件 + task 模板 + SKILL 说明） / I have updated documentation
- [x] 我已经考虑了向后兼容性（`verify_issue_fields` 默认关闭，`create-issue` 既有 REST type-set 不动，零回归面） / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- **架构取舍**：写入侧采用纯散文规则（与本仓库所有 Issue/PR 写操作一致），未引入写入侧脚本；校验侧用 JS，沿用 `verify_issue_type` 的 write=规则 / verify=JS 分工。
- **冒烟关键发现**：改 Issue Type（Feature→Task）后 GitHub **不会**自动清除已不适用的字段值，date 值会残留——这证明 Flow B 的 `delete:true` 是**必需**的（而非仅幂等保险）。
- **待人工验证**：审查阶段标记的 env-blocked（真实 mutation 端到端）已在本 PR 前通过 #337 实测闭环，无遗留待验证项。

---

**审查者注意事项 / Reviewer Notes:**

重点关注 `platform-sync.github.js` 的 `verify_issue_fields` 取数失败降级是否与 `verify_issue_type` 一致，以及 `issue-fields.github.*.md` Flow B 的同名迁移 / `delete:true` 约定描述是否清晰。

---

Generated with AI assistance
