### PR TITLE
refactor(templates): re-estimate priority/effort in analyze/plan

### DIFF
--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -118,6 +118,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 记录本轮分析产物：`{analysis-artifact}`（Round `{analysis-round}`）
 - 如任务模板包含 `## 分析` 段落，更新为指向 `{analysis-artifact}` 的链接
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
+- 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
+  - 用新值覆盖 frontmatter 的 `priority` 字段
+  - 在 `Requirement Analysis (Round N)` 条目之前追加一条转移记录：
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
+    ```
+  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
+  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -95,6 +95,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 记录本轮方案产物：`{plan-artifact}`（Round `{plan-round}`）
 - 如任务模板包含 `## 设计` 段落，更新为指向 `{plan-artifact}` 的链接
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
+- 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
+  - 用新值覆盖 frontmatter 的 `effort` 字段
+  - 在 `Technical Design (Round N)` 条目之前追加一条转移记录：
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
+    ```
+  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
+  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -118,6 +118,14 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Record the analysis artifact for this round: `{analysis-artifact}` (Round `{analysis-round}`)
 - If the task template contains a `## Analysis` section, update it to link to `{analysis-artifact}`
 - Mark requirement-analysis as complete in workflow progress and include the actual round when the task template supports it
+- Before appending the workflow Activity Log entry, re-estimate `priority` based on the analysis findings (business impact, risks, dependencies, blockers). If the re-estimated value differs from the current value in `task.md`:
+  - Overwrite the `priority` field in frontmatter with the new value
+  - Prepend an Activity Log entry recording the transition (placed before the `Requirement Analysis (Round N)` entry):
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {short basis grounded in this analysis})
+    ```
+  Both entries may share the same timestamp; ordering is conveyed by list position only.
+  If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -118,6 +118,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 记录本轮分析产物：`{analysis-artifact}`（Round `{analysis-round}`）
 - 如任务模板包含 `## 分析` 段落，更新为指向 `{analysis-artifact}` 的链接
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
+- 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
+  - 用新值覆盖 frontmatter 的 `priority` 字段
+  - 在 `Requirement Analysis (Round N)` 条目之前追加一条转移记录：
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
+    ```
+  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
+  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -95,6 +95,14 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Record the plan artifact for this round: `{plan-artifact}` (Round `{plan-round}`)
 - If the task template contains a `## Design` section, update it to link to `{plan-artifact}`
 - Mark technical-design as complete in workflow progress and include the actual round when the task template supports it
+- Before appending the workflow Activity Log entry, re-estimate `effort` based on the technical plan (number of implementation steps, files touched, test matrix scope, integration surface). If the re-estimated value differs from the current value in `task.md`:
+  - Overwrite the `effort` field in frontmatter with the new value
+  - Prepend an Activity Log entry recording the transition (placed before the `Technical Design (Round N)` entry):
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {short basis grounded in this plan})
+    ```
+  Both entries may share the same timestamp; ordering is conveyed by list position only.
+  If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -95,6 +95,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 记录本轮方案产物：`{plan-artifact}`（Round `{plan-round}`）
 - 如任务模板包含 `## 设计` 段落，更新为指向 `{plan-artifact}` 的链接
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
+- 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
+  - 用新值覆盖 frontmatter 的 `effort` 字段
+  - 在 `Technical Design (Round N)` 条目之前追加一条转移记录：
+    ```
+    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
+    ```
+  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
+  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/tests/templates/skills.test.ts
+++ b/tests/templates/skills.test.ts
@@ -278,3 +278,24 @@ test("import-issue checklists include the task comment sync step", () => {
     );
   });
 });
