### PR TITLE
fix(sandbox): 进入沙箱始终复用同一个 tmux work 会话

### DIFF
--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -146,7 +146,7 @@ RUN cat > /usr/local/bin/sandbox-tmux-entry <<'SCRIPT' && chmod +x /usr/local/bi
 #!/bin/sh
 set -eu
 
-sandbox-dotfiles-link >/dev/null || true
+sandbox-dotfiles-link >/dev/null 2>&1 || true
 
 SESSION=work
 
@@ -154,20 +154,21 @@ if ! command -v tmux >/dev/null 2>&1; then
   exec bash
 fi
 
-if ! tmux has-session -t "$SESSION" 2>/dev/null; then
-  exec tmux new-session -s "$SESSION"
+# Drop stale grouped sessions left by older entry-script versions (the windows
+# live on $SESSION, so killing the group members only removes view entries).
+tmux list-sessions -F '#{session_name}' 2>/dev/null | while IFS= read -r name; do
+    case "$name" in
+      "$SESSION"-*) tmux kill-session -t "$name" 2>/dev/null || true ;;
+    esac
+done
+
+# Reuse the single $SESSION; -d detaches any pre-existing client so the new
+# one becomes the sole owner of window-size, eliminating size races.
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  exec tmux attach -d -t "$SESSION"
 fi
 
-tmux list-sessions -F '#{session_name} #{session_attached}' 2>/dev/null | \
-  while read -r name attached; do
-    [ "$name" = "$SESSION" ] && continue
-    case "$name" in
-      ''|*[!0-9]*) continue ;;
-    esac
-    [ "$attached" = "0" ] && tmux kill-session -t "$name" 2>/dev/null || true
-  done
-
-exec tmux new-session -t "$SESSION"
+exec tmux new-session -s "$SESSION"
 SCRIPT
 
 ENV LANG=en_US.UTF-8

