### PR TITLE
fix(ci): 彻底排查并修复 Homebrew bottle 发布链路

### DIFF
--- a/.agents/rules/release-commands.md
+++ b/.agents/rules/release-commands.md
@@ -1,6 +1,6 @@
 # Release 平台命令
 
-在读取历史 release、查询已合并 PR，或创建 draft release 前先读取本文件。
+在读取历史 release、查询已合并 PR，或发布 Release notes 前先读取本文件。
 
 ## Release 查询
 
@@ -37,10 +37,16 @@ gh issue view {issue-number} --json number,title,labels,url,author
 
 GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
 
-## 创建 Draft Release
+## 发布 Release notes
+
+`v{version}` 的 GitHub Release 由 release 工作流自动创建并发布，为 Homebrew bottle 提供稳定的上传落点。本命令把精修后的 notes 写到这个已存在的 Release 上；若 Release 尚不存在则兜底创建。
 
 ```bash
-gh release create "v{version}" --draft --title "v{version}" --notes-file "{notes-file}"
+if gh release view "v{version}" >/dev/null 2>&1; then
+  gh release edit "v{version}" --notes-file "{notes-file}"
+else
+  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
+fi
 ```
 
 失败时按调用方规则停止或提示人工介入。

--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -156,31 +156,28 @@ git log v<prev-version>..v<version> \
 
 询问：
 1. 需要调整吗？
-2. 是否创建 draft release？
+2. 是否把 notes 写入该版本的 Release？
 
-### 9. 创建 Draft Release（如确认）
+### 9. 发布 Release notes（如确认）
 
-按 `.agents/rules/release-commands.md` 的 Draft Release 创建命令执行。
+按 `.agents/rules/release-commands.md` 的「发布 Release notes」命令执行（写入已由 release 工作流自动创建/发布的 Release；不存在时兜底创建）。
 
 输出：
 ```
-Draft Release created.
+Release notes 已更新。
 
-- URL: {draft-release-url}
+- URL: {release-url}
 - Version: v{version}
-- Status: Draft
+- Status: Published
 
-Please review and publish on the platform:
-1. Open the URL above
-2. Review the release notes
-3. Click "Publish release"
+发布说明已写入该 Release。如需进一步调整，可在上面的 URL 直接编辑。
 ```
 
 ## 注意事项
 
 1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
-3. **草稿模式**：创建草稿 —— 不会自动发布
+3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能只往该 Release 写入/刷新 notes，不再创建草稿
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
 
 ## 错误处理

--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -177,7 +177,7 @@ Release notes 已更新。
 
 1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
-3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能只往该 Release 写入/刷新 notes，不再创建草稿
+3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能往该 Release 写入/刷新 notes
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
 
 ## 错误处理

--- a/.github/scripts/generate-bottle-block.mjs
+++ b/.github/scripts/generate-bottle-block.mjs
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const EXPECTED_TAGS = ["arm64_tahoe", "arm64_sequoia", "arm64_sonoma", "sonoma"];
+const SYMBOL_CELLARS = new Set(["any", "any_skip_relocation"]);
+
+export function generateBottleBlock(jsonObjects, { expectedTags = EXPECTED_TAGS } = {}) {
+  let rootUrl;
+  let rebuild;
+  const tags = {};
+
+  for (const obj of jsonObjects) {
+    const entry = Object.values(obj)[0];
+    const bottle = entry?.bottle;
+    if (!bottle) {
+      throw new Error("bottle json missing .bottle");
+    }
+
+    if (rootUrl === undefined) {
+      rootUrl = bottle.root_url;
+    } else if (rootUrl !== bottle.root_url) {
+      throw new Error(`root_url mismatch: ${rootUrl} vs ${bottle.root_url}`);
+    }
+
+    if (rebuild === undefined) {
+      rebuild = bottle.rebuild ?? 0;
+    }
+
+    for (const [tag, info] of Object.entries(bottle.tags ?? {})) {
+      tags[tag] = {
+        sha256: info.sha256,
+        cellar: info.cellar ?? bottle.cellar ?? "any_skip_relocation",
+      };
+    }
+  }
+
+  if (!rootUrl) {
+    throw new Error("no root_url found in bottle json");
+  }
+
+  for (const tag of expectedTags) {
+    if (!tags[tag]) {
+      throw new Error(`missing bottle for platform: ${tag}`);
+    }
+  }
+
+  const cellarToken = (cellar) => (
+    SYMBOL_CELLARS.has(cellar) ? `:${cellar}` : JSON.stringify(cellar)
+  );
+  const width = Math.max(...expectedTags.map((tag) => tag.length));
+  const lines = [
+    "  bottle do",
+    `    root_url "${rootUrl}"`,
+  ];
+
+  if (rebuild > 0) {
+    lines.push(`    rebuild ${rebuild}`);
+  }
+
+  for (const tag of expectedTags) {
+    const { sha256, cellar } = tags[tag];
+    const pad = " ".repeat(width - tag.length);
+    lines.push(`    sha256 cellar: ${cellarToken(cellar)}, ${tag}:${pad} "${sha256}"`);
+  }
+
+  lines.push("  end");
+  return lines.join("\n");
+}
+
+function getArg(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const bottlesDir = getArg(args, "--bottles");
+  const formulaPath = getArg(args, "--formula");
+
+  if (!bottlesDir) {
+    throw new Error("usage: --bottles <dir> [--formula <path>]");
+  }
+
+  const jsonObjects = readdirSync(bottlesDir)
+    .filter((file) => file.endsWith(".bottle.json"))
+    .map((file) => JSON.parse(readFileSync(join(bottlesDir, file), "utf8")));
+  const block = generateBottleBlock(jsonObjects);
+
+  if (formulaPath) {
+    const formula = readFileSync(formulaPath, "utf8");
+    const placeholder = /^[ \t]*# __BOTTLE_BLOCK__[ \t]*$/m;
+    if (!placeholder.test(formula)) {
+      throw new Error("placeholder # __BOTTLE_BLOCK__ not found in formula");
+    }
+    writeFileSync(formulaPath, formula.replace(placeholder, block));
+  }
+
+  console.log(block);
+}

