### PR TITLE
feat(cli): 在 macOS Docker 沙箱中支持 AI TUI 粘贴宿主剪贴板图片

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 `ai sandbox exec` also forwards a small terminal-detection whitelist (`TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `LC_TERMINAL`, `LC_TERMINAL_VERSION`) into the container. This keeps interactive TUIs aligned with the host terminal for behaviors such as Claude Code's Shift+Enter newline support, without passing through the full host environment.
 
+On macOS, interactive `ai sandbox exec <branch>` sessions can bridge image paste into the sandbox. When you press `Ctrl+V` and the host clipboard currently holds an image, agent-infra reads the image from the host clipboard, writes a PNG under `~/.agent-infra/clipboard/`, and injects the container path as bracketed paste so Claude Code, Codex, Gemini CLI, and OpenCode can attach it. The host clipboard is only read, never rewritten. The bridge is best-effort: existing sandboxes must be rebuilt to receive the `/clipboard` mount, and if the optional pty dependency or clipboard probe is unavailable the session falls back to the normal interactive path.
+
 `ai sandbox exec` and `ai sandbox refresh` reconcile Claude Code credentials in both directions across the host credential store and every sandbox project copy under `~/.agent-infra/credentials/*`. When a long-running sandbox refreshes OAuth tokens first, the next entry or refresh command writes the freshest valid copy back to the host Keychain or `~/.claude/.credentials.json`; when the host is fresher, it updates the project copies. If every copy is stale, `ai sandbox refresh` probes `claude /status` and asks you to log in only when the probe cannot recover credentials.
 
 ### Host-sandbox file exchange
@@ -215,6 +217,8 @@ the host and the sandbox without polluting the git worktree:
   sandbox of the same project, regardless of branch.
 - `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/` -
   exclusive to the current branch sandbox.
+- `/clipboard` <- `~/.agent-infra/clipboard/` - read-only image paste bridge
+  storage on macOS.
 
 These paths are intentionally hardcoded; there is no `.airc.json` knob. Both
 host directories are created automatically on first `create`. When you

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,6 +204,8 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 `ai sandbox exec` 也会向容器透传一小组终端检测白名单变量（`TERM_PROGRAM`、`TERM_PROGRAM_VERSION`、`LC_TERMINAL`、`LC_TERMINAL_VERSION`）。这样可以让交互式 TUI 保持与宿主终端一致的行为，例如 Claude Code 的 `Shift+Enter` 换行支持，同时避免把整个宿主环境灌入容器。
 
+在 macOS 上，交互式 `ai sandbox exec <branch>` 会尽力桥接宿主图片粘贴。当你按下 `Ctrl+V` 且宿主剪贴板当前是图片时，agent-infra 会从宿主剪贴板读取图片，将 PNG 写到 `~/.agent-infra/clipboard/`，再以 bracketed paste 注入容器内路径，让 Claude Code、Codex、Gemini CLI 和 OpenCode 按图片附件处理。宿主剪贴板只读，不会被改写。该能力会自动降级：已有沙箱需要重建后才有 `/clipboard` 挂载；如果可选 pty 依赖或剪贴板探测不可用，会回退到原本的交互进入方式。
+
 `ai sandbox exec` 和 `ai sandbox refresh` 会在宿主机凭证存储与 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本之间做双向 reconcile。长时间运行的沙箱如果先刷新了 OAuth token，下一次进入或刷新命令会把最新有效副本回写到宿主 Keychain 或 `~/.claude/.credentials.json`；宿主机更新时也会继续覆盖项目副本。如果所有副本都已失效，`ai sandbox refresh` 会尝试 `claude /status` 探活，只有探活无法恢复时才提示重新登录。
 
 ### 宿主-沙箱文件交换
@@ -212,6 +214,7 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 - `/share/common` <- `~/.agent-infra/share/<project>/common/`：项目级共享，跨分支可见。
 - `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/`：分支独占。
+- `/clipboard` <- `~/.agent-infra/clipboard/`：macOS 图片粘贴桥接使用的只读存储。
 
 这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；`ai sandbox rm <branch>` 与 `ai sandbox rm --all` 删除时会附带询问是否清理（默认 yes）。
 可先用 `ai sandbox prune --dry-run` 查看旧版本或异常中断遗留的孤儿 per-branch 状态目录，再用 `ai sandbox prune` 只删除没有活跃 sandbox 容器对应的目录。

--- a/lib/sandbox/clipboard/bridge.ts
+++ b/lib/sandbox/clipboard/bridge.ts
@@ -194,23 +194,32 @@ async function runBridge({
     return exitCode(await onceExit(child, stdin));
   } finally {
     clearFlushTimer();
-    for (const token of detector.feed(inputDecoder.end())) {
-      if (token.kind === 'text') {
-        child.write(token.raw);
-      } else {
-        handleCtrlV(token, child);
+    // The child pty is already exiting here; flushing buffered input is
+    // best-effort and must never block terminal/stdin cleanup below.
+    try {
+      for (const token of detector.feed(inputDecoder.end())) {
+        if (token.kind === 'text') {
+          child.write(token.raw);
+        } else {
+          handleCtrlV(token, child);
+        }
       }
-    }
-    for (const token of detector.flush()) {
-      if (token.kind === 'text') {
-        child.write(token.raw);
+      for (const token of detector.flush()) {
+        if (token.kind === 'text') {
+          child.write(token.raw);
+        }
       }
+    } catch {
+      // Writing to an already-closed pty can throw; ignore on teardown.
     }
     stdin.off('data', onData);
     stdout.off('resize', onResize);
     process.off('SIGINT', onSigint);
     process.off('SIGTERM', onSigterm);
     stdin.setRawMode?.(false);
+    // Release stdin so the resumed TTY handle stops keeping the event loop
+    // alive; without this the CLI hangs after the sandbox exits until Ctrl+C.
+    stdin.pause?.();
     restoreTerminal();
   }
 }

--- a/lib/sandbox/clipboard/bridge.ts
+++ b/lib/sandbox/clipboard/bridge.ts
@@ -1,0 +1,261 @@
+import { once } from 'node:events';
+import { StringDecoder } from 'node:string_decoder';
+import { createClipboardAdapter, type ClipboardAdapter } from './index.ts';
+import { buildBracketedPaste, CtrlVDetector, type CtrlVMatch } from './keys.ts';
+import {
+  clipboardHostDir,
+  containerClipboardPath,
+  pngClipboardFilename,
+  pruneClipboardDir,
+  writeClipboardPngAtomic
+} from './paths.ts';
+import { commandForEngine, restoreTerminal, runInteractiveEngine, runOkEngine } from '../shell.ts';
+import { loadNodePty, type NodePty, type PtyProcess } from './node-pty.ts';
+
+type BridgeOptions = {
+  engine: string;
+  dockerArgs: string[];
+  container: string;
+  home: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platformName?: NodeJS.Platform;
+  adapter?: ClipboardAdapter | null;
+  loadPty?: () => Promise<NodePty | null>;
+  runInteractive?: typeof runInteractiveEngine;
+  runOk?: typeof runOkEngine;
+  writeStderr?: (chunk: string) => unknown;
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+  createDetector?: () => CtrlVDetector;
+};
+
+const FALLBACK_PREFIX = 'Warning: clipboard image paste bridge disabled';
+const PARTIAL_ESCAPE_FLUSH_MS = 30;
+
+export async function runInteractiveWithClipboardBridge(options: BridgeOptions): Promise<number> {
+  const {
+    engine,
+    dockerArgs,
+    container,
+    home,
+    cwd = process.cwd(),
+    env = process.env,
+    platformName = process.platform,
+    adapter = createClipboardAdapter({ platformName }),
+    loadPty = loadNodePty,
+    runInteractive = runInteractiveEngine,
+    runOk = runOkEngine,
+    writeStderr = (chunk) => process.stderr.write(chunk),
+    stdin = process.stdin,
+    stdout = process.stdout,
+    createDetector = () => new CtrlVDetector()
+  } = options;
+
+  function fallback(reason: string): number {
+    writeStderr(`${FALLBACK_PREFIX}: ${reason}\n`);
+    return runInteractive(engine, 'docker', dockerArgs);
+  }
+
+  if (platformName !== 'darwin') {
+    return runInteractive(engine, 'docker', dockerArgs);
+  }
+  if (!stdin.isTTY || !stdout.isTTY) {
+    return fallback('host stdin/stdout is not a TTY');
+  }
+  if (!adapter) {
+    return fallback('macOS clipboard adapter is unavailable');
+  }
+  const available = adapter.available();
+  if (!available.ok) {
+    return fallback(available.reason);
+  }
+  if (!runOk(engine, 'docker', ['exec', container, 'sh', '-c', '[ -d /clipboard ] && [ -r /clipboard ]'])) {
+    return fallback('container /clipboard mount is missing; rebuild the sandbox to enable image paste');
+  }
+
+  const pty = await loadPty();
+  if (!pty) {
+    return fallback('node-pty optional dependency is unavailable');
+  }
+
+  const command = commandForEngine(engine, 'docker', dockerArgs);
+  return runBridge({
+    pty,
+    command,
+    home,
+    cwd,
+    env,
+    adapter,
+    writeStderr,
+    stdin,
+    stdout,
+    detector: createDetector()
+  });
+}
+
+async function runBridge({
+  pty,
+  command,
+  home,
+  cwd,
+  env,
+  adapter,
+  writeStderr,
+  stdin,
+  stdout,
+  detector
+}: {
+  pty: NodePty;
+  command: { cmd: string; args: string[] };
+  home: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  adapter: ClipboardAdapter;
+  writeStderr: (chunk: string) => unknown;
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+  detector: CtrlVDetector;
+}): Promise<number> {
+  const child = pty.spawn(command.cmd, command.args, {
+    name: env.TERM || 'xterm-256color',
+    cols: stdout.columns || 120,
+    rows: stdout.rows || 40,
+    cwd,
+    env
+  });
+  let warnedPasteFailure = false;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  const inputDecoder = new StringDecoder('utf8');
+
+  const onData = (chunk: Buffer) => {
+    clearFlushTimer();
+    for (const token of detector.feed(inputDecoder.write(chunk))) {
+      if (token.kind === 'text') {
+        child.write(token.raw);
+      } else {
+        handleCtrlV(token, child);
+      }
+    }
+    if (detector.hasPending()) {
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        for (const token of detector.flush()) {
+          if (token.kind === 'text') {
+            child.write(token.raw);
+          } else {
+            handleCtrlV(token, child);
+          }
+        }
+      }, PARTIAL_ESCAPE_FLUSH_MS);
+    }
+  };
+  const onResize = () => child.resize(stdout.columns || 120, stdout.rows || 40);
+  const onSigint = () => child.kill('SIGINT');
+  const onSigterm = () => child.kill('SIGTERM');
+
+  function handleCtrlV(match: CtrlVMatch, target: PtyProcess): void {
+    try {
+      if (!adapter.hasImage()) {
+        target.write(match.raw);
+        return;
+      }
+
+      const png = adapter.readImagePng();
+      if (!png) {
+        throw new Error('clipboard image could not be read');
+      }
+      const filename = pngClipboardFilename(png);
+      writeClipboardPngAtomic(clipboardHostDir(home), filename, png);
+      pruneClipboardDir(clipboardHostDir(home));
+      target.write(buildBracketedPaste(containerClipboardPath(filename)));
+    } catch (error) {
+      target.write(match.raw);
+      if (!warnedPasteFailure) {
+        warnedPasteFailure = true;
+        writeStderr(`Warning: clipboard image paste failed; forwarded original Ctrl+V (${error instanceof Error ? error.message : 'unknown error'})\n`);
+      }
+    }
+  }
+
+  function clearFlushTimer(): void {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+  }
+
+  try {
+    stdin.setRawMode?.(true);
+    stdin.resume();
+    stdin.on('data', onData);
+    stdout.on('resize', onResize);
+    process.on('SIGINT', onSigint);
+    process.on('SIGTERM', onSigterm);
+    child.onData((data) => stdout.write(data));
+
+    const [event] = await onceExit(child);
+    return exitCode(event);
+  } finally {
+    clearFlushTimer();
+    for (const token of detector.feed(inputDecoder.end())) {
+      if (token.kind === 'text') {
+        child.write(token.raw);
+      } else {
+        handleCtrlV(token, child);
+      }
+    }
+    for (const token of detector.flush()) {
+      if (token.kind === 'text') {
+        child.write(token.raw);
+      }
+    }
+    stdin.off('data', onData);
+    stdout.off('resize', onResize);
+    process.off('SIGINT', onSigint);
+    process.off('SIGTERM', onSigterm);
+    stdin.setRawMode?.(false);
+    restoreTerminal();
+  }
+}
+
+async function onceExit(child: PtyProcess): Promise<[{ exitCode: number; signal?: number | string }]> {
+  const emitter = new EventTarget();
+  child.onExit((event) => emitter.dispatchEvent(new CustomEvent('exit', { detail: event })));
+  const [event] = await once(emitter, 'exit') as [CustomEvent<{ exitCode: number; signal?: number | string }>];
+  return [event.detail];
+}
+
+function exitCode(event: { exitCode: number; signal?: number | string }): number {
+  if (event.signal !== undefined && event.signal !== null) {
+    return signalExitCode(event.signal);
+  }
+  if (event.exitCode !== undefined && event.exitCode !== null) {
+    return event.exitCode;
+  }
+  return 1;
+}
+
+function signalExitCode(signal: number | string): number {
+  if (typeof signal === 'number') {
+    return 128 + signal;
+  }
+  const signals: Record<string, number> = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGQUIT: 3,
+    SIGILL: 4,
+    SIGTRAP: 5,
+    SIGABRT: 6,
+    SIGBUS: 7,
+    SIGFPE: 8,
+    SIGKILL: 9,
+    SIGUSR1: 10,
+    SIGSEGV: 11,
+    SIGUSR2: 12,
+    SIGPIPE: 13,
+    SIGALRM: 14,
+    SIGTERM: 15
+  };
+  return 128 + (signals[signal] ?? 0);
+}

--- a/lib/sandbox/clipboard/bridge.ts
+++ b/lib/sandbox/clipboard/bridge.ts
@@ -1,4 +1,3 @@
-import { once } from 'node:events';
 import { StringDecoder } from 'node:string_decoder';
 import { createClipboardAdapter, type ClipboardAdapter } from './index.ts';
 import { buildBracketedPaste, CtrlVDetector, type CtrlVMatch } from './keys.ts';
@@ -80,12 +79,23 @@ export async function runInteractiveWithClipboardBridge(options: BridgeOptions):
   }
 
   const command = commandForEngine(engine, 'docker', dockerArgs);
+  let child: PtyProcess;
+  try {
+    child = pty.spawn(command.cmd, command.args, {
+      name: env.TERM || 'xterm-256color',
+      cols: stdout.columns || 120,
+      rows: stdout.rows || 40,
+      cwd,
+      env
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    return fallback(`node-pty spawn failed: ${message}`);
+  }
+
   return runBridge({
-    pty,
-    command,
+    child,
     home,
-    cwd,
-    env,
     adapter,
     writeStderr,
     stdin,
@@ -95,35 +105,22 @@ export async function runInteractiveWithClipboardBridge(options: BridgeOptions):
 }
 
 async function runBridge({
-  pty,
-  command,
+  child,
   home,
-  cwd,
-  env,
   adapter,
   writeStderr,
   stdin,
   stdout,
   detector
 }: {
-  pty: NodePty;
-  command: { cmd: string; args: string[] };
+  child: PtyProcess;
   home: string;
-  cwd: string;
-  env: NodeJS.ProcessEnv;
   adapter: ClipboardAdapter;
   writeStderr: (chunk: string) => unknown;
   stdin: NodeJS.ReadStream;
   stdout: NodeJS.WriteStream;
   detector: CtrlVDetector;
 }): Promise<number> {
-  const child = pty.spawn(command.cmd, command.args, {
-    name: env.TERM || 'xterm-256color',
-    cols: stdout.columns || 120,
-    rows: stdout.rows || 40,
-    cwd,
-    env
-  });
   let warnedPasteFailure = false;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   const inputDecoder = new StringDecoder('utf8');
@@ -194,8 +191,7 @@ async function runBridge({
     process.on('SIGTERM', onSigterm);
     child.onData((data) => stdout.write(data));
 
-    const [event] = await onceExit(child);
-    return exitCode(event);
+    return exitCode(await onceExit(child, stdin));
   } finally {
     clearFlushTimer();
     for (const token of detector.feed(inputDecoder.end())) {
@@ -219,11 +215,30 @@ async function runBridge({
   }
 }
 
-async function onceExit(child: PtyProcess): Promise<[{ exitCode: number; signal?: number | string }]> {
-  const emitter = new EventTarget();
-  child.onExit((event) => emitter.dispatchEvent(new CustomEvent('exit', { detail: event })));
-  const [event] = await once(emitter, 'exit') as [CustomEvent<{ exitCode: number; signal?: number | string }>];
-  return [event.detail];
+function onceExit(
+  child: PtyProcess,
+  stdin: NodeJS.ReadStream
+): Promise<{ exitCode: number; signal?: number | string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (event: { exitCode: number; signal?: number | string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      stdin.off('end', onStdinEnd);
+      stdin.off('close', onStdinEnd);
+      resolve(event);
+    };
+    const onStdinEnd = () => {
+      child.kill('SIGHUP');
+      finish({ exitCode: 0, signal: 'SIGHUP' });
+    };
+
+    child.onExit(finish);
+    stdin.once('end', onStdinEnd);
+    stdin.once('close', onStdinEnd);
+  });
 }
 
 function exitCode(event: { exitCode: number; signal?: number | string }): number {

--- a/lib/sandbox/clipboard/darwin.ts
+++ b/lib/sandbox/clipboard/darwin.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ExecFileSyncOptions } from 'node:child_process';
+
+const HAS_IMAGE_TIMEOUT_MS = 500;
+const READ_IMAGE_TIMEOUT_MS = 5_000;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+type ExecFn = (cmd: string, args: string[], options?: ExecFileSyncOptions) => Buffer | string;
+
+export type DarwinClipboardAdapter = {
+  available(): { ok: true } | { ok: false; reason: string };
+  hasImage(): boolean;
+  readImagePng(): Buffer | null;
+};
+
+export function createDarwinClipboardAdapter({
+  execFn = execFileSync,
+  mkdtempFn = fs.mkdtempSync,
+  readFileFn = fs.readFileSync,
+  rmFn = fs.rmSync
+}: {
+  execFn?: ExecFn;
+  mkdtempFn?: typeof fs.mkdtempSync;
+  readFileFn?: typeof fs.readFileSync;
+  rmFn?: typeof fs.rmSync;
+} = {}): DarwinClipboardAdapter {
+  return {
+    available() {
+      try {
+        execFn('osascript', ['-e', 'return "ok"'], { encoding: 'utf8', timeout: HAS_IMAGE_TIMEOUT_MS });
+        return { ok: true };
+      } catch {
+        return { ok: false, reason: 'macOS osascript is unavailable' };
+      }
+    },
+    hasImage() {
+      try {
+        const output = String(execFn('osascript', ['-e', 'clipboard info'], {
+          encoding: 'utf8',
+          timeout: HAS_IMAGE_TIMEOUT_MS
+        }));
+        return /\b(PNGf|TIFF|JPEG|GIFf)\b/.test(output);
+      } catch {
+        return false;
+      }
+    },
+    readImagePng() {
+      const tmpDir = mkdtempFn(path.join(os.tmpdir(), 'agent-infra-clipboard-'));
+      const outputPath = path.join(tmpDir, 'clipboard.png');
+      try {
+        try {
+          execFn('osascript', ['-e', pngWriteScript(outputPath)], {
+            encoding: 'utf8',
+            timeout: READ_IMAGE_TIMEOUT_MS
+          });
+        } catch {
+          execFn('pngpaste', [outputPath], {
+            encoding: 'utf8',
+            timeout: READ_IMAGE_TIMEOUT_MS
+          });
+        }
+        const png = Buffer.from(readFileFn(outputPath));
+        return isPng(png) ? png : null;
+      } catch {
+        return null;
+      } finally {
+        rmFn(tmpDir, { recursive: true, force: true });
+      }
+    }
+  };
+}
+
+function isPng(buffer: Buffer): boolean {
+  return buffer.length >= PNG_MAGIC.length && PNG_MAGIC.every((byte, index) => buffer[index] === byte);
+}
+
+function pngWriteScript(outputPath: string): string {
+  const escapedPath = outputPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return [
+    'set pngData to the clipboard as «class PNGf»',
+    `set outFile to POSIX file "${escapedPath}"`,
+    'set fileRef to open for access outFile with write permission',
+    'set eof fileRef to 0',
+    'write pngData to fileRef',
+    'close access fileRef'
+  ].join('\n');
+}

--- a/lib/sandbox/clipboard/index.ts
+++ b/lib/sandbox/clipboard/index.ts
@@ -1,0 +1,13 @@
+import { platform } from 'node:os';
+import { createDarwinClipboardAdapter, type DarwinClipboardAdapter } from './darwin.ts';
+
+export type ClipboardAdapter = DarwinClipboardAdapter;
+
+export function createClipboardAdapter({
+  platformName = platform()
+}: { platformName?: NodeJS.Platform } = {}): ClipboardAdapter | null {
+  if (platformName !== 'darwin') {
+    return null;
+  }
+  return createDarwinClipboardAdapter();
+}

--- a/lib/sandbox/clipboard/keys.ts
+++ b/lib/sandbox/clipboard/keys.ts
@@ -1,0 +1,78 @@
+export type CtrlVMatch = {
+  kind: 'ctrl-v';
+  raw: string;
+  label: string;
+};
+
+export type KeyToken =
+  | { kind: 'text'; raw: string }
+  | CtrlVMatch;
+
+const CTRL_V_SEQUENCES = [
+  { raw: '\x16', label: 'ctrl-v 0x16' },
+  { raw: '\x1b[118;5u', label: 'ctrl-v csi-u ESC[118;5u' },
+  { raw: '\x1b[27;5;118~', label: 'ctrl-v modifyOtherKeys ESC[27;5;118~' }
+];
+
+export class CtrlVDetector {
+  #pending = '';
+
+  hasPending(): boolean {
+    return this.#pending.length > 0;
+  }
+
+  feed(raw: string): KeyToken[] {
+    let input = this.#pending + raw;
+    this.#pending = '';
+    const tokens: KeyToken[] = [];
+
+    while (input.length > 0) {
+      const match = CTRL_V_SEQUENCES.find((sequence) => input.startsWith(sequence.raw));
+      if (match) {
+        tokens.push({ kind: 'ctrl-v', raw: match.raw, label: match.label });
+        input = input.slice(match.raw.length);
+        continue;
+      }
+
+      const partial = CTRL_V_SEQUENCES.some((sequence) =>
+        sequence.raw.startsWith(input) && input.length < sequence.raw.length
+      );
+      if (partial) {
+        this.#pending = input;
+        break;
+      }
+
+      const first = input.slice(0, 1);
+      tokens.push({ kind: 'text', raw: first });
+      input = input.slice(first.length);
+    }
+
+    return coalesceText(tokens);
+  }
+
+  flush(): KeyToken[] {
+    if (!this.#pending) {
+      return [];
+    }
+    const raw = this.#pending;
+    this.#pending = '';
+    return [{ kind: 'text', raw }];
+  }
+}
+
+function coalesceText(tokens: KeyToken[]): KeyToken[] {
+  const result: KeyToken[] = [];
+  for (const token of tokens) {
+    const previous = result.at(-1);
+    if (token.kind === 'text' && previous?.kind === 'text') {
+      previous.raw += token.raw;
+    } else {
+      result.push(token);
+    }
+  }
+  return result;
+}
+
+export function buildBracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}

--- a/lib/sandbox/clipboard/node-pty.d.ts
+++ b/lib/sandbox/clipboard/node-pty.d.ts
@@ -1,0 +1,19 @@
+declare module '@lydell/node-pty' {
+  export function spawn(
+    file: string,
+    args: string[],
+    options: {
+      name: string;
+      cols: number;
+      rows: number;
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+    }
+  ): {
+    onData(callback: (data: string) => void): void;
+    onExit(callback: (event: { exitCode: number; signal?: number | string }) => void): void;
+    write(data: string): void;
+    resize(cols: number, rows: number): void;
+    kill(signal?: string): void;
+  };
+}

--- a/lib/sandbox/clipboard/node-pty.ts
+++ b/lib/sandbox/clipboard/node-pty.ts
@@ -1,0 +1,34 @@
+import { createRequire } from 'node:module';
+
+export type PtyProcess = {
+  onData(callback: (data: string) => void): void;
+  onExit(callback: (event: { exitCode: number; signal?: number | string }) => void): void;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+};
+
+export type NodePty = {
+  spawn(
+    file: string,
+    args: string[],
+    options: {
+      name: string;
+      cols: number;
+      rows: number;
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+    }
+  ): PtyProcess;
+};
+
+export async function loadNodePty(): Promise<NodePty | null> {
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require('@lydell/node-pty') as NodePty | { default?: NodePty };
+    const maybeDefault = mod as { default?: NodePty };
+    return maybeDefault.default ?? (mod as NodePty);
+  } catch {
+    return null;
+  }
+}

--- a/lib/sandbox/clipboard/paths.ts
+++ b/lib/sandbox/clipboard/paths.ts
@@ -1,0 +1,71 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { hostJoin } from '../engines/wsl2-paths.ts';
+
+export const CONTAINER_CLIPBOARD_MOUNT = '/clipboard';
+const DEFAULT_KEEP = 20;
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export function clipboardHostDir(home: string): string {
+  return hostJoin(home, '.agent-infra', 'clipboard');
+}
+
+export function containerClipboardPath(filename: string): string {
+  return path.posix.join(CONTAINER_CLIPBOARD_MOUNT, filename);
+}
+
+export function pngClipboardFilename(buffer: Buffer): string {
+  return `${crypto.createHash('sha256').update(buffer).digest('hex').slice(0, 16)}.png`;
+}
+
+export function writeClipboardPngAtomic(dir: string, filename: string, buffer: Buffer): string {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Best effort: existing directories may live on filesystems that ignore chmod.
+  }
+
+  const target = path.join(dir, filename);
+  const tmp = path.join(dir, `.${filename}.${process.pid}.tmp`);
+  fs.writeFileSync(tmp, buffer);
+  fs.renameSync(tmp, target);
+  return target;
+}
+
+export function pruneClipboardDir(
+  dir: string,
+  { keep = DEFAULT_KEEP, maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now() }:
+  { keep?: number; maxAgeMs?: number; now?: number } = {}
+): string[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir)
+    .filter((name) => name.endsWith('.png'))
+    .map((name) => {
+      const fullPath = path.join(dir, name);
+      const stat = fs.statSync(fullPath);
+      return { fullPath, mtimeMs: stat.mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const keepSet = new Set(entries.slice(0, keep).map((entry) => entry.fullPath));
+  const removed: string[] = [];
+
+  for (const entry of entries) {
+    if (keepSet.has(entry.fullPath) && now - entry.mtimeMs <= maxAgeMs) {
+      continue;
+    }
+    try {
+      fs.rmSync(entry.fullPath, { force: true });
+      removed.push(entry.fullPath);
+    } catch {
+      // Cleanup is opportunistic; a failed prune should not break paste.
+    }
+  }
+
+  return removed;
+}

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -39,6 +39,7 @@ import { resolveTaskBranch } from '../task-resolver.ts';
 import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../tools.ts';
 import type { SandboxTool } from '../tools.ts';
 import { hostJoin, toEnginePath, volumeArg } from '../engines/wsl2-paths.ts';
+import { clipboardHostDir, CONTAINER_CLIPBOARD_MOUNT } from '../clipboard/paths.ts';
 import { validateSelinuxDisableEnv } from '../engines/selinux.ts';
 import { resolveBuildUid } from '../engines/native.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
@@ -131,6 +132,13 @@ export function hostShellConfigDir(home: string, project: string, branch: string
     { shellConfigBase: hostJoin(home, '.agent-infra', 'config', project) },
     branch
   );
+}
+
+export function buildClipboardVolumeArgs(engine: string, home: string): string[] {
+  return [
+    '-v',
+    volumeArg(engine, clipboardHostDir(home), CONTAINER_CLIPBOARD_MOUNT, ':ro')
+  ];
 }
 
 function runtimeChecks(runtimes: string[]): RuntimeCheck[] {
@@ -1347,6 +1355,7 @@ export async function create(args: string[]): Promise<void> {
             fs.mkdirSync(workspaceDir, { recursive: true });
             fs.mkdirSync(shareCommon, { recursive: true });
             fs.mkdirSync(shareBranch, { recursive: true });
+            fs.mkdirSync(clipboardHostDir(effectiveConfig.home), { recursive: true, mode: 0o700 });
 
             const dotfilesSnapshot = materializeDotfiles(
               effectiveConfig.dotfilesDir,
@@ -1375,6 +1384,7 @@ export async function create(args: string[]): Promise<void> {
               volumeArg(engine, shareCommon, '/share/common'),
               '-v',
               volumeArg(engine, shareBranch, '/share/branch'),
+              ...buildClipboardVolumeArgs(engine, effectiveConfig.home),
               '-v',
               volumeArg(
                 engine,

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -11,6 +11,7 @@ import {
 import { runInteractiveEngine, runSafeEngine } from '../shell.ts';
 import { resolveTaskBranch } from '../task-resolver.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
+import { runInteractiveWithClipboardBridge } from '../clipboard/bridge.ts';
 
 const USAGE = `Usage: ai sandbox exec <branch> [cmd...]`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
@@ -65,7 +66,7 @@ export function formatCredentialSyncStatus(
   return null;
 }
 
-export function enter(args: string[]): number {
+export async function enter(args: string[]): Promise<number> {
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(`${USAGE}\n`);
     if (args.length === 0) {
@@ -108,7 +109,12 @@ export function enter(args: string[]): number {
       process.stderr.write(`Warning: dotfiles snapshot rebuild failed: ${redactCommandError(error instanceof Error ? error.message : 'unknown error')}\n`);
     }
 
-    return runInteractiveEngine(engine, 'docker', ['exec', '-it', ...envFlags, container, 'bash', TMUX_ENTRY_PATH]);
+    return runInteractiveWithClipboardBridge({
+      engine,
+      dockerArgs: ['exec', '-it', ...envFlags, container, 'bash', TMUX_ENTRY_PATH],
+      container,
+      home: config.home
+    });
   }
 
   return runInteractiveEngine(engine, 'docker', ['exec', '-it', ...envFlags, container, ...cmd]);

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -34,7 +34,7 @@ export async function runSandbox(args: string[]): Promise<void> {
     }
     case 'exec': {
       const { enter } = await import('./commands/enter.ts');
-      const exitCode = enter(rest);
+      const exitCode = await enter(rest);
       if (typeof exitCode === 'number' && exitCode !== 0) {
         process.exitCode = exitCode;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.4.0",
+        "@lydell/node-pty": "1.2.0-beta.12",
         "cross-spawn": "^7.0.6",
         "picocolors": "1.1.1",
         "semver": "^7.8.1",
@@ -27,6 +28,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@lydell/node-pty": "^1.2.0-beta.12"
       }
     },
     "node_modules/@clack/core": {
@@ -56,6 +60,99 @@
       "engines": {
         "node": ">= 20.12.0"
       }
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-arm64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.4.0",
-        "@lydell/node-pty": "1.2.0-beta.12",
         "cross-spawn": "^7.0.6",
         "picocolors": "1.1.1",
         "semver": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "@types/node": "^25.9.1",
     "@types/semver": "^7.7.1",
     "typescript": "~6.0"
+  },
+  "optionalDependencies": {
+    "@lydell/node-pty": "^1.2.0-beta.12"
   }
 }

--- a/tests/cli/sandbox-clipboard.test.ts
+++ b/tests/cli/sandbox-clipboard.test.ts
@@ -182,6 +182,53 @@ test("clipboard bridge falls back when optional node-pty is unavailable", async 
   assert.deepEqual(calls, [["docker", "exec", "-it", "demo", "bash"]]);
 });
 
+test("clipboard bridge falls back when node-pty spawn fails", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & { isTTY: boolean };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+  };
+  const calls: string[][] = [];
+  const stderr: string[] = [];
+
+  stdin.isTTY = true;
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+
+  const exitCode = await runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        throw new Error("cwd missing");
+      }
+    }),
+    runInteractive(_engine, cmd, args) {
+      calls.push([cmd, ...args]);
+      return 11;
+    },
+    writeStderr: (chunk) => stderr.push(chunk)
+  });
+
+  assert.equal(exitCode, 11);
+  assert.deepEqual(calls, [["docker", "exec", "-it", "demo", "bash"]]);
+  assert.match(stderr.join(""), /node-pty spawn failed: cwd missing/);
+});
+
 test("clipboard bridge injects bracketed paste for image Ctrl+V", async () => {
   const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-bridge-home-"));
@@ -484,6 +531,65 @@ test("clipboard bridge returns signal exit codes before numeric exitCode", async
   exitHandler?.({ exitCode: 0, signal: "SIGTERM" });
 
   assert.equal(await promise, 143);
+});
+
+test("clipboard bridge ends and restores terminal when stdin closes before pty onExit", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const rawModes: boolean[] = [];
+  const killSignals: Array<string | undefined> = [];
+
+  stdin.isTTY = true;
+  stdin.setRawMode = (value) => { rawModes.push(value); };
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit() {},
+          write() {},
+          resize() {},
+          kill(signal) { killSignals.push(signal); }
+        };
+      }
+    })
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  stdin.emit("close");
+
+  assert.equal(await promise, 129);
+  assert.deepEqual(killSignals, ["SIGHUP"]);
+  assert.deepEqual(rawModes, [true, false]);
 });
 
 test("clipboard bridge forwards original Ctrl+V sequence when image handling fails", async () => {

--- a/tests/cli/sandbox-clipboard.test.ts
+++ b/tests/cli/sandbox-clipboard.test.ts
@@ -654,3 +654,66 @@ test("clipboard bridge forwards original Ctrl+V sequence when image handling fai
   assert.equal(stderr.length, 1);
   assert.match(stderr[0] ?? "", /probe failed/);
 });
+
+test("clipboard bridge pauses stdin on exit so the host process can exit", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+    pause(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const lifecycle: string[] = [];
+  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => { lifecycle.push("resume"); };
+  stdin.pause = () => { lifecycle.push("pause"); };
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    writeStderr: () => {},
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write() {},
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  exitHandler?.({ exitCode: 0 });
+
+  assert.equal(await promise, 0);
+  // stdin must be paused on teardown, after it was resumed, so the resumed TTY
+  // handle stops keeping the event loop alive (otherwise the CLI hangs on exit).
+  assert.deepEqual(lifecycle, ["resume", "pause"]);
+});

--- a/tests/cli/sandbox-clipboard.test.ts
+++ b/tests/cli/sandbox-clipboard.test.ts
@@ -1,0 +1,550 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+
+import { loadFreshEsm } from "../helpers.ts";
+
+type KeysModule = typeof import("../../lib/sandbox/clipboard/keys.ts");
+type PathsModule = typeof import("../../lib/sandbox/clipboard/paths.ts");
+type DarwinModule = typeof import("../../lib/sandbox/clipboard/darwin.ts");
+type BridgeModule = typeof import("../../lib/sandbox/clipboard/bridge.ts");
+
+test("CtrlVDetector recognizes plain, CSI-u, and modifyOtherKeys Ctrl+V sequences", async () => {
+  const { CtrlVDetector } = await loadFreshEsm<KeysModule>("lib/sandbox/clipboard/keys.js");
+  const detector = new CtrlVDetector();
+
+  const tokens = [
+    ...detector.feed("a\x16"),
+    ...detector.feed("\x1b[118;5u"),
+    ...detector.feed("\x1b[27;5;118~z")
+  ];
+
+  assert.deepEqual(tokens, [
+    { kind: "text", raw: "a" },
+    { kind: "ctrl-v", raw: "\x16", label: "ctrl-v 0x16" },
+    { kind: "ctrl-v", raw: "\x1b[118;5u", label: "ctrl-v csi-u ESC[118;5u" },
+    { kind: "ctrl-v", raw: "\x1b[27;5;118~", label: "ctrl-v modifyOtherKeys ESC[27;5;118~" },
+    { kind: "text", raw: "z" }
+  ]);
+});
+
+test("CtrlVDetector buffers partial escape sequences across chunks", async () => {
+  const { CtrlVDetector } = await loadFreshEsm<KeysModule>("lib/sandbox/clipboard/keys.js");
+  const detector = new CtrlVDetector();
+
+  assert.deepEqual(detector.feed("\x1b[27;"), []);
+  assert.deepEqual(detector.feed("5;118~"), [
+    { kind: "ctrl-v", raw: "\x1b[27;5;118~", label: "ctrl-v modifyOtherKeys ESC[27;5;118~" }
+  ]);
+});
+
+test("CtrlVDetector flushes incomplete escape sequences as text", async () => {
+  const { CtrlVDetector } = await loadFreshEsm<KeysModule>("lib/sandbox/clipboard/keys.js");
+  const detector = new CtrlVDetector();
+
+  assert.deepEqual(detector.feed("\x1b[118"), []);
+  assert.deepEqual(detector.flush(), [{ kind: "text", raw: "\x1b[118" }]);
+});
+
+test("buildBracketedPaste wraps text in paste markers", async () => {
+  const { buildBracketedPaste } = await loadFreshEsm<KeysModule>("lib/sandbox/clipboard/keys.js");
+
+  assert.equal(buildBracketedPaste("/clipboard/a.png"), "\x1b[200~/clipboard/a.png\x1b[201~");
+});
+
+test("clipboard path helpers write atomically and prune old png files", async () => {
+  const paths = await loadFreshEsm<PathsModule>("lib/sandbox/clipboard/paths.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-clipboard-"));
+
+  try {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const filename = paths.pngClipboardFilename(png);
+    const target = paths.writeClipboardPngAtomic(tmpDir, filename, png);
+
+    assert.equal(paths.containerClipboardPath(filename), `/clipboard/${filename}`);
+    assert.deepEqual(fs.readFileSync(target), png);
+
+    const now = Date.now();
+    for (let i = 0; i < 22; i += 1) {
+      const file = path.join(tmpDir, `${i}.png`);
+      fs.writeFileSync(file, "x");
+      fs.utimesSync(file, new Date(now - i * 1000), new Date(now - i * 1000));
+    }
+
+    const removed = paths.pruneClipboardDir(tmpDir, { keep: 20, maxAgeMs: 24 * 60 * 60 * 1000, now });
+
+    assert.equal(removed.length, 3);
+    assert.equal(fs.readdirSync(tmpDir).filter((name) => name.endsWith(".png")).length, 20);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("darwin clipboard adapter reads PNG through a temporary file", async () => {
+  const { createDarwinClipboardAdapter } = await loadFreshEsm<DarwinModule>("lib/sandbox/clipboard/darwin.js");
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const execCalls: Array<{ cmd: string; args: string[]; timeout?: number }> = [];
+
+  const adapter = createDarwinClipboardAdapter({
+    execFn(cmd, args, options) {
+      execCalls.push({ cmd, args, timeout: options?.timeout });
+      if (args[1] === "clipboard info") {
+        return "«class PNGf»";
+      }
+      const script = String(args[1]);
+      const match = script.match(/POSIX file "([^"]+)"/);
+      if (match?.[1]) {
+        fs.writeFileSync(match[1], png);
+      }
+      return "";
+    }
+  });
+
+  assert.deepEqual(adapter.available(), { ok: true });
+  assert.equal(adapter.hasImage(), true);
+  assert.deepEqual(adapter.readImagePng(), png);
+  assert.equal(execCalls.every((call) => typeof call.timeout === "number"), true);
+});
+
+test("darwin clipboard adapter rejects empty or invalid PNG output", async () => {
+  const { createDarwinClipboardAdapter } = await loadFreshEsm<DarwinModule>("lib/sandbox/clipboard/darwin.js");
+
+  const adapter = createDarwinClipboardAdapter({
+    execFn(cmd, args) {
+      if (args[1] === "clipboard info" || cmd === "osascript") {
+        return "";
+      }
+      return "";
+    },
+    readFileFn() {
+      return Buffer.from("not a png", "utf8");
+    }
+  });
+
+  assert.equal(adapter.readImagePng(), null);
+});
+
+test("clipboard bridge falls back on non-darwin platforms", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const calls: string[][] = [];
+
+  const exitCode = await runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "linux",
+    runInteractive(_engine, cmd, args) {
+      calls.push([cmd, ...args]);
+      return 7;
+    }
+  });
+
+  assert.equal(exitCode, 7);
+  assert.deepEqual(calls, [["docker", "exec", "-it", "demo", "bash"]]);
+});
+
+test("clipboard bridge falls back when optional node-pty is unavailable", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & { isTTY: boolean };
+  const stdout = new EventEmitter() as EventEmitter & { isTTY: boolean };
+  const calls: string[][] = [];
+
+  stdin.isTTY = true;
+  stdout.isTTY = true;
+
+  const exitCode = await runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => null,
+    runInteractive(_engine, cmd, args) {
+      calls.push([cmd, ...args]);
+      return 9;
+    },
+    writeStderr: () => {}
+  });
+
+  assert.equal(exitCode, 9);
+  assert.deepEqual(calls, [["docker", "exec", "-it", "demo", "bash"]]);
+});
+
+test("clipboard bridge injects bracketed paste for image Ctrl+V", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-bridge-home-"));
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const writes: string[] = [];
+  const rawModes: boolean[] = [];
+  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = (value) => { rawModes.push(value); };
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  try {
+    const promise = runInteractiveWithClipboardBridge({
+      engine: "native",
+      dockerArgs: ["exec", "-it", "demo", "bash"],
+      container: "demo",
+      home: tmpDir,
+      platformName: "darwin",
+      stdin: stdin as never,
+      stdout: stdout as never,
+      adapter: {
+        available: () => ({ ok: true }),
+        hasImage: () => true,
+        readImagePng: () => Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      },
+      runOk: () => true,
+      loadPty: async () => ({
+        spawn() {
+          return {
+            onData() {},
+            onExit(callback) { exitHandler = callback; },
+            write(data) { writes.push(data); },
+            resize() {},
+            kill() {}
+          };
+        }
+      })
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    stdin.emit("data", Buffer.from("\x1b[27;5;118~", "binary"));
+    exitHandler?.({ exitCode: 0 });
+
+    assert.equal(await promise, 0);
+    assert.equal(writes.length, 1);
+    assert.match(writes[0] ?? "", /^\x1b\[200~\/clipboard\/[a-f0-9]{16}\.png\x1b\[201~$/);
+    assert.deepEqual(rawModes, [true, false]);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("clipboard bridge flushes a standalone ESC after the partial-sequence delay", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const writes: string[] = [];
+  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write(data) { writes.push(data); },
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  stdin.emit("data", Buffer.from("\x1b", "utf8"));
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  exitHandler?.({ exitCode: 0 });
+
+  assert.equal(await promise, 0);
+  assert.deepEqual(writes, ["\x1b"]);
+});
+
+test("clipboard bridge preserves UTF-8 input bytes for normal text", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const writes: string[] = [];
+  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write(data) { writes.push(data); },
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  const input = Buffer.from("中文😊", "utf8");
+  await new Promise((resolve) => setImmediate(resolve));
+  stdin.emit("data", input);
+  exitHandler?.({ exitCode: 0 });
+
+  assert.equal(await promise, 0);
+  assert.deepEqual(Buffer.from(writes.join(""), "utf8"), input);
+});
+
+test("clipboard bridge preserves UTF-8 input split across chunks", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const writes: string[] = [];
+  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write(data) { writes.push(data); },
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  const input = Buffer.from("文", "utf8");
+  await new Promise((resolve) => setImmediate(resolve));
+  stdin.emit("data", input.subarray(0, 1));
+  stdin.emit("data", input.subarray(1));
+  exitHandler?.({ exitCode: 0 });
+
+  assert.equal(await promise, 0);
+  assert.deepEqual(Buffer.from(writes.join(""), "utf8"), input);
+});
+
+test("clipboard bridge returns signal exit codes before numeric exitCode", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => false,
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write() {},
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  exitHandler?.({ exitCode: 0, signal: "SIGTERM" });
+
+  assert.equal(await promise, 143);
+});
+
+test("clipboard bridge forwards original Ctrl+V sequence when image handling fails", async () => {
+  const { runInteractiveWithClipboardBridge } = await loadFreshEsm<BridgeModule>("lib/sandbox/clipboard/bridge.js");
+  const stdin = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode(value: boolean): void;
+    resume(): void;
+  };
+  const stdout = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    columns: number;
+    rows: number;
+    write(chunk: string): void;
+  };
+  const writes: string[] = [];
+  const stderr: string[] = [];
+  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.resume = () => {};
+  stdout.isTTY = true;
+  stdout.columns = 100;
+  stdout.rows = 30;
+  stdout.write = () => {};
+
+  const promise = runInteractiveWithClipboardBridge({
+    engine: "native",
+    dockerArgs: ["exec", "-it", "demo", "bash"],
+    container: "demo",
+    home: "/tmp/home",
+    platformName: "darwin",
+    stdin: stdin as never,
+    stdout: stdout as never,
+    adapter: {
+      available: () => ({ ok: true }),
+      hasImage: () => { throw new Error("probe failed"); },
+      readImagePng: () => null
+    },
+    runOk: () => true,
+    writeStderr: (chunk) => stderr.push(chunk),
+    loadPty: async () => ({
+      spawn() {
+        return {
+          onData() {},
+          onExit(callback) { exitHandler = callback; },
+          write(data) { writes.push(data); },
+          resize() {},
+          kill() {}
+        };
+      }
+    })
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  stdin.emit("data", Buffer.from("\x1b[27;5;118~", "binary"));
+  exitHandler?.({ exitCode: 0 });
+
+  assert.equal(await promise, 0);
+  assert.deepEqual(writes, ["\x1b[27;5;118~"]);
+  assert.equal(stderr.length, 1);
+  assert.match(stderr[0] ?? "", /probe failed/);
+});

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -83,6 +83,7 @@ type SandboxCreateModule = {
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;
   ensureShellConfigSymlinks(engine: string, container: string, execFn?: EngineExecFn): void;
   ensureSandboxAliasesFile(home: string): { created: boolean; path: string };
+  buildClipboardVolumeArgs(engine: string, home: string): string[];
   prepareHostShellConfig(config: Record<string, unknown>): {
     hostDir: string;
     mounts: Array<{ hostPath: string; containerPath: string; options?: string }>;
@@ -1792,6 +1793,20 @@ test("sandbox create resolves to configured engine", onPlatforms("linux", "darwi
     assert.ok(
       fixture.readDockerCalls().some((call) => call[0] === "build"),
       "expected sandbox create to reach docker build through the configured native engine"
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox create builds clipboard mount as read-only container path", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-create-clipboard-"));
+
+  try {
+    assert.deepEqual(
+      sandboxCreate.buildClipboardVolumeArgs("native", tmpDir),
+      ["-v", path.join(tmpDir, ".agent-infra", "clipboard") + ":/clipboard:ro"]
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #381

Closes #381

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

在 macOS Docker 沙箱中，让容器内运行的 4 个 AI TUI（claude-code / codex / opencode / gemini-cli）能用 **Ctrl+V** 粘贴宿主剪贴板里的图片——此前因容器与宿主剪贴板隔离而无法实现。

采用「**架构 A — 宿主侧 PTY 中继**」：复制时零动作；仅当用户在沙箱里按下 **Ctrl+V** 且宿主剪贴板确为图片时，宿主侧（node-pty 中继）才读图转 PNG 落 `~/.agent-infra/clipboard/<hash>.png`，并以 bracketed paste 把容器视角路径注入 TUI；**全程只读宿主剪贴板、绝不改写**。不修改任何 TUI 源码。

## 📋 主要变更 / Brief Changelog

- 新增 `lib/sandbox/clipboard/`：跨平台 adapter 接口（首版仅 darwin 实现）、Ctrl+V 序列识别状态机（`0x16` / CSI-u / modifyOtherKeys）、`/clipboard` 路径与 PNG 哈希命名 + 原子写 + 清理、宿主 PTY 中继 bridge。
- `enter.ts`：交互式 `sandbox exec` 改走 clipboard bridge（带命令的 exec 保持原路径）。
- `create.ts`：创建 `~/.agent-infra/clipboard` 并只读挂载到容器 `/clipboard`。
- `package.json`：以 **`optionalDependencies`** 接入 `@lydell/node-pty`（动态加载 + 本地最小类型；安装失败/缺预编译时整包仍可用，仅图片粘贴回退）。
- 文档（README / README.zh-CN）补充该能力与 `/clipboard` 共享目录说明。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 完整套件 553 通过 / 1 skipped / 0 失败。
2. `node --experimental-strip-types --no-warnings --test tests/cli/sandbox-clipboard.test.ts` —— clipboard 套件 17/17 通过（含 keys 状态机、ESC flush、UTF-8 含跨 chunk、PNG magic 校验、bridge 四门槛/回退/失败不吞键、spawn 回退、stdin-EOF 兜底）。
3. **macOS 真机端到端**（CI 无法覆盖，见下「待人工验证」）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（macOS 端到端待维护者验证，见下）

## ⚠️ 待人工验证 / Manual verification required (env-blocked)

> 以下为 AI 在 linux / 非 TTY / 无 docker·osascript 环境**无法闭环**的项，需在 **macOS** 真机验证。注意：ESC flush、UTF-8、`onceExit`、`spawn` 等修复均在上次手测之后落地，**建议合入前重跑**。

1. **端到端 4 TUI 贴图**：复制一张图 → `ai sandbox exec <branch>` → 按 **Ctrl+V** → 确认 claude-code / codex / opencode / gemini-cli 均作为图片附件接收，且生成 `~/.agent-infra/clipboard/<hash>.png`。
2. **ESC 即时响应**：单按 ESC 应立即生效（Claude Code 中断 / vim 退出插入模式），不需再按一个键。
3. **多字节无乱码**：输入中文 / emoji，显示正常无乱码。
4. **resize**：交互中改终端窗口大小，TUI 布局正确跟随。
5. **退出码 / 终端恢复**：正常退出、Ctrl+C、关闭终端（stdin EOF 兜底）三种情况都能干净结束、退出码合理、终端不卡在 raw 模式。
6. **降级**：旧沙箱（无 `/clipboard` 挂载）进入时提示重建并正常裸交互；非 macOS 平台行为零变化。

## 📋 附加信息 / Additional Notes

**范围 / Scope（首版仅 macOS）：**
- 本版图片粘贴桥接 **仅 darwin 启用**；**Linux / Windows 不启用**，进沙箱时走与本功能上线前完全一致的裸 `docker exec -it` 交互路径（零行为变化、零副作用）。

**后续优化 / Follow-ups（不阻断本 PR）：**
- Linux（`xclip`/`wl-paste`）与 Windows（PowerShell / ConPTY）adapter 留待后续轮次。
- Ctrl+V 读图链路的同步 shell-out 异步化（仅在带图粘贴瞬间、有超时上限；若实测卡顿明显再做）。

**审查轨迹：** 经 4 轮代码审查收敛（R1 需要修改 → R4 通过、0/0/0），详见 Issue #381 评论中的 review-r1~r4 与 refinement-r1~r3。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `lib/sandbox/clipboard/bridge.ts` 的 raw stdin 中继、终端恢复、退出码透传与失败回退语义。
- `@lydell/node-pty` 作为 optional dependency 在发布安装矩阵（darwin arm64/x64）中的行为。
- 本 PR 引入项目首个原生依赖（optional），合入前请确认 CI 安装矩阵无碍。

---

Generated with AI assistance
