### PR TITLE
fix(build): drop dist/package.json (#365)

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,8 +1,15 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
-const { version } = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
-);
+const packageJsonUrl = [
+  new URL('../package.json', import.meta.url),
+  new URL('../../package.json', import.meta.url),
+].find((url) => existsSync(url));
+
+if (!packageJsonUrl) {
+  throw new Error('Unable to locate package.json for agent-infra version');
+}
+
+const { version } = JSON.parse(readFileSync(packageJsonUrl, 'utf8'));
 const VERSION = `v${version}`;
 
 export { VERSION };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,13 +17,6 @@ copyFile(
   path.join(distLib, "defaults.json")
 );
 
-const rootPackage = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8"));
-fs.writeFileSync(
-  path.join(rootDir, "dist", "package.json"),
-  `${JSON.stringify({ name: rootPackage.name, version: rootPackage.version, type: rootPackage.type }, null, 2)}\n`
-);
-process.stdout.write("Wrote dist/package.json\n");
-
 const runtimesSrc = path.join(rootDir, "lib", "sandbox", "runtimes");
 const runtimesDst = path.join(distLib, "sandbox", "runtimes");
 for (const file of fs.readdirSync(runtimesSrc)) {

--- a/tests/scripts/build-dist-invariants.test.ts
+++ b/tests/scripts/build-dist-invariants.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { filePath } from "../helpers.ts";
+
+test("build does not emit dist/package.json", () => {
+  assert.equal(
+    fs.existsSync(filePath("dist/package.json")),
+    false,
+    "dist/package.json makes sync-templates resolve templates/ under dist/ instead of the package root (#365).",
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #365

Closes #365

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`/update-agent-infra` 调用随包分发的 `sync-templates.js` 时，resolver 从 `realpath(command -v ai)` 沿父目录上溯找首个 `package.json`，遇到根名匹配（`@fitlab-ai/agent-infra`）就尝试该层的 `templates/`。当前 `scripts/build.js` 会把一份仅含 `{name, version, type}` 的 `package.json` 副本写到 `dist/`，名字与根包一致，所以 resolver 在 `dist/` 提前命中并把模板根锁死为不存在的 `dist/templates`，0.6.2 安装产物上的 `ai update` 因此报错：

```
Template source not found.

Attempted binary lookups:
  - ai: templates/ not found at /opt/homebrew/Cellar/agent-infra/0.6.2/libexec/lib/node_modules/@fitlab-ai/agent-infra/dist/templates
  - agent-infra: templates/ not found at /opt/homebrew/Cellar/agent-infra/0.6.2/libexec/lib/node_modules/@fitlab-ai/agent-infra/dist/templates
```

`dist/package.json` 是历史冗余——根 `package.json` 已声明 `"type": "module"`，`dist/` 作为子目录天然继承 ESM 解析，副本对运行时没有任何正向作用，只起到「让 resolver 在错误层级停步」的反效果。本 PR 选 B 方案：直接停止产出该副本，并把「`dist/` 不应出现 `package.json`」固化为打包不变量测试，避免回归。

> 关于「方案 A：让 `sync-templates.js` 在 name 匹配但 `templates/` 缺失时继续上溯」被否决的理由：`sync-templates.js` 随包分发，现有 0.6.2 用户拿不到带 A 的新脚本；一旦升级到含 B 的版本，resolver 自动正常，A 永远不会触发，是死代码。

## 📋 主要变更 / Brief Changelog

- `scripts/build.js`：移除向 `dist/package.json` 写入 `{name, version, type}` 副本的 5 个语句（含孤儿 `rootPackage` 读取与 stdout 提示），保留 `defaults.json` 拷贝、`*.dockerfile` 拷贝和 `cli.js` chmod 三个独立副作用不动。
- `lib/version.ts`：CLI 在编译后通过 `dist/lib/version.js → ../package.json` 间接依赖 `dist/package.json` 读取版本号。改为按候选 URL 列表 `[../package.json, ../../package.json]` 同时兼容源码直跑（`lib/` 一层即包根）与编译运行（`dist/lib/` 两层到包根）两种布局；属于步骤 2「同步检查依赖 `dist/package.json` 的其他位置」的必要兜底。
- `tests/scripts/build-dist-invariants.test.ts`（新建）：单条存在性断言锁定「构建后 `dist/` 下不应出现 `package.json`」打包不变量，防止 build 步骤未来再次写入同名文件造成 resolver 回退到旧 bug。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`，确认输出中不再出现 `Wrote dist/package.json`，且 `dist/` 内不存在 `package.json`（`ls dist/` 只看到 `bin/`、`lib/`）。
2. `npm test` 全套通过（`tests 512 / pass 511 / fail 0 / skipped 1`），包含新增的 `ok build does not emit dist/package.json` 与既有的 `cli version output stays in sync with package.json`、`cli version raw output returns the bare version string` 用例。
3. `node dist/bin/cli.js version` 与 `node --experimental-strip-types ./bin/cli.ts version` 均输出 `agent-infra v0.6.3-alpha.0`，验证 `lib/version.ts` 在源码和编译两种模式下都能正确定位根 `package.json`。
4. `npm pack --dry-run` 列出的 `package.json` 仅根包一处（外加模板内分发的 `templates/.agents/skills/update-agent-infra/scripts/package.json`，与本修复无关），未包含 `dist/package.json`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

### Migration / Upgrade（重要）

`@fitlab-ai/agent-infra@0.6.2` 用户在升级到含本修复的版本之前，`ai update` 会因 `dist/package.json` 误导 resolver 而失败。建议在 Release Note 中给出明确升级路径：

- Homebrew：`brew upgrade fitlab-ai/agent-infra/agent-infra`
- npm：`npm install -g @fitlab-ai/agent-infra`

升级后 `dist/package.json` 不再存在，resolver 正确定位包根的 `templates/`。无需为旧版本提供 in-place 修补。

### 范围声明

- 不修改 `src/sync-templates.js` 的 resolver 逻辑（A 方案被否决，理由见上方）。
- 不顺手清理 `scripts/build.js` 的其它独立副作用（`defaults.json` 拷贝、`*.dockerfile` 拷贝、`cli.js` chmod）。
- 未触碰 `package.json#files` —— 通配 `dist/` 在删除 `dist/package.json` 后行为自动收敛。

---

**审查者注意事项 / Reviewer Notes:**

- 重点 1：`lib/version.ts` 的候选 URL 顺序 `[../package.json, ../../package.json]`——源码模式第一候选命中 `lib/../package.json`，编译模式第一候选指向已被移除的 `dist/package.json`（被新增测试拦截）后回落到 `dist/lib/../../package.json`，两种模式都已实测验证。
- 重点 2：新增测试只做结构性存在性断言（不绑定文案），符合 `.agents/rules/testing-discipline.md` 的「正向已覆盖时不再加反向断言」原则——这里的「不应存在 `dist/package.json`」是打包不变量，不是「记住一个已删除概念」。
- 重点 3：CI 任务工作流（analysis → plan → impl → review → refine → review-r2 → commit）的完整记录见关联 Issue #365 的同步评论；review-r2 结论为通过，0 blocker / 0 major / 0 minor。

Generated with AI assistance