### PR TITLE
fix(cli): 修复 `ai sandbox ls` 表格列对齐问题

### DIFF
--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -9,7 +9,13 @@ import { runSafeEngine } from '../shell.ts';
 import { resolveTools, toolProjectDirCandidates } from '../tools.ts';
 
 const USAGE = 'Usage: ai sandbox ls';
-const CONTAINER_LIST_HEADER = 'NAMES\tSTATUS\tBRANCH';
+const CONTAINER_TABLE_HEADERS = ['NAMES', 'STATUS', 'BRANCH'] as const;
+
+type ContainerTableRow = {
+  name: string;
+  status: string;
+  branch: string;
+};
 
 // Exported to lock the docker/podman-compatible format in unit tests.
 export function containerListFormat(): string {
@@ -33,6 +39,22 @@ export function parseLabels(csv: string): Record<string, string> {
     labels[pair.slice(0, eq)] = pair.slice(eq + 1);
   }
   return labels;
+}
+
+export function formatContainerTable(rows: ContainerTableRow[]): string[] {
+  const columns = rows.map((row) => [row.name, row.status, row.branch] as const);
+  const widths = [
+    Math.max(CONTAINER_TABLE_HEADERS[0].length, ...rows.map((row) => row.name.length)),
+    Math.max(CONTAINER_TABLE_HEADERS[1].length, ...rows.map((row) => row.status.length)),
+    Math.max(CONTAINER_TABLE_HEADERS[2].length, ...rows.map((row) => row.branch.length))
+  ] as const;
+  const renderRow = (values: readonly [string, string, string]): string =>
+    `${values[0].padEnd(widths[0])}  ${values[1].padEnd(widths[1])}  ${values[2]}`.trimEnd();
+
+  return [
+    renderRow(CONTAINER_TABLE_HEADERS),
+    ...columns.map((column) => renderRow(column))
+  ];
 }
 
 function listChildren(dir: string): string[] {
@@ -69,11 +91,13 @@ export function ls(args: string[] = []): void {
     p.log.warn('  No sandbox containers');
   } else {
     const branchKey = sandboxBranchLabel(config);
-    process.stdout.write(`  ${CONTAINER_LIST_HEADER}\n`);
-    for (const line of containers.split('\n')) {
+    const rows = containers.split('\n').map((line) => {
       const [name = '', status = '', labelsCsv = ''] = line.split('\t');
       const branch = parseLabels(labelsCsv)[branchKey] ?? '';
-      process.stdout.write(`  ${name}\t${status}\t${branch}\n`);
+      return { name, status, branch };
+    });
+    for (const line of formatContainerTable(rows)) {
+      process.stdout.write(`  ${line}\n`);
     }
   }
 

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -5379,6 +5379,31 @@ test("sandbox ls format is engine-neutral and embeds raw Labels", async () => {
   );
 });
 
+test("sandbox ls formatContainerTable aligns header and rows by column width", async () => {
+  const { formatContainerTable } = await loadFreshEsm<typeof import("../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
+
+  const rows = [
+    { name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
+    { name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
+    { name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
+  ];
+  const lines = formatContainerTable(rows);
+  const statusColumn = lines[0].indexOf("STATUS");
+  const branchColumn = lines[0].indexOf("BRANCH");
+
+  assert.equal(lines.length, rows.length + 1);
+  assert.ok(statusColumn > 0);
+  assert.ok(branchColumn > statusColumn);
+  for (let i = 0; i < rows.length; i += 1) {
+    assert.equal(lines[i + 1].indexOf(rows[i].status), statusColumn);
+    assert.equal(lines[i + 1].indexOf(rows[i].branch), branchColumn);
+  }
+  for (const line of lines) {
+    assert.equal(line.includes("\t"), false);
+    assert.doesNotMatch(line, /\s+$/);
+  }
+});
+
 test("sandbox ls parseLabels parses docker label CSV", async () => {
   const { parseLabels } = await loadFreshEsm<typeof import("../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #327

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`ai sandbox ls` 的 Containers 表头与数据行此前都用 `\t` 作为列分隔符。终端按 8 字符 tab stop 渲染时，容器名长度跨越多个 tab stop 就会把表头 `NAMES\tSTATUS\tBRANCH` 推到列 0/8/16，而数据行（典型容器名约 18 字符）的 tab 推到列 24/32，导致「表头堆在最左、数据列错位」的视觉错乱，用户无法直观判断每个值属于哪一列（#327）。

修复思路：把展示层的 `\t` 替换为按列宽 padding 的字符串拼接。新增纯函数 `formatContainerTable(rows)`，把表头与所有数据行一起参与列宽计算，前两列 `padEnd` 到统一宽度、列间固定两个空格、最后一列 `trimEnd` 不补尾随空白。`ls()` 只负责解析 docker 输出和写 stdout，渲染逻辑下沉到纯函数后可单测。

刻意**不动**的内容：

- `containerListFormat()` 返回的 `{{.Names}}\t{{.Status}}\t{{.Labels}}`——这是与 docker/podman CLI 的占位符契约，已被 `tests/cli/sandbox.test.ts` 的格式断言锁定。
- `parseLabels()`、Worktrees 段落、tool state 段落——本任务范围之外。
- 不引入 `text-table` / `cli-table3` 等第三方依赖。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/commands/ls.ts`：删除局部常量 `CONTAINER_LIST_HEADER`；新增导出函数 `formatContainerTable(rows: ContainerTableRow[]): string[]`，用 `Math.max(headerLen, ...rowLens)` 统一三列列宽、`padEnd + 2 空格` 拼接、行尾 `trimEnd`；`ls()` 主体改为先把 docker 输出解析为 `[{name, status, branch}]`，再交给 `formatContainerTable` 渲染逐行写出。
- `tests/cli/sandbox.test.ts`：新增回归测试 `sandbox ls formatContainerTable aligns header and rows by column width`，构造 3 条名字 / 状态 / 分支长度差异化的样本，断言 `STATUS` 与 `BRANCH` 在表头与每条数据行的 `indexOf` 列起始位置完全相等、整体无 `\t`、无尾随空白。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install && npm run build`：TypeScript 编译通过。
2. `npm test`：全套 514 用例，513 passed / 1 skipped / 0 failed（含新增的列对齐回归测试）。
3. 单独跑新用例：`node --experimental-strip-types --no-warnings --test tests/cli/sandbox.test.ts --test-name-pattern "sandbox ls formatContainerTable aligns header and rows by column width"`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 真实 docker / podman 环境下的目视确认见下方「待人工验证」清单。

## 📸 截图 / Screenshots

N/A — 改动仅影响 CLI 文本输出列对齐；终端截图请见维护者本机手工验证。

## 📋 附加信息 / Additional Notes

### 待人工验证 / Pending Manual Verification

review-r2.md 中的环境性遗留（沙箱无 docker），请维护者在本机完成一次目视确认：

- [ ] 切到本分支：`git checkout agent-infra-bugfix-sandbox-ls-table-align && npm install && npm run build`
- [ ] 在已 `ai sandbox create` 过若干分支的开发机执行 `ai sandbox ls`
- [ ] 目视确认 Containers 段三列表头与每行数据列对齐、无 tab 错位
- [ ] 至少覆盖一组「容器名长度差异 ≥ 10 字符」的样本

### 范围声明 / Scope Notes

- 不修改 docker `--format` 占位符（`containerListFormat()`）
- 不修改 `parseLabels()` 或 Worktrees / tool state 段落
- 不引入新的 npm 依赖

---

**审查者注意事项 / Reviewer Notes:**

- 重点 1：`formatContainerTable` 的列宽计算在空 `rows` 时退化为 `Math.max(headerLen)`，仍正确返回表头宽度；同时 `ls()` 的 `if (!containers)` 分支已经短路了这条路径，行为兼容。
- 重点 2：新测试采用「正向不变量断言」（列起始索引相等、无 `\t`、无尾随空白），不是反向删除断言——这里锁定的是新引入的对齐契约，而非记住一个已删除概念，符合 `.agents/rules/testing-discipline.md`。
- 重点 3：完整任务工作流（analysis → plan → impl → review → refine → review-r2 → commit）的产物已同步到 Issue #327 的关联评论；review-r2 结论为通过，0 blocker / 0 major / 0 minor，仅余 1 项环境性遗留如上。

Generated with AI assistance
