### PR TITLE
refactor(test): convert validate-artifact.test.ts to table-driven

### DIFF
--- a/tests/cli/sandbox-clipboard.test.ts
+++ b/tests/cli/sandbox-clipboard.test.ts
@@ -11,6 +11,13 @@ type KeysModule = typeof import("../../lib/sandbox/clipboard/keys.ts");
 type PathsModule = typeof import("../../lib/sandbox/clipboard/paths.ts");
 type DarwinModule = typeof import("../../lib/sandbox/clipboard/darwin.ts");
 type BridgeModule = typeof import("../../lib/sandbox/clipboard/bridge.ts");
+type PtyExitEvent = { exitCode: number; signal?: number | string };
+type PtyExitHandler = (event: PtyExitEvent) => void;
+
+function invokeExitHandler(handler: PtyExitHandler | null, event: PtyExitEvent) {
+  assert.ok(handler, "pty exit handler should be registered");
+  handler(event);
+}
 
 test("CtrlVDetector recognizes plain, CSI-u, and modifyOtherKeys Ctrl+V sequences", async () => {
   const { CtrlVDetector } = await loadFreshEsm<KeysModule>("lib/sandbox/clipboard/keys.js");
@@ -117,13 +124,15 @@ test("darwin clipboard adapter rejects empty or invalid PNG output", async () =>
 
   const adapter = createDarwinClipboardAdapter({
     execFn(cmd, args) {
+      const script = String(args[1]);
+      const match = script.match(/POSIX file "([^"]+)"/);
+      if (match?.[1]) {
+        fs.writeFileSync(match[1], "not a png");
+      }
       if (args[1] === "clipboard info" || cmd === "osascript") {
         return "";
       }
       return "";
-    },
-    readFileFn() {
-      return Buffer.from("not a png", "utf8");
     }
   });
 
@@ -246,7 +255,7 @@ test("clipboard bridge injects bracketed paste for image Ctrl+V", async () => {
   };
   const writes: string[] = [];
   const rawModes: boolean[] = [];
-  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = (value) => { rawModes.push(value); };
@@ -285,7 +294,7 @@ test("clipboard bridge injects bracketed paste for image Ctrl+V", async () => {
 
     await new Promise((resolve) => setImmediate(resolve));
     stdin.emit("data", Buffer.from("\x1b[27;5;118~", "binary"));
-    exitHandler?.({ exitCode: 0 });
+    invokeExitHandler(exitHandler, { exitCode: 0 });
 
     assert.equal(await promise, 0);
     assert.equal(writes.length, 1);
@@ -311,7 +320,7 @@ test("clipboard bridge silently forwards Ctrl+V when the clipboard holds no imag
   };
   const writes: string[] = [];
   const stderr: string[] = [];
-  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -350,7 +359,7 @@ test("clipboard bridge silently forwards Ctrl+V when the clipboard holds no imag
 
   await new Promise((resolve) => setImmediate(resolve));
   stdin.emit("data", Buffer.from("\x1b[27;5;118~", "binary"));
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   assert.deepEqual(writes, ["\x1b[27;5;118~"]);
@@ -371,7 +380,7 @@ test("clipboard bridge flushes a standalone ESC after the partial-sequence delay
     write(chunk: string): void;
   };
   const writes: string[] = [];
-  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -410,7 +419,7 @@ test("clipboard bridge flushes a standalone ESC after the partial-sequence delay
   await new Promise((resolve) => setImmediate(resolve));
   stdin.emit("data", Buffer.from("\x1b", "utf8"));
   await new Promise((resolve) => setTimeout(resolve, 50));
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   assert.deepEqual(writes, ["\x1b"]);
@@ -430,7 +439,7 @@ test("clipboard bridge preserves UTF-8 input bytes for normal text", async () =>
     write(chunk: string): void;
   };
   const writes: string[] = [];
-  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -469,7 +478,7 @@ test("clipboard bridge preserves UTF-8 input bytes for normal text", async () =>
   const input = Buffer.from("中文😊", "utf8");
   await new Promise((resolve) => setImmediate(resolve));
   stdin.emit("data", input);
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   assert.deepEqual(Buffer.from(writes.join(""), "utf8"), input);
@@ -489,7 +498,7 @@ test("clipboard bridge preserves UTF-8 input split across chunks", async () => {
     write(chunk: string): void;
   };
   const writes: string[] = [];
-  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -529,7 +538,7 @@ test("clipboard bridge preserves UTF-8 input split across chunks", async () => {
   await new Promise((resolve) => setImmediate(resolve));
   stdin.emit("data", input.subarray(0, 1));
   stdin.emit("data", input.subarray(1));
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   assert.deepEqual(Buffer.from(writes.join(""), "utf8"), input);
@@ -548,7 +557,7 @@ test("clipboard bridge returns signal exit codes before numeric exitCode", async
     rows: number;
     write(chunk: string): void;
   };
-  let exitHandler: ((event: { exitCode: number; signal?: number | string }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -585,7 +594,7 @@ test("clipboard bridge returns signal exit codes before numeric exitCode", async
   });
 
   await new Promise((resolve) => setImmediate(resolve));
-  exitHandler?.({ exitCode: 0, signal: "SIGTERM" });
+  invokeExitHandler(exitHandler, { exitCode: 0, signal: "SIGTERM" });
 
   assert.equal(await promise, 143);
 });
@@ -663,7 +672,7 @@ test("clipboard bridge forwards original Ctrl+V sequence when image handling fai
   };
   const writes: string[] = [];
   const stderr: string[] = [];
-  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -705,7 +714,7 @@ test("clipboard bridge forwards original Ctrl+V sequence when image handling fai
 
   await new Promise((resolve) => setImmediate(resolve));
   stdin.emit("data", Buffer.from("\x1b[27;5;118~", "binary"));
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   assert.deepEqual(writes, ["\x1b[27;5;118~"]);
@@ -728,7 +737,7 @@ test("clipboard bridge pauses stdin on exit so the host process can exit", async
     write(chunk: string): void;
   };
   const lifecycle: string[] = [];
-  let exitHandler: ((event: { exitCode: number }) => void) | null = null;
+  let exitHandler: PtyExitHandler | null = null;
 
   stdin.isTTY = true;
   stdin.setRawMode = () => {};
@@ -767,7 +776,7 @@ test("clipboard bridge pauses stdin on exit so the host process can exit", async
   });
 
   await new Promise((resolve) => setImmediate(resolve));
-  exitHandler?.({ exitCode: 0 });
+  invokeExitHandler(exitHandler, { exitCode: 0 });
 
   assert.equal(await promise, 0);
   // stdin must be paused on teardown, after it was resumed, so the resumed TTY

--- a/tests/core/test-tier-coverage.test.ts
+++ b/tests/core/test-tier-coverage.test.ts
@@ -60,6 +60,7 @@ test("test:core does not include slow contract suites reserved for full layer", 
   const core = pkg.scripts["test:core"];
   const fullOnly = [
     "tests/core/validate-artifact.test.ts",
+    "tests/core/validate-artifact-platform-sync.test.ts",
     "tests/core/sync-labels-script.test.ts",
     "tests/core/archive-tasks.test.ts",
   ];

--- a/tests/core/validate-artifact-helpers.ts
+++ b/tests/core/validate-artifact-helpers.ts
@@ -1,0 +1,636 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import type { SpawnSyncReturns } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+import {
+  filePath,
+  gitSafeEnv,
+  initIsolatedGitRepo,
+  pathWithPrependedBin,
+  read,
+  writeNodeCommandShim
+} from "../helpers.ts";
+
+const scriptPath = filePath(".agents/scripts/validate-artifact.js");
+
+type FrontmatterOverrides = Record<string, string | number | boolean | null | undefined>;
+type FixtureReplacements = Record<string, string | number | boolean | null | undefined>;
+type TaskCommentOptions = {
+  summaryText?: string;
+  rawBody?: boolean;
+};
+type IssuePayloadOverrides = Record<string, unknown>;
+type PlatformSyncConfig = Record<string, unknown>;
+type ValidatorOptions = {
+  env?: NodeJS.ProcessEnv;
+  fakeGhPath?: string;
+};
+type ValidatorCheck = {
+  type: string;
+  status: string;
+  fail_type?: string;
+  warnings?: string[];
+};
+type ValidatorPayload = {
+  gate: string;
+  checks: ValidatorCheck[];
+  type: string;
+  status: string;
+  message: string;
+  warnings?: string[];
+};
+type PayloadStatusExpectation = {
+  type?: string;
+  status?: string;
+  message?: RegExp;
+};
+type PlatformSyncEnv = {
+  taskDir: string;
+  binDir: string;
+  ghPath: string;
+  issuePath: string;
+  commentsPath: string;
+  prPath: string;
+  prCommentsPath: string;
+  issueFieldsPath: string;
+  labelsPath: string;
+  env(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+};
+
+function parseValidatorPayload(stdout: string): ValidatorPayload {
+  return JSON.parse(stdout) as ValidatorPayload;
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = Math.floor(absoluteOffsetMinutes / 60);
+  const offsetRemainderMinutes = absoluteOffsetMinutes % 60;
+
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate())
+  ].join("-") + " " + [
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+  ].join(":") + `${sign}${pad(offsetHours)}:${pad(offsetRemainderMinutes)}`;
+}
+
+function formatTimestampInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false
+  }).formatToParts(date);
+
+  const values = Object.fromEntries(
+    parts
+      .filter(({ type }) => type !== "literal")
+      .map(({ type, value }) => [type, value])
+  );
+
+  const offsetPart = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "longOffset"
+  }).formatToParts(date).find(({ type }) => type === "timeZoneName")?.value;
+  const normalizedOffset = offsetPart === "GMT" ? "+00:00" : offsetPart?.replace("GMT", "") || "+00:00";
+
+  return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute}:${values.second}${normalizedOffset}`;
+}
+
+function write(filePathname: string, content: string) {
+  fs.mkdirSync(path.dirname(filePathname), { recursive: true });
+  fs.writeFileSync(filePathname, content, "utf8");
+}
+
+function writeJson(filePathname: string, value: unknown) {
+  write(filePathname, JSON.stringify(value));
+}
+
+function buildTaskFrontmatter(overrides: FrontmatterOverrides = {}) {
+  const now = new Date();
+  const metadata = {
+    id: "TASK-20260328-000001",
+    type: "refactor",
+    workflow: "refactoring",
+    status: "active",
+    created_at: formatTimestamp(new Date(now.getTime() - 60_000)),
+    updated_at: formatTimestamp(now),
+    issue_number: "N/A",
+    created_by: "human",
+    current_step: "implementation",
+    assigned_to: "codex",
+    ...overrides
+  };
+
+  return [
+    "---",
+    ...Object.entries(metadata).map(([key, value]) => `${key}: ${value}`),
+    "---"
+  ].join("\n");
+}
+
+function loadFixture(name: string, replacements: FixtureReplacements = {}) {
+  let content = read(path.join("tests/fixtures/validate-artifact", name));
+
+  for (const [key, value] of Object.entries(replacements)) {
+    content = content.split(`{{${key}}}`).join(String(value));
+  }
+
+  return content;
+}
+
+function buildTaskContent(overrides: FrontmatterOverrides = {}, replacements: FixtureReplacements = {}) {
+  return loadFixture("valid-task.md", {
+    FRONTMATTER: buildTaskFrontmatter(overrides),
+    NOW: formatTimestamp(new Date()),
+    ...replacements
+  });
+}
+
+function buildCompletedTaskContent(checklistLines: string[], overrides: FrontmatterOverrides = {}) {
+  const now = formatTimestamp(new Date());
+  return [
+    buildTaskFrontmatter({
+      status: "completed",
+      current_step: "commit",
+      completed_at: now,
+      updated_at: now,
+      ...overrides
+    }),
+    "",
+    "# 任务：完成任务校验",
+    "",
+    "## 需求",
+    "",
+    "- [x] 保留最新验证输出",
+    "",
+    "## 状态核对",
+    "",
+    "```text",
+    "$ git status -s",
+    "```",
+    "",
+    "## 活动日志",
+    "",
+    `- ${now} — **Completed** by codex — Task archived to completed/`,
+    "",
+    "## 完成检查清单",
+    "",
+    ...checklistLines
+  ].join("\n");
+}
+
+function runValidator(args: string[], options: ValidatorOptions = {}): SpawnSyncReturns<string> {
+  const env = gitSafeEnv({
+    ...(options.fakeGhPath ? {
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([options.fakeGhPath])
+    } : {}),
+    ...options.env
+  });
+  if (env.PATH) {
+    for (const key of Object.keys(env)) {
+      if (key.toLowerCase() === "path") {
+        env[key] = env.PATH;
+      }
+    }
+  }
+
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+    cwd: filePath("."),
+    env
+  });
+}
+
+function writeFakeGh(filePathname: string) {
+  write(filePathname, loadFixture("fake-gh.js"));
+  if (process.platform === "win32") {
+    writeNodeCommandShim(filePathname, filePathname);
+    return filePathname;
+  }
+
+  fs.chmodSync(filePathname, 0o755);
+  return filePathname;
+}
+
+function buildArtifactMarker(taskId: string, artifactFile: string) {
+  return `<!-- sync-issue:${taskId}:${path.basename(artifactFile, path.extname(artifactFile))} -->`;
+}
+
+function buildArtifactComment(taskId: string, artifactFile: string, title: string, body: string) {
+  return loadFixture("artifact-comment.md", {
+    MARKER: buildArtifactMarker(taskId, artifactFile),
+    TITLE: title,
+    BODY: body.trim(),
+    TASK_ID: taskId,
+    AGENT: "codex"
+  });
+}
+
+function buildTaskComment(taskId: string, taskContent: string, options: TaskCommentOptions = {}) {
+  const match = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  const body = match ? taskContent.slice(match[0].length).trim() : taskContent.trim();
+  const summaryText = options.summaryText || "元数据 (frontmatter)";
+  const detailsBlock = match
+    ? [
+        `<details><summary>${summaryText}</summary>`,
+        "",
+        "```yaml",
+        match[0].trim(),
+        "```",
+        "",
+        "</details>"
+      ].join("\n")
+    : "";
+  const renderedBody = options.rawBody
+    ? taskContent.trim()
+    : [detailsBlock, body].filter(Boolean).join("\n\n");
+
+  return loadFixture("task-comment.md", {
+    TASK_ID: taskId,
+    AGENT: "codex",
+    BODY: renderedBody
+  });
+}
+
+function buildMilestone(title: string = "Sprint 24") {
+  return { title };
+}
+
+function buildIssueType(name: string = "Task") {
+  return { name };
+}
+
+function buildIssueFieldsPayload({
+  pinnedFields = [
+    { typename: "IssueFieldSingleSelect", name: "Priority" },
+    { typename: "IssueFieldSingleSelect", name: "Effort" }
+  ],
+  values = [
+    { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
+    { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" }
+  ]
+}: {
+  pinnedFields?: Array<{ typename: string; name: string }>;
+  values?: Array<{ typename: string; fieldName: string; value: string }>;
+} = {}) {
+  return {
+    data: {
+      repository: {
+        issue: {
+          issueType: {
+            name: "Feature",
+            pinnedFields: pinnedFields.map((field) => ({
+              __typename: field.typename,
+              id: `field-${field.name}`,
+              name: field.name
+            }))
+          },
+          issueFieldValues: {
+            nodes: values.map((value) => value.typename === "IssueFieldDateValue"
+              ? {
+                  __typename: value.typename,
+                  value: value.value,
+                  field: { name: value.fieldName }
+                }
+              : {
+                  __typename: value.typename,
+                  name: value.value,
+                  optionId: `option-${value.value}`,
+                  field: { name: value.fieldName }
+                })
+          }
+        }
+      }
+    }
+  };
+}
+
+function buildIssuePayload(overrides: IssuePayloadOverrides = {}) {
+  return {
+    state: "OPEN",
+    labels: [{ name: "status: in-progress" }],
+    body: "# Issue\n\n- [x] 保留最新验证输出\n",
+    milestone: buildMilestone(),
+    type: buildIssueType(),
+    ...overrides
+  };
+}
+
+function parseTestFrontmatter(content: string) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return null;
+  }
+  const body = match[1];
+  if (body === undefined) {
+    return null;
+  }
+
+  const metadata: Record<string, string> = {};
+  for (const line of body.split(/\r?\n/)) {
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!field) {
+      continue;
+    }
+    const key = field[1];
+    const value = field[2];
+    if (key === undefined || value === undefined) {
+      continue;
+    }
+    metadata[key] = value.trim();
+  }
+
+  return metadata;
+}
+
+async function runPlatformSyncAdapter(taskDir: string, config: PlatformSyncConfig, env: NodeJS.ProcessEnv = {}) {
+  const oldEnv: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    oldEnv[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    const adapter = await import(pathToFileURL(filePath(".agents/scripts/platform-adapters/platform-sync.js")).href);
+    return adapter.check({ taskDir, config, artifactFile: undefined }, {
+      repoRoot: filePath("."),
+      loadTask(dir: string) {
+        const taskPath = path.join(dir, "task.md");
+        const content = fs.readFileSync(taskPath, "utf8");
+        const metadata = parseTestFrontmatter(content);
+        if (!metadata) {
+          return { ok: false, message: "task.md frontmatter not found or invalid" };
+        }
+        return { ok: true, content, metadata };
+      },
+      getCheckedRequirements() {
+        return [];
+      },
+      normalizeContent(value: string) {
+        return String(value || "").replace(/\r\n/g, "\n").trim();
+      },
+      isBlank(value: unknown) {
+        return value === undefined || value === null || String(value).trim() === "";
+      },
+      escapeRegExp(value: string) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      },
+      passResult(type: string, message: string) {
+        return { type, status: "pass", message };
+      },
+      failResult(type: string, message: string, failType = "check_failed") {
+        return { type, status: "fail", message, fail_type: failType };
+      },
+      blockedResult(type: string, message: string, failType = "network_error") {
+        return { type, status: "blocked", message, fail_type: failType };
+      },
+      safeStat(filePathname: string) {
+        try {
+          return fs.statSync(filePathname);
+        } catch {
+          return null;
+        }
+      },
+      parseIssueNumber(value: unknown) {
+        const number = Number(value);
+        return Number.isInteger(number) && number > 0 ? number : null;
+      },
+      parsePrNumber(value: unknown) {
+        const number = Number(value);
+        return Number.isInteger(number) && number > 0 ? number : null;
+      }
+    });
+  } finally {
+    for (const [key, value] of Object.entries(oldEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function buildPrPayload(overrides: IssuePayloadOverrides = {}) {
+  return {
+    labels: [],
+    milestone: buildMilestone(),
+    assignees: [{ login: "test-user" }],
+    ...overrides
+  };
+}
+
+function assertPointsToPrSyncRule(filePathname: string) {
+  const content = read(filePathname);
+  assert.match(content, /`\.agents\/rules\/pr-sync\.md`/);
+}
+
+function assertHasCanonicalPrSyncStructure(filePathname: string, headings: RegExp[]) {
+  const content = read(filePathname);
+  assert.match(content, /<!-- sync-pr:\{task-id\}:summary -->/);
+  assert.match(content, /<!-- last-commit: \{git-head-sha\} -->/);
+  for (const heading of headings) {
+    assert.match(content, heading);
+  }
+}
+
+function createHeadCommit(repoRoot: string): string {
+  const env = gitSafeEnv();
+  const emailResult = spawnSync("git", ["config", "user.email", "codex@example.com"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env
+  });
+  assert.equal(emailResult.status, 0, emailResult.stderr);
+
+  const nameResult = spawnSync("git", ["config", "user.name", "Codex"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env
+  });
+  assert.equal(nameResult.status, 0, nameResult.stderr);
+
+  write(path.join(repoRoot, "README.md"), "# temp\n");
+
+  const addResult = spawnSync("git", ["add", "README.md"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env
+  });
+  assert.equal(addResult.status, 0, addResult.stderr);
+
+  const commitResult = spawnSync("git", ["commit", "-qm", "test commit"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env
+  });
+  assert.equal(commitResult.status, 0, commitResult.stderr);
+
+  const revParseResult = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env
+  });
+  assert.equal(revParseResult.status, 0, revParseResult.stderr);
+
+  return revParseResult.stdout.trim();
+}
+
+function addWorktree(repoRoot: string, worktreePath: string, branch: string) {
+  const result = spawnSync("git", ["worktree", "add", worktreePath, "-b", branch], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function commitInWorktree(worktreePath: string, message: string): string {
+  const commitResult = spawnSync("git", ["commit", "--allow-empty", "-qm", message], {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(commitResult.status, 0, commitResult.stderr);
+
+  const revParseResult = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(revParseResult.status, 0, revParseResult.stderr);
+
+  return revParseResult.stdout.trim();
+}
+
+async function withTempRoot<T>(prefix: string, fn: (tempRoot: string) => T | Promise<T>): Promise<T> {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(tempRoot);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function withProjectTempRoot<T>(prefix: string, fn: (tempRoot: string) => T | Promise<T>): Promise<T> {
+  const scratchRoot = filePath(".tmp");
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(scratchRoot, prefix));
+  try {
+    return await fn(tempRoot);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function setupPlatformSyncEnv(tempRoot: string): PlatformSyncEnv {
+  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const binDir = path.join(tempRoot, "bin");
+  const ghPath = writeFakeGh(path.join(binDir, "gh"));
+  const issuePath = path.join(tempRoot, "issue.json");
+  const commentsPath = path.join(tempRoot, "comments.json");
+  const prPath = path.join(tempRoot, "pr.json");
+  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
+  const labelsPath = path.join(tempRoot, "labels.json");
+
+  initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+
+  return {
+    taskDir,
+    binDir,
+    ghPath,
+    issuePath,
+    commentsPath,
+    prPath,
+    prCommentsPath,
+    issueFieldsPath,
+    labelsPath,
+    env(extra: NodeJS.ProcessEnv = {}) {
+      return {
+        PATH: pathWithPrependedBin(binDir),
+        ...extra
+      };
+    }
+  };
+}
+
+function runValidatorWithFakeGh(args: string[], ctx: PlatformSyncEnv, env: NodeJS.ProcessEnv = {}) {
+  return runValidator(args, {
+    fakeGhPath: ctx.ghPath,
+    env: ctx.env(env)
+  });
+}
+
+function assertPayloadStatus(result: SpawnSyncReturns<string>, expected: PayloadStatusExpectation) {
+  const payload = parseValidatorPayload(result.stdout);
+  if (expected.type) {
+    assert.equal(payload.type, expected.type);
+  }
+  if (expected.status) {
+    assert.equal(payload.status, expected.status);
+  }
+  if (expected.message) {
+    assert.match(payload.message, expected.message);
+  }
+  return payload;
+}
+
+export {
+  addWorktree,
+  assertHasCanonicalPrSyncStructure,
+  assertPayloadStatus,
+  assertPointsToPrSyncRule,
+  buildArtifactComment,
+  buildCompletedTaskContent,
+  buildIssueFieldsPayload,
+  buildIssuePayload,
+  buildIssueType,
+  buildPrPayload,
+  buildTaskComment,
+  buildTaskContent,
+  buildTaskFrontmatter,
+  commitInWorktree,
+  createHeadCommit,
+  formatTimestamp,
+  formatTimestampInTimeZone,
+  loadFixture,
+  parseValidatorPayload,
+  runPlatformSyncAdapter,
+  runValidator,
+  runValidatorWithFakeGh,
+  setupPlatformSyncEnv,
+  withProjectTempRoot,
+  withTempRoot,
+  write,
+  writeFakeGh,
+  writeJson
+};
+
+export type {
+  FrontmatterOverrides,
+  IssuePayloadOverrides,
+  PlatformSyncConfig,
+  PlatformSyncEnv,
+  ValidatorPayload
+};

--- a/tests/core/validate-artifact-platform-sync.test.ts
+++ b/tests/core/validate-artifact-platform-sync.test.ts
@@ -1,0 +1,710 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  gitSafeEnv,
+  initIsolatedGitRepo,
+  pathWithPrependedBin,
+  read
+} from "../helpers.ts";
+import {
+  addWorktree,
+  assertPayloadStatus,
+  buildArtifactComment,
+  buildIssueFieldsPayload,
+  buildIssuePayload,
+  buildIssueType,
+  buildPrPayload,
+  buildTaskComment,
+  buildTaskContent,
+  commitInWorktree,
+  createHeadCommit,
+  loadFixture,
+  parseValidatorPayload,
+  runPlatformSyncAdapter,
+  runValidator,
+  runValidatorWithFakeGh,
+  setupPlatformSyncEnv,
+  withProjectTempRoot,
+  withTempRoot,
+  write,
+  writeJson
+} from "./validate-artifact-helpers.ts";
+
+const taskId = "TASK-20260328-000001";
+const summaryComment = "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good.";
+const summaryCommentWithSha = (sha: string) => (
+  `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${sha} -->\n## Review Summary\n\nLooks good.`
+);
+
+const implementSyncCases = [
+  {
+    name: "validate-artifact gate passes when synced artifact and task comments match local files",
+    gate: true,
+    skill: "implement-task",
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseValidatorPayload(result.stdout);
+      assert.equal(payload.gate, "pass");
+      assert.deepEqual(
+        payload.checks.map((check) => check.status),
+        ["pass", "pass", "pass", "pass"]
+      );
+    }
+  },
+  {
+    name: "validate-artifact platform-sync fails when artifact comment content differs from the local artifact",
+    skill: "implement-task",
+    comments(taskContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "实现报告", "# 摘要\n\n这不是原文。") },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /Comment content mismatch for 'implementation'/
+      });
+      assert.match(parseValidatorPayload(result.stdout).message, /first difference near char \d+/);
+    }
+  },
+  {
+    name: "validate-artifact platform-sync fails when the task comment does not use the rendered frontmatter details block",
+    skill: "implement-task",
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent, { rawBody: true }) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /Comment content mismatch for 'task'/
+      });
+      assert.match(parseValidatorPayload(result.stdout).message, /line \d+, column \d+/);
+    }
+  },
+  {
+    name: "validate-artifact platform-sync fails when the Issue Type does not match task type",
+    skill: "implement-task",
+    taskOverrides: { type: "feature" },
+    issuePayload: buildIssuePayload({ type: buildIssueType("Task") }),
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /has type 'Task', expected 'Feature'/
+      });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync skips Issue Type verification when the REST query is unavailable",
+    skill: "implement-task",
+    extraEnv: {
+      GH_FAKE_ISSUE_REST_FAIL: "Issue Types are unavailable",
+      VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+    },
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync accepts English task frontmatter summary when language override is en",
+    skill: "implement-task",
+    extraEnv: { VALIDATE_ARTIFACT_LANGUAGE: "en" },
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "implementation.md", "Implementation Report", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent, { summaryText: "Metadata (frontmatter)" }) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync fails for create-task when the task comment is missing",
+    skill: "create-task",
+    issuePayload: buildIssuePayload({
+      labels: [{ name: "status: waiting-for-triage" }],
+      body: "# Issue\n"
+    }),
+    comments() {
+      return [];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /sync-issue:TASK-20260328-000001:task/
+      });
+    }
+  }
+];
+
+for (const c of implementSyncCases) {
+  test(c.name, () => withTempRoot("agent-infra-platform-sync-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const taskContent = buildTaskContent({ issue_number: "65", ...c.taskOverrides });
+    const artifactContent = loadFixture("valid-implementation.md");
+    write(path.join(ctx.taskDir, "task.md"), taskContent);
+    if (c.skill === "implement-task") {
+      write(path.join(ctx.taskDir, "implementation.md"), artifactContent);
+    }
+    writeJson(ctx.issuePath, c.issuePayload || buildIssuePayload());
+    writeJson(ctx.commentsPath, c.comments(taskContent, artifactContent));
+
+    const args = c.gate
+      ? ["gate", "implement-task", ctx.taskDir, "implementation.md"]
+      : [
+          "check",
+          "platform-sync",
+          ctx.taskDir,
+          ...(c.skill === "implement-task" ? ["implementation.md"] : []),
+          "--skill",
+          c.skill
+        ];
+    c.assertResult(runValidatorWithFakeGh(args, ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_COMMENTS_PATH: ctx.commentsPath,
+      ...c.extraEnv
+    }));
+  }));
+}
+
+const issueFieldCases = [
+  {
+    name: "validate-artifact platform-sync passes when Issue fields match task frontmatter",
+    taskOverrides: {
+      issue_number: "65",
+      type: "feature",
+      priority: "高",
+      effort: "Medium",
+      start_date: "2026-06-01"
+    },
+    fields: buildIssueFieldsPayload({
+      pinnedFields: [
+        { typename: "IssueFieldSingleSelect", name: "Priority" },
+        { typename: "IssueFieldDate", name: "Start date" },
+        { typename: "IssueFieldSingleSelect", name: "Effort" }
+      ],
+      values: [
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" },
+        { typename: "IssueFieldDateValue", fieldName: "Start date", value: "2026-06-01" }
+      ]
+    }),
+    expectedStatus: "pass"
+  },
+  {
+    name: "validate-artifact platform-sync fails when an Issue field differs from task frontmatter",
+    taskOverrides: {
+      issue_number: "65",
+      priority: "High"
+    },
+    fields: buildIssueFieldsPayload({
+      values: [
+        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "Low" }
+      ]
+    }),
+    expectedStatus: "fail",
+    message: /field 'Priority' is 'Low', expected 'High'/
+  }
+];
+
+for (const c of issueFieldCases) {
+  test(c.name, async () => withTempRoot("agent-infra-platform-sync-issue-fields-", async (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent(c.taskOverrides));
+    writeJson(ctx.issuePath, buildIssuePayload());
+    writeJson(ctx.issueFieldsPath, c.fields);
+
+    const result = await runPlatformSyncAdapter(ctx.taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(ctx.binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ctx.ghPath]),
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: ctx.issueFieldsPath
+    });
+    assert.equal(result.status, c.expectedStatus);
+    if (c.message) {
+      assert.match(result.message, c.message);
+    }
+  }));
+}
+
+test("validate-artifact platform-sync skips Issue field verification when fields are inapplicable or unavailable", async () => (
+  withTempRoot("agent-infra-platform-sync-issue-fields-skip-", async (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      target_date: "2026-06-30"
+    }));
+    writeJson(ctx.issuePath, buildIssuePayload());
+    writeJson(ctx.issueFieldsPath, buildIssueFieldsPayload({
+      pinnedFields: [
+        { typename: "IssueFieldSingleSelect", name: "Priority" },
+        { typename: "IssueFieldSingleSelect", name: "Effort" }
+      ],
+      values: []
+    }));
+
+    const inapplicableResult = await runPlatformSyncAdapter(ctx.taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(ctx.binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ctx.ghPath]),
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: ctx.issueFieldsPath
+    });
+    assert.equal(inapplicableResult.status, "pass");
+
+    const unavailableResult = await runPlatformSyncAdapter(ctx.taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(ctx.binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ctx.ghPath]),
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_ISSUE_FIELDS_FAIL: "Issue fields are unavailable",
+      VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+    });
+    assert.equal(unavailableResult.status, "pass");
+  })
+));
+
+const createPrCases = [
+  {
+    name: "validate-artifact platform-sync fails when create-pr milestone is missing",
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }], milestone: null }),
+    expectedStatus: 1,
+    message: [/PR #77 has no milestone set/]
+  },
+  {
+    name: "validate-artifact platform-sync fails when PR and Issue in: labels diverge",
+    issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }, { name: "in: cli" }, { name: "in: core" }] }),
+    expectedStatus: 1,
+    message: [/in: labels mismatch/, /PR #77/, /Issue #65/]
+  },
+  {
+    name: "validate-artifact platform-sync fails when create-pr is missing the expected type label",
+    taskOverrides: { type: "feature" },
+    issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
+    prPayload: buildPrPayload({ labels: [{ name: "in: core" }] }),
+    expectedStatus: 1,
+    message: [/Expected type label 'type: feature' not found on PR #77/]
+  },
+  {
+    name: "validate-artifact platform-sync passes when create-pr includes the expected type label",
+    taskOverrides: { type: "feature" },
+    issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
+    prPayload: buildPrPayload({ labels: [{ name: "type: feature" }, { name: "in: core" }] }),
+    expectedStatus: 0
+  },
+  {
+    name: "validate-artifact platform-sync skips create-pr type label verification without triage permission",
+    taskOverrides: { type: "feature" },
+    issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
+    prPayload: buildPrPayload({ labels: [{ name: "in: core" }] }),
+    env: { GH_FAKE_PERMISSIONS: JSON.stringify({ triage: false, push: false }) },
+    expectedStatus: 0
+  },
+  {
+    name: "validate-artifact platform-sync fails when create-pr has no assignee",
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }], assignees: [] }),
+    expectedStatus: 1,
+    message: [/PR #77 has no assignee/]
+  },
+  {
+    name: "validate-artifact platform-sync skips create-pr assignee verification without push permission",
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }], assignees: [] }),
+    env: { GH_FAKE_PERMISSIONS: JSON.stringify({ triage: true, push: false }) },
+    expectedStatus: 0
+  },
+  {
+    name: "validate-artifact platform-sync passes when create-pr summary comment exists on the PR",
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }] }),
+    expectedStatus: 0
+  },
+  {
+    name: "validate-artifact platform-sync fails when create-pr summary comment is missing on the PR",
+    prPayload: buildPrPayload(),
+    prComments: [],
+    expectedStatus: 1,
+    message: [/Expected PR comment marker/, /PR #77/]
+  }
+];
+
+for (const c of createPrCases) {
+  test(c.name, () => withTempRoot("agent-infra-platform-sync-pr-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      pr_number: "77",
+      ...c.taskOverrides
+    }));
+    writeJson(ctx.issuePath, c.issuePayload || buildIssuePayload({ labels: [], body: "# Issue\n" }));
+    writeJson(ctx.prPath, c.prPayload);
+    writeJson(ctx.prCommentsPath, c.prComments ?? [{ body: summaryComment }]);
+
+    const result = runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "--skill", "create-pr"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_PR_PATH: ctx.prPath,
+      GH_FAKE_PR_COMMENTS_PATH: ctx.prCommentsPath,
+      GH_FAKE_ISSUE_NUMBER: "65",
+      GH_FAKE_PR_NUMBER: "77",
+      ...c.env
+    });
+    assert.equal(result.status, c.expectedStatus, result.stderr);
+    const payload = assertPayloadStatus(result, {
+      type: "platform-sync",
+      status: c.expectedStatus === 0 ? "pass" : "fail"
+    });
+    for (const matcher of c.message || []) {
+      assert.match(payload.message, matcher);
+    }
+  }));
+}
+
+const commitCases = [
+  {
+    name: "validate-artifact platform-sync skips for commit when task has no pr_number",
+    taskOverrides: { issue_number: "65" },
+    useFakeGh: false,
+    expectedStatus: 0,
+    assertMessage: "Skipped: task has no pr_number"
+  },
+  {
+    name: "validate-artifact platform-sync passes for commit when summary comment exists on the PR",
+    setupHead: true,
+    prComments(sha: string) {
+      return [{ body: summaryCommentWithSha(sha) }];
+    },
+    expectedStatus: 0
+  },
+  {
+    name: "validate-artifact platform-sync fails for commit when summary comment last-commit metadata mismatches HEAD",
+    setupHead: true,
+    prComments() {
+      return [{ body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: deadbee -->\n## Review Summary\n\nLooks good." }];
+    },
+    expectedStatus: 1,
+    message: /last-commit metadata mismatch/
+  },
+  {
+    name: "validate-artifact platform-sync fails for commit when summary comment last-commit metadata is missing",
+    setupHead: true,
+    prComments() {
+      return [{ body: summaryComment }];
+    },
+    expectedStatus: 1,
+    message: /missing '<!-- last-commit: <sha> -->' metadata/
+  },
+  {
+    name: "validate-artifact platform-sync fails for commit when summary comment is missing on the PR",
+    prComments() {
+      return [];
+    },
+    expectedStatus: 1,
+    message: /Expected PR comment marker/
+  }
+];
+
+for (const c of commitCases) {
+  test(c.name, () => withTempRoot("agent-infra-platform-sync-commit-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const headSha = c.setupHead ? createHeadCommit(tempRoot) : "";
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({
+      issue_number: "65",
+      ...(c.useFakeGh === false ? {} : { pr_number: "77" }),
+      ...c.taskOverrides
+    }));
+    if (c.useFakeGh !== false) {
+      writeJson(ctx.issuePath, buildIssuePayload({ labels: [], body: "# Issue\n" }));
+      writeJson(ctx.prCommentsPath, c.prComments?.(headSha) || []);
+    }
+
+    const result = c.useFakeGh === false
+      ? runValidator(["check", "platform-sync", ctx.taskDir, "--skill", "commit"])
+      : runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "--skill", "commit"], ctx, {
+          GH_FAKE_ISSUE_PATH: ctx.issuePath,
+          GH_FAKE_PR_COMMENTS_PATH: ctx.prCommentsPath,
+          GH_FAKE_ISSUE_NUMBER: "65",
+          GH_FAKE_PR_NUMBER: "77"
+        });
+    assert.equal(result.status, c.expectedStatus, result.stderr);
+    const payload = assertPayloadStatus(result, {
+      type: "platform-sync",
+      status: c.expectedStatus === 0 ? "pass" : "fail"
+    });
+    if (c.assertMessage) {
+      assert.equal(payload.message, c.assertMessage);
+    }
+    if (c.message) {
+      assert.match(payload.message, c.message);
+    }
+  }));
+}
+
+test("validate-artifact platform-sync passes for commit with last-commit from task branch worktree", () => (
+  withTempRoot("agent-infra-platform-sync-commit-worktree-pass-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const branch = "agent-infra-feature-pr";
+    const worktreePath = path.join(tempRoot, "sandbox-worktree");
+    const mainSha = createHeadCommit(tempRoot);
+    addWorktree(tempRoot, worktreePath, branch);
+    const prSha = commitInWorktree(worktreePath, "sandbox commit");
+    assert.notEqual(prSha, mainSha);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({ branch, issue_number: "65", pr_number: "77" }));
+    writeJson(ctx.issuePath, buildIssuePayload({ labels: [], body: "# Issue\n" }));
+    writeJson(ctx.prCommentsPath, [{ body: summaryCommentWithSha(prSha) }]);
+
+    const result = runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "--skill", "commit"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_PR_COMMENTS_PATH: ctx.prCommentsPath,
+      GH_FAKE_ISSUE_NUMBER: "65",
+      GH_FAKE_PR_NUMBER: "77"
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+  })
+));
+
+test("validate-artifact platform-sync falls back to taskDir HEAD when task branch is missing", () => (
+  withTempRoot("agent-infra-platform-sync-commit-no-branch-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const mainSha = createHeadCommit(tempRoot);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
+    writeJson(ctx.issuePath, buildIssuePayload({ labels: [], body: "# Issue\n" }));
+    writeJson(ctx.prCommentsPath, [{ body: summaryCommentWithSha(mainSha) }]);
+
+    const result = runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "--skill", "commit"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_PR_COMMENTS_PATH: ctx.prCommentsPath,
+      GH_FAKE_ISSUE_NUMBER: "65",
+      GH_FAKE_PR_NUMBER: "77"
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+  })
+));
+
+test("validate-artifact platform-sync falls back to taskDir HEAD when task branch worktree is unmatched", () => (
+  withTempRoot("agent-infra-platform-sync-commit-unmatched-branch-", (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const mainSha = createHeadCommit(tempRoot);
+    write(path.join(ctx.taskDir, "task.md"), buildTaskContent({
+      branch: "agent-infra-feature-missing",
+      issue_number: "65",
+      pr_number: "77"
+    }));
+    writeJson(ctx.issuePath, buildIssuePayload({ labels: [], body: "# Issue\n" }));
+    writeJson(ctx.prCommentsPath, [{ body: summaryCommentWithSha(mainSha) }]);
+
+    const result = runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "--skill", "commit"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_PR_COMMENTS_PATH: ctx.prCommentsPath,
+      GH_FAKE_ISSUE_NUMBER: "65",
+      GH_FAKE_PR_NUMBER: "77"
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+  })
+));
+
+test("validate-artifact platform-sync blocks after retry exhaustion on gh network errors", () => (
+  withTempRoot("agent-infra-gate-blocked-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, taskId);
+    const binDir = path.join(tempRoot, "bin");
+    const ghPath = path.join(binDir, "gh");
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
+    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
+    write(ghPath, "#!/bin/sh\necho 'network timeout' >&2\nexit 1\n");
+    fs.chmodSync(ghPath, 0o755);
+
+    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
+      env: {
+        PATH: pathWithPrependedBin(binDir),
+        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+      }
+    });
+    assert.equal(result.status, 2);
+    const payload = parseValidatorPayload(result.stdout);
+    assert.equal(payload.gate, "blocked");
+    const githubCheck = payload.checks.find((check) => check.type === "platform-sync");
+    if (!githubCheck) {
+      throw new Error("expected platform-sync check");
+    }
+    assert.equal(githubCheck.status, "blocked");
+    assert.equal(githubCheck.fail_type, "network_error");
+  })
+));
+
+const retryCases = [
+  {
+    name: "validate-artifact platform-sync retries upstream repo lookup on transient gh failure",
+    prefix: "agent-infra-platform-sync-retry-upstream-",
+    matcher: "api repos/fitlab-ai/agent-infra"
+  },
+  {
+    name: "validate-artifact platform-sync retries permission lookup on transient gh failure",
+    prefix: "agent-infra-platform-sync-retry-permissions-",
+    matcher: ".permissions"
+  }
+];
+
+for (const c of retryCases) {
+  test(c.name, () => withTempRoot(c.prefix, (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const counterPath = path.join(tempRoot, "transient.count");
+    const taskContent = buildTaskContent({ issue_number: "65" });
+    const artifactContent = loadFixture("valid-implementation.md");
+    write(path.join(ctx.taskDir, "task.md"), taskContent);
+    write(path.join(ctx.taskDir, "implementation.md"), artifactContent);
+    writeJson(ctx.issuePath, buildIssuePayload());
+    writeJson(ctx.commentsPath, [
+      { body: buildArtifactComment(taskId, "implementation.md", "实现报告", artifactContent) },
+      { body: buildTaskComment(taskId, taskContent) }
+    ]);
+    write(counterPath, "1");
+
+    const result = runValidatorWithFakeGh(["gate", "implement-task", ctx.taskDir, "implementation.md"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_COMMENTS_PATH: ctx.commentsPath,
+      GH_FAKE_TRANSIENT_FAIL_MATCHER: c.matcher,
+      GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
+      VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
+    assert.equal(parseValidatorPayload(result.stdout).gate, "pass");
+  }));
+}
+
+test("validate-artifact platform-sync retries label list fallback when in: label mapping is empty", () => (
+  withProjectTempRoot("agent-infra-platform-sync-retry-labels-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, taskId);
+    const binDir = path.join(tempRoot, "bin");
+    const ghPath = path.join(binDir, "gh.cjs");
+    const issuePath = path.join(tempRoot, "issue.json");
+    const commentsPath = path.join(tempRoot, "comments.json");
+    const prCommentsPath = path.join(tempRoot, "pr-comments.json");
+    const labelsPath = path.join(tempRoot, "labels.json");
+    const counterPath = path.join(tempRoot, "transient-labels.count");
+    const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+    const adapterCopy = path.join(tempRoot, ".agents/scripts/platform-adapters/platform-sync.js");
+    const verifyCopy = path.join(tempRoot, ".agents/skills/commit/config/verify.json");
+
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
+    write(path.join(tempRoot, ".agents/.airc.json"), JSON.stringify({
+      project: "agent-infra",
+      labels: { in: {} }
+    }, null, 2));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
+    write(verifyCopy, read(".agents/skills/commit/config/verify.json"));
+    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+    const headSha = createHeadCommit(tempRoot);
+    write(ghPath, loadFixture("fake-gh.js"));
+    fs.chmodSync(ghPath, 0o755);
+
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
+    writeJson(issuePath, buildIssuePayload({ labels: [] }));
+    writeJson(commentsPath, []);
+    writeJson(prCommentsPath, [{ body: summaryCommentWithSha(headSha) }]);
+    writeJson(labelsPath, [{ name: "in: tests" }]);
+    write(counterPath, "1");
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptCopy, "check", "platform-sync", taskDir, "--skill", "commit"],
+      {
+        encoding: "utf8",
+        cwd: tempRoot,
+        env: gitSafeEnv({
+          AGENT_INFRA_GH_BIN: process.execPath,
+          AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
+          GH_FAKE_ISSUE_PATH: issuePath,
+          GH_FAKE_COMMENTS_PATH: commentsPath,
+          GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
+          GH_FAKE_LABELS_PATH: labelsPath,
+          GH_FAKE_ISSUE_NUMBER: "65",
+          GH_FAKE_PR_NUMBER: "77",
+          GH_FAKE_TRANSIENT_FAIL_MATCHER: "label list",
+          GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
+          VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
+        })
+      }
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
+    assertPayloadStatus(result, { status: "pass" });
+  })
+));
+
+test("validate-artifact platform-sync skips when no platform adapter is registered", () => (
+  withTempRoot("agent-infra-platform-sync-skip-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, taskId);
+    const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
+    const verifyCopy = path.join(tempRoot, ".agents/skills/implement-task/config/verify.json");
+    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
+    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
+    write(verifyCopy, read(".agents/skills/implement-task/config/verify.json"));
+    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
+    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptCopy, "check", "platform-sync", taskDir, "implementation.md", "--skill", "implement-task"],
+      {
+        encoding: "utf8",
+        cwd: tempRoot,
+        env: process.env
+      }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, {
+      type: "platform-sync",
+      status: "pass",
+      message: /Skipped: no platform adapter registered for 'platform-sync'/
+    });
+  })
+));