+
+test("analyze-task and plan-task docs require field re-estimation in update step", () => {
+  const targets: Array<[string, string]> = [
+    [".agents/skills/analyze-task/SKILL.md", "重估"],
+    [".agents/skills/plan-task/SKILL.md", "重估"],
+    ["templates/.agents/skills/analyze-task/SKILL.en.md", "re-estimate"],
+    ["templates/.agents/skills/plan-task/SKILL.en.md", "re-estimate"],
+    ["templates/.agents/skills/analyze-task/SKILL.zh-CN.md", "重估"],
+    ["templates/.agents/skills/plan-task/SKILL.zh-CN.md", "重估"]
+  ];
+
+  targets.forEach(([relativePath, reEstimateToken]) => {
+    const content = read(relativePath);
+
+    assert.match(
+      content,
+      new RegExp(escapeRegExp(reEstimateToken), "i"),
+      `${relativePath} should reference the re-estimation vocabulary token`
+    );
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #363

Closes #363

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`create-task` 阶段 AI 仅凭标题+简述推断 `priority`/`effort`，准确性有限；现有 `analyze-task` / `plan-task` / `complete-task` 都只「propagate」、不「revise」，错误初值会一路漂到 close（#363）。

参照系统内已有 label 处理规律——`status:` / `in:` 由客观锚点驱动自动覆盖、`type:` 无客观锚点故一次定型——拆分字段责任到信号源对齐的阶段：

- **`analyze-task`** 完成需求理解、风险、依赖分析后 → 重估 `priority`
- **`plan-task`** 完成实施步骤、文件清单、测试矩阵后 → 重估 `effort`

每次重估若与 `task.md` 当前值不一致，**直接覆盖 frontmatter** + **追加 Activity Log 一条 `Analysis Re-estimate` / `Plan Re-estimate` 转移条目**（含 `{old} → {new}` 与简短依据）。Activity Log 提供时间维度审计轨迹——覆盖不再静默，与 #358 single-source-of-truth 哲学并存（`task.md` 仍是唯一权威源，不引入 `priority_source` / `effort_source` 状态机字段）。

设计取舍记录（详见关联 Issue 评论中 `plan.md`）：原方向曾对齐方案 B（plan-task 写"建议"由人工拍板）。复盘时发现真正反对的是「**静默**覆盖人工修正」，而非「覆盖」本身；Activity Log 解决静默问题后，A+ 与 `status:` / `in:` 的处理模式对称，无需引入独此一份的建议层机制。

## 📋 主要变更 / Brief Changelog

- `templates/.agents/skills/analyze-task/SKILL.{en,zh-CN}.md` 与部署副本 `.agents/skills/analyze-task/SKILL.md`：在「Update Task Status」步骤内嵌 `priority` 重估子段；触发时覆盖 frontmatter 并在 `Requirement Analysis (Round N)` 主条目之前追加 `Analysis Re-estimate` Activity Log 条目；附明确说明「两条条目可共用同一时间戳，顺序仅通过列表位置表达」。
- `templates/.agents/skills/plan-task/SKILL.{en,zh-CN}.md` 与部署副本 `.agents/skills/plan-task/SKILL.md`：在「Update Task Status」步骤内嵌 `effort` 重估子段，结构与 analyze-task 对称；触发时覆盖 frontmatter 并在 `Technical Design (Round N)` 主条目之前追加 `Plan Re-estimate` Activity Log 条目。
- `tests/templates/skills.test.ts`：新增结构性测试 `analyze-task and plan-task docs require field re-estimation in update step`，断言 6 份目标文档（zh/en/部署副本各 3 份）均包含重估词汇令牌（`重估` / `re-estimate`）。仅做令牌级断言，不绑定自然语言措辞——符合 `.agents/rules/testing-discipline.md`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install && npm run build`：TypeScript 编译通过。
2. `npm test`：全套 514 用例，513 passed / 1 skipped / 0 failed（baseline 一致；新增测试在 6 份文件上均断言成功）。
3. 单独跑新用例：`node --experimental-strip-types --no-warnings --test tests/templates/skills.test.ts --test-name-pattern "analyze-task and plan-task docs require field re-estimation in update step"`。
4. 三方一致性 spot-check：`git diff` 显示 `.agents/skills/analyze-task/SKILL.md` 与 `templates/.agents/skills/analyze-task/SKILL.zh-CN.md` blob hash 完全相同（`b87c549..8904940`）；plan-task 同理（`763d1c2..ae41e09`）。中文/部署副本镜像零漂移。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 真实工作流端到端（连续两轮 analyze/plan、Re-estimate 条目首次/再次触发）的目视确认见下方「待人工验证」清单。

## 📸 截图 / Screenshots

N/A — 改动仅影响 SKILL.md 文档与一个结构性测试，无 UI 输出。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change（#363）
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（review.md / review-r2.md）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code（SKILL.md 内嵌行内说明）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks（本改动无跨模块依赖）
- [x] 代码检查通过 / Lint checks pass（项目未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（SKILL.md 即文档）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更——既有 `verify.json` 的 `expected_action_pattern` 由主工作流条目作为「最新条目」满足，Re-estimate 条目位置在主条目之前不影响该检查）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

### 待人工验证 / Pending Manual Verification

本 PR 的 review-r2 结论为 Approved（0 blocker / 0 major / 0 minor），且 sandbox 内已跑通完整任务工作流（analyze → plan → impl → review → refine → review-r2 → commit）。为防止 SKILL.md 文案在真实工作流下意外失败，建议维护者在合入前抽查：

- [ ] 跑一次 `/analyze-task` 模拟「priority 不一致」场景，观察 frontmatter 被覆盖、Activity Log 多一条 `Analysis Re-estimate` 条目（位于 `Requirement Analysis (Round N)` 之前）
- [ ] 跑一次 `/plan-task` 模拟「effort 不一致」场景，观察类似行为针对 `Plan Re-estimate`
- [ ] 跑一次「值一致」场景，确认未追加 Re-estimate 条目（条件性触发正确）
- [ ] 在 Re-estimate 触发的产物上跑 `validate-artifact gate`，确认 `expected_action_pattern` 仍由主工作流条目满足

### 范围声明 / Scope Notes

- 不修改 `create-task` SKILL（初始 AI 推断保留；推送已由 `.agents/rules/create-issue.md` 覆盖）
- 不修改 `complete-task` / `create-pr` / `implement-task` / `refine-task` / `review-task` 的字段处理
- 不引入 source 状态机字段
- 不调整既有 open issue 的字段值
- 不引入新规则文件、新 frontmatter 字段、新 verify.json 检查项

---

**审查者注意事项 / Reviewer Notes:**

- **重点 1 — Activity Log 位置约束**：Re-estimate 条目必须位于主工作流条目（`Requirement Analysis (Round N)` / `Technical Design (Round N)`）**之前**。这保证 `verify.json` 的 `expected_action_pattern: "Requirement Analysis \\(Round \\d+\\)"` / `"Technical Design \\(Round \\d+\\)"`「最新条目匹配」检查仍命中主条目，不被打破。SKILL.md 中已显式约束此位置。
- **重点 2 — 双语对齐**：中英文模板的限定条件一一对应（`business impact, risks, dependencies, blockers` ↔ `业务影响、风险、依赖、阻塞条件`；`number of implementation steps, files touched, test matrix scope, integration surface` ↔ `实施步骤数、涉及文件、测试矩阵范围、集成面`）。无单边漂移。
- **重点 3 — 测试纪律**：新测试只用词汇令牌（`重估` / `re-estimate`）作为锚点，不绑定整段措辞；这是对项目词汇的承诺，类比 `expected_action_pattern` 中的 action label 承诺。符合 `.agents/rules/testing-discipline.md` §「正向已覆盖时不应再加反向断言」。
- **重点 4 — 工作流完整记录**：本任务的 analysis → plan → impl → review → refine → review-r2 → commit 全部产物同步在关联 Issue #363 的评论中（含历史方案 B → A+ 的对齐过程），方便审阅决策路径。

Generated with AI assistance
