### PR TITLE
fix(cli): 清理 sandbox rm 遗漏的 per-branch shell 配置目录

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -17,9 +17,9 @@ import {
   sandboxBranchLabel,
   sandboxImageConfigLabel,
   sandboxLabel,
-  sanitizeBranchName,
   shareBranchDir,
   shareCommonDir,
+  shellConfigDir,
   worktreeDirCandidates
 } from '../constants.ts';
 import { prepareDockerfile } from '../dockerfile.ts';
@@ -127,7 +127,10 @@ function resolveToolDirs(config: Pick<SandboxCreateConfig, 'project'>, tools: Sa
 }
 
 export function hostShellConfigDir(home: string, project: string, branch: string): string {
-  return hostJoin(home, '.agent-infra', 'config', project, sanitizeBranchName(branch));
+  return shellConfigDir(
+    { shellConfigBase: hostJoin(home, '.agent-infra', 'config', project) },
+    branch
+  );
 }
 
 function runtimeChecks(runtimes: string[]): RuntimeCheck[] {

--- a/lib/sandbox/commands/rm.ts
+++ b/lib/sandbox/commands/rm.ts
@@ -11,6 +11,7 @@ import {
   sandboxBranchLabel,
   sandboxLabel,
   shareBranchDir,
+  shellConfigDirCandidates,
   worktreeDirCandidates
 } from '../constants.ts';
 import { ENGINES, detectEngine, engineDisplayName, isManagedEngine, stopManagedVm } from '../engine.ts';
@@ -122,6 +123,12 @@ async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string
     }
   }
 