--- a/tests/core/validate-artifact.test.ts
+++ b/tests/core/validate-artifact.test.ts
@@ -1,902 +1,357 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import type { SpawnSyncReturns } from "node:child_process";
-import { pathToFileURL } from "node:url";
 
 import {
-  filePath,
   exists,
-  gitSafeEnv,
-  initIsolatedGitRepo,
-  pathWithPrependedBin,
-  read,
-  writeNodeCommandShim
+  read
 } from "../helpers.ts";
+import {
+  assertHasCanonicalPrSyncStructure,
+  assertPayloadStatus,
+  assertPointsToPrSyncRule,
+  buildCompletedTaskContent,
+  buildTaskContent,
+  buildTaskFrontmatter,
+  formatTimestamp,
+  formatTimestampInTimeZone,
+  loadFixture,
+  parseValidatorPayload,
+  runValidator,
+  withTempRoot,
+  write
+} from "./validate-artifact-helpers.ts";
 
-const scriptPath = filePath(".agents/scripts/validate-artifact.js");
 const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-let currentFakeGhPath: string | null = null;
 
-type FrontmatterOverrides = Record<string, string | number | boolean | null | undefined>;
-type FixtureReplacements = Record<string, string | number | boolean | null | undefined>;
-type ValidatorOptions = {
-  env?: NodeJS.ProcessEnv;
-};
-type TaskCommentOptions = {
-  summaryText?: string;
-  rawBody?: boolean;
-};
-type IssuePayloadOverrides = Record<string, unknown>;
-type PlatformSyncConfig = Record<string, unknown>;
-type ValidatorCheck = {
-  type: string;
-  status: string;
-  fail_type?: string;
-  warnings?: string[];
-};
-type ValidatorPayload = {
-  gate: string;
-  checks: ValidatorCheck[];
-  type: string;
-  status: string;
-  message: string;
-  warnings?: string[];
+type TaskMetaCase = {
+  name: string;
+  skill: string;
+  content(): string;
+  assertResult(result: ReturnType<typeof runValidator>): void;
 };
 
-function parseValidatorPayload(stdout: string): ValidatorPayload {
-  return JSON.parse(stdout) as ValidatorPayload;
+type ActivityLogCase = {
+  name: string;
+  issueNumber: number | string;
+  activityLines(now: string): string[];
+  assertResult(result: ReturnType<typeof runValidator>): void;
+};
+
+function writeImplementationFixture(taskDir: string, fixture = "valid-implementation.md") {
+  write(path.join(taskDir, "implementation.md"), loadFixture(fixture));
 }
 
-function formatTimestamp(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, "0");
-  const offsetMinutes = -date.getTimezoneOffset();
-  const sign = offsetMinutes >= 0 ? "+" : "-";
-  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
-  const offsetHours = Math.floor(absoluteOffsetMinutes / 60);
-  const offsetRemainderMinutes = absoluteOffsetMinutes % 60;
-
-  return [
-    date.getFullYear(),
-    pad(date.getMonth() + 1),
-    pad(date.getDate())
-  ].join("-") + " " + [
-    pad(date.getHours()),
-    pad(date.getMinutes()),
-    pad(date.getSeconds())
-  ].join(":") + `${sign}${pad(offsetHours)}:${pad(offsetRemainderMinutes)}`;
+function writeCreateTaskDocument(
+  taskDir: string,
+  frontmatterOverrides: Record<string, string | number>,
+  activityLines: string[] = []
+) {
+  write(path.join(taskDir, "task.md"), [
+    buildTaskFrontmatter(frontmatterOverrides),
+    "",
+    "# 任务：创建任务",
+    ...(activityLines.length > 0 ? ["", "## 活动日志", "", ...activityLines] : [])
+  ].join("\n"));
 }
 
-function formatTimestampInTimeZone(date: Date, timeZone: string): string {
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false
-  }).formatToParts(date);
-
-  const values = Object.fromEntries(
-    parts
-      .filter(({ type }) => type !== "literal")
-      .map(({ type, value }) => [type, value])
-  );
-
-  const offsetPart = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "longOffset"
-  }).formatToParts(date).find(({ type }) => type === "timeZoneName")?.value;
-  const normalizedOffset = offsetPart === "GMT" ? "+00:00" : offsetPart?.replace("GMT", "") || "+00:00";
-
-  return `${values.year}-${values.month}-${values.day} ${values.hour}:${values.minute}:${values.second}${normalizedOffset}`;
-}
-
-function write(filePathname: string, content: string) {
-  fs.mkdirSync(path.dirname(filePathname), { recursive: true });
-  fs.writeFileSync(filePathname, content, "utf8");
-}
-
-function writeJson(filePathname: string, value: unknown) {
-  write(filePathname, JSON.stringify(value));
-}
-
-function buildTaskFrontmatter(overrides: FrontmatterOverrides = {}) {
-  const now = new Date();
-  const metadata = {
-    id: "TASK-20260328-000001",
-    type: "refactor",
-    workflow: "refactoring",
-    status: "active",
-    created_at: formatTimestamp(new Date(now.getTime() - 60_000)),
-    updated_at: formatTimestamp(now),
-    issue_number: "N/A",
-    created_by: "human",
-    current_step: "implementation",
-    assigned_to: "codex",
-    ...overrides
-  };
-
-  return [
-    "---",
-    ...Object.entries(metadata).map(([key, value]) => `${key}: ${value}`),
-    "---"
-  ].join("\n");
-}
-
-function loadFixture(name: string, replacements: FixtureReplacements = {}) {
-  let content = read(path.join("tests/fixtures/validate-artifact", name));
-
-  for (const [key, value] of Object.entries(replacements)) {
-    content = content.split(`{{${key}}}`).join(String(value));
-  }
-
-  return content;
-}
-
-function buildTaskContent(overrides: FrontmatterOverrides = {}, replacements: FixtureReplacements = {}) {
-  return loadFixture("valid-task.md", {
-    FRONTMATTER: buildTaskFrontmatter(overrides),
-    NOW: formatTimestamp(new Date()),
-    ...replacements
-  });
-}
-
-function buildCompletedTaskContent(checklistLines: string[], overrides: FrontmatterOverrides = {}) {
-  const now = formatTimestamp(new Date());
-  return [
-    buildTaskFrontmatter({
-      status: "completed",
-      current_step: "commit",
-      completed_at: now,
-      updated_at: now,
-      ...overrides
-    }),
-    "",
-    "# 任务：完成任务校验",
-    "",
-    "## 需求",
-    "",
-    "- [x] 保留最新验证输出",
-    "",
-    "## 状态核对",
-    "",
-    "```text",
-    "$ git status -s",
-    "```",
-    "",
-    "## 活动日志",
-    "",
-    `- ${now} — **Completed** by codex — Task archived to completed/`,
-    "",
-    "## 完成检查清单",
-    "",
-    ...checklistLines
-  ].join("\n");
-}
-
-function runValidator(args: string[], options: ValidatorOptions = {}): SpawnSyncReturns<string> {
-  const useFakeGh = currentFakeGhPath && Object.keys(options.env || {}).some((key) => key.startsWith("GH_FAKE_"));
-  const env = gitSafeEnv({
-    ...(useFakeGh ? {
-      AGENT_INFRA_GH_BIN: process.execPath,
-      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([currentFakeGhPath])
-    } : {}),
-    ...options.env
-  });
-  if (env.PATH) {
-    for (const key of Object.keys(env)) {
-      if (key.toLowerCase() === "path") {
-        env[key] = env.PATH;
-      }
+const gateCases = [
+  {
+    name: "validate-artifact gate passes for implement-task with fresh task and artifact",
+    prefix: "agent-infra-gate-pass-",
+    args(taskDir: string) {
+      return ["gate", "implement-task", taskDir, "implementation.md"];
+    },
+    prepare(taskDir: string) {
+      write(path.join(taskDir, "task.md"), buildTaskContent());
+      writeImplementationFixture(taskDir);
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseValidatorPayload(result.stdout);
+      assert.equal(payload.gate, "pass");
+      assert.equal(payload.checks.length, 4);
+      assert.deepEqual(
+        payload.checks.map((check) => check.status),
+        ["pass", "pass", "pass", "pass"]
+      );
+    }
+  },
+  {
+    name: "validate-artifact gate supports human-readable text output",
+    prefix: "agent-infra-gate-text-",
+    args(taskDir: string) {
+      return ["gate", "implement-task", taskDir, "implementation.md", "--format", "text"];
+    },
+    prepare(taskDir: string) {
+      write(path.join(taskDir, "task.md"), buildTaskContent());
+      writeImplementationFixture(taskDir);
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /^Verification: pass \| Skill: implement-task$/m);
+      assert.match(result.stdout, /^\s+\[pass\] task-meta - /m);
+      assert.match(result.stdout, /^\s+\[pass\] artifact - /m);
+      assert.match(result.stdout, /^Result: 4 passed, 0 failed - All declared checks passed$/m);
+    }
+  },
+  {
+    name: "validate-artifact gate passes for complete-task when completion checklist is fully checked",
+    prefix: "agent-infra-complete-task-pass-",
+    args(taskDir: string) {
+      return ["gate", "complete-task", taskDir];
+    },
+    prepare(taskDir: string) {
+      write(path.join(taskDir, "task.md"), buildCompletedTaskContent([
+        "- [x] 所有需求已满足",
+        "- [x] 测试已编写并通过",
+        "- [x] 代码已审查",
+        "- [x] 文档已更新（如适用）",
+        "- [x] PR 已创建"
+      ]));
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseValidatorPayload(result.stdout);
+      assert.equal(payload.gate, "pass");
+      assert.deepEqual(
+        payload.checks.map((check) => check.type),
+        ["task-meta", "activity-log", "completion-checklist", "platform-sync", "artifact"]
+      );
+      assert.deepEqual(
+        payload.checks.map((check) => check.status),
+        ["pass", "pass", "pass", "pass", "pass"]
+      );
     }
   }
+];
 
-  return spawnSync(process.execPath, [scriptPath, ...args], {
-    encoding: "utf8",
-    cwd: filePath("."),
-    env
-  });
+for (const c of gateCases) {
+  test(c.name, () => withTempRoot(c.prefix, (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    c.prepare(taskDir);
+    c.assertResult(runValidator(c.args(taskDir)));
+  }));
 }
 
-function writeFakeGh(filePathname: string) {
-  write(filePathname, loadFixture("fake-gh.js"));
-  currentFakeGhPath = filePathname;
-
-  if (process.platform === "win32") {
-    writeNodeCommandShim(filePathname, filePathname);
-    return;
-  }
-
-  fs.chmodSync(filePathname, 0o755);
-}
-
-function buildArtifactMarker(taskId: string, artifactFile: string) {
-  return `<!-- sync-issue:${taskId}:${path.basename(artifactFile, path.extname(artifactFile))} -->`;
-}
-
-function buildArtifactComment(taskId: string, artifactFile: string, title: string, body: string) {
-  return loadFixture("artifact-comment.md", {
-    MARKER: buildArtifactMarker(taskId, artifactFile),
-    TITLE: title,
-    BODY: body.trim(),
-    TASK_ID: taskId,
-    AGENT: "codex"
-  });
-}
-
-function buildTaskComment(taskId: string, taskContent: string, options: TaskCommentOptions = {}) {
-  const match = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
-  const body = match ? taskContent.slice(match[0].length).trim() : taskContent.trim();
-  const summaryText = options.summaryText || "元数据 (frontmatter)";
-  const detailsBlock = match
-    ? [
-        `<details><summary>${summaryText}</summary>`,
+const taskMetaCases: TaskMetaCase[] = [
+  {
+    name: "validate-artifact create-task task-meta accepts a generated branch",
+    skill: "create-task",
+    content() {
+      const now = formatTimestamp(new Date());
+      return [
+        buildTaskFrontmatter({
+          type: "feature",
+          workflow: "feature-development",
+          branch: "agent-infra-feature-cli-generic-sandbox",
+          current_step: "requirement-analysis"
+        }),
         "",
-        "```yaml",
-        match[0].trim(),
-        "```",
+        "# 任务：创建任务",
         "",
-        "</details>"
-      ].join("\n")
-    : "";
-  const renderedBody = options.rawBody
-    ? taskContent.trim()
-    : [detailsBlock, body].filter(Boolean).join("\n\n");
-
-  return loadFixture("task-comment.md", {
-    TASK_ID: taskId,
-    AGENT: "codex",
-    BODY: renderedBody
-  });
-}
-
-function buildMilestone(title: string = "Sprint 24") {
-  return { title };
-}
-
-function buildIssueType(name: string = "Task") {
-  return { name };
-}
-
-function buildIssueFieldsPayload({
-  pinnedFields = [
-    { typename: "IssueFieldSingleSelect", name: "Priority" },
-    { typename: "IssueFieldSingleSelect", name: "Effort" }
-  ],
-  values = [
-    { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
-    { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" }
-  ]
-}: {
-  pinnedFields?: Array<{ typename: string; name: string }>;
-  values?: Array<{ typename: string; fieldName: string; value: string }>;
-} = {}) {
-  return {
-    data: {
-      repository: {
-        issue: {
-          issueType: {
-            name: "Feature",
-            pinnedFields: pinnedFields.map((field) => ({
-              __typename: field.typename,
-              id: `field-${field.name}`,
-              name: field.name
-            }))
-          },
-          issueFieldValues: {
-            nodes: values.map((value) => value.typename === "IssueFieldDateValue"
-              ? {
-                  __typename: value.typename,
-                  value: value.value,
-                  field: { name: value.fieldName }
-                }
-              : {
-                  __typename: value.typename,
-                  name: value.value,
-                  optionId: `option-${value.value}`,
-                  field: { name: value.fieldName }
-                })
-          }
-        }
-      }
+        "## 活动日志",
+        "",
+        `- ${now} — **Task Created** by codex — Task created from description`
+      ].join("\n");
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
     }
-  };
-}
-
-function buildIssuePayload(overrides: IssuePayloadOverrides = {}) {
-  return {
-    state: "OPEN",
-    labels: [{ name: "status: in-progress" }],
-    body: "# Issue\n\n- [x] 保留最新验证输出\n",
-    milestone: buildMilestone(),
-    type: buildIssueType(),
-    ...overrides
-  };
-}
-
-function parseTestFrontmatter(content: string) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
-  if (!match) {
-    return null;
-  }
-  const body = match[1];
-  if (body === undefined) {
-    return null;
-  }
-
-  const metadata: Record<string, string> = {};
-  for (const line of body.split(/\r?\n/)) {
-    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (!field) {
-      continue;
+  },
+  {
+    name: "validate-artifact create-task task-meta rejects invalid branch naming",
+    skill: "create-task",
+    content() {
+      return [
+        buildTaskFrontmatter({
+          branch: "wrong-prefix-feature-cli-generic-sandbox",
+          current_step: "requirement-analysis"
+        }),
+        "",
+        "# 任务：创建任务"
+      ].join("\n");
+    },
+    assertResult(result) {
+      assert.equal(result.status, 1);
+      assert.match(result.stdout, /Invalid branch/);
     }
-    const key = field[1];
-    const value = field[2];
-    if (key === undefined || value === undefined) {
-      continue;
+  },
+  {
+    name: "validate-artifact task-meta warns without blocking when agent_infra_version is missing",
+    skill: "implement-task",
+    content() {
+      return buildTaskContent();
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /agent_infra_version.*missing/);
+      const payload = parseValidatorPayload(result.stdout);
+      assert.deepEqual(payload.warnings, [
+        "field 'agent_infra_version' missing — historical task or skipped version stamp"
+      ]);
     }
-    metadata[key] = value.trim();
-  }
-
-  return metadata;
-}
-
-async function runPlatformSyncAdapter(taskDir: string, config: PlatformSyncConfig, env: NodeJS.ProcessEnv = {}) {
-  const oldEnv: Record<string, string | undefined> = {};
-  for (const [key, value] of Object.entries(env)) {
-    oldEnv[key] = process.env[key];
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
+  },
+  {
+    name: "validate-artifact task-meta rejects malformed agent_infra_version",
+    skill: "implement-task",
+    content() {
+      return buildTaskContent({ agent_infra_version: "0.6.1" });
+    },
+    assertResult(result) {
+      assert.equal(result.status, 1);
+      assert.match(result.stdout, /Invalid agent_infra_version/);
+    }
+  },
+  {
+    name: "validate-artifact task-meta accepts unknown agent_infra_version fallback",
+    skill: "implement-task",
+    content() {
+      return buildTaskContent({ agent_infra_version: "unknown" });
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
+    }
+  },
+  {
+    name: "validate-artifact task-meta accepts SemVer build metadata in agent_infra_version",
+    skill: "implement-task",
+    content() {
+      return buildTaskContent({ agent_infra_version: "v0.6.1-alpha.0+build.7" });
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.doesNotMatch(result.stdout, /Invalid agent_infra_version/);
+    }
+  },
+  {
+    name: "validate-artifact task-meta accepts stamped agent_infra_version",
+    skill: "implement-task",
+    content() {
+      return buildTaskContent({ agent_infra_version: "v0.6.1-alpha.0" });
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
+    }
+  },
+  {
+    name: "validate-artifact task-meta supports cancel-task cancelled_at requirements",
+    skill: "cancel-task",
+    content() {
+      const cancelledAt = formatTimestamp(new Date());
+      return buildTaskContent({
+        status: "completed",
+        cancelled_at: cancelledAt,
+        cancel_reason: "No longer needed after investigation"
+      }, {
+        NOW: cancelledAt
+      });
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "task-meta", status: "pass" });
     }
   }
+];
 
-  try {
-    const adapter = await import(pathToFileURL(filePath(".agents/scripts/platform-adapters/platform-sync.js")).href);
-    return adapter.check({ taskDir, config, artifactFile: undefined }, {
-      repoRoot: filePath("."),
-      loadTask(dir: string) {
-        const taskPath = path.join(dir, "task.md");
-        const content = fs.readFileSync(taskPath, "utf8");
-        const metadata = parseTestFrontmatter(content);
-        if (!metadata) {
-          return { ok: false, message: "task.md frontmatter not found or invalid" };
-        }
-        return { ok: true, content, metadata };
-      },
-      getCheckedRequirements() {
-        return [];
-      },
-      normalizeContent(value: string) {
-        return String(value || "").replace(/\r\n/g, "\n").trim();
-      },
-      isBlank(value: unknown) {
-        return value === undefined || value === null || String(value).trim() === "";
-      },
-      escapeRegExp(value: string) {
-        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      },
-      passResult(type: string, message: string) {
-        return { type, status: "pass", message };
-      },
-      failResult(type: string, message: string, failType = "check_failed") {
-        return { type, status: "fail", message, fail_type: failType };
-      },
-      blockedResult(type: string, message: string, failType = "network_error") {
-        return { type, status: "blocked", message, fail_type: failType };
-      },
-      safeStat(filePathname: string) {
-        try {
-          return fs.statSync(filePathname);
-        } catch {
-          return null;
-        }
-      },
-      parseIssueNumber(value: unknown) {
-        const number = Number(value);
-        return Number.isInteger(number) && number > 0 ? number : null;
-      },
-      parsePrNumber(value: unknown) {
-        const number = Number(value);
-        return Number.isInteger(number) && number > 0 ? number : null;
-      }
-    });
-  } finally {
-    for (const [key, value] of Object.entries(oldEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
+for (const c of taskMetaCases) {
+  test(c.name, () => withTempRoot("agent-infra-task-meta-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    write(path.join(taskDir, "task.md"), c.content());
+    c.assertResult(runValidator(["check", "task-meta", taskDir, "--skill", c.skill]));
+  }));
+}
+
+const activityLogCases: ActivityLogCase[] = [
+  {
+    name: "validate-artifact activity-log passes for create-task happy path with Issue created",
+    issueNumber: 296,
+    activityLines(now) {
+      return [`- ${now} — **Task Created** by codex — Task created from description`];
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+    }
+  },
+  {
+    name: "validate-artifact activity-log fails for create-task when Create Issue entry is appended",
+    issueNumber: 296,
+    activityLines(now) {
+      return [
+        `- ${now} — **Task Created** by codex — Task created from description`,
+        `- ${now} — **Create Issue** by codex — Created GitHub Issue #296`
+      ];
+    },
+    assertResult(result) {
+      assert.equal(result.status, 1);
+      assert.match(result.stdout, /Latest action 'Create Issue' does not match/);
+    }
+  },
+  {
+    name: "validate-artifact activity-log fails for create-task when Issue Creation Skipped entry is appended",
+    issueNumber: "N/A",
+    activityLines(now) {
+      return [
+        `- ${now} — **Task Created** by codex — Task created from description`,
+        `- ${now} — **Issue Creation Skipped** by codex — GitHub Issue creation failed`
+      ];
+    },
+    assertResult(result) {
+      assert.equal(result.status, 1);
+      assert.match(result.stdout, /Latest action 'Issue Creation Skipped' does not match/);
     }
   }
-}
+];
 
-function buildPrPayload(overrides: IssuePayloadOverrides = {}) {
-  return {
-    labels: [],
-    milestone: buildMilestone(),
-    assignees: [{ login: "test-user" }],
-    ...overrides
-  };
-}
-
-function assertPointsToPrSyncRule(filePathname: string) {
-  const content = read(filePathname);
-  assert.match(content, /`\.agents\/rules\/pr-sync\.md`/);
-}
-
-function assertHasCanonicalPrSyncStructure(filePathname: string, headings: RegExp[]) {
-  const content = read(filePathname);
-  assert.match(content, /<!-- sync-pr:\{task-id\}:summary -->/);
-  assert.match(content, /<!-- last-commit: \{git-head-sha\} -->/);
-  for (const heading of headings) {
-    assert.match(content, heading);
-  }
-}
-
-function createHeadCommit(repoRoot: string): string {
-  const env = gitSafeEnv();
-  const emailResult = spawnSync("git", ["config", "user.email", "codex@example.com"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env
-  });
-  assert.equal(emailResult.status, 0, emailResult.stderr);
-
-  const nameResult = spawnSync("git", ["config", "user.name", "Codex"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env
-  });
-  assert.equal(nameResult.status, 0, nameResult.stderr);
-
-  write(path.join(repoRoot, "README.md"), "# temp\n");
-
-  const addResult = spawnSync("git", ["add", "README.md"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env
-  });
-  assert.equal(addResult.status, 0, addResult.stderr);
-
-  const commitResult = spawnSync("git", ["commit", "-qm", "test commit"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env
-  });
-  assert.equal(commitResult.status, 0, commitResult.stderr);
-
-  const revParseResult = spawnSync("git", ["rev-parse", "HEAD"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env
-  });
-  assert.equal(revParseResult.status, 0, revParseResult.stderr);
-
-  return revParseResult.stdout.trim();
-}
-
-function addWorktree(repoRoot: string, worktreePath: string, branch: string) {
-  const result = spawnSync("git", ["worktree", "add", worktreePath, "-b", branch], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: gitSafeEnv()
-  });
-  assert.equal(result.status, 0, result.stderr);
-}
-
-function commitInWorktree(worktreePath: string, message: string): string {
-  const commitResult = spawnSync("git", ["commit", "--allow-empty", "-qm", message], {
-    cwd: worktreePath,
-    encoding: "utf8",
-    env: gitSafeEnv()
-  });
-  assert.equal(commitResult.status, 0, commitResult.stderr);
-
-  const revParseResult = spawnSync("git", ["rev-parse", "HEAD"], {
-    cwd: worktreePath,
-    encoding: "utf8",
-    env: gitSafeEnv()
-  });
-  assert.equal(revParseResult.status, 0, revParseResult.stderr);
-
-  return revParseResult.stdout.trim();
-}
-
-test("validate-artifact gate passes for implement-task with fresh task and artifact", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent());
-    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
-
-    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"]);
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "pass");
-    assert.equal(payload.checks.length, 4);
-    assert.deepEqual(
-      payload.checks.map((check) => check.status),
-      ["pass", "pass", "pass", "pass"]
-    );
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact gate supports human-readable text output", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-text-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent());
-    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
-
-    const result = runValidator([
-      "gate",
-      "implement-task",
-      taskDir,
-      "implementation.md",
-      "--format",
-      "text"
-    ]);
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /^Verification: pass \| Skill: implement-task$/m);
-    assert.match(result.stdout, /^\s+\[pass\] task-meta - /m);
-    assert.match(result.stdout, /^\s+\[pass\] artifact - /m);
-    assert.match(result.stdout, /^Result: 4 passed, 0 failed - All declared checks passed$/m);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact create-task task-meta accepts a generated branch", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-branch-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), [
-      buildTaskFrontmatter({
-        type: "feature",
-        workflow: "feature-development",
-        branch: "agent-infra-feature-cli-generic-sandbox",
-        current_step: "requirement-analysis"
-      }),
-      "",
-      "# 任务：创建任务",
-      "",
-      "## 活动日志",
-      "",
-      `- ${formatTimestamp(new Date())} — **Task Created** by codex — Task created from description`
-    ].join("\n"));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "create-task"]);
-    assert.equal(result.status, 0, result.stderr);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact create-task task-meta rejects invalid branch naming", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-branch-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), [
-      buildTaskFrontmatter({
-        branch: "wrong-prefix-feature-cli-generic-sandbox",
-        current_step: "requirement-analysis"
-      }),
-      "",
-      "# 任务：创建任务"
-    ].join("\n"));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "create-task"]);
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, /Invalid branch/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact task-meta warns without blocking when agent_infra_version is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-missing-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent());
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /agent_infra_version.*missing/);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.deepEqual(payload.warnings, [
-      "field 'agent_infra_version' missing — historical task or skipped version stamp"
-    ]);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact task-meta rejects malformed agent_infra_version", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-invalid-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      agent_infra_version: "0.6.1"
-    }));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, /Invalid agent_infra_version/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact task-meta accepts unknown agent_infra_version fallback", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-unknown-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      agent_infra_version: "unknown"
-    }));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact task-meta accepts SemVer build metadata in agent_infra_version", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-build-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      agent_infra_version: "v0.6.1-alpha.0+build.7"
-    }));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.doesNotMatch(result.stdout, /Invalid agent_infra_version/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact task-meta accepts stamped agent_infra_version", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-valid-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      agent_infra_version: "v0.6.1-alpha.0"
-    }));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "implement-task"]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.doesNotMatch(result.stdout, /agent_infra_version.*missing/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact activity-log passes for create-task happy path with Issue created", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-activity-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
+for (const c of activityLogCases) {
+  test(c.name, () => withTempRoot("agent-infra-create-task-activity-", (tempRoot) => {
     const now = formatTimestamp(new Date());
-    write(path.join(taskDir, "task.md"), [
-      buildTaskFrontmatter({
-        branch: "agent-infra-refactor-create-task-gate",
-        current_step: "requirement-analysis",
-        issue_number: 296,
-        updated_at: now
-      }),
-      "",
-      "# 任务：创建任务",
-      "",
-      "## 活动日志",
-      "",
-      `- ${now} — **Task Created** by codex — Task created from description`
-    ].join("\n"));
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    writeCreateTaskDocument(taskDir, {
+      branch: "agent-infra-refactor-create-task-gate",
+      current_step: "requirement-analysis",
+      issue_number: c.issueNumber,
+      updated_at: now
+    }, c.activityLines(now));
+    c.assertResult(runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]));
+  }));
+}
 
