### PR TITLE
refactor(core): 优化 post-release 技能让 demo 录制使用本地编译产物

### DIFF
--- a/.agents/skills/post-release/SKILL.md
+++ b/.agents/skills/post-release/SKILL.md
@@ -26,7 +26,27 @@ git status --short
 
 - 如果存在未提交变更，报错："Workspace has uncommitted changes. Please commit or stash first."
 
-### 3. 准备下一个开发版本
+### 3. 重建项目
+
+```bash
+npm run build
+```
+
+- demo 录制依赖 `dist/bin/cli.js`，必须先用当前 HEAD 重新编译
+- 如果构建失败，停止并先修复编译错误
+
+### 4. 录制执行动图（可选）
+
+```bash
+command -v vhs >/dev/null 2>&1
+```
+
+- 如果 `vhs` 可用，执行 `npm run demo:regen`
+- 此时 `package.json.version` 仍是刚发布的 `vX.Y.Z`，GIF 中 `ai version` 显示的是 released 版本号
+- `scripts/demo-regen.sh` 已通过 shim 把 tape 中的 `ai` 命令锁定到本地构建产物，不依赖全局 `ai`
+- 如果 `vhs` 不可用，跳过录制并提示用户稍后手动生成演示动图
+
+### 5. 准备下一个开发版本
 
 ```bash
 npm version prerelease --preid=alpha --no-git-tag-version
@@ -36,7 +56,7 @@ npm install --package-lock-only
 - 读取新的 prerelease 版本号
 - 确保 `package.json` 与 `package-lock.json` 的版本保持一致
 
-### 4. 重新生成内联产物
+### 6. 重新生成内联产物
 
 ```bash
 node scripts/build-inline.js
@@ -47,23 +67,14 @@ cp templates/.agents/skills/update-agent-infra/scripts/sync-templates.js \
 - 版本更新后必须重建内联产物，避免嵌入的默认模板版本号过期
 - 如果命令失败，停止并先修复构建问题
 
-### 5. 录制执行动图（可选）
-
-```bash
-command -v vhs >/dev/null 2>&1
-```
-
-- 如果 `vhs` 可用，执行 `npm run demo:regen`
-- 如果 `vhs` 不可用，跳过录制并提示用户稍后手动生成演示动图
-
-### 6. 创建后处理提交
+### 7. 创建后处理提交
 
 ```bash
 git add -A
 git commit -m "chore: prepare next dev iteration after v{released-version}"
 ```
 
-### 7. 输出摘要
+### 8. 输出摘要
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 
@@ -85,11 +96,13 @@ git commit -m "chore: prepare next dev iteration after v{released-version}"
 2. **需要干净工作区**：避免将无关变更混入版本 bump 提交
 3. **VHS 可选**：缺少 `vhs` 或 `ffmpeg` 时允许跳过，不阻塞其余步骤
 4. **本地执行**：本技能只准备本地变更，不自动推送
+5. **步骤顺序敏感**：demo 录制必须在 `npm version prerelease` 之前，否则 GIF 录到 alpha 版本号
 
 ## 错误处理
 
 - 未找到发布标签：提示先完成版本发布并推送标签
 - 工作区不干净：提示先提交或暂存
+- 构建失败：显示 `tsc` / build 错误并停止；后续步骤依赖 `dist/` 产物
 - 版本 bump 失败：显示命令错误并停止
 - 内联产物重建失败：显示构建错误并停止
 - Git 提交失败：显示错误并保留当前工作区供人工处理

--- a/scripts/demo-regen.sh
+++ b/scripts/demo-regen.sh
@@ -15,9 +15,30 @@ local="assets/demo-settings.tape"
 gif="assets/demo-init.gif"
 webm="assets/demo-init.webm"
 target_duration=25  # seconds — fixed across all machines
+repo_root=$(pwd)
+local_cli="$repo_root/dist/bin/cli.js"
 
 tmp=$(mktemp).tape