--- a/.github/scripts/generate-bottle-block.mjs
+++ b/.github/scripts/generate-bottle-block.mjs
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const EXPECTED_TAGS = ["arm64_tahoe", "arm64_sequoia", "arm64_sonoma", "sonoma"];
 const SYMBOL_CELLARS = new Set(["any", "any_skip_relocation"]);
@@ -72,7 +73,7 @@ function getArg(args, name) {
   return index >= 0 ? args[index + 1] : undefined;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
   const bottlesDir = getArg(args, "--bottles");
   const formulaPath = getArg(args, "--formula");

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -1,8 +1,9 @@
 name: Post-Release Smoke
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Update Homebrew Formula"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -13,7 +14,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: post-release-smoke-${{ github.event.release.id || inputs.version }}
+  group: post-release-smoke-${{ github.event.workflow_run.id || inputs.version }}
   cancel-in-progress: true
 
 jobs:
@@ -21,21 +22,31 @@ jobs:
     name: Resolve target version
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
     outputs:
       version: ${{ steps.pick.outputs.version }}
     steps:
-      - name: Pick version from event or input
+      - name: Download release-version artifact (workflow_run)
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/download-artifact@v7
+        with:
+          name: release-version
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pick version from artifact or input
         id: pick
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_VERSION: ${{ inputs.version }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="$DISPATCH_VERSION"
           else
-            VERSION="${RELEASE_TAG#v}"
+            VERSION=$(cat release-version.txt)
           fi
           if [ -z "$VERSION" ]; then
             echo "::error::Could not resolve version"
@@ -98,7 +109,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
-      - name: Wait for Homebrew tap formula update
+      - name: Wait for Homebrew tap formula bottle block
         shell: bash
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
@@ -106,19 +117,25 @@ jobs:
           FORMULA_URL="https://raw.githubusercontent.com/fitlab-ai/homebrew-tap/main/Formula/agent-infra.rb"
           for i in $(seq 1 60); do
             BODY=$(curl -fsSL "$FORMULA_URL" 2>/dev/null || true)
-            if printf '%s' "$BODY" | grep -qF "agent-infra-${VERSION}.tgz"; then
-              echo "Formula updated to ${VERSION}"
+            if printf '%s' "$BODY" | grep -qF "agent-infra-${VERSION}.tgz" \
+               && printf '%s' "$BODY" | grep -q "bottle do"; then
+              echo "Formula updated to ${VERSION} with bottle block"
               exit 0
             fi
-            echo "Waiting for tap formula update... (attempt $i/60)"
+            echo "Waiting for tap formula bottle block... (attempt $i/60)"
             sleep 10
           done
-          echo "::error::Tap formula not updated to ${VERSION} after 10 minutes"
+          echo "::error::Tap formula bottle block for ${VERSION} not present after 10 minutes"
           exit 1
 
-      - name: brew install
+      - name: brew install (must pour from bottle)
         shell: bash
-        run: brew install fitlab-ai/tap/agent-infra
+        run: |
+          brew install --verbose fitlab-ai/tap/agent-infra 2>&1 | tee install.log
+          if ! grep -q "Pouring" install.log; then
+            echo "::error::agent-infra was not poured from a bottle (no 'Pouring' in output)"
+            exit 1
+          fi
 
       - name: Smoke test - agent-infra version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,11 @@ jobs:
           if npm view "@fitlab-ai/agent-infra@${TAG_VERSION}" version >/dev/null 2>&1; then
             echo "@fitlab-ai/agent-infra@${TAG_VERSION} already published, skipping"
           else
-            npm publish --provenance
+            # Publish prereleases (e.g. 0.6.2-alpha.1) under the "next" dist-tag so
+            # they never move "latest"; stable versions keep the default latest tag.
+            NPM_TAG_ARGS=""
+            case "$TAG_VERSION" in *-*) NPM_TAG_ARGS="--tag next" ;; esac
+            npm publish --provenance $NPM_TAG_ARGS
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -41,4 +41,22 @@ jobs:
         run: npm test
 
       - name: Publish package
-        run: npm publish --provenance
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "@fitlab-ai/agent-infra@${TAG_VERSION}" version >/dev/null 2>&1; then
+            echo "@fitlab-ai/agent-infra@${TAG_VERSION} already published, skipping"
+          else
+            npm publish --provenance
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists"
+            exit 0
+          fi
+          PRERELEASE_FLAG=""
+          case "$GITHUB_REF_NAME" in *-*) PRERELEASE_FLAG="--prerelease" ;; esac
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes $PRERELEASE_FLAG

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -115,12 +115,20 @@ jobs:
           git commit -m "agent-infra ${VERSION}"
           git push
 