-    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
-    assert.equal(result.status, 0, result.stderr);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact activity-log fails for create-task when Create Issue entry is appended", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-create-issue-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    const now = formatTimestamp(new Date());
-    write(path.join(taskDir, "task.md"), [
-      buildTaskFrontmatter({
-        branch: "agent-infra-refactor-create-task-gate",
-        current_step: "requirement-analysis",
-        issue_number: 296,
-        updated_at: now
-      }),
-      "",
-      "# 任务：创建任务",
-      "",
-      "## 活动日志",
-      "",
-      `- ${now} — **Task Created** by codex — Task created from description`,
-      `- ${now} — **Create Issue** by codex — Created GitHub Issue #296`
-    ].join("\n"));
-
-    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, /Latest action 'Create Issue' does not match/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact activity-log fails for create-task when Issue Creation Skipped entry is appended", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-create-task-skipped-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    const now = formatTimestamp(new Date());
-    write(path.join(taskDir, "task.md"), [
-      buildTaskFrontmatter({
-        branch: "agent-infra-refactor-create-task-gate",
-        current_step: "requirement-analysis",
-        issue_number: "N/A",
-        updated_at: now
-      }),
-      "",
-      "# 任务：创建任务",
-      "",
-      "## 活动日志",
-      "",
-      `- ${now} — **Task Created** by codex — Task created from description`,
-      `- ${now} — **Issue Creation Skipped** by codex — GitHub Issue creation failed`
-    ].join("\n"));
-
-    const result = runValidator(["check", "activity-log", taskDir, "--skill", "create-task"]);
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, /Latest action 'Issue Creation Skipped' does not match/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact artifact check fails when a required section is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
+test("validate-artifact artifact check fails when a required section is missing", () => (
+  withTempRoot("agent-infra-gate-fail-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
     write(path.join(taskDir, "task.md"), buildTaskContent());
-    write(path.join(taskDir, "implementation.md"), loadFixture("missing-section-implementation.md"));
+    writeImplementationFixture(taskDir, "missing-section-implementation.md");
 
     const result = runValidator(["check", "artifact", taskDir, "implementation.md", "--skill", "implement-task"]);
     assert.equal(result.status, 1);
+    assertPayloadStatus(result, { type: "artifact", status: "fail", message: /missing sections/i });
+  })
+));
 
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "artifact");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /missing sections/i);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact activity-log freshness uses local timestamps", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-stale-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
+test("validate-artifact activity-log freshness uses local timestamps", () => (
+  withTempRoot("agent-infra-gate-stale-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
     const staleTimestamp = formatTimestampInTimeZone(new Date(Date.now() - 45 * 60_000), localTimeZone);
-    const staleTask = buildTaskContent(
+    write(path.join(taskDir, "task.md"), buildTaskContent(
       { updated_at: staleTimestamp },
       { NOW: staleTimestamp }
-    );
-
-    write(path.join(taskDir, "task.md"), staleTask);
-    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
+    ));
+    writeImplementationFixture(taskDir);
 
     const result = runValidator(["check", "activity-log", taskDir, "--skill", "implement-task"], {
-      env: {
-        TZ: localTimeZone
-      }
+      env: { TZ: localTimeZone }
     });
-
     assert.equal(result.status, 1);
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "activity-log");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /stale/i);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
+    assertPayloadStatus(result, { type: "activity-log", status: "fail", message: /stale/i });
+  })
+));
 