-trap 'rm -f "$tmp" "$webm" /tmp/demo-palette.png' EXIT
+shim_dir=$(mktemp -d)
+trap 'rm -rf "$tmp" "$webm" /tmp/demo-palette.png "$shim_dir"' EXIT
+
+# ── Ensure local build exists and shim `ai` / `agent-infra` to it ──
+# Demo tape types `ai version` / `ai init`; without this shim those resolve
+# to whatever global `ai` is on PATH, not the current workspace build.
+if [ ! -f "$local_cli" ]; then
+  echo "demo-regen: $local_cli not found. Run 'npm run build' first." >&2
+  exit 1
+fi
+
+for name in ai agent-infra; do
+  cat >"$shim_dir/$name" <<SHIM
+#!/bin/sh
+exec node "$local_cli" "\$@"
+SHIM
+  chmod +x "$shim_dir/$name"
+done
+
+export PATH="$shim_dir:$PATH"
 
 # ── Merge local settings + switch output to WebM ──
 {
@@ -27,6 +48,13 @@ trap 'rm -f "$tmp" "$webm" /tmp/demo-palette.png' EXIT
 
 # ── Record via VHS (lossless WebM) ──
 vhs "$tmp"
+
+# ── Sanity check: local CLI version should match package.json ──
+pkg_version=$(node -p "require('./package.json').version" 2>/dev/null || echo "")
+shim_version=$("$shim_dir/ai" version --raw 2>/dev/null || echo "")
+if [ -n "$pkg_version" ] && [ -n "$shim_version" ] && [ "$pkg_version" != "$shim_version" ]; then
+  echo "demo-regen: WARNING dist/bin/cli.js reports $shim_version but package.json is $pkg_version (rebuild before recording)." >&2
+fi
 
 # ── Encode GIF with color-accurate palette ──
 # Pass 1: Generate palette with Catppuccin Mocha key colors injected.

--- a/tests/core/demo-regen.test.ts
+++ b/tests/core/demo-regen.test.ts
@@ -54,12 +54,15 @@ function setupDemoRegenFixture({ withLocalSettings }: { withLocalSettings: boole
   const assetsDir = path.join(repoDir, "assets");
   const scriptsDir = path.join(repoDir, "scripts");
   const binDir = path.join(repoDir, "bin");
+  const distBinDir = path.join(repoDir, "dist", "bin");
   const capturedTapePath = path.join(repoDir, "captured.tape");
+  const capturedAiOutPath = path.join(repoDir, "captured-ai-out.txt");
   const sourceGifPath = path.join(repoDir, "source.gif");
 
   fs.mkdirSync(assetsDir, { recursive: true });
   fs.mkdirSync(scriptsDir, { recursive: true });
   fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(distBinDir, { recursive: true });
 
   fs.writeFileSync(path.join(assetsDir, "demo-init.tape"), read("assets/demo-init.tape"), "utf8");
   if (withLocalSettings) {
@@ -72,6 +75,19 @@ function setupDemoRegenFixture({ withLocalSettings }: { withLocalSettings: boole
     "utf8"
   );
   fs.writeFileSync(sourceGifPath, makeFakeGif(4));
+  fs.writeFileSync(
+    path.join(distBinDir, "cli.js"),
+    `#!/usr/bin/env node
+process.stdout.write("9.9.9-test\\n");
+`,
+    "utf8"
+  );
+  fs.chmodSync(path.join(distBinDir, "cli.js"), 0o755);
+  fs.writeFileSync(
+    path.join(repoDir, "package.json"),
+    JSON.stringify({ name: "fake", version: "9.9.9-test" }),
+    "utf8"
+  );
 
   // VHS shim: captures the merged tape and outputs the source GIF as a webm
   const vhsShimPath = path.join(binDir, "vhs");
@@ -81,6 +97,7 @@ function setupDemoRegenFixture({ withLocalSettings }: { withLocalSettings: boole
 set -e
 cp "$1" "$TEST_CAPTURE_TAPE"
 cp "$TEST_SOURCE_GIF" assets/demo-init.webm
+ai version --raw > "$TEST_CAPTURE_AI_OUT" 2>&1 || true
 `,
     "utf8"
   );
@@ -107,11 +124,14 @@ esac
   return {
     repoDir,
     assetsDir,
+    binDir,
     capturedTapePath,
+    capturedAiOutPath,
     sourceGifPath,
     env: {
       ...envWithPrependedPath(process.env, binDir),
       TEST_CAPTURE_TAPE: capturedTapePath,
+      TEST_CAPTURE_AI_OUT: capturedAiOutPath,
       TEST_SOURCE_GIF: sourceGifPath
     }
   };
@@ -218,6 +238,38 @@ test("demo-regen works without a local settings tape", () => {
     assert.doesNotMatch(mergedTape, /^Set Framerate 19$/m);
     assert.match(mergedTape, /Output assets\/demo-init\.webm/);
     assert.match(result.stdout, /Normalized: 4 frames, 6250ms, total 25\.0s/);
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("demo-regen shims `ai` to the local dist build, not the PATH-installed binary", () => {
+  const fixture = setupDemoRegenFixture({ withLocalSettings: false });
+  const {
+    repoDir,
+    binDir,
+    capturedAiOutPath,
+    env
+  } = fixture;
+
+  fs.writeFileSync(
+    path.join(binDir, "ai"),
+    `#!/bin/sh
+echo "GLOBAL-FAKE"
+`,
+    "utf8"
+  );
+  fs.chmodSync(path.join(binDir, "ai"), 0o755);
+
+  try {
+    const result = spawnSync("sh", ["scripts/demo-regen.sh"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(capturedAiOutPath, "utf8").trim(), "9.9.9-test");
   } finally {
     fs.rmSync(repoDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #328

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`post-release` 技能会调用 `npm run demo:regen` 重新录制 `assets/demo-init.gif`。但 VHS tape (`assets/demo-init.tape`) 中直接键入 `ai version` / `ai init`，这些命令在录制时解析到 PATH 上的**全局 `ai` 二进制**（通常是上一个发布版本），与当前 workspace 编译产物完全无关。v0.6.0 发布事故正是这样发生：已发布 0.6.0，但 demo GIF 录的是 0.5.x 的行为，技能没有把这个不一致检查出来。

本 PR 做两层修复：

1. **结构层**：在 `scripts/demo-regen.sh` 内构造临时 shim 目录，写入 `ai` / `agent-infra` 指向 `dist/bin/cli.js`，并将该目录 prepend 到 PATH。tape 中可视的 `ai ...` 字样保持不变，但实际执行的是当前 workspace 编译产物。
2. **流程层**：调整 `post-release` 步骤顺序为「先 build → 再录 demo → 最后 prerelease bump」，确保 `dist/` 与刚发布的 tag 对齐，且录制时 `package.json.version` 仍是 released 版本号（不是下一轮 alpha）。

## 📋 主要变更 / Brief Changelog

- `scripts/demo-regen.sh`: 录制前检查 `dist/bin/cli.js` 是否存在；构造临时目录写入 `ai` / `agent-infra` shim 并 prepend 到 PATH；trap 升级到 `rm -rf` 含 shim 目录；VHS 跑完后比对 `package.json.version` 与 `ai version --raw`，不一致时输出 stderr warning（不阻断）
- `.agents/skills/post-release/SKILL.md`: 在「验证工作区干净」之后新增「重建项目（`npm run build`）」；把 demo 录制提前到 `npm version prerelease` 之前；调整后续步骤编号；注意事项与错误处理各 +1 条
- `tests/core/demo-regen.test.ts`: fixture 增加 fake `dist/bin/cli.js` 与 `package.json`；VHS shim 额外捕获 `ai version --raw` 输出；新增结构性用例验证「PATH 上人为放置 fake global `ai` 时，shim 仍胜出，捕获到 local fake cli 的输出」

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（含 `tests/core/demo-regen.test.ts`）—— 全套测试通过（511 passed, 1 skipped）
2. 手动 e2e（待人工验证）：把本机全局 `ai` 锁到旧版本 → `npm run demo:regen` → 打开 `assets/demo-init.gif`，确认 `ai version` 一帧显示当前 `package.json.version`
3. 手动 e2e（待人工验证）：模拟「`dist/` 与 `package.json` 不一致」 → 触发 stderr WARNING，且 GIF 录制不被阻断

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 手动 e2e（依赖 `vhs`/`ffmpeg` 二进制 + GIF 视觉确认）留给维护者在 PR 合并前完成。

## 📸 截图 / Screenshots

N/A — 本 PR 仅改动录制脚本与流程文档，UI 无变化；demo GIF 的可视化校验需在维护者本机手动跑一次 `npm run demo:regen` 并对比新旧 GIF。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- shim PATH 修改的作用域限定在 `sh scripts/demo-regen.sh` 子进程内，不污染父 shell；trap 在脚本退出时清理临时目录
- 模板侧 `templates/.agents/skills/post-release/SKILL.{en,zh-CN}.md` 未改动 —— 模板中的 demo 步骤是 `<!-- TODO -->` 占位，不绑定本仓库具体命令
- `assets/demo-init.tape` 也未改动 —— shim 注入在 shell 层完成，对 tape 内容透明

---

**审查者注意事项 / Reviewer Notes:**

- `scripts/demo-regen.sh` 的 heredoc 在写入 shim 时使用未引号化 `SHIM` 让 `$local_cli` 展开为绝对路径，同时 `\$@` 转义为运行时字面量 `$@`；请重点核对这两个转义点
- `post-release` 步骤顺序变化：现在 build 紧随 clean-status 检查，demo 录制在 prerelease bump 之前 —— 此顺序对「GIF 中 `ai version` 显示 released 版本号」是必要前提
- 新测试用例采用结构性断言：在同 fixture binDir 放 fake「global ai」（`GLOBAL-FAKE`），断言捕获到的是 local fake cli 的 `9.9.9-test`；如果 PATH shim 注入失败，断言会立即失败

Generated with AI assistance