+      - name: Record release version
+        run: echo "${{ steps.version.outputs.version }}" > release-version.txt
+
+      - name: Upload release-version artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-version
+          path: release-version.txt
+
   bake-bottle:
     needs: prepare-formula
     if: ${{ needs.prepare-formula.outputs.version != '' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    continue-on-error: true
     permissions:
       contents: write
     strategy:
@@ -147,24 +155,20 @@ jobs:
           brew install --build-bottle --formula --verbose agent-infra
           brew bottle --json --no-rebuild --root-url="$ROOT_URL" agent-infra
 
-      - name: Verify bottle artifacts
-        env:
-          VERSION: ${{ needs.prepare-formula.outputs.version }}
-          PLATFORM: ${{ matrix.platform }}
-        run: |
-          ls -la *.bottle.tar.gz *.bottle.json
-          test -f "agent-infra--${VERSION}.${PLATFORM}.bottle.tar.gz"
-          test -f "agent-infra--${VERSION}.${PLATFORM}.bottle.json"
-
-      - name: Upload bottle to GitHub Release
+      - name: Rename to canonical filename and upload bottle
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.prepare-formula.outputs.version }}
           PLATFORM: ${{ matrix.platform }}
         run: |
-          gh release upload "v${VERSION}" \
-            "agent-infra--${VERSION}.${PLATFORM}.bottle.tar.gz" \
-            --clobber --repo fitlab-ai/agent-infra
+          ls -la *.bottle.tar.gz *.bottle.json
+          JSON="agent-infra--${VERSION}.${PLATFORM}.bottle.json"
+          LOCAL=$(jq -r --arg p "$PLATFORM" '.[] | .bottle.tags[$p].local_filename' "$JSON")
+          CANON=$(jq -r --arg p "$PLATFORM" '.[] | .bottle.tags[$p].filename' "$JSON")
+          test "$LOCAL" != "null" && test "$CANON" != "null"
+          test -n "$LOCAL" && test -n "$CANON" && test -f "$LOCAL"
+          mv "$LOCAL" "$CANON"
+          gh release upload "v${VERSION}" "$CANON" --clobber --repo fitlab-ai/agent-infra
 
       - name: Upload bottle JSON as workflow artifact
         uses: actions/upload-artifact@v7
@@ -175,35 +179,17 @@ jobs:
 
   publish-bottle:
     needs: [prepare-formula, bake-bottle]
-    if: ${{ always() && needs.prepare-formula.result == 'success' }}
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
-      - name: Download all bottle JSON artifacts
-        uses: actions/download-artifact@v8
+      - name: Checkout repository (for generator script)
+        uses: actions/checkout@v6
         with:
-          pattern: bottle-json-*
-          path: ./bottles
-          merge-multiple: true
-        continue-on-error: true
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Determine bake outcome
-        id: outcome
-        run: |
-          SUCCESS_COUNT=$(find ./bottles -name '*.bottle.json' 2>/dev/null | wc -l | tr -d ' ')
-          echo "success_count=$SUCCESS_COUNT" >> "$GITHUB_OUTPUT"
-          if [ "$SUCCESS_COUNT" -eq 0 ]; then
-            echo "::warning::All bottle bake jobs failed; publishing Formula without bottle block"
-            echo "has_bottles=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "## Homebrew bottle publish"
-              echo ""
-              echo "No bottle artifacts were available for this version."
-              echo "The workflow will publish the Formula without a bottle block."
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "has_bottles=true" >> "$GITHUB_OUTPUT"
-            echo "Found $SUCCESS_COUNT bottle JSON files (expected 4)"
-          fi
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v6
@@ -213,25 +199,32 @@ jobs:
           path: homebrew-tap
           fetch-depth: 0
 