--- a/tests/cli/sandbox-dockerfile.test.ts
+++ b/tests/cli/sandbox-dockerfile.test.ts
@@ -247,9 +247,11 @@ test("composeDockerfile bakes sandbox-tmux-entry script", async () => {
     assert.match(content, /chmod \+x \/usr\/local\/bin\/sandbox-tmux-entry/);
     assert.match(content, /command -v tmux/);
     assert.match(content, /tmux has-session -t "\$SESSION"/);
-    assert.match(content, /tmux list-sessions -F '#\{session_name\} #\{session_attached\}'/);
+    assert.match(content, /tmux list-sessions -F '#\{session_name\}'/);
+    assert.match(content, /case "\$name" in\s*"\$SESSION"-\*\)/);
     assert.match(content, /tmux kill-session -t "\$name"/);
-    assert.match(content, /exec tmux new-session -t "\$SESSION"/);
+    assert.match(content, /exec tmux attach -d -t "\$SESSION"/);
+    assert.match(content, /exec tmux new-session -s "\$SESSION"/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -300,7 +302,7 @@ test("composeDockerfile invokes sandbox-dotfiles-link from sandbox-tmux-entry", 
     });
     const content = fs.readFileSync(dockerfilePath, "utf8");
 
-    assert.match(content, /sandbox-dotfiles-link >\/dev\/null \|\| true/);
+    assert.match(content, /sandbox-dotfiles-link[^\n]*\|\| true/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #389

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`sandbox-tmux-entry` 在远程 SSH 进入沙箱时使用 `tmux new-session -t work` 创建同组的 `work-N` 会话——这是 tmux session group 语义，新会话与 `work` 共享窗口集合但**客户端尺寸各自独立**。两端（本机 + 远程 SSH）附着到不同 group 成员时，tmux `window-size latest` 在两端尺寸之间反复跳动，渲染出右半屏字符残影/错位。

叠加问题：清理 `work-N` 的 case 模式 `''|*[!0-9]*) continue` 用 `*[!0-9]*` 匹配完整名 `work-1`（命中字母 `w/o/r/k` 与连字符），永远 `continue` → 该分支自首次引入起就是死代码，导致 `work-N` 持续堆积。

本 PR 修复 #389，根因消除尺寸竞争。

## 📋 主要变更 / Brief Changelog

- 重写 `lib/sandbox/runtimes/base.dockerfile` 中的 `sandbox-tmux-entry` heredoc：始终复用单一 `work` 会话；已有会话时用 `tmux attach -d -t work` 把旧客户端踢下线，新客户端独占；启动时清理早期版本残留的 `work-*` 同组会话。
- 同步更新 `tests/cli/sandbox-dockerfile.test.ts` 的结构性断言（`#{session_name}` 单字段、`"$SESSION"-*` 前缀清理、`attach -d` / `new-session -s` 双分支），并把 dotfiles-link 断言收敛为单条同行容错形态。
- 行为面变化：新客户端进入时自动 detach 旧客户端（被踢端连接不断、显示冻结），换取「永远一个 `work` + 一个尺寸 + 一份渲染」。已在 #389 中与用户对齐。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

自动化（已在 CI 与本地执行）：

1. `npm test` —— 全量 575 用例，574 pass / 1 skipped / 0 failed。
2. `npm test -- --test-name-pattern='composeDockerfile bakes sandbox-tmux-entry script|composeDockerfile invokes sandbox-dotfiles-link from sandbox-tmux-entry'` —— 受影响 2 个用例 + 同 suite 15 个用例全通过。
3. heredoc 内提取后的脚本通过 POSIX `sh -n` 静态语法检查。

待人工验证（env-blocked；AI agent 沙箱内无 Docker/OrbStack/`ai`，无法闭环）：

1. `ai sandbox rebuild`，确认 dockerfileSignature 因脚本文本变化而换签 → 不命中旧缓存。
2. `ai sandbox enter`，正常进入 tmux，`tmux ls` 只看到一个 `work`。
3. 第一终端保持 attach，第二终端 `ai sandbox enter`：第一终端自动 detach（光标冻结、输入无效），第二终端正常接管；`tmux ls` 仍只有一个 `work`。
4. 退出沙箱后 `docker exec -it <container> sh -c 'tmux new-session -d -s work-zombie'` 注入残留；再 `ai sandbox enter`：进入瞬间 `work-zombie` 应被清掉，`tmux ls` 只剩 `work`。
5. 卸载/禁用 tmux 后 `ai sandbox enter`：应 fallback 到 `exec bash`，不报错退出。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（更新现有结构性断言，覆盖 `attach -d` 和 cleanup 分支）
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（沙箱端到端需在具备 Docker/OrbStack 的宿主执行，见上述 5 步清单）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（#389）
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范（POSIX sh、英文注释、AGENTS.md 规约）
- [x] 我已经进行了自我代码审查（2 轮 review.md / review-r2.md，最终 0 阻塞 / 0 主要 / 0 次要）
- [x] 我已经为复杂的代码添加了必要的注释（heredoc 内两段简短英文注释解释 cleanup 范围和 `attach -d` 动机）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过（暂未配置 lint 工具）
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档（脚本是沙箱内部行为，无对外文档暴露）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（`attach -d` 行为面变化已说明）
- [x] 我已经考虑了向后兼容性（dockerfileSignature 自动换签触发重建；存量 `work-N` 残留会在新脚本首次执行时被清理）

## 📋 附加信息 / Additional Notes

- 行为面权衡：放弃 session group 多视图能力，换取「永远只有一个客户端 + 一个尺寸 + 一份渲染」。
- 与现有 PR #287、#309 的历史脉络：#287 首次引入该脚本，#309 在脚本顶部追加 dotfiles-link 调用、未改 session 逻辑。

Closes #389

---

**审查者注意事项 / Reviewer Notes:**

请重点关注「待人工验证」清单的 5 个手工子步骤——AI 在沙箱内无 Docker/OrbStack，未执行真实重建/抢占/残留清理；脚本逻辑通过 `sh -n` + tmux-mock 三路径覆盖（`has-session`/`no-session`/`no-tmux`）已验证，但 `attach -d` 让 tmux `window-size latest` 真的不再错位需要在宿主上确认。

Generated with AI assistance