### PR TITLE
fix(ci): tighten brew-smoke Pouring assertion

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -132,8 +132,8 @@ jobs:
         shell: bash
         run: |
           brew install --verbose fitlab-ai/tap/agent-infra 2>&1 | tee install.log
-          if ! grep -q "Pouring" install.log; then
-            echo "::error::agent-infra was not poured from a bottle (no 'Pouring' in output)"
+          if ! grep -q "Pouring agent-infra-" install.log; then
+            echo "::error::agent-infra was not poured from a bottle (no 'Pouring agent-infra-' in output)"
             exit 1
           fi
 

--- a/tests/core/release.test.ts
+++ b/tests/core/release.test.ts
@@ -113,6 +113,6 @@ test("post-release-smoke workflow verifies npm and brew install channels", () =>
   assert.match(workflow, /grep -q "bottle do"/);
   assert.match(workflow, /name: brew install \(must pour from bottle\)/);
   assert.match(workflow, /brew install --verbose fitlab-ai\/tap\/agent-infra/);
-  assert.match(workflow, /Pouring/);
+  assert.match(workflow, /grep -q "Pouring agent-infra-"/);
   assert.match(workflow, /agent-infra version/);
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #355

Closes #355

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`.github/workflows/post-release-smoke.yml` 的 `brew-smoke` 作业里「brew install (must pour from bottle)」步骤当前用 `grep -q "Pouring"` 判断是否走 bottle 路径。问题是该模式会命中 brew verbose 日志里**任意 formula**（`node`、`fmt`、`ada-url` 等依赖）的 `==> Pouring ...` 行；即便 `agent-infra` 本体走源码构建、只是依赖被 pour，断言仍判定通过，失去了「确认本体走 bottle」的把关作用（#355；在 `v0.6.2-alpha.1` prerelease dry-run 中观察到）。

The `brew-smoke` job's `grep -q "Pouring"` matched any formula's `==> Pouring …` line in brew's verbose log, including `agent-infra`'s dependencies. The assertion would pass even when `agent-infra` itself fell back to a source build, masking the very case #355 was meant to guard.

## 📋 主要变更 / Brief Changelog

- 把 `.github/workflows/post-release-smoke.yml:135` 的 `grep -q "Pouring"` 收紧为 `grep -q "Pouring agent-infra-"`；尾部的 `-` 顺带挡掉未来 `agent-infra-cli` / `agent-infra-mcp` 这类 sibling formula 的误命中。
- 同步把第 136 行 `::error::` 提示里引号镜像 `(no 'Pouring' in output)` 更新为 `(no 'Pouring agent-infra-' in output)`，避免排错时看到与实际 grep 不一致的字符串。
- 把 `tests/core/release.test.ts:116` 的结构断言从 `/Pouring/` 收紧为 `/grep -q "Pouring agent-infra-"/`，防止 YAML 回滚到弱模式时测试仍通过。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 513 用例：512 pass / 1 skipped / 0 failed。
2. `grep -n 'grep -q "Pouring agent-infra-"' .github/workflows/post-release-smoke.yml` 命中第 135 行；`grep -n "no 'Pouring agent-infra-' in output" .github/workflows/post-release-smoke.yml` 命中第 136 行。
3. `grep -n 'grep -q "Pouring agent-infra-"' tests/core/release.test.ts` 命中第 116 行；旧 `assert.match(workflow, /Pouring/)` 不再存在。
4. `grep -rn '"Pouring"' .github tests` 无输出（无残留旧模式）。
5. 本地 ad-hoc 模式验证：构造两份样本 log，仅含依赖 `Pouring fmt--12.1.0...` 的样本 `grep -q "Pouring agent-infra-"` 退出非零；含本体 `Pouring agent-infra-0.6.2...` 的样本退出零，行为符合预期。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（同步收紧了 `tests/core/release.test.ts:116` 的结构断言，覆盖 YAML 不回滚到弱模式）
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（macOS runner 上的端到端 `brew install` 留待下次正式 release 的 Post-Release Smoke 自动覆盖）

## 📸 截图 / Screenshots

不适用（CI 工作流字符串收紧）。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change（#355）
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code（本改动为字符串收紧，未引入需要额外注释的复杂逻辑）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests（联动收紧结构断言）
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（本改动无跨模块依赖）
- [x] 代码检查通过 / Lint checks pass（项目未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（无文档需要更新）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（断言收紧不改变运行时行为；仅在本体未走 bottle 的真实失败场景下会从「假通过」变为「正确失败」）

## 📋 附加信息 / Additional Notes

⚠️ 行为变化预告：本改动收紧了 `brew-smoke` 的 bottle 把关——如未来某次 release 的 Post-Release Smoke 在该步骤失败，意味着 `agent-infra` 本体确实未走 bottle（runner 上 bottle 拉取失败 / 平台 stanza 缺失 / 签名失败而回退源码构建等），而**不是断言回归**。oncall 应据此排查 release 主路径，而非反向修断言。

---

**审查者注意事项 / Reviewer Notes:**

重点关注两点：
1. `grep -q "Pouring agent-infra-"` 中尾部 `-` 的取舍——见 `plan.md §方案对比`：保留 `-` 既挡住未来 sibling formula 的误命中（防 #355 同型复发），又不绑死 `==> ` 前缀或 `.tar.gz` 后缀，保留对 brew 输出格式微调的容忍度。
2. `tests/core/release.test.ts:116` 的新断言仍为「命令字面量结构断言」，未滑向自然语言文案匹配；未引入 `doesNotMatch` 反向断言保护已删除的弱模式（符合 `.agents/rules/testing-discipline.md` §「正向已覆盖时不应再加反向断言」）。

Generated with AI assistance