-      - name: Merge bottle block into Formula
-        if: steps.outcome.outputs.has_bottles == 'true'
-        working-directory: homebrew-tap
-        run: |
-          for json in ../bottles/*.bottle.json; do
-            [ -e "$json" ] || continue
-            brew bottle --merge --write --no-commit "$json"
-          done
-          sed -i.bak '/# __BOTTLE_BLOCK__/d' Formula/agent-infra.rb && rm Formula/agent-infra.rb.bak
+      - name: Download all bottle JSON artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: bottle-json-*
+          path: ./bottles
+          merge-multiple: true
 
-      - name: Strip placeholder when no bottles
-        if: steps.outcome.outputs.has_bottles == 'false'
-        working-directory: homebrew-tap
-        run: sed -i.bak '/# __BOTTLE_BLOCK__/d' Formula/agent-infra.rb && rm Formula/agent-infra.rb.bak
+      - name: Require all four bottles
+        run: |
+          COUNT=$(find ./bottles -name '*.bottle.json' | wc -l | tr -d ' ')
+          echo "Found $COUNT bottle JSON files (expected 4)"
+          if [ "$COUNT" -ne 4 ]; then
+            echo "::error::Expected 4 bottle JSON files but found $COUNT"
+            exit 1
+          fi
+
+      - name: Generate bottle block into Formula
+        run: |
+          node .github/scripts/generate-bottle-block.mjs \
+            --bottles ./bottles \
+            --formula homebrew-tap/Formula/agent-infra.rb
+          echo "----- resulting Formula -----"
+          cat homebrew-tap/Formula/agent-infra.rb
 
       - name: Commit Formula with bottle block
         working-directory: homebrew-tap
-        env:
-          VERSION: ${{ needs.prepare-formula.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/templates/.agents/rules/release-commands.github.en.md
+++ b/templates/.agents/rules/release-commands.github.en.md
@@ -1,6 +1,6 @@
 # Release Platform Commands
 
-Read this file before loading release history, querying merged PRs, or creating a draft release.
+Read this file before loading release history, querying merged PRs, or publishing the Release notes.
 
 ## Query Releases
 
@@ -37,10 +37,16 @@ gh issue view {issue-number} --json number,title,labels,url,author
 
 Map GitHub no-reply emails with this rule: if `Name <email>` contains an email matching `(\d+\+)?(\S+?)@users\.noreply\.github\.com`, use the second capture group lowercased as the login. This covers both `{id}+{login}@users.noreply.github.com` and `{login}@users.noreply.github.com`.
 
-## Create a Draft Release
+## Publish the Release Notes
+
+The GitHub Release for `v{version}` is created and published automatically by the release workflow so Homebrew bottles have a stable upload target. This command writes the curated notes onto that existing Release, falling back to creating it if it does not exist yet.
 
 ```bash
-gh release create "v{version}" --draft --title "v{version}" --notes-file "{notes-file}"
+if gh release view "v{version}" >/dev/null 2>&1; then
+  gh release edit "v{version}" --notes-file "{notes-file}"
+else
+  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
+fi
 ```
 
 If commands fail, stop or escalate according to the calling skill.

--- a/templates/.agents/rules/release-commands.github.zh-CN.md
+++ b/templates/.agents/rules/release-commands.github.zh-CN.md
@@ -1,6 +1,6 @@
 # Release 平台命令
 
-在读取历史 release、查询已合并 PR，或创建 draft release 前先读取本文件。
+在读取历史 release、查询已合并 PR，或发布 Release notes 前先读取本文件。
 
 ## Release 查询
 
@@ -37,10 +37,16 @@ gh issue view {issue-number} --json number,title,labels,url,author
 
 GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
 
-## 创建 Draft Release
+## 发布 Release notes
+
+`v{version}` 的 GitHub Release 由 release 工作流自动创建并发布，为 Homebrew bottle 提供稳定的上传落点。本命令把精修后的 notes 写到这个已存在的 Release 上；若 Release 尚不存在则兜底创建。
 
 ```bash
-gh release create "v{version}" --draft --title "v{version}" --notes-file "{notes-file}"
+if gh release view "v{version}" >/dev/null 2>&1; then
+  gh release edit "v{version}" --notes-file "{notes-file}"
+else
+  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
+fi
 ```
 
 失败时按调用方规则停止或提示人工介入。

--- a/templates/.agents/skills/create-release-note/SKILL.en.md
+++ b/templates/.agents/skills/create-release-note/SKILL.en.md
@@ -177,7 +177,7 @@ The notes have been written to the Release. Edit further at the URL above if nee
 
 1. **Requires the platform CLI**: Must have the platform CLI installed and authenticated
 2. **Tags must exist**: Run the release skill first to create tags
-3. **Release auto-published**: the `v{version}` Release is created and published by the release workflow (the upload target for Homebrew bottles); this skill only writes/refreshes its notes and no longer creates a draft
+3. **Release auto-published**: the `v{version}` Release is created and published by the release workflow (the upload target for Homebrew bottles); this skill writes/refreshes the notes on that Release
 4. **Classification accuracy**: Auto-classification is based on title/scope/files; complex PRs may need manual adjustment
 
 ## Error Handling

--- a/templates/.agents/skills/create-release-note/SKILL.en.md
+++ b/templates/.agents/skills/create-release-note/SKILL.en.md
@@ -156,31 +156,28 @@ Show the generated release notes to the user.
 
 Ask:
 1. Need any adjustments?
-2. Create a draft release?
+2. Write these notes onto the Release for this version?
 
-### 9. Create Draft Release (If Confirmed)
+### 9. Publish the Release Notes (If Confirmed)
 
-Create the draft release by following `.agents/rules/release-commands.md`.
+Write the notes by following the "Publish the Release Notes" command in `.agents/rules/release-commands.md` (it updates the Release already created and published by the release workflow, falling back to creating it if missing).
 
 Output:
 ```
-Draft Release created.
+Release notes updated.
 
-- URL: {draft-release-url}
+- URL: {release-url}
 - Version: v{version}
-- Status: Draft
+- Status: Published
 
-Please review and publish on the platform:
-1. Open the URL above
-2. Review the release notes
-3. Click "Publish release"
+The notes have been written to the Release. Edit further at the URL above if needed.
 ```
 
 ## Notes
 
 1. **Requires the platform CLI**: Must have the platform CLI installed and authenticated
 2. **Tags must exist**: Run the release skill first to create tags
-3. **Draft mode**: Creates a draft - won't auto-publish
+3. **Release auto-published**: the `v{version}` Release is created and published by the release workflow (the upload target for Homebrew bottles); this skill only writes/refreshes its notes and no longer creates a draft
 4. **Classification accuracy**: Auto-classification is based on title/scope/files; complex PRs may need manual adjustment
 
 ## Error Handling

--- a/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
@@ -156,31 +156,28 @@ git log v<prev-version>..v<version> \
 
 询问：
 1. 需要调整吗？
-2. 是否创建 draft release？
+2. 是否把 notes 写入该版本的 Release？
 
-### 9. 创建 Draft Release（如确认）
+### 9. 发布 Release notes（如确认）
 
-按 `.agents/rules/release-commands.md` 的 Draft Release 创建命令执行。
+按 `.agents/rules/release-commands.md` 的「发布 Release notes」命令执行（写入已由 release 工作流自动创建/发布的 Release；不存在时兜底创建）。
 
 输出：
 ```
-Draft Release created.
+Release notes 已更新。
 
-- URL: {draft-release-url}
+- URL: {release-url}
 - Version: v{version}
-- Status: Draft
+- Status: Published
 
-Please review and publish on the platform:
-1. Open the URL above
-2. Review the release notes
-3. Click "Publish release"
+发布说明已写入该 Release。如需进一步调整，可在上面的 URL 直接编辑。
 ```
 
 ## 注意事项
 
 1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
-3. **草稿模式**：创建草稿 —— 不会自动发布
+3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能只往该 Release 写入/刷新 notes，不再创建草稿
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
 
 ## 错误处理

--- a/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
@@ -177,7 +177,7 @@ Release notes 已更新。
 
 1. **需要 the platform CLI**：必须安装并认证 the platform CLI
 2. **标签必须存在**：先执行 release 技能创建标签
-3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能只往该 Release 写入/刷新 notes，不再创建草稿
+3. **Release 已自动发布**：`v{version}` 的 Release 由 release 工作流自动创建并发布（给 Homebrew bottle 提供上传落点）；本技能往该 Release 写入/刷新 notes
 4. **分类准确性**：自动分类基于标题/scope/文件；复杂的 PR 可能需要手动调整
 
 ## 错误处理

--- a/tests/core/release.test.ts
+++ b/tests/core/release.test.ts
@@ -48,6 +48,7 @@ test("release workflow publishes to npm on tag push", () => {
   assert.match(workflow, /node-version: 24/);
   assert.match(workflow, /npm view "@fitlab-ai\/agent-infra@\$\{TAG_VERSION\}" version/);
   assert.match(workflow, /npm publish --provenance/);
+  assert.match(workflow, /NPM_TAG_ARGS="--tag next"/);
   assert.match(workflow, /gh release create "\$GITHUB_REF_NAME"/);
   assert.match(workflow, /--prerelease/);
 });

--- a/tests/core/release.test.ts
+++ b/tests/core/release.test.ts
@@ -44,8 +44,12 @@ test("release workflow publishes to npm on tag push", () => {
   assert.match(workflow, /run: npm test/);
   assert.match(workflow, /package\.json version \$PACKAGE_VERSION does not match tag \$GITHUB_REF_NAME/);
   assert.match(workflow, /id-token: write/);
+  assert.match(workflow, /contents: write/);
   assert.match(workflow, /node-version: 24/);
+  assert.match(workflow, /npm view "@fitlab-ai\/agent-infra@\$\{TAG_VERSION\}" version/);
   assert.match(workflow, /npm publish --provenance/);
+  assert.match(workflow, /gh release create "\$GITHUB_REF_NAME"/);
+  assert.match(workflow, /--prerelease/);
 });
 
 test("update-homebrew workflow syncs the tap after a successful release run", () => {
@@ -72,6 +76,7 @@ test("update-homebrew workflow syncs the tap after a successful release run", ()
   assert.match(workflow, /class AgentInfra < Formula/);
   assert.match(workflow, /name: Commit and push/);
   assert.match(workflow, /git commit -m "agent-infra \$\{VERSION\}"/);
+  assert.match(workflow, /name: Upload release-version artifact[\s\S]*name: release-version/);
   assert.match(workflow, /workflow_dispatch:[\s\S]*inputs:[\s\S]*version:/);
   assert.match(workflow, /prepare-formula:/);
   assert.match(workflow, /bake-bottle:/);
@@ -86,9 +91,15 @@ test("update-homebrew workflow syncs the tap after a successful release run", ()
   assert.match(workflow, /brew bottle --json --no-rebuild --root-url="\$ROOT_URL" agent-infra/);
   assert.match(workflow, /https:\/\/github\.com\/fitlab-ai\/agent-infra\/releases\/download\/v\$\{VERSION\}/);
   assert.match(workflow, /gh release upload "v\$\{VERSION\}"/);
-  assert.match(workflow, /bake-bottle:[\s\S]*continue-on-error: true/);
-  assert.match(workflow, /publish-bottle:[\s\S]*if: \$\{\{ always\(\)/);
-  assert.match(workflow, /brew bottle --merge --write --no-commit "\$json"/);
+  assert.match(workflow, /fail-fast: false/);
+  assert.match(workflow, /Expected 4 bottle JSON files but found/);
+  assert.match(workflow, /publish-bottle:[\s\S]*needs: \[prepare-formula, bake-bottle\]/);
+  assert.match(workflow, /generate-bottle-block\.mjs/);
+  assert.match(workflow, /actions\/download-artifact@v7/);
+  assert.match(
+    workflow,
+    /name: Checkout repository \(for generator script\)[\s\S]*name: Checkout homebrew-tap[\s\S]*name: Download all bottle JSON artifacts[\s\S]*name: Generate bottle block into Formula/
+  );
 });
 
 test("CLI help advertises scoped npm install commands and Homebrew", () => {
@@ -132,18 +143,23 @@ test("post-release-smoke workflow verifies npm and brew install channels", () =>
   const workflow = read(".github/workflows/post-release-smoke.yml");
 
   assert.match(workflow, /name: Post-Release Smoke/);
-  assert.match(workflow, /release:[\s\S]*types: \[published\]/);
+  assert.match(workflow, /workflow_run:[\s\S]*workflows: \["Update Homebrew Formula"\]/);
+  assert.match(workflow, /github\.event\.workflow_run\.conclusion == 'success'/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /inputs:[\s\S]*version:/);
   assert.match(workflow, /permissions: \{\}/);
   assert.match(workflow, /concurrency:/);
   assert.match(workflow, /cancel-in-progress: true/);
+  assert.match(workflow, /post-release-smoke-\$\{\{ github\.event\.workflow_run\.id \|\| inputs\.version \}\}/);
 
   assert.match(workflow, /resolve-version:/);
   assert.match(workflow, /timeout-minutes: 5/);
+  assert.match(workflow, /actions: read/);
+  assert.match(workflow, /name: release-version/);
+  assert.match(workflow, /run-id: \$\{\{ github\.event\.workflow_run\.id \}\}/);
   assert.match(workflow, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
   assert.match(workflow, /DISPATCH_VERSION: \$\{\{ inputs\.version \}\}/);
-  assert.match(workflow, /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \}\}/);
+  assert.match(workflow, /VERSION=\$\(cat release-version\.txt\)/);
   assert.match(workflow, /outputs:[\s\S]*version:/);
 
   assert.match(workflow, /npm-smoke:/);
@@ -159,7 +175,9 @@ test("post-release-smoke workflow verifies npm and brew install channels", () =>
   assert.match(workflow, /runs-on: macos-latest/);
   assert.match(workflow, /timeout-minutes: 20/);
   assert.match(workflow, /raw\.githubusercontent\.com\/fitlab-ai\/homebrew-tap\/main\/Formula\/agent-infra\.rb/);
-  assert.match(workflow, /name: brew install\s*\n\s*shell: bash/);
-  assert.match(workflow, /brew install fitlab-ai\/tap\/agent-infra/);
+  assert.match(workflow, /grep -q "bottle do"/);
+  assert.match(workflow, /name: brew install \(must pour from bottle\)/);
+  assert.match(workflow, /brew install --verbose fitlab-ai\/tap\/agent-infra/);
+  assert.match(workflow, /Pouring/);
   assert.match(workflow, /agent-infra version/);
 });

--- a/tests/scripts/generate-bottle-block.test.ts
+++ b/tests/scripts/generate-bottle-block.test.ts
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { filePath } from "../helpers.ts";
+
+const scriptPath = filePath(".github/scripts/generate-bottle-block.mjs");
+const rootUrl = "https://github.com/fitlab-ai/agent-infra/releases/download/v0.6.2";
+const platforms = ["arm64_tahoe", "arm64_sequoia", "arm64_sonoma", "sonoma"];
+
+function bottleJson(platform: string, sha256: string, options: { rootUrl?: string; cellar?: string } = {}) {
+  return {
+    "fitlab-ai/tap/agent-infra": {
+      formula: {
+        name: "agent-infra",
+        pkg_version: "0.6.2",
+      },
+      bottle: {
+        root_url: options.rootUrl ?? rootUrl,
+        cellar: options.cellar ?? "any_skip_relocation",
+        rebuild: 0,
+        tags: {
+          [platform]: {
+            filename: `agent-infra-0.6.2.${platform}.bottle.tar.gz`,
+            local_filename: `agent-infra--0.6.2.${platform}.bottle.tar.gz`,
+            sha256,
+          },
+        },
+      },
+    },
+  };
+}
+
+function withTempDir(callback: (dir: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-bottles-"));
+  try {
+    callback(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeBottles(dir: string, selectedPlatforms = platforms, options: { rootUrl?: string; cellar?: string } = {}) {
+  for (const [index, platform] of selectedPlatforms.entries()) {
+    const sha256 = `${index + 1}`.repeat(64).slice(0, 64);
+    fs.writeFileSync(
+      path.join(dir, `agent-infra--0.6.2.${platform}.bottle.json`),
+      JSON.stringify(bottleJson(platform, sha256, options), null, 2),
+    );
+  }
+}
+
+function runScript(args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: filePath("."),
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
+test("generate-bottle-block prints a Homebrew bottle block for all expected platforms", () => {
+  withTempDir((dir) => {
+    writeBottles(dir);
+
+    const result = runScript(["--bottles", dir]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /  bottle do/);
+    assert.match(result.stdout, new RegExp(`root_url "${rootUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
+    for (const platform of platforms) {
+      assert.match(result.stdout, new RegExp(`sha256 cellar: :any_skip_relocation, ${platform}:\\s+"[0-9a-f]+"`));
+    }
+    assert.match(result.stdout, /  end/);
+  });
+});
+
+test("generate-bottle-block replaces the formula placeholder when a formula path is provided", () => {
+  withTempDir((dir) => {
+    writeBottles(dir);
+    const formulaPath = path.join(dir, "agent-infra.rb");
+    fs.writeFileSync(formulaPath, [
+      "class AgentInfra < Formula",
+      "  license \"MIT\"",
+      "  # __BOTTLE_BLOCK__",
+      "end",
+      "",
+    ].join("\n"));
+
+    const result = runScript(["--bottles", dir, "--formula", formulaPath]);
+    const formula = fs.readFileSync(formulaPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(formula, /  bottle do/);
+    assert.match(formula, /root_url/);
+    assert.match(formula, /sha256 cellar: :any_skip_relocation, sonoma:/);
+  });
+});
+
+test("generate-bottle-block fails when an expected platform is missing", () => {
+  withTempDir((dir) => {
+    writeBottles(dir, platforms.filter((platform) => platform !== "sonoma"));
+
+    const result = runScript(["--bottles", dir]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing bottle for platform: sonoma/);
+  });
+});
+
+test("generate-bottle-block fails when root URLs disagree", () => {
+  withTempDir((dir) => {
+    writeBottles(dir, ["arm64_tahoe"]);
+    fs.writeFileSync(
+      path.join(dir, "agent-infra--0.6.2.arm64_sequoia.bottle.json"),
+      JSON.stringify(bottleJson("arm64_sequoia", "2".repeat(64), { rootUrl: `${rootUrl}-other` }), null, 2),
+    );
+    writeBottles(dir, ["arm64_sonoma", "sonoma"]);
+
+    const result = runScript(["--bottles", dir]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /root_url mismatch/);
+  });
+});
+
+test("generate-bottle-block quotes path cellar values", () => {
+  withTempDir((dir) => {
+    writeBottles(dir, platforms, { cellar: "/opt/homebrew/Cellar" });
+
+    const result = runScript(["--bottles", dir]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /cellar: "\/opt\/homebrew\/Cellar"/);
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #342

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

v0.6.1 发布暴露出 Homebrew bottle 发布链路（`release.yml` → `update-homebrew.yml` 的 `bake-bottle`/`publish-bottle`）的一整条串联缺陷，导致每次发布都要手工恢复（手算 sha256、改 formula、重命名/重传 asset、修 tap 历史）。本 PR 从工作流层面彻底重构，使一次完整 release 能**自动产出含 bottle 的 formula**、**失败即红（不再"假绿"）**、**命名与 `brew install` 期望对齐**。

## 📋 主要变更 / Brief Changelog

- **`release.yml`**：发布后创建 GitHub Release（补齐 bottle 上传落点，#7）；`npm publish` 改幂等（整条可安全重跑）；预发布版用 `--tag next` 发布，避免污染 npm `latest`。
- **`update-homebrew.yml`**：`bake-bottle` 上传 `.bottle.json` 中的规范单 dash 文件名（修 `brew install` 404，#3）、去掉 job 级 `continue-on-error`；`publish-bottle` 改用新增脚本从 `.bottle.json` 生成 `bottle do` 块写回 tap clone（弃用错位的 `brew bottle --merge`，#2/#9），并改为「4 平台全绿才发布」（去掉 `always()`/`::warning::` 的假绿短路，#5/#6）；`prepare-formula` 上传 `release-version` artifact 供 smoke 跨 run 取版本。
- **新增 `.github/scripts/generate-bottle-block.mjs`** + 单元测试：从 bottle JSON 生成 Homebrew bottle block（cellar 用 `:any_skip_relocation`，#8）。
- **`post-release-smoke.yml`**：触发改为 `workflow_run: ["Update Homebrew Formula"]`（绕开 `GITHUB_TOKEN` 创建 Release 不触发 `release` 事件的限制，并消除与 publish 的赛跑）；按触发 run id 跨 run 下载 `release-version` 取真实发布版本；`brew install --verbose` 断言日志含 `Pouring`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（Node ≥ 22）：新增 `tests/scripts/generate-bottle-block.test.ts`（生成器逻辑：正常/占位符替换/缺平台/root_url 不一致/路径 cellar）+ `tests/core/release.test.ts` 三个 workflow 的结构契约。
2. 端到端：合并后打一个 prerelease tag（如 `v0.6.2-alpha.1`）走 dry-run（详见下方「待人工验证」）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（需 macOS + 真实 release，见「待人工验证」）

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述
- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释
- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 单元测试通过 / Unit tests pass
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes — 待人工验证 / Manual Verification

> 以下为本执行环境无法闭环（env-blocked）或与本 PR 无关的既有项，需维护者承接：

1. **prerelease dry-run（需先合入 main）**：`update-homebrew.yml` / `post-release-smoke.yml` 经 `workflow_run` 触发，使用的是**默认分支上的文件**；故需先合并到 `main`，再打 `v0.6.2-alpha.1` 验证整链。
2. **env-blocked（需真实 GitHub Actions + macOS）**：
   - `workflow_run` 第二跳（Update Homebrew → Post-Release Smoke）是否真正触发；若不触发，回退方案：把 brew-smoke 并入 `update-homebrew.yml` 的 `needs: publish-bottle` job。
   - Pouring 路径：`brew uninstall agent-infra && brew install --verbose fitlab-ai/tap/agent-infra` 日志含 `Pouring`、无需 `--build-from-source`。
   - 真实 `brew bottle --json` 的 schema 与生成器字段假设一致（用一份真实 `.bottle.json` 核对）。
3. **既有无关问题**：`npm run typecheck` 因既有 `tests/core/validate-artifact.test.ts`（未触及）空值类型错误而红，非本 PR 引入，建议另开任务修复。
4. **运维注意**：`macos-14-large`（sonoma/Intel）因「4 平台全绿」门禁必须可用，否则 release 会红；预发布版已用 `--tag next`，不会污染 npm `latest`。

Closes #342

---

Generated with AI assistance