-test("validate-artifact task-meta supports cancel-task cancelled_at requirements", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-cancel-task-meta-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const cancelledAt = formatTimestamp(new Date());
-
-  try {
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      status: "completed",
-      cancelled_at: cancelledAt,
-      cancel_reason: "No longer needed after investigation"
-    }, {
-      NOW: cancelledAt
-    }));
-
-    const result = runValidator(["check", "task-meta", taskDir, "--skill", "cancel-task"]);
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "task-meta");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact gate passes for complete-task when completion checklist is fully checked", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-complete-task-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    write(path.join(taskDir, "task.md"), buildCompletedTaskContent([
-      "- [x] 所有需求已满足",
-      "- [x] 测试已编写并通过",
-      "- [x] 代码已审查",
-      "- [x] 文档已更新（如适用）",
-      "- [x] PR 已创建"
-    ]));
-
-    const result = runValidator(["gate", "complete-task", taskDir]);
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "pass");
-    assert.deepEqual(
-      payload.checks.map((check) => check.type),
-      ["task-meta", "activity-log", "completion-checklist", "platform-sync", "artifact"]
-    );
-    assert.deepEqual(
-      payload.checks.map((check) => check.status),
-      ["pass", "pass", "pass", "pass", "pass"]
-    );
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact completion-checklist fails when a complete-task item is unchecked", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-complete-task-checklist-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
+test("validate-artifact completion-checklist fails when a complete-task item is unchecked", () => (
+  withTempRoot("agent-infra-complete-task-checklist-fail-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
     write(path.join(taskDir, "task.md"), buildCompletedTaskContent([
       "- [x] 所有需求已满足",
       "- [ ] 测试已编写并通过",
@@ -905,1140 +360,13 @@ test("validate-artifact completion-checklist fails when a complete-task item is 
 
     const result = runValidator(["check", "completion-checklist", taskDir, "--skill", "complete-task"]);
     assert.equal(result.status, 1, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "completion-checklist");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Completion Checklist has unchecked items: 测试已编写并通过/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync blocks after retry exhaustion on gh network errors", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-gate-blocked-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-
-  try {
-    write(
-      path.join(taskDir, "task.md"),
-      buildTaskContent({ issue_number: "65" })
-    );
-    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
-    write(
-      ghPath,
-      "#!/bin/sh\n" +
-        "echo 'network timeout' >&2\n" +
-        "exit 1\n"
-    );
-    fs.chmodSync(ghPath, 0o755);
-
-    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-      }
+    assertPayloadStatus(result, {
+      type: "completion-checklist",
+      status: "fail",
+      message: /Completion Checklist has unchecked items: 测试已编写并通过/
     });
-
-    assert.equal(result.status, 2);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "blocked");
-    const githubCheck = payload.checks.find((check) => check.type === "platform-sync");
-    if (!githubCheck) {
-      throw new Error("expected platform-sync check");
-    }
-    assert.equal(githubCheck.status, "blocked");
-    assert.equal(githubCheck.fail_type, "network_error");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync retries upstream repo lookup on transient gh failure", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-retry-upstream-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-  const counterPath = path.join(tempRoot, "transient-upstream.count");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-    write(counterPath, "1");
-
-    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath,
-        GH_FAKE_TRANSIENT_FAIL_MATCHER: "api repos/fitlab-ai/agent-infra",
-        GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
-        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync retries permission lookup on transient gh failure", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-retry-permissions-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-  const counterPath = path.join(tempRoot, "transient-permissions.count");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-    write(counterPath, "1");
-
-    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath,
-        GH_FAKE_TRANSIENT_FAIL_MATCHER: ".permissions",
-        GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
-        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync retries label list fallback when in: label mapping is empty", () => {
-  const scratchRoot = filePath(".tmp");
-  fs.mkdirSync(scratchRoot, { recursive: true });
-  const tempRoot = fs.mkdtempSync(path.join(scratchRoot, "agent-infra-platform-sync-retry-labels-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh.cjs");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-  const labelsPath = path.join(tempRoot, "labels.json");
-  const counterPath = path.join(tempRoot, "transient-labels.count");
-  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
-  const adapterCopy = path.join(tempRoot, ".agents/scripts/platform-adapters/platform-sync.js");
-  const verifyCopy = path.join(tempRoot, ".agents/skills/commit/config/verify.json");
-
-  try {
-    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
-    write(path.join(tempRoot, ".agents/.airc.json"), JSON.stringify({
-      project: "agent-infra",
-      labels: { in: {} }
-    }, null, 2));
-    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
-    write(adapterCopy, read(".agents/scripts/platform-adapters/platform-sync.js"));
-    write(verifyCopy, read(".agents/skills/commit/config/verify.json"));
-
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    const headSha = createHeadCommit(tempRoot);
-    write(ghPath, loadFixture("fake-gh.js"));
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({ labels: [] }));
-    writeJson(commentsPath, []);
-    writeJson(prCommentsPath, [
-      {
-        body: [
-          "<!-- sync-pr:TASK-20260328-000001:summary -->",
-          `<!-- last-commit: ${headSha} -->`,
-          "## Review Summary",
-          "",
-          "Looks good."
-        ].join("\n")
-      }
-    ]);
-    writeJson(labelsPath, [{ name: "in: tests" }]);
-    write(counterPath, "1");
-
-    const result = spawnSync(
-      process.execPath,
-      [scriptCopy, "check", "platform-sync", taskDir, "--skill", "commit"],
-      {
-        encoding: "utf8",
-        cwd: tempRoot,
-        env: gitSafeEnv({
-          AGENT_INFRA_GH_BIN: process.execPath,
-          AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
-          GH_FAKE_ISSUE_PATH: issuePath,
-          GH_FAKE_COMMENTS_PATH: commentsPath,
-          GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-          GH_FAKE_LABELS_PATH: labelsPath,
-          GH_FAKE_ISSUE_NUMBER: "65",
-          GH_FAKE_PR_NUMBER: "77",
-          GH_FAKE_TRANSIENT_FAIL_MATCHER: "label list",
-          GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counterPath,
-          VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-        })
-      }
-    );
-
-    assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.equal(fs.readFileSync(counterPath, "utf8").trim(), "0");
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync skips when no platform adapter is registered", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const scriptCopy = path.join(tempRoot, ".agents/scripts/validate-artifact.js");
-  const verifyCopy = path.join(tempRoot, ".agents/skills/implement-task/config/verify.json");
-
-  try {
-    write(path.join(tempRoot, "package.json"), JSON.stringify({ type: "module" }, null, 2));
-    write(scriptCopy, read(".agents/scripts/validate-artifact.js"));
-    write(verifyCopy, read(".agents/skills/implement-task/config/verify.json"));
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
-    write(path.join(taskDir, "implementation.md"), loadFixture("valid-implementation.md"));
-
-    const result = spawnSync(
-      process.execPath,
-      [scriptCopy, "check", "platform-sync", taskDir, "implementation.md", "--skill", "implement-task"],
-      {
-        encoding: "utf8",
-        cwd: tempRoot,
-        env: process.env
-      }
-    );
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-    assert.equal(payload.message, "Skipped: no platform adapter registered for 'platform-sync'");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact gate passes when synced artifact and task comments match local files", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-
-    const result = runValidator(["gate", "implement-task", taskDir, "implementation.md"], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.gate, "pass");
-    assert.deepEqual(
-      payload.checks.map((check) => check.status),
-      ["pass", "pass", "pass", "pass"]
-    );
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when artifact comment content differs from the local artifact", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-artifact-mismatch-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", "# 摘要\n\n这不是原文。") },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "implementation.md",
-      "--skill",
-      "implement-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Comment content mismatch for 'implementation'/);
-    assert.match(payload.message, /first difference near char \d+/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when the task comment does not use the rendered frontmatter details block", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-task-mismatch-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent, { rawBody: true }) }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "implementation.md",
-      "--skill",
-      "implement-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Comment content mismatch for 'task'/);
-    assert.match(payload.message, /line \d+, column \d+/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when the Issue Type does not match task type", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-type-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65", type: "feature" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload({
-      type: buildIssueType("Task")
-    }));
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "implementation.md",
-      "--skill",
-      "implement-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /has type 'Task', expected 'Feature'/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync skips Issue Type verification when the REST query is unavailable", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-type-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "实现报告", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent) }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "implementation.md",
-      "--skill",
-      "implement-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath,
-        GH_FAKE_ISSUE_REST_FAIL: "Issue Types are unavailable",
-        VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync passes when Issue fields match task frontmatter", async () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      issue_number: "65",
-      type: "feature",
-      priority: "高",
-      effort: "Medium",
-      start_date: "2026-06-01"
-    }));
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(issueFieldsPath, buildIssueFieldsPayload({
-      pinnedFields: [
-        { typename: "IssueFieldSingleSelect", name: "Priority" },
-        { typename: "IssueFieldDate", name: "Start date" },
-        { typename: "IssueFieldSingleSelect", name: "Effort" }
-      ],
-      values: [
-        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "High" },
-        { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" },
-        { typename: "IssueFieldDateValue", fieldName: "Start date", value: "2026-06-01" }
-      ]
-    }));
-
-    const result = await runPlatformSyncAdapter(taskDir, {
-      when: "issue_number_exists",
-      verify_issue_fields: true
-    }, {
-      PATH: pathWithPrependedBin(binDir),
-      AGENT_INFRA_GH_BIN: process.execPath,
-      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
-      GH_FAKE_ISSUE_PATH: issuePath,
-      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
-    });
-
-    assert.equal(result.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when an Issue field differs from task frontmatter", async () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      issue_number: "65",
-      priority: "High"
-    }));
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(issueFieldsPath, buildIssueFieldsPayload({
-      values: [
-        { typename: "IssueFieldSingleSelectValue", fieldName: "Priority", value: "Low" }
-      ]
-    }));
-
-    const result = await runPlatformSyncAdapter(taskDir, {
-      when: "issue_number_exists",
-      verify_issue_fields: true
-    }, {
-      PATH: pathWithPrependedBin(binDir),
-      AGENT_INFRA_GH_BIN: process.execPath,
-      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
-      GH_FAKE_ISSUE_PATH: issuePath,
-      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
-    });
-
-    assert.equal(result.status, "fail");
-    assert.match(result.message, /field 'Priority' is 'Low', expected 'High'/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync skips Issue field verification when fields are inapplicable or unavailable", async () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-issue-fields-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const issueFieldsPath = path.join(tempRoot, "issue-fields.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      issue_number: "65",
-      target_date: "2026-06-30"
-    }));
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(issueFieldsPath, buildIssueFieldsPayload({
-      pinnedFields: [
-        { typename: "IssueFieldSingleSelect", name: "Priority" },
-        { typename: "IssueFieldSingleSelect", name: "Effort" }
-      ],
-      values: []
-    }));
-
-    const inapplicableResult = await runPlatformSyncAdapter(taskDir, {
-      when: "issue_number_exists",
-      verify_issue_fields: true
-    }, {
-      PATH: pathWithPrependedBin(binDir),
-      AGENT_INFRA_GH_BIN: process.execPath,
-      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
-      GH_FAKE_ISSUE_PATH: issuePath,
-      GH_FAKE_ISSUE_FIELDS_PATH: issueFieldsPath
-    });
-    assert.equal(inapplicableResult.status, "pass");
-
-    const unavailableResult = await runPlatformSyncAdapter(taskDir, {
-      when: "issue_number_exists",
-      verify_issue_fields: true
-    }, {
-      PATH: pathWithPrependedBin(binDir),
-      AGENT_INFRA_GH_BIN: process.execPath,
-      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ghPath]),
-      GH_FAKE_ISSUE_PATH: issuePath,
-      GH_FAKE_ISSUE_FIELDS_FAIL: "Issue fields are unavailable",
-      VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
-    });
-    assert.equal(unavailableResult.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync accepts English task frontmatter summary when language override is en", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-task-en-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    const taskContent = buildTaskContent({ issue_number: "65" });
-    const artifactContent = loadFixture("valid-implementation.md");
-
-    write(path.join(taskDir, "task.md"), taskContent);
-    write(path.join(taskDir, "implementation.md"), artifactContent);
-    writeJson(issuePath, buildIssuePayload());
-    writeJson(commentsPath, [
-      { body: buildArtifactComment("TASK-20260328-000001", "implementation.md", "Implementation Report", artifactContent) },
-      { body: buildTaskComment("TASK-20260328-000001", taskContent, { summaryText: "Metadata (frontmatter)" }) }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "implementation.md",
-      "--skill",
-      "implement-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath,
-        VALIDATE_ARTIFACT_LANGUAGE: "en"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when create-pr milestone is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-milestone-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: enhancement" }],
-      milestone: null
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /PR #77 has no milestone set/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when PR and Issue in: labels diverge", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-in-labels-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [{ name: "in: core" }],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: enhancement" }, { name: "in: cli" }, { name: "in: core" }]
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /in: labels mismatch/);
-    assert.match(payload.message, /PR #77/);
-    assert.match(payload.message, /Issue #65/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when create-pr is missing the expected type label", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-type-label-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      type: "feature",
-      issue_number: "65",
-      pr_number: "77"
-    }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [{ name: "in: core" }],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "in: core" }]
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Expected type label 'type: feature' not found on PR #77/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync passes when create-pr includes the expected type label", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-type-label-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      type: "feature",
-      issue_number: "65",
-      pr_number: "77"
-    }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [{ name: "in: core" }],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: feature" }, { name: "in: core" }]
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync skips create-pr type label verification without triage permission", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-type-label-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      type: "feature",
-      issue_number: "65",
-      pr_number: "77"
-    }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [{ name: "in: core" }],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "in: core" }]
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77",
-        GH_FAKE_PERMISSIONS: JSON.stringify({ triage: false, push: false })
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when create-pr has no assignee", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-assignee-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: enhancement" }],
-      assignees: []
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /PR #77 has no assignee/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync skips create-pr assignee verification without push permission", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-assignee-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: enhancement" }],
-      assignees: []
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77",
-        GH_FAKE_PERMISSIONS: JSON.stringify({ triage: true, push: false })
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync passes when create-pr summary comment exists on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-comment-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload({
-      labels: [{ name: "type: enhancement" }]
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
+  })
+));
 
 test("commit and create-pr references point to the shared pr-sync rule", () => {
   assertPointsToPrSyncRule(".agents/skills/commit/reference/pr-summary-sync.md");
@@ -2061,474 +389,6 @@ test("local and zh-CN rule files contain the canonical PR summary structure", ()
 test("template English rule contains the canonical PR summary structure", () => {
   const enHeadings = [/## Review Summary/, /### Key Technical Decisions/, /### Review History/, /### Test Results/];
   assertHasCanonicalPrSyncStructure("templates/.agents/rules/pr-sync.github.en.md", enHeadings);
-});
-
-test("validate-artifact platform-sync skips for commit when task has no pr_number", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-skip-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ]);
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-    assert.equal(payload.message, "Skipped: task has no pr_number");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync passes for commit when summary comment exists on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    const headSha = createHeadCommit(tempRoot);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${headSha} -->\n## Review Summary\n\nLooks good.` }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync passes for commit with last-commit from task branch worktree", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-worktree-pass-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const worktreePath = path.join(tempRoot, "sandbox-worktree");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-  const branch = "agent-infra-feature-pr";
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    const mainSha = createHeadCommit(tempRoot);
-    addWorktree(tempRoot, worktreePath, branch);
-    const prSha = commitInWorktree(worktreePath, "sandbox commit");
-    assert.notEqual(prSha, mainSha);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ branch, issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${prSha} -->\n## Review Summary\n\nLooks good.` }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync falls back to taskDir HEAD when task branch is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-no-branch-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    const mainSha = createHeadCommit(tempRoot);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${mainSha} -->\n## Review Summary\n\nLooks good.` }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync falls back to taskDir HEAD when task branch worktree is unmatched", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-unmatched-branch-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    const mainSha = createHeadCommit(tempRoot);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({
-      branch: "agent-infra-feature-missing",
-      issue_number: "65",
-      pr_number: "77"
-    }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: `<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: ${mainSha} -->\n## Review Summary\n\nLooks good.` }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "pass");
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails for commit when summary comment last-commit metadata mismatches HEAD", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-head-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    createHeadCommit(tempRoot);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n<!-- last-commit: deadbee -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /last-commit metadata mismatch/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails for commit when summary comment last-commit metadata is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-head-missing-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    createHeadCommit(tempRoot);
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, [
-      { body: "<!-- sync-pr:TASK-20260328-000001:summary -->\n## Review Summary\n\nLooks good." }
-    ]);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /missing '<!-- last-commit: <sha> -->' metadata/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails when create-pr summary comment is missing on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-pr-comment-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prPath = path.join(tempRoot, "pr.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prPath, buildPrPayload());
-    writeJson(prCommentsPath, []);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-pr"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_PATH: prPath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Expected PR comment marker/);
-    assert.match(payload.message, /PR #77/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails for commit when summary comment is missing on the PR", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-commit-fail-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const prCommentsPath = path.join(tempRoot, "pr-comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65", pr_number: "77" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [],
-      body: "# Issue\n"
-    }));
-    writeJson(prCommentsPath, []);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "commit"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_PR_COMMENTS_PATH: prCommentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65",
-        GH_FAKE_PR_NUMBER: "77"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /Expected PR comment marker/);
-    assert.match(payload.message, /PR #77/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test("validate-artifact platform-sync fails for create-task when the task comment is missing", () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-platform-sync-create-task-task-"));
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
-  const binDir = path.join(tempRoot, "bin");
-  const ghPath = path.join(binDir, "gh");
-  const issuePath = path.join(tempRoot, "issue.json");
-  const commentsPath = path.join(tempRoot, "comments.json");
-
-  try {
-    initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
-    writeFakeGh(ghPath);
-
-    write(path.join(taskDir, "task.md"), buildTaskContent({ issue_number: "65" }));
-    writeJson(issuePath, buildIssuePayload({
-      labels: [{ name: "status: waiting-for-triage" }],
-      body: "# Issue\n"
-    }));
-    writeJson(commentsPath, []);
-
-    const result = runValidator([
-      "check",
-      "platform-sync",
-      taskDir,
-      "--skill",
-      "create-task"
-    ], {
-      env: {
-        PATH: pathWithPrependedBin(binDir),
-        GH_FAKE_ISSUE_PATH: issuePath,
-        GH_FAKE_COMMENTS_PATH: commentsPath,
-        GH_FAKE_ISSUE_NUMBER: "65"
-      }
-    });
-
-    assert.equal(result.status, 1);
-
-    const payload = parseValidatorPayload(result.stdout);
-    assert.equal(payload.type, "platform-sync");
-    assert.equal(payload.status, "fail");
-    assert.match(payload.message, /sync-issue:TASK-20260328-000001:task/);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
 });
 
 test("verification assets are present in local and template trees", () => {

--- a/tests/templates/skills.test.ts
+++ b/tests/templates/skills.test.ts
@@ -193,7 +193,7 @@ test("workflow verify config language variants keep only artifact language field
 });
 
 test("workflow report templates include evidence sections", () => {
-  [
+  const reportTemplateCases: Array<[string, string, string]> = [
     [".agents/skills/implement-task/reference/report-template.md", "## 状态核对", "## 证据原文"],
     [".agents/skills/review-task/reference/report-template.md", "## 状态核对", "## 证据原文"],
     [".agents/skills/refine-task/reference/report-template.md", "## 状态核对", "## 证据原文"],
@@ -203,7 +203,9 @@ test("workflow report templates include evidence sections", () => {
     ["templates/.agents/skills/implement-task/reference/report-template.en.md", "## State Check", "## Evidence"],
     ["templates/.agents/skills/review-task/reference/report-template.en.md", "## State Check", "## Evidence"],
     ["templates/.agents/skills/refine-task/reference/report-template.en.md", "## State Check", "## Evidence"]
-  ].forEach(([relativePath, stateHeading, evidenceHeading]) => {
+  ];
+
+  reportTemplateCases.forEach(([relativePath, stateHeading, evidenceHeading]) => {
     const content = read(relativePath);
 
     assert.match(content, new RegExp(escapeRegExp(stateHeading)));
@@ -212,11 +214,13 @@ test("workflow report templates include evidence sections", () => {
 });
 
 test("workflow skill output instructions align with state check artifact gates", () => {
-  [
+  const analyzeTaskCases: Array<[string, string]> = [
     [".agents/skills/analyze-task/SKILL.md", "## 状态核对"],
     ["templates/.agents/skills/analyze-task/SKILL.zh-CN.md", "## 状态核对"],
     ["templates/.agents/skills/analyze-task/SKILL.en.md", "## State Check"]
-  ].forEach(([relativePath, heading]) => {
+  ];
+
+  analyzeTaskCases.forEach(([relativePath, heading]) => {
     assert.match(
       read(relativePath),
       new RegExp(`^${escapeRegExp(heading)}$`, "m"),
@@ -224,11 +228,13 @@ test("workflow skill output instructions align with state check artifact gates",
     );
   });
 
-  [
+  const completeTaskCases: Array<[string, string]> = [
     [".agents/skills/complete-task/SKILL.md", "## 状态核对"],
     ["templates/.agents/skills/complete-task/SKILL.zh-CN.md", "## 状态核对"],
     ["templates/.agents/skills/complete-task/SKILL.en.md", "## State Check"]
-  ].forEach(([relativePath, heading]) => {
+  ];
+
+  completeTaskCases.forEach(([relativePath, heading]) => {
     const content = read(relativePath);
     const updateSection = content.match(/^### 3\. .+?(?=^### 4\. )/ms)?.[0] || "";
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #349

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #349

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

`tests/core/validate-artifact.test.ts` 是仓库第二大测试文件（2557 行），针对 `.agents/scripts/validate-artifact.js` 的 contract 校验测试。其重复 setup 平铺、inline fixture 膨胀，新增 scenario 必须复制整段 setup + 断言。本 PR 将其重构为 table-driven 结构，单文件控制在 1000 行以内，且**不改动被测脚本**与对外契约。

## 📋 主要变更 / Brief Changelog

- 将 2557 行单文件拆为 table-driven 主文件 `validate-artifact.test.ts`（22 场景，417 行）+ `validate-artifact-platform-sync.test.ts`（32 场景，710 行），两者均 ≤ 1000 行
- 新增 suite-local helper `validate-artifact-helpers.ts`（非 `.test.ts`），集中 runner / fixture builder / fake gh / platform-sync env / 共享断言；删除模块级可变状态 `currentFakeGhPath`，改为 `runValidator({ fakeGhPath })` 显式注入
- `test-tier-coverage.test.ts` 的 full-only 守卫纳入新 platform-sync 文件
- 附带修复 `sandbox-clipboard.test.ts` / `skills.test.ts` 既有的 typecheck 错误（基线既存、与本重构无关），以满足全项目 `npm run typecheck` 门禁；改动为纯类型修正

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run typecheck` —— 全绿
2. `node --experimental-strip-types --no-warnings --test --test-reporter=tap tests/core/validate-artifact.test.ts tests/core/validate-artifact-platform-sync.test.ts | rg -c '^ok '` —— 输出 `54`（= 重构前基线，覆盖未回退）
3. `npm test` —— 574 pass, 1 skip, 0 fail
4. `git diff --stat .agents/scripts/ templates/.agents/scripts/` —— 无输出（被测脚本零改动）

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（仅测试结构变化，契约零改动）

## 📋 附加信息 / Additional Notes

- 覆盖回归采用双重硬门禁：scenario 不减（combined TAP `ok` = 54）+ 断言覆盖不减（baseline 正则 matcher 差集为空，详见 `review-r2.md`）。静态 `assert.*` 计数 176→88 系共享断言 helper 的 DRY 折叠所致，运行时断言执行不减。
- 父 Issue：#347。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `validate-artifact-platform-sync.test.ts` 的 32 个 platform-sync 场景是否与原 contract 断言一一对应，以及 `validate-artifact-helpers.ts` 中 fake gh 显式注入是否覆盖原 `currentFakeGhPath` 的所有调用形态。

Generated with AI assistance
