### PR TITLE
fix(cli): 修复沙箱默认运行时 node20 与 engines>=22 矛盾

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -9,7 +9,7 @@
   "sandbox": {
     "engine": "orbstack",
     "runtimes": [
-      "node20"
+      "node22"
     ],
     "tools": [
       "claude-code",

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -26,7 +26,7 @@ const DEFAULTS = {
   "sandbox": {
     "engine": null,
     "runtimes": [
-      "node20"
+      "node22"
     ],
     "tools": [
       "claude-code",

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -5,7 +5,7 @@
   "sandbox": {
     "engine": null,
     "runtimes": [
-      "node20"
+      "node22"
     ],
     "tools": [
       "claude-code",

--- a/lib/sandbox/config.ts
+++ b/lib/sandbox/config.ts
@@ -2,12 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { homedir, platform } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import pc from 'picocolors';
 import { validateSandboxEngine } from './engine.ts';
 import { hostJoin } from './engines/wsl2-paths.ts';
+import { findRuntimeEngineMismatches } from './runtime-engines.ts';
 
 const DEFAULTS = Object.freeze({
   engine: null,
-  runtimes: ['node20'],
+  runtimes: ['node22'],
   tools: ['claude-code', 'codex', 'gemini-cli', 'opencode'],
   dockerfile: null,
   vm: {
@@ -18,6 +20,7 @@ const DEFAULTS = Object.freeze({
 });
 
 type PlatformFn = typeof platform;
+type WriteStderr = (chunk: string) => unknown;
 
 type SandboxConfigInput = {
   engine?: string | null;
@@ -82,7 +85,10 @@ function cloneDefaults(): SandboxConfigInput & { vm: SandboxVmConfig; runtimes: 
   };
 }
 
-export function loadConfig({ platformFn = platform }: { platformFn?: PlatformFn } = {}): SandboxConfig {
+export function loadConfig({
+  platformFn = platform,
+  writeStderr = (chunk) => process.stderr.write(chunk)
+}: { platformFn?: PlatformFn; writeStderr?: WriteStderr } = {}): SandboxConfig {
   const repoRoot = detectRepoRoot();
   const home = homedir();
 
@@ -105,6 +111,30 @@ export function loadConfig({ platformFn = platform }: { platformFn?: PlatformFn 
     throw new Error('sandbox: .agents/.airc.json is missing a valid "project" field');
   }
 
+  const runtimes = Array.isArray(sandbox.runtimes) && sandbox.runtimes.length > 0
+    ? [...sandbox.runtimes]
+    : defaults.runtimes;
+  const dockerfile = typeof sandbox.dockerfile === 'string' ? sandbox.dockerfile : defaults.dockerfile ?? null;
+
+  if (!dockerfile) {
+    let enginesNode: string | undefined;
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+        engines?: { node?: unknown };
+      };
+      enginesNode = typeof pkg.engines?.node === 'string' ? pkg.engines.node : undefined;
+    } catch {
+      enginesNode = undefined;
+    }
+
+    for (const { runtimes: invalidRuntimes, enginesNode: range } of findRuntimeEngineMismatches(runtimes, enginesNode)) {
+      writeStderr(pc.yellow(
+        `Warning: sandbox runtimes ${invalidRuntimes.map((runtime) => `"${runtime}"`).join(', ')} do not satisfy this project's package.json "engines.node" ("${range}").\n` +
+        '  Update "sandbox.runtimes" in .agents/.airc.json (e.g. "node22"), or relax "engines.node".\n'
+      ));
+    }
+  }
+
   return {
     repoRoot,
     configPath,
@@ -117,13 +147,11 @@ export function loadConfig({ platformFn = platform }: { platformFn?: PlatformFn 
     shareBase: hostJoin(home, '.agent-infra', 'share', project),
     dotfilesDir: hostJoin(home, '.agent-infra', 'dotfiles'),
     engine,
-    runtimes: Array.isArray(sandbox.runtimes) && sandbox.runtimes.length > 0
-      ? [...sandbox.runtimes]
-      : defaults.runtimes,
+    runtimes,
     tools: Array.isArray(sandbox.tools) && sandbox.tools.length > 0
       ? [...sandbox.tools]
       : defaults.tools,
-    dockerfile: typeof sandbox.dockerfile === 'string' ? sandbox.dockerfile : defaults.dockerfile ?? null,
+    dockerfile,
     vm: {
       cpu: asPositiveNumberOrNull(sandbox.vm?.cpu) ?? defaults.vm.cpu,
       memory: asPositiveNumberOrNull(sandbox.vm?.memory) ?? defaults.vm.memory,

--- a/lib/sandbox/runtime-engines.ts
+++ b/lib/sandbox/runtime-engines.ts
@@ -1,0 +1,39 @@
+import semver from 'semver';
+
+export type RuntimeEngineMismatch = {
+  runtimes: string[];
+  enginesNode: string;
+};
+
+function nodeMajor(runtime: string): number | null {
+  const match = /^node(\d+)$/.exec(runtime);
+  return match ? Number(match[1]) : null;
+}
+
+export function findRuntimeEngineMismatches(
+  runtimes: string[],
+  enginesNode: string | undefined
+): RuntimeEngineMismatch[] {
+  if (!enginesNode) {
+    return [];
+  }
+
+  const range = semver.validRange(enginesNode);
+  if (!range) {
+    return [];
+  }
+
+  const nodeRuntimes: string[] = [];
+  for (const runtime of runtimes) {
+    const major = nodeMajor(runtime);
+    if (major === null) {
+      continue;
+    }
+    nodeRuntimes.push(runtime);
+    if (semver.intersects(`${major}.x`, range)) {
+      return [];
+    }
+  }
+
+  return nodeRuntimes.length > 0 ? [{ runtimes: nodeRuntimes, enginesNode }] : [];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@clack/prompts": "1.4.0",
         "cross-spawn": "^7.0.6",
         "picocolors": "1.1.1",
+        "semver": "^7.8.1",
         "smol-toml": "^1.6.1"
       },
       "bin": {
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
         "@types/node": "^25.9.1",
+        "@types/semver": "^7.7.1",
         "typescript": "~6.0"
       },
       "engines": {
@@ -74,6 +76,13 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -133,6 +142,18 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@clack/prompts": "1.4.0",
     "cross-spawn": "^7.0.6",
     "picocolors": "1.1.1",
+    "semver": "^7.8.1",
     "smol-toml": "^1.6.1"
   },
   "scripts": {
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^25.9.1",
+    "@types/semver": "^7.7.1",
     "typescript": "~6.0"
   }
 }

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -26,7 +26,7 @@ const DEFAULTS = {
   "sandbox": {
     "engine": null,
     "runtimes": [
-      "node20"
+      "node22"
     ],
     "tools": [
       "claude-code",

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -81,7 +81,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.ok(!config.source, "consumer projects should not have source: self");
     assert.deepEqual(config.sandbox, {
       engine: DEFAULT_SANDBOX_ENGINE,
-      runtimes: ["node20"],
+      runtimes: ["node22"],
       tools: ["claude-code", "codex", "gemini-cli", "opencode"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }
@@ -483,7 +483,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     assert.deepEqual(updated.platform, { type: "github" }, "update should backfill default platform config");
     assert.deepEqual(updated.sandbox, {
       engine: null,
-      runtimes: ["node20"],
+      runtimes: ["node22"],
       tools: ["claude-code", "codex", "gemini-cli", "opencode"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -527,7 +527,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.equal(config.org, "fitlab-ai");
     assert.equal(config.containerPrefix, "demo-dev");
     assert.equal(config.imageName, "demo-sandbox:latest");
-    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.deepEqual(config.runtimes, ["node22"]);
     assert.deepEqual(config.tools, ["claude-code", "codex", "gemini-cli", "opencode"]);
     assert.equal(config.engine, null);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
@@ -571,7 +571,7 @@ test("loadConfig preserves configured sandbox engine", async () => {
     const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig());
 
     assert.equal(config.engine, "docker-desktop");
-    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.deepEqual(config.runtimes, ["node22"]);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
   } finally {
     process.chdir(previousCwd);
@@ -648,6 +648,170 @@ test("loadConfig fails when .agents/.airc.json is missing", async () => {
       () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
       /No \.agents\/\.airc\.json found/
     );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("findRuntimeEngineMismatches reports node runtime engine conflicts", async () => {
+  const runtimeEngines = await loadFreshEsm<typeof import("../../lib/sandbox/runtime-engines.ts")>("lib/sandbox/runtime-engines.js");
+
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20"], ">=22"), [
+    { runtimes: ["node20"], enginesNode: ">=22" }
+  ]);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node22"], ">=22"), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20", "node22"], ">=22"), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node18", "node20"], ">=22"), [
+    { runtimes: ["node18", "node20"], enginesNode: ">=22" }
+  ]);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20"], ">=20"), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20"], "20 || 22"), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20"], undefined), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["node20"], "not-a-range"), []);
+  assert.deepEqual(runtimeEngines.findRuntimeEngineMismatches(["java21", "python3"], ">=22"), []);
+});
+
+test("loadConfig warns when sandbox node runtime does not satisfy package engines", async () => {
+  const sandboxConfig = await loadFreshEsm<typeof import("../../lib/sandbox/config.ts")>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-engine-mismatch-"));
+  const previousCwd = process.cwd();
+  const stderr: string[] = [];
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ engines: { node: ">=22" } }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        org: "fitlab-ai",
+        sandbox: { runtimes: ["node20"] }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig({
+      writeStderr: (chunk) => stderr.push(chunk)
+    }));
+
+    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.match(stderr.join(""), /sandbox runtimes "node20" do not satisfy this project's package\.json "engines\.node" \(">=22"\)/);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig does not warn when sandbox node runtime satisfies package engines", async () => {
+  const sandboxConfig = await loadFreshEsm<typeof import("../../lib/sandbox/config.ts")>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-engine-match-"));
+  const previousCwd = process.cwd();
+  const stderr: string[] = [];
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ engines: { node: ">=22" } }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        sandbox: { runtimes: ["node22"] }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig({
+      writeStderr: (chunk) => stderr.push(chunk)
+    }));
+
+    assert.deepEqual(config.runtimes, ["node22"]);
+    assert.equal(stderr.join(""), "");
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig skips runtime engine warnings for invalid package json", async () => {
+  const sandboxConfig = await loadFreshEsm<typeof import("../../lib/sandbox/config.ts")>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-invalid-package-"));
+  const previousCwd = process.cwd();
+  const stderr: string[] = [];
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    fs.writeFileSync(path.join(tmpDir, "package.json"), "{ not json", "utf8");
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        sandbox: { runtimes: ["node20"] }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig({
+      writeStderr: (chunk) => stderr.push(chunk)
+    }));
+
+    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.equal(stderr.join(""), "");
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig skips runtime engine warnings when a custom Dockerfile is configured", async () => {
+  const sandboxConfig = await loadFreshEsm<typeof import("../../lib/sandbox/config.ts")>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-dockerfile-"));
+  const previousCwd = process.cwd();
+  const stderr: string[] = [];
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ engines: { node: ">=22" } }, null, 2) + "\n",
+      "utf8"
+    );
+    fs.writeFileSync(path.join(tmpDir, "Dockerfile"), "FROM node:20\n", "utf8");
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify({
+        project: "demo",
+        sandbox: {
+          dockerfile: "Dockerfile",
+          runtimes: ["node20"]
+        }
+      }, null, 2) + "\n",
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig({
+      writeStderr: (chunk) => stderr.push(chunk)
+    }));
+
+    assert.equal(config.dockerfile, "Dockerfile");
+    assert.deepEqual(config.runtimes, ["node20"]);
+    assert.equal(stderr.join(""), "");
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/core/airc.test.ts
+++ b/tests/core/airc.test.ts
@@ -58,7 +58,7 @@ test(".agents/.airc.json declares default sandbox configuration", () => {
 
   assert.deepEqual(collaborator.sandbox, {
     engine: "orbstack",
-    runtimes: ["node20"],
+    runtimes: ["node22"],
     tools: ["claude-code", "codex", "gemini-cli", "opencode"],
     dockerfile: null,
     vm: {

--- a/tests/core/release.test.ts
+++ b/tests/core/release.test.ts
@@ -28,6 +28,7 @@ test("package metadata supports scoped npm publishing", () => {
     "@clack/prompts",
     "cross-spawn",
     "picocolors",
+    "semver",
     "smol-toml"
   ]);
   assert.equal(


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #341 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

沙箱默认运行时为 `node20`，与项目 `package.json` 的 `engines.node: ">=22"` 直接冲突。自 #320（JS→TS 迁移）起，测试脚本改用 `node --experimental-strip-types`（仅 Node 22.6+ 支持），在 Node 20 沙箱中执行 `npm test` 或 git 提交（pre-commit 跑 `test:core`）会报 `node: bad option: --experimental-strip-types`。CI 因显式 `setup-node` 指定 22/24 而未暴露。

The sandbox default runtime `node20` conflicts with `engines.node: ">=22"`. Since #320, test scripts use `--experimental-strip-types` (Node 22.6+ only), so running tests/commits inside the Node 20 sandbox fails with `node: bad option`.

> ⚠️ **验收口径说明 / Acceptance note**：范围 3（防御性校验）按已批准的设计决策以 **warning 形式交付，而非中止式 error**——当 `runtimes` 不满足 `engines.node` 时输出清晰可读的告警并继续，不阻塞命令。这有意软化了 Issue 字面的"清晰可读的报错"，以避免阻塞 `rm`/`ls` 等共用 `loadConfig` 的清理命令、并在解析不确定时失败安全。Scope 3 is delivered as a **warning (not an aborting error)** by approved design.

## 📋 主要变更 / Brief Changelog

- 沙箱默认运行时 `node20` → `node22`（三处默认源：`.agents/.airc.json`、`lib/defaults.json`、`lib/sandbox/config.ts` 的 `DEFAULTS`）。
- 新增 `lib/sandbox/runtime-engines.ts`：用 `semver` 判定 node 运行时主版本线是否满足 `engines.node`；多 node 运行时时只要任一满足即不告警，全部不满足才发一条聚合告警。
- `loadConfig` 接入告警（`writeStderr` 可注入）：自定义 Dockerfile、缺失/非法 `package.json`、缺失/无法解析 `engines` 时均静默跳过（失败安全）。
- 新增 `semver` / `@types/semver` 依赖；`npm run build` 同步了 `update-agent-infra` 脚本及模板镜像中的默认 runtime 副本。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `npm test`（需 Node ≥ 22）
3. 新增回归测试覆盖：`node20`+`>=22` 告警、`node22`+`>=22` 不告警、多 node 一者满足不告警、全部不满足聚合告警、非法 JSON / 自定义 Dockerfile 失败安全。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（full 506 → 505 passed / 1 skipped，Node 22 实跑）
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / There is a Github issue for the change
- [x] 你的 Pull Request 只解决一个 Issue / This PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body
- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented hard-to-understand areas
- [x] 我已经编写了必要的单元测试 / I have written necessary unit tests
- [x] 单元测试通过 / Unit tests pass
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（`node20.dockerfile` 保留，现存项目显式 `runtimes` 不受默认变更影响）

## 📋 附加信息 / Additional Notes

- 已知：`npm run typecheck` 在未改动文件 `tests/core/validate-artifact.test.ts:324/327` 存在预存的严格空值类型报错，与本 PR 无关（已在干净基线复现确认）。
- 本环境主机 Node 为 v20，pre-commit 与测试均在 Node 22 下运行通过。

Closes #341

---

Generated with AI assistance