+  for (const dir of shellConfigDirCandidates(config, effectiveBranch).filter((candidate) => fs.existsSync(candidate))) {
+    assertManagedPath(config.shellConfigBase, dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+    p.log.success(`Shell config removed: ${dir}`);
+  }
+
   const shareBranch = shareBranchDir(config, effectiveBranch);
   if (fs.existsSync(shareBranch)) {
     const shouldRemoveShare = await p.confirm({
@@ -187,6 +194,22 @@ async function rmAll(config: SandboxConfig, tools: SandboxTool[]): Promise<void>
       assertManagedPath(path.dirname(dir), dir);
       fs.rmSync(dir, { recursive: true, force: true });
       p.log.success(`Removed tool state: ${dir}`);
+    }
+  }
+
+  if (fs.existsSync(config.shellConfigBase) && fs.readdirSync(config.shellConfigBase).length > 0) {
+    const shouldRemoveShellConfigs = await p.confirm({
+      message: `Remove all shell config dirs in ${config.shellConfigBase}?`,
+      initialValue: true
+    });
+
+    if (!p.isCancel(shouldRemoveShellConfigs) && shouldRemoveShellConfigs) {
+      for (const entry of fs.readdirSync(config.shellConfigBase)) {
+        const dir = path.join(config.shellConfigBase, entry);
+        assertManagedPath(config.shellConfigBase, dir);
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+      p.log.success(`Project shell config dirs removed: ${config.shellConfigBase}`);
     }
   }
 

--- a/lib/sandbox/config.ts
+++ b/lib/sandbox/config.ts
@@ -46,6 +46,7 @@ export type SandboxConfig = {
   imageName: string;
   worktreeBase: string;
   shareBase: string;
+  shellConfigBase: string;
   dotfilesDir: string;
   engine: string | null;
   runtimes: string[];
@@ -145,6 +146,7 @@ export function loadConfig({
     imageName: `${project}-sandbox:latest`,
     worktreeBase: hostJoin(home, '.agent-infra', 'worktrees', project),
     shareBase: hostJoin(home, '.agent-infra', 'share', project),
+    shellConfigBase: hostJoin(home, '.agent-infra', 'config', project),
     dotfilesDir: hostJoin(home, '.agent-infra', 'dotfiles'),
     engine,
     runtimes,

--- a/lib/sandbox/constants.ts
+++ b/lib/sandbox/constants.ts
@@ -9,6 +9,7 @@ type SandboxPathConfig = {
   containerPrefix: string;
   worktreeBase: string;
   shareBase: string;
+  shellConfigBase: string;
 };
 
 type HostResources = {
@@ -84,6 +85,14 @@ export function shareCommonDir(config: Pick<SandboxPathConfig, 'shareBase'>): st
 
 export function shareBranchDir(config: Pick<SandboxPathConfig, 'shareBase'>, branch: string): string {
   return hostJoin(config.shareBase, 'branches', sanitizeBranchName(branch));
+}
+
+export function shellConfigDir(config: Pick<SandboxPathConfig, 'shellConfigBase'>, branch: string): string {
+  return hostJoin(config.shellConfigBase, sanitizeBranchName(branch));
+}
+
+export function shellConfigDirCandidates(config: Pick<SandboxPathConfig, 'shellConfigBase'>, branch: string): string[] {
+  return safeNameCandidates(branch).map((name) => hostJoin(config.shellConfigBase, name));
 }
 
 export function sandboxLabel(config: Pick<SandboxPathConfig, 'project'>): string {

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -394,6 +394,41 @@ test("sandbox rm defaults local branch deletion confirmation to yes", () => {
   );
 });
 
+test("sandbox rm cleans per-branch shell config dir", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-rm-shell-config-"));
+  const project = "demo";
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project });
+    const shellConfigBase = path.join(tmpDir, ".agent-infra", "config", project);
+    const removedBranchDir = path.join(shellConfigBase, "feature..rm-config");
+    const keptBranchDir = path.join(shellConfigBase, "feature..keep");
+    fs.mkdirSync(removedBranchDir, { recursive: true });
+    fs.mkdirSync(keptBranchDir, { recursive: true });
+    fs.writeFileSync(path.join(removedBranchDir, ".bash_aliases"), "alias demo=true\n", "utf8");
+    fs.writeFileSync(path.join(removedBranchDir, ".gitconfig"), "[user]\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "feature/rm-config"]);
+
+    assert.equal(result.signal, null);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(removedBranchDir), false);
+    assert.equal(fs.existsSync(keptBranchDir), true);
+    assert.equal(fs.existsSync(shellConfigBase), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all cleans shell config dirs through a single confirm", () => {
+  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
+
+  assert.match(
+    commandSource,
+    /config\.shellConfigBase[\s\S]*?p\.confirm\(\{[\s\S]*?config\.shellConfigBase[\s\S]*?\}\);[\s\S]*?readdirSync\(config\.shellConfigBase\)[\s\S]*?assertManagedPath\(config\.shellConfigBase, dir\);[\s\S]*?fs\.rmSync\(dir, \{ recursive: true, force: true \}\);/
+  );
+});
+
 test("sandbox create warns and continues past missing Claude credentials", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-create-no-credentials-"));
   const project = `sandbox-no-leak-${process.pid}-${Date.now()}`;
@@ -522,6 +557,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME ?? "", ".agent-infra", "worktrees", "demo"));
     assert.equal(config.shareBase, path.join(process.env.HOME ?? "", ".agent-infra", "share", "demo"));
+    assert.equal(config.shellConfigBase, path.join(process.env.HOME ?? "", ".agent-infra", "config", "demo"));
     assert.equal(config.dotfilesDir, path.join(process.env.HOME ?? "", ".agent-infra", "dotfiles"));
   } finally {
     process.chdir(previousCwd);
@@ -5165,6 +5201,17 @@ test("share helpers compose project share namespace under shareBase", async () =
     sandboxConstants.shareBranchDir(config, "feat/foo"),
     "/tmp/share/demo/branches/feat..foo"
   );
+});
+
+test("shell config helpers compose branch dirs under shellConfigBase", async () => {
+  const sandboxConstants = await loadFreshEsm<typeof import("../../lib/sandbox/constants.ts")>("lib/sandbox/constants.js");
+  const config = { shellConfigBase: "/tmp/config/demo" };
+
+  assert.equal(sandboxConstants.shellConfigDir(config, "feat/foo"), "/tmp/config/demo/feat..foo");
+  assert.deepEqual(sandboxConstants.shellConfigDirCandidates(config, "feat/foo"), [
+    "/tmp/config/demo/feat..foo",
+    "/tmp/config/demo/feat-foo"
+  ]);
 });
 
 test("resolveTaskBranch returns plain branch names unchanged", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #371

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`sandbox rm <branch>` 与 `sandbox rm --all` 此前都不会清理 per-branch shell 配置目录 `~/.agent-infra/config/<project>/<branch>/`（由 `lib/sandbox/commands/create.ts:hostShellConfigDir()` 在 sandbox 启动时创建，内含 `.bash_aliases` / `.gitconfig`）。结果：sandbox 删除流程跑完后，这些目录全部留在文件系统上，越积越多。本机 `~/.agent-infra/config/agent-infra/` 已经堆出 46 个残留子目录，同期 Docker 容器、worktree、其它工具 state 都已清空，CLI `sandbox ls` 也显示空，唯独这一类 per-branch shell 配置没人清（#371）。

修复思路：把路径派生集中到 `SandboxConfig.shellConfigBase`，在 `constants.ts` 加 `shellConfigDir` / `shellConfigDirCandidates` helper 与 `worktreeDir*` / `shareBranchDir` 对称；`create.ts:hostShellConfigDir` 改委托新 helper，消除 create / rm 间的路径漂移风险。`rmOne` 在 `toolCandidates` 段之后追加无 confirm 的 shell config 清理（与 tool state 同语义）；`rmAll` 在 `projectToolDirs` 段之后追加单 confirm 网关整批清理（与 worktree / share 段一致）。所有删除前一律 `existsSync` 守卫 + `assertManagedPath(config.shellConfigBase, dir)` 校验，绝不对 `shellConfigBase` 本身调用 `fs.rmSync`，保留 project 壳目录与同级 sandboxes / worktrees 壳。

刻意**不动**的内容：

- `hostShellConfigDir(home, project, branch)` 外部签名保持不变，`prepareHostShellConfig`（`create.ts:330`）零修改。
- `~/.agent-infra/config/<project>/`、`~/.agent-infra/sandboxes/*/<project>/`、`~/.agent-infra/worktrees/<project>/` 这些空壳目录都保留。
- 不引入新的清理子命令；本次只让 `rm` 自身向前不再产生孤儿，历史孤儿目录的清理另有专项任务（#374）。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/config.ts`：`SandboxConfig` 类型与 `loadConfig()` 派生新增 `shellConfigBase: hostJoin(home, '.agent-infra', 'config', project)`，与 `worktreeBase` / `shareBase` 同形态。
- `lib/sandbox/constants.ts`：`SandboxPathConfig` 新增 `shellConfigBase` 字段；新增 `shellConfigDir(config, branch)` / `shellConfigDirCandidates(config, branch)` helper，复用 `sanitizeBranchName` / `safeNameCandidates` 覆盖当前 `feature..x` 与 legacy `feature-x` 命名。
- `lib/sandbox/commands/create.ts`：`hostShellConfigDir` 改为内部委托 `shellConfigDir`，签名不变；同步移除文件级未再使用的 `sanitizeBranchName` import。
- `lib/sandbox/commands/rm.ts`：`rmOne` 在 tool state 段之后插入 `shellConfigDirCandidates(config, effectiveBranch)` 遍历删除（无 confirm，与 tool state 同模式）；`rmAll` 在 `projectToolDirs` 段之后插入 `readdirSync(shellConfigBase)` 遍历删除（单 `p.confirm({ initialValue: true })` 网关整批，循环只删一级子目录，绝不触碰 `shellConfigBase` 自身）。
- `tests/cli/sandbox.test.ts`：新增 4 处覆盖 —— spawnSandboxCli 集成断言单分支清理路径（兄弟分支保留 + project 壳保留）、结构正则覆盖 `rmAll` 的 `confirm + readdirSync + assertManagedPath + fs.rmSync` 序列、`loadConfig` 派生 `shellConfigBase` 路径、`shellConfigDir*` helper 单元等价（包含 legacy 命名）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install && npm run build`：TypeScript 编译通过。
2. `npm test`：全套 518 用例，517 passed / 1 skipped / 0 failed（含 4 处新增 / 调整）。
3. 单独跑新用例：`node --test tests/cli/sandbox.test.ts --test-name-pattern="shell config|rm cleans|rm --all cleans"`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 真实本机 macOS + OrbStack 环境下的目视确认见下方「待人工验证」清单。

## 📸 截图 / Screenshots

N/A — 改动仅影响 CLI 删除路径的副作用；无新增 UI 输出。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change（#371）
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（review.md / review-r2.md，两轮 Approved）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas（删除路径无新增注释，保持与 worktree / share 段一致）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks（spawnSandboxCli 通过 fake HOME + fake docker fixture 隔离）
- [x] 代码检查通过 / Lint checks pass（项目未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（无需新增文档；CLI help 文本未变化）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更：`hostShellConfigDir` 签名保持不变；新增清理路径只针对此前从未被清理的孤儿目录）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（legacy `/` → `-` 命名通过 `safeNameCandidates` / `readdirSync` 自然覆盖）

## 📋 附加信息 / Additional Notes

### 待人工验证 / Pending Manual Verification

review-r2.md 中的环境性遗留（沙箱无 macOS / OrbStack；本机也无 46 个残留目录可清）请维护者在本机完成一次目视确认：

- [ ] `ls ~/.agent-infra/config/agent-infra/ | wc -l` 期望 46（或同等数量的残留）
- [ ] `node ./dist/bin/cli.js sandbox rm --all`，在 confirm 处选 yes
- [ ] `ls ~/.agent-infra/config/agent-infra/ | wc -l` 期望 0
- [ ] `[ -d ~/.agent-infra/config/agent-infra ]` 仍真（project 壳保留）
- [ ] `[ -d ~/.agent-infra/worktrees/agent-infra ]` 仍真（worktrees 壳保留）
- [ ] `ls ~/.agent-infra/sandboxes/*/agent-infra 2>/dev/null` 空壳目录未被改动

> 提示：如果本机此刻有正在使用的活跃 sandbox，`rm --all` 会把它们一并删掉；可改为对孤儿分支逐一 `sandbox rm <branch>`，或等 #374 的 `sandbox prune` 落地后再做兜底清理。

### 范围声明 / Scope Notes

- 不修改 `hostShellConfigDir` 外部签名
- 不删除 project 壳目录（`config/<project>/`、`worktrees/<project>/`、`sandboxes/*/<project>/`）
- 不引入「只清孤儿」的新子命令；属于独立任务 #374
- 不调整 `assertManagedPath`、`sanitizeBranchName` / `safeNameCandidates` 既有契约

---

**审查者注意事项 / Reviewer Notes:**

- **重点 1 — `rmAll` 不能删 base 自身**：删除循环固定为 `for entry of readdirSync(shellConfigBase)` + `rmSync(path.join(shellConfigBase, entry))`；`assertManagedPath` 的 root 用 `config.shellConfigBase` 自身，确保 entry 无法逃逸到上层 `config/` 目录。请核对这一段（`lib/sandbox/commands/rm.ts:200-214`）。
- **重点 2 — 双语 import 顺序**：`create.ts:12-25` 与 `rm.ts:8-17` 的 `../constants.ts` 命名导入保持字母序（`sandboxLabel` → `share*` → `shell*` → `worktree*`）；refinement 已修。
- **重点 3 — 测试纪律**：新增结构断言只匹配代码符号（`config.shellConfigBase`、`p.confirm`、`readdirSync`、`assertManagedPath`、`fs.rmSync`），不绑定自然语言措辞，符合 `.agents/rules/testing-discipline.md`。
- **重点 4 — 工作流完整记录**：本任务的 analysis → plan → impl → review → refine → review-r2 → commit 全部产物已同步到关联 Issue #371 的评论中；review-r2 结论为 Approved（0 blocker / 0 major / 0 minor），仅余 1 项环境性遗留如上。

Generated with AI assistance
