### PR TITLE
fix(cli): 宿主无 Claude Code 凭证时 warn-skip 而不是硬抛错

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -43,7 +43,7 @@ import { validateSelinuxDisableEnv } from '../engines/selinux.ts';
 import { resolveBuildUid } from '../engines/native.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
 import {
-  assertClaudeCredentialsAvailable,
+  prepareClaudeCredentials,
   redactCommandError,
   validateClaudeCredentialsEnvOverride
 } from '../credentials.ts';
@@ -1100,15 +1100,17 @@ export async function create(args: string[]): Promise<void> {
   assertBranchAvailable(config.repoRoot, branch, { allowedWorktrees: worktreeCandidates });
   const tools = resolveTools(effectiveConfig);
   const resolvedTools = resolveToolDirs(effectiveConfig, tools, branch);
-  // Fail fast before any filesystem/docker side effects so a missing
-  // Claude Code credential blob doesn't leave the user with a stale
-  // worktree, docker image, or temporary Dockerfile they need to manually
-  // clean up.
-  assertClaudeCredentialsAvailable(
+  // Fatal credential states still fail before filesystem/docker side effects.
+  // A genuinely missing Claude Code credential only removes Claude Code's
+  // sandbox config and credential mounts for this create run.
+  const credentialOutcome = prepareClaudeCredentials(
     effectiveConfig.home,
     effectiveConfig.project,
     resolvedTools
   );
+  const effectiveResolvedTools = credentialOutcome.status === 'SKIPPED'
+    ? resolvedTools.filter(({ tool }) => tool.id !== 'claude-code')
+    : resolvedTools;
   const container = containerName(effectiveConfig, branch);
   const worktree = worktreeCandidates.find((candidate) => fs.existsSync(candidate)) ?? worktreeCandidates[0] ?? '';
   const shareCommon = shareCommonDir(effectiveConfig);
@@ -1122,6 +1124,13 @@ export async function create(args: string[]): Promise<void> {
   p.log.info(
     `Project: ${pc.bold(effectiveConfig.project)} | Branch: ${pc.bold(branch)} | Base: ${pc.bold(baseBranch || 'HEAD')}`
   );
+  if (credentialOutcome.status === 'SKIPPED') {
+    p.log.warn(
+      'Claude Code credentials not found on host - creating this sandbox WITHOUT Claude Code credentials.\n'
+      + '  Claude Code is still installed in the image but will not be authenticated.\n'
+      + '  To enable it: run "claude" once on the host to complete login, then re-run "ai sandbox create".'
+    );
+  }
 
   try {
     p.log.step('Checking container engine...');
@@ -1206,7 +1215,7 @@ export async function create(args: string[]): Promise<void> {
       {
         title: 'Preparing tool state',
         task: async () => {
-          for (const { tool, dir } of resolvedTools) {
+          for (const { tool, dir } of effectiveResolvedTools) {
             fs.mkdirSync(dir, { recursive: true });
 
             for (const { hostPath, sandboxName } of tool.hostPreSeedFiles ?? []) {
@@ -1243,7 +1252,7 @@ export async function create(args: string[]): Promise<void> {
             }
           }
 
-          return `${resolvedTools.length} tool config directories ready`;
+          return `${effectiveResolvedTools.length} tool config directories ready`;
         }
       },
       {
@@ -1283,31 +1292,32 @@ export async function create(args: string[]): Promise<void> {
               signingKey
             )
             : null;
-          const envFile = buildContainerEnvFile(resolvedTools, engine);
+          const envFile = buildContainerEnvFile(effectiveResolvedTools, engine);
           let hostShellConfig: HostShellConfig;
           try {
-            const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
+            const claudeCodeEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'claude-code');
             if (claudeCodeEntry) {
               ensureClaudeOnboarding(claudeCodeEntry.dir, effectiveConfig.home);
               ensureClaudeSettings(claudeCodeEntry.dir, effectiveConfig.home);
-              // Credential availability is asserted up-front in create() so we
-              // know the shared credentials file already exists at this point.
+              // prepareClaudeCredentials wrote the shared credentials file
+              // before this point. If credentials were missing, the
+              // claude-code entry was removed from effectiveResolvedTools.
             }
-            const codexEntry = resolvedTools.find(({ tool }) => tool.id === 'codex');
+            const codexEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'codex');
             if (codexEntry) {
               ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home);
               ensureCodexWorkspaceTrust(codexEntry.dir);
             }
-            const geminiEntry = resolvedTools.find(({ tool }) => tool.id === 'gemini-cli');
+            const geminiEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'gemini-cli');
             if (geminiEntry) {
               ensureGeminiWorkspaceTrust(geminiEntry.dir);
             }
-            const opencodeEntry = resolvedTools.find(({ tool }) => tool.id === 'opencode');
+            const opencodeEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'opencode');
             if (opencodeEntry) {
               // The TUI reads <toolDir>/opencode.json via OPENCODE_CONFIG pinned in tools.js.
               ensureOpenCodeModelInheritance(opencodeEntry.dir, effectiveConfig.home);
             }
-            const toolVolumes = resolvedTools.flatMap(({ tool, dir }) => [
+            const toolVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) => [
               '-v',
               volumeArg(engine, dir, tool.containerMount)
             ]);
@@ -1322,7 +1332,7 @@ export async function create(args: string[]): Promise<void> {
               '-v',
               volumeArg(engine, hostPath, containerPath, ':ro')
             ]);
-            const liveMountVolumes = resolvedTools.flatMap(({ tool }) =>
+            const liveMountVolumes = effectiveResolvedTools.flatMap(({ tool }) =>
               (tool.hostLiveMounts ?? [])
                 .filter(({ hostPath }) => fs.existsSync(hostPath))
                 .flatMap(({ hostPath, containerSubpath }) => [
@@ -1435,7 +1445,7 @@ export async function create(args: string[]): Promise<void> {
             }
           }
 
-          for (const { tool } of resolvedTools) {
+          for (const { tool } of effectiveResolvedTools) {
             for (const command of tool.postSetupCmds ?? []) {
               runSafeEngine(engine, 'docker', ['exec', container, 'bash', '-lc', command]);
             }
@@ -1477,7 +1487,7 @@ export async function create(args: string[]): Promise<void> {
 
   p.outro(pc.green('Sandbox ready'));
 
-  const toolHints = resolvedTools.map(({ tool, dir }) => {
+  const toolHints = effectiveResolvedTools.map(({ tool, dir }) => {
     const hasLiveMount = (tool.hostLiveMounts ?? []).some(({ hostPath }) => fs.existsSync(hostPath));
     const hint = hasLiveMount
       ? 'Live-mounted auth/config files stay in sync with the host.'

--- a/lib/sandbox/credentials.ts
+++ b/lib/sandbox/credentials.ts
@@ -92,6 +92,11 @@ type ResolvedTool = {
   };
 };
 
+export type ClaudeCredentialOutcome =
+  | { status: 'OK' }
+  | { status: 'SKIPPED' }
+  | { status: 'NOT_APPLICABLE' };
+
 type CredentialPayload = {
   claudeAiOauth?: CredentialPayload;
   scopes?: unknown;
@@ -584,17 +589,17 @@ export function formatRemaining(expiresAt: unknown): string {
   return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
 }
 
-export function assertClaudeCredentialsAvailable(
+export function prepareClaudeCredentials(
   home: string,
   project: string,
   resolvedTools: ResolvedTool[],
   extractFn: (home: string) => string | null = extractClaudeCredentialsBlob,
   writeFn: (home: string, project: string, blob: string) => void = writeClaudeCredentialsFile,
   inspectFn: (home: string) => CredentialInspection = inspectClaudeKeychainStatus
-): void {
+): ClaudeCredentialOutcome {
   const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
   if (!claudeCodeEntry) {
-    return;
+    return { status: 'NOT_APPLICABLE' };
   }
 
   let blob: string | null = null;
@@ -602,33 +607,51 @@ export function assertClaudeCredentialsAvailable(
   const hasCustomExtractFn = extractFn !== extractClaudeCredentialsBlob;
   if (hasCustomInspectFn || !hasCustomExtractFn) {
     const inspection = inspectFn(home);
-    if (inspection.status === 'KEYCHAIN_LOCKED') {
-      throw new Error([
-        'Claude Code credentials are stored in the macOS keychain, but the keychain is locked.',
-        '',
-        buildLockedGuidance()
-      ].join('\n'));
+    switch (inspection.status) {
+      case 'OK':
+        blob = inspection.blob;
+        break;
+      case 'MISSING':
+        return { status: 'SKIPPED' };
+      case 'KEYCHAIN_LOCKED':
+        throw new Error([
+          'Claude Code credentials are stored in the macOS keychain, but the keychain is locked.',
+          '',
+          buildLockedGuidance()
+        ].join('\n'));
+      case 'STALE_ACCESS':
+        throw new Error([
+          'Claude Code credentials on host are invalid or expired.',
+          '',
+          'The sandbox needs valid Claude Code OAuth credentials so the container can use Claude Code.',
+          '',
+          'To fix:',
+          '  1. On the host, run "claude" once and complete the OAuth login flow.',
+          '  2. Verify with "claude /status" that you see your subscription.',
+          '  3. Re-run "ai sandbox create".'
+        ].join('\n'));
+      case 'KEYCHAIN_ERROR':
+        throw new Error([
+          'Claude Code credentials could not be read from the host keychain.',
+          '',
+          inspection.detail ? `Detail: ${inspection.detail}` : 'Detail: unknown keychain error',
+          '',
+          'To fix:',
+          '  1. Unlock or repair the host keychain, then re-run "ai sandbox create".',
+          '  2. For SSH / CI, set AGENT_INFRA_CLAUDE_CREDENTIALS_FILE to an absolute path containing a valid credentials blob.'
+        ].join('\n'));
+      default: {
+        const _exhaustive: never = inspection;
+        throw new Error(`Unhandled Claude Code credential inspection status: ${(_exhaustive as { status: string }).status}`);
+      }
     }
-    blob = inspection.status === 'OK' ? inspection.blob : null;
   } else {
     blob = extractFn(home);
-  }
-
-  if (!blob) {
-    throw new Error([
-      'Claude Code credentials not found on host.',
-      '',
-      'The sandbox needs your Claude Code OAuth credentials so the container can use Claude Code.',
-      '',
-      'To fix:',
-      '  1. On the host, run "claude" once and complete the OAuth login flow.',
-      '  2. Verify with "claude /status" that you see your subscription.',
-      '  3. Re-run "ai sandbox create".',
-      '',
-      'Alternatively, if you do not need Claude Code in this sandbox,',
-      'remove "claude-code" from the "sandbox.tools" array in .agents/.airc.json.'
-    ].join('\n'));
+    if (!blob) {
+      return { status: 'SKIPPED' };
+    }
   }
 
   writeFn(home, project, blob);
+  return { status: 'OK' };
 }

--- a/tests/cli/sandbox-credentials.test.ts
+++ b/tests/cli/sandbox-credentials.test.ts
@@ -257,21 +257,22 @@ test("credential path helpers and writer manage the shared credential file", asy
   }
 });
 
-test("assertClaudeCredentialsAvailable writes credentials only when claude-code is enabled", async () => {
+test("prepareClaudeCredentials writes credentials only when claude-code is enabled", async () => {
   const credentials = await loadFreshEsm<typeof import("../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
   const writes: Array<[string, string, string]> = [];
 
-  credentials.assertClaudeCredentialsAvailable(
+  const outcome = credentials.prepareClaudeCredentials(
     "/Users/demo",
     "agent-infra",
     [{ tool: { id: "claude-code" } }],
     () => "valid-blob",
     (home: string, project: string, blob: string) => writes.push([home, project, blob])
   );
+  assert.deepEqual(outcome, { status: "OK" });
   assert.deepEqual(writes, [["/Users/demo", "agent-infra", "valid-blob"]]);
 
   let extractCalled = false;
-  credentials.assertClaudeCredentialsAvailable(
+  const missingToolOutcome = credentials.prepareClaudeCredentials(
     "/Users/demo",
     "agent-infra",
     [{ tool: { id: "codex" } }],
@@ -281,25 +282,55 @@ test("assertClaudeCredentialsAvailable writes credentials only when claude-code 
     },
     () => {}
   );
+  assert.deepEqual(missingToolOutcome, { status: "NOT_APPLICABLE" });
   assert.equal(extractCalled, false);
 });
 
-test("assertClaudeCredentialsAvailable throws a readable error when credentials are missing", async () => {
+test("prepareClaudeCredentials returns SKIPPED and writes nothing when credentials are missing", async () => {
   const credentials = await loadFreshEsm<typeof import("../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+  let writeCalled = false;
 
-  assert.throws(() => credentials.assertClaudeCredentialsAvailable(
+  const outcome = credentials.prepareClaudeCredentials(
     "/Users/demo",
     "agent-infra",
     [{ tool: { id: "claude-code" } }],
     () => null,
-    () => {}
-  ), /Claude Code credentials not found on host/);
+    () => {
+      writeCalled = true;
+    },
+    () => ({ status: "MISSING" })
+  );
+
+  assert.deepEqual(outcome, { status: "SKIPPED" });
+  assert.equal(writeCalled, false);
 });
 
-test("assertClaudeCredentialsAvailable reports keychain locked guidance", async () => {
+test("prepareClaudeCredentials rejects stale and keychain error states", async () => {
   const credentials = await loadFreshEsm<typeof import("../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
 
-  assert.throws(() => credentials.assertClaudeCredentialsAvailable(
+  for (const inspection of [
+    { status: "STALE_ACCESS" as const },
+    { status: "KEYCHAIN_ERROR" as const, detail: "security failed" }
+  ]) {
+    let writeCalled = false;
+    assert.throws(() => credentials.prepareClaudeCredentials(
+      "/Users/demo",
+      "agent-infra",
+      [{ tool: { id: "claude-code" } }],
+      () => null,
+      () => {
+        writeCalled = true;
+      },
+      () => inspection
+    ), /Claude Code credentials/);
+    assert.equal(writeCalled, false);
+  }
+});
+
+test("prepareClaudeCredentials reports keychain locked guidance", async () => {
+  const credentials = await loadFreshEsm<typeof import("../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+
+  assert.throws(() => credentials.prepareClaudeCredentials(
     "/Users/demo",
     "agent-infra",
     [{ tool: { id: "claude-code" } }],

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -394,10 +394,8 @@ test("sandbox rm defaults local branch deletion confirmation to yes", () => {
   );
 });
 
-test("sandbox create fails before preparing a temporary Dockerfile when Claude credentials are missing", () => {
+test("sandbox create warns and continues past missing Claude credentials", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-create-no-credentials-"));
-  const repoDir = path.join(tmpDir, "repo");
-  const homeDir = path.join(tmpDir, "home");
   const project = `sandbox-no-leak-${process.pid}-${Date.now()}`;
   const dockerfilePrefix = `${project}-sandbox-`;
   const existingEntries = new Set(
@@ -405,34 +403,22 @@ test("sandbox create fails before preparing a temporary Dockerfile when Claude c
   );
 
   try {
-    fs.mkdirSync(repoDir, { recursive: true });
-    fs.mkdirSync(homeDir, { recursive: true });
-    execSync("git init", { cwd: repoDir, env: gitSafeEnv(), stdio: "pipe" });
-    fs.mkdirSync(path.join(repoDir, ".agents"), { recursive: true });
-    fs.writeFileSync(
-      path.join(repoDir, ".agents", ".airc.json"),
-      JSON.stringify({ project, org: "fitlab-ai" }, null, 2) + "\n",
-      "utf8"
+    const fixture = writeSandboxEngineFixture(tmpDir, { project });
+
+    const result = spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["create", "feature/no-credentials"],
+      {
+        DOCKER_EXIT_FOR_RUN: "1",
+        AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: path.join(tmpDir, "missing-claude-credentials.json")
+      },
+      { timeout: 5_000 }
     );
 
-    let commandError: (Error & { stderr?: string | Buffer }) | null = null;
-    try {
-      execFileSync(
-        process.execPath,
-        cliArgs("sandbox", "create", "feature/no-credentials"),
-        {
-          cwd: repoDir,
-          env: gitSafeEnv({ HOME: homeDir }),
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"]
-        }
-      );
-    } catch (error) {
-      commandError = error as Error & { stderr?: string | Buffer };
-    }
-
-    assert.ok(commandError);
-    assert.match(String(commandError.stderr ?? ""), /Claude Code credentials not found on host/);
+    assert.equal(result.signal, null);
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}\n${result.stderr}`, /WITHOUT Claude Code credentials/);
 
     const leakedEntries = fs.readdirSync(os.tmpdir()).filter((entry) => (
       entry.startsWith(dockerfilePrefix) && !existingEntries.has(entry)

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -410,10 +410,13 @@ test("sandbox create warns and continues past missing Claude credentials", () =>
       tmpDir,
       ["create", "feature/no-credentials"],
       {
-        DOCKER_EXIT_FOR_RUN: "1",
+        // Fail at ensureDocker (the first docker call) so the test exits
+        // quickly on slow CI runners (e.g. Windows). The credential gate
+        // runs before ensureDocker, so a missing claude credential will
+        // emit its warning to stderr first.
+        DOCKER_EXIT_FOR_INFO: "1",
         AGENT_INFRA_CLAUDE_CREDENTIALS_FILE: path.join(tmpDir, "missing-claude-credentials.json")
-      },
-      { timeout: 5_000 }
+      }
     );
 
     assert.equal(result.signal, null);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -347,6 +347,9 @@ function writeSandboxEngineFixture(
       "if (args[0] === 'run' && process.env.DOCKER_EXIT_FOR_RUN) {",
       "  process.exit(Number(process.env.DOCKER_EXIT_FOR_RUN));",
       "}",
+      "if (args[0] === 'info' && process.env.DOCKER_EXIT_FOR_INFO) {",
+      "  process.exit(Number(process.env.DOCKER_EXIT_FOR_INFO));",
+      "}",
       "process.exit(0);"
     ].join("\n"),
     "utf8"


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#357</mark> 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 #357：在没有跑过 `claude /login` 的宿主上（Keychain 无 `Claude Code-credentials` 条目，且无环境变量覆盖文件），`ai sandbox create` 会在前置凭证校验阶段直接抛 `Claude Code credentials not found on host`，强迫用户手动编辑 `.agents/.airc.json` 删掉 `claude-code` 才能继续，体验非常不友好。

参照 #279 让 `enter` 路径凭证同步实现 fail-soft 的做法，本次把 `create` 路径中**真无凭证**的硬抛错改为 warn-and-skip：剔除本次 `claude-code` 的凭证/配置挂载，打印醒目 warning，沙箱照常创建。但 `STALE_ACCESS` / `KEYCHAIN_LOCKED` / `KEYCHAIN_ERROR` 这三种"凭证存在但不可用"的状态仍硬抛错并附带状态特定的引导，避免误降级。

## 📋 主要变更 / Brief Changelog

- **`lib/sandbox/credentials.ts`**: 把 `assertClaudeCredentialsAvailable` 重命名为 `prepareClaudeCredentials`，返回判别联合 `{ status: 'OK' | 'SKIPPED' | 'NOT_APPLICABLE' }`。`inspect` 五态精确分流：仅 `MISSING` 返回 `SKIPPED`；`STALE_ACCESS` / `KEYCHAIN_LOCKED` / `KEYCHAIN_ERROR` 各自抛针对性可读错误。switch 末尾有 `never` 穷尽性兜底，未来新增状态会在编译期暴露。
- **`lib/sandbox/commands/create.ts`**: 调用点接收 outcome，按 `SKIPPED` 从派生出的 `effectiveResolvedTools` 剔除 `claude-code`（不创建配置目录、不写/挂载凭证文件、不跑 onboarding、不进 env/volume）；`tools`（镜像签名 / 构建 / 版本检查）保持不变，避免触发镜像重建。warning 在 `p.intro` 之后、`ensureDocker()` 之前输出，无 Docker 环境也能看到。
- **测试**: 新增 `MISSING → SKIPPED 不写`、`STALE_ACCESS / KEYCHAIN_ERROR 仍 throw`、`NOT_APPLICABLE` 共 6 条 outcome 路径覆盖；集成测试改写为"放行凭证门禁 + 输出 warning"断言，并保留"零临时 Dockerfile 泄漏"断言防回归。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 在一台没有跑过 `claude /login`、Keychain 中无 `Claude Code-credentials` 条目的宿主上执行 `ai sandbox create <branch>`
2. 观察：命令不再抛错，stderr 显示 `creating this sandbox WITHOUT Claude Code credentials` warning，沙箱正常创建（不挂载 CC 凭证文件）
3. 在已 login 的宿主上执行同样命令，行为不变（CC 凭证按既有逻辑挂载）
4. macOS keychain locked 场景下，命令仍硬抛错并引导 `security unlock-keychain` / 环境变量覆盖

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（macOS keychain 真机场景需人工验证，列在「待人工验证」中）

### 测试结果

```
$ npm run build
通过（tsc 无类型错误）

$ node --test tests/cli/sandbox-credentials.test.ts
# tests 45
# pass 45

$ npm test
# tests 512
# pass 511
# fail 0
# skipped 1
```

### 待人工验证

- [ ] 在真实 macOS 宿主（无 CC 登录）上跑 `ai sandbox create`，确认 warning + 沙箱创建成功
- [ ] 锁定 macOS keychain 后跑 `ai sandbox create`，确认硬抛错并显示解锁引导
- [ ] 在已 login 的 macOS 宿主上跑 `ai sandbox create`，确认 CC 在沙箱内可正常认证（回归确认）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查（两轮 `review-task` + 一轮 `refine-task`）
- [x] 我已经为复杂的代码添加了必要的注释（同步更新了 `create.ts` 中关于凭证文件存在性假设的过时注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock（注入 `extractFn` / `writeFn` / `inspectFn`）
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / 不适用：README 未单独文档化原 create 硬错行为；help 文本未涉及
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（见下方）
- [x] 我已经考虑了向后兼容性

### 破坏性变更说明

包内导出函数 `assertClaudeCredentialsAvailable` 重命名为 `prepareClaudeCredentials`，返回类型由 `void` 改为 `ClaudeCredentialOutcome` 判别联合。该函数仅在 `lib/sandbox/commands/create.ts` 内部调用，未在 `package.json` 的 `exports` 字段中暴露，外部消费者无影响。

## 📋 附加信息 / Additional Notes

- 关联 #279（`enter` 路径 fail-soft 的前作）
- **不在本任务范围**：
  - 沙箱镜像里预装哪些 TUI 的可选化（另一新需求，需单开 issue）
  - `ai init` 阶段的 TUI 模板选择（已由 #240 跟踪）
- **与原方案的偏差**：原方案曾倾向"TTY 交互弹窗 + 非 TTY 静默降级 + 持久化到 `.airc.json` + CLI flag"组合方案；经用户明确否决（理由：交互打断心流）后改为"永远 warn + skip"。
- **经 codex review 修订**：仅 `inspect` 返回 `MISSING` 才降级，`STALE_ACCESS` / `KEYCHAIN_ERROR` 仍抛可读错误；warning 文案为"WITHOUT Claude Code **credentials**"（CC 二进制仍随镜像安装，只是不挂凭证）。

---

**审查者注意事项 / Reviewer Notes:**

重点核对：

1. `prepareClaudeCredentials` 是否只在 `inspection.status === 'MISSING'` 时返回 `SKIPPED`，没有误吞 `STALE_ACCESS` / `KEYCHAIN_ERROR` / `KEYCHAIN_LOCKED`
2. `create.ts` 中所有配置、env、volume、post-setup、tool notes 路径是否都使用 `effectiveResolvedTools`，同时镜像签名（`buildSignature`）、构建（`buildImage`）、版本检查（`toolChecks`）仍保留原 `tools`
3. warning 位置是否早于 `ensureDocker()`，且文案准确表达"WITHOUT Claude Code credentials"

Closes #357

---

Generated with AI assistance.
