### PR TITLE
fix(tests): 修复 validate-artifact 测试的 typecheck 空值错误

### DIFF
--- a/tests/core/validate-artifact.test.ts
+++ b/tests/core/validate-artifact.test.ts
@@ -319,13 +319,23 @@ function parseTestFrontmatter(content: string) {
   if (!match) {
     return null;
   }
+  const body = match[1];
+  if (body === undefined) {
+    return null;
+  }
 
   const metadata: Record<string, string> = {};
-  for (const line of match[1].split(/\r?\n/)) {
+  for (const line of body.split(/\r?\n/)) {
     const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (field) {
-      metadata[field[1]] = field[2].trim();
+    if (!field) {
+      continue;
     }
+    const key = field[1];
+    const value = field[2];
+    if (key === undefined || value === undefined) {
+      continue;
+    }
+    metadata[key] = value.trim();
   }
 
   return metadata;


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #356

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`npm run typecheck`（即 `tsc -p tsconfig.test.json --noEmit`）此前因 `tests/core/validate-artifact.test.ts` 中 `parseTestFrontmatter` 的 3 个空值类型错误而红：

```text
tests/core/validate-artifact.test.ts(324,22): error TS2532: Object is possibly 'undefined'.
tests/core/validate-artifact.test.ts(327,16): error TS2538: Type 'undefined' cannot be used as an index type.
tests/core/validate-artifact.test.ts(327,28): error TS2532: Object is possibly 'undefined'.
```

这是仓库长期既有问题（在 `noUncheckedIndexedAccess: true` 下，正则捕获组被推导为 `string | undefined`），与 #342 / #354 的 Homebrew bottle 链路无关——`#354` 的实现报告/审查里已多次标注其为「既有、与本任务无关」，本 PR 单独拆出修复，避免再次被误判为某个无关 PR 引入。

修复要求：让 `npm run typecheck` 恢复绿，且**不改变测试的原有行为与断言意图**。

## 📋 主要变更 / Brief Changelog

- 重写 `tests/core/validate-artifact.test.ts:317-342` 的 `parseTestFrontmatter` 函数体：
  - `match[1]` 提到具名局部变量 `body`，配 `if (body === undefined) return null;` 守卫
  - 内层 `if (field)` 改为 `if (!field) continue;` 早出，再把 `field[1]`/`field[2]` 提到 `key`/`value`，配 `if (key === undefined || value === undefined) continue;` 守卫
  - 访问点变为 `body.split(...)` 和 `metadata[key] = value.trim()`，意图自描述
- **不引入** `!` 非空断言、**不**新增辅助函数、**不**改正则、**不**改函数签名/返回类型、**不**改唯一调用点

新增的 `=== undefined` 分支在正则匹配成功后**运行时永远不会触发**（regex group 1/2 在 match 成功时必定捕获），纯粹是给 TypeScript 编译期的类型缩窄提示，因此运行时行为与原实现严格一致。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install`
2. `npm run typecheck`（含 `tsc -p tsconfig.test.json` 和 `tsc -p tsconfig.jschecks.json` 两步）
3. `npm test`（含 `parseTestFrontmatter` 的所有调用点）

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

未新增测试用例：新增守卫的运行时分支不可触发（regex 匹配后 group 不可能为 undefined），写测试只会得到「永远绿但断言 dead branch」的伪覆盖。该决定与 `.agents/rules/testing-discipline.md` 中「断言要锁定具体期望值」一致。

本地验证结果：

```text
npm run typecheck    # exit 0，无 error TS
npm test             # tests 513 / pass 512 / fail 0 / skipped 1
```

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change（#356）
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（见任务工作区 `review.md`）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas（无需注释：访问点已自描述）

**测试要求 / Testing Requirements:**

- [ ] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests（见上文「未新增测试用例」说明）
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（无新增跨模块依赖）
- [x] 代码检查通过 / Lint checks pass（本项目以 `npm run typecheck` 作为类型门禁；本 PR 即修复该门禁）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（仅类型守卫修复，不涉及文档）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（运行时行为与原实现严格一致）

## 📋 附加信息 / Additional Notes

- 任务工作区：`.agents/workspace/active/TASK-20260527-111506/`（含 analysis / plan / implementation / review 完整轨迹）
- 方案曾在 Round 1 内修订过一次：初版选了「收紧 if 守卫（方案 A）」，用户指出「改动大小应按影响范围而非行数衡量」后切到「局部变量 + 提前 return/continue（方案 C）」——两者影响范围等同，但 C 的访问点局部可读性更好。
- diff stat：1 file changed, +13 / -3，严格落在 `parseTestFrontmatter` 函数体内。

---

**审查者注意事项 / Reviewer Notes:**

- 重点核对 `parseTestFrontmatter` 重写后函数体与 `plan.md`「技术方法」段的代码块是否字面一致。
- 重点核对正则两处字面量、函数签名、返回结构、唯一调用点（line 362 附近）是否未触及。
- 新增的 `=== undefined` 分支属于「死分支」（regex 匹配成功后不可触发），是 TS 类型缩窄而非运行时语义改动；如审查者倾向于 `!` 非空断言或其他风格，欢迎评论。

---

Generated with AI assistance
