### PR TITLE
refactor(core): convert airc.test.ts to table-driven

### DIFF
--- a/tests/core/airc.test.ts
+++ b/tests/core/airc.test.ts
@@ -3,49 +3,19 @@ import assert from "node:assert/strict";
 
 import { read } from "../helpers.ts";
 
-test(".agents/.airc.json does not declare templateSource", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
+const collaborator = JSON.parse(read(".agents/.airc.json"));
+const merged = collaborator.files.merged;
+const managed = collaborator.files.managed;
 
+test(".agents/.airc.json does not declare templateSource", () => {
   assert.ok(!("templateSource" in collaborator));
 });
 
-test(".agents/.airc.json merged patterns use recursive command globs and explicit skill paths", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
-  const merged = collaborator.files.merged;
-
-  [
-    ".git-hooks/pre-commit",
-    "**/test.*",
-    "**/test-integration.*",
-    "**/release.*",
-    "**/upgrade-dependency.*",
-    ".agents/skills/test/SKILL.*",
-    ".agents/skills/test-integration/SKILL.*",
-    ".agents/skills/release/SKILL.*",
-    ".agents/skills/upgrade-dependency/SKILL.*"
-  ].forEach((pattern) => {
-    assert.ok(merged.includes(pattern), `merged should include ${pattern}`);
-  });
-
-  [
-    "*/test.*",
-    "*/test-integration.*",
-    "*/release.*",
-    "*/upgrade-dependency.*"
-  ].forEach((pattern) => {
-    assert.ok(!merged.includes(pattern), `merged should not include legacy ${pattern}`);
-  });
-});
-
 test(".agents/.airc.json does not contain license field", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
-
   assert.ok(!("license" in collaborator), "license field should not exist in .agents/.airc.json");
 });
 
 test(".agents/.airc.json declares labels.in mapping for module labels", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
-
   assert.deepEqual(collaborator.labels.in, {
     cli: ["bin/", "lib/", "src/", "tests/cli/"],
     templates: ["templates/", "tests/templates/"],
@@ -55,60 +25,72 @@ test(".agents/.airc.json declares labels.in mapping for module labels", () => {
 });
 
 test(".agents/.airc.json declares default sandbox configuration", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
-
   assert.deepEqual(collaborator.sandbox, {
     engine: "orbstack",
     runtimes: ["node22"],
     tools: ["claude-code", "codex", "gemini-cli", "opencode"],
     dockerfile: null,
-    vm: {
-      cpu: null,
-      memory: null,
-      disk: null
-    }
+    vm: { cpu: null, memory: null, disk: null }
   });
 });
 
 test(".agents/.airc.json declares github as the default platform", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
-
   assert.deepEqual(collaborator.platform, { type: "github" });
 });
 
-test(".agents/.airc.json excludes deprecated codex prompt paths", () => {
-  const collaborator = JSON.parse(read(".agents/.airc.json"));
+const mergedPresent = [
+  ".git-hooks/pre-commit",
+  "**/test.*",
+  "**/test-integration.*",
+  "**/release.*",
+  "**/upgrade-dependency.*",
+  ".agents/skills/test/SKILL.*",
+  ".agents/skills/test-integration/SKILL.*",
+  ".agents/skills/release/SKILL.*",
+  ".agents/skills/upgrade-dependency/SKILL.*"
+];
 
-  assert.ok(
-    collaborator.files.managed.includes(".git-hooks/check-version-format.sh"),
-    ".git-hooks/check-version-format.sh should be in managed list"
-  );
-  assert.ok(
-    collaborator.files.managed.includes(".agents/scripts/"),
-    ".agents/scripts/ should be in managed list"
-  );
-  assert.ok(
-    collaborator.files.managed.includes(".agents/hooks/"),
-    ".agents/hooks/ should be in managed list"
-  );
-  assert.ok(
-    collaborator.files.managed.includes(".codex/hooks.json"),
-    ".codex/hooks.json should be in managed list"
-  );
-  assert.ok(
-    !collaborator.files.managed.includes(".codex/commands/"),
-    ".codex/commands/ should not be in managed list"
-  );
-  assert.ok(
-    !collaborator.files.managed.includes(".codex/scripts/"),
-    ".codex/scripts/ should not be in managed list"
-  );
-  assert.ok(
-    !collaborator.files.managed.includes(".editorconfig"),
-    ".editorconfig should not be in managed list"
-  );
-  assert.ok(
-    !collaborator.files.merged.includes(".mailmap"),
-    ".mailmap should not be in merged list"
-  );
-});
+const mergedAbsent = [
+  "*/test.*",
+  "*/test-integration.*",
+  "*/release.*",
+  "*/upgrade-dependency.*",
+  ".mailmap"
+];
+
+for (const pattern of mergedPresent) {
+  test(`.agents/.airc.json merged includes \`${pattern}\``, () => {
+    assert.ok(merged.includes(pattern));
+  });
+}
+
+for (const pattern of mergedAbsent) {
+  test(`.agents/.airc.json merged excludes \`${pattern}\``, () => {
+    assert.ok(!merged.includes(pattern));
+  });
+}
+
+const managedPresent = [
+  ".git-hooks/check-version-format.sh",
+  ".agents/scripts/",
+  ".agents/hooks/",
+  ".codex/hooks.json"
+];
+
+const managedAbsent = [
+  ".codex/commands/",
+  ".codex/scripts/",
+  ".editorconfig"
+];
+
+for (const pattern of managedPresent) {
+  test(`.agents/.airc.json managed includes \`${pattern}\``, () => {
+    assert.ok(managed.includes(pattern));
+  });
+}
+
+for (const pattern of managedAbsent) {
+  test(`.agents/.airc.json managed excludes \`${pattern}\``, () => {
+    assert.ok(!managed.includes(pattern));
+  });
+}


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #351

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

`tests/core/airc.test.ts` 此前对 `.agents/.airc.json` 的 `files.merged` / `files.managed` 字段采用「每字段一个 `test()` + 内部 `forEach` 批量 `assert.ok`」的写法（114 行，7 个 test）。同一个 `test()` 块里挂 10+ 条断言时，失败信息只能定位到「该 test 内某一条」，无法直接告诉你**哪一个 pattern** 出错。

此次重构按 Issue #351 的提议引入 table-driven：
- 把 `.airc.json` 解析提到模块顶层一次复用；
- 把批量包含/不包含 pattern 断言拆为 4 张 case 表（`mergedPresent` / `mergedAbsent` / `managedPresent` / `managedAbsent`）；
- 每条 pattern 注册一个独立 `test()`，失败时可精准定位到具体 glob。

保留 5 个结构性 deepEqual / `in` 断言为独立 test（`templateSource` / `license` / `labels.in` / `sandbox` / `platform`），不并入表中——这些断言的语义是「整体快照」，table 化反而失真。

## 📋 主要变更 / Brief Changelog

- 在 `tests/core/airc.test.ts` 顶层一次性加载 `collaborator` 并派生 `merged` / `managed`，5 个结构性 test 复用同一份只读快照，删除 `forEach` 内的重复 `JSON.parse`。
- 将 merged / managed 的批量包含/不包含断言拆为 `mergedPresent`（9 条）、`mergedAbsent`（5 条，含 `.mailmap`）、`managedPresent`（4 条）、`managedAbsent`（3 条）四张 case 表，配 `for (const pattern of ...)` 为每条 pattern 注册一个独立 `test()`。
- `.mailmap` 从原独立 test 块并入 `mergedAbsent` 末尾；test 名统一为 `merged excludes \`${pattern}\``——**不再带 `legacy` 字样**，避免把 `.mailmap` 误标为 legacy glob（采纳 codex pre-implement 反馈）。
- 测试数量由 7 升到 26（5 结构 + 9 + 5 + 4 + 3），无覆盖损失。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm install`（首次检出）
2. `node --experimental-strip-types --test tests/core/airc.test.ts` — 单文件运行：`26 tests, 26 pass, 0 fail`
3. `npm test` — 完整套件：`575 tests, 574 pass, 1 skipped, 0 fail`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（抽查若干 pattern 名独立 test 名是否如预期；`git diff -- .agents/.airc.json` 为空确认配置未被改动）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change（#351）
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards（仅 erasable TypeScript，无新依赖，全文零注释——靠变量名自承载语义）
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code（见 `.agents/workspace/active/TASK-20260526-235438/review.md`，结论 Approved / 0 blocker / 0 major / 0 minor）
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas（变更全是测试结构调整，逻辑直白；无新注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（不适用：纯配置文件结构断言）
- [x] 代码检查通过 / Lint checks pass（项目未启用 lint 工具）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（无需更新，纯测试结构调整）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（不影响运行时代码与外部行为）

## 📋 附加信息 / Additional Notes

任务工作区产物（供审查参考）：
- 需求分析：`.agents/workspace/active/TASK-20260526-235438/analysis.md`
- 技术方案：`.agents/workspace/active/TASK-20260526-235438/plan.md`
- 实现报告：`.agents/workspace/active/TASK-20260526-235438/implementation.md`
- 代码审查：`.agents/workspace/active/TASK-20260526-235438/review.md`

---

**审查者注意事项 / Reviewer Notes:**

- 重点核对 4 张 case 表的 pattern 是否完整覆盖原 21 条 includes / excludes 断言（review.md 中已附逐条对照表）
- `mergedAbsent` 把 `.mailmap` 并入到与 `*/test.*` 等 legacy glob 同一张表，是否符合预期；test 名故意去掉了 `legacy` 字样以避免对 `.mailmap` 失真，如有不同意见欢迎反馈
- 模块顶层加载 vs 每 test 内 parse 的取舍详见 `plan.md` 「方案对比」一节

Generated with AI assistance
