### PR TITLE
fix(sandbox): inject host timezone at runtime

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -48,6 +48,7 @@ import {
   redactCommandError,
   validateClaudeCredentialsEnvOverride
 } from '../credentials.ts';
+import { detectHostTimezone } from '../host-timezone.ts';
 
 const OPENCODE_YOLO_PERMISSION = '{"*":"allow","read":"allow","bash":"allow","edit":"allow","webfetch":"allow","external_directory":"allow","doom_loop":"allow"}';
 const SANDBOX_ALIAS_BLOCK_BEGIN = '# >>> agent-infra managed aliases >>>';
@@ -1364,6 +1365,8 @@ export async function create(args: string[]): Promise<void> {
             const dotfilesMount = dotfilesSnapshot
               ? buildDotfilesVolumeArgs(engine, dotfilesSnapshot.cacheDir)
               : [];
+            const hostTz = detectHostTimezone();
+            const tzFlags = hostTz ? ['-e', `TZ=${hostTz}`] : [];
 
             runEngineTaskCommand(engine, 'docker', [
               'run',
@@ -1398,6 +1401,7 @@ export async function create(args: string[]): Promise<void> {
               ...liveMountVolumes,
               ...shellConfigVolumes,
               ...envFile.dockerArgs,
+              ...tzFlags,
               '-w',
               '/workspace',
               effectiveConfig.imageName

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -12,6 +12,7 @@ import { runInteractiveEngine, runSafeEngine } from '../shell.ts';
 import { resolveTaskBranch } from '../task-resolver.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
 import { runInteractiveWithClipboardBridge } from '../clipboard/bridge.ts';
+import { detectHostTimezone } from '../host-timezone.ts';
 
 const USAGE = `Usage: ai sandbox exec <branch> [cmd...]`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
@@ -37,6 +38,11 @@ export function terminalEnvFlags(env: NodeJS.ProcessEnv = process.env): string[]
     }
   }
   return flags;
+}
+
+export function hostTimezoneEnvFlags(detect = detectHostTimezone): string[] {
+  const tz = detect();
+  return tz ? ['-e', `TZ=${tz}`] : [];
 }
 
 export function formatCredentialSyncStatus(
@@ -101,7 +107,7 @@ export async function enter(args: string[]): Promise<number> {
     }
   }
 
-  const envFlags = terminalEnvFlags();
+  const envFlags = [...terminalEnvFlags(), ...hostTimezoneEnvFlags()];
   if (cmd.length === 0) {
     try {
       materializeDotfiles(config.dotfilesDir, dotfilesCacheDir(config.home, config.project));

--- a/lib/sandbox/host-timezone.ts
+++ b/lib/sandbox/host-timezone.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import os from 'node:os';
+
+export type DetectHostTimezoneOptions = {
+  platform?: NodeJS.Platform;
+  readlink?: (targetPath: string) => string;
+  env?: NodeJS.ProcessEnv;
+};
+
+const ZONEINFO_MARK = '/zoneinfo/';
+const IANA_ZONE_RE = /^[A-Za-z][A-Za-z0-9_+-]*(\/[A-Za-z0-9_+-]+)*$/;
+
+function safeTimezone(value: string | undefined): string | null {
+  if (!value || !IANA_ZONE_RE.test(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function detectHostTimezone(options: DetectHostTimezoneOptions = {}): string | null {
+  const platform = options.platform ?? os.platform();
+  const env = options.env ?? process.env;
+  if (env.TZ) {
+    return safeTimezone(env.TZ);
+  }
+
+  if (platform !== 'darwin' && platform !== 'linux') {
+    return null;
+  }
+
+  const readlink = options.readlink ?? fs.readlinkSync;
+  try {
+    const target = readlink('/etc/localtime');
+    const idx = target.indexOf(ZONEINFO_MARK);
+    if (idx < 0) {
+      return null;
+    }
+    return safeTimezone(target.slice(idx + ZONEINFO_MARK.length));
+  } catch {
+    return null;
+  }
+}

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:22.04
 LABEL description="AI coding sandbox"
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Asia/Shanghai
 
 ARG HOST_UID=1000
 ARG HOST_GID=1000
@@ -22,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     build-essential ca-certificates gnupg lsb-release \
     libevent-core-2.1-7 libncursesw6 libtinfo6 \
     pkg-config bison libevent-dev libncurses-dev \
-    locales \
+    locales tzdata \
     && locale-gen en_US.UTF-8 \
     && (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg) \
@@ -45,13 +44,13 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable extended keys in CSI u format so Shift+Enter and other modified
-# keys are forwarded through tmux. Preserve terminal-detection variables
+# keys are forwarded through tmux. Preserve terminal/timezone variables
 # injected at `docker exec` time when new tmux sessions are created.
 RUN printf '%s\n' \
       'set -g extended-keys always' \
       'set -g extended-keys-format csi-u' \
       "set -as terminal-features 'xterm*:extkeys'" \
-      "set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'" \
+      "set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION TZ'" \
       'set -g mouse on' \
       'set -g status-interval 1' \
       'set -g status-right-length 80' \
@@ -165,6 +164,11 @@ done
 # Reuse the single $SESSION; -d detaches any pre-existing client so the new
 # one becomes the sole owner of window-size, eliminating size races.
 if tmux has-session -t "$SESSION" 2>/dev/null; then
+  # Push the per-exec TZ into the running session's env so new
+  # windows/panes pick up the host timezone without a session kill.
+  if [ -n "${TZ:-}" ]; then
+    tmux set-environment -t "$SESSION" TZ "$TZ" 2>/dev/null || true
+  fi
   exec tmux attach -d -t "$SESSION"
 fi
 

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -22,10 +22,8 @@ RUN apt-get update && apt-get install -y \
     build-essential ca-certificates gnupg lsb-release \
     libevent-core-2.1-7 libncursesw6 libtinfo6 \
     pkg-config bison libevent-dev libncurses-dev \
-    locales tzdata \
+    locales \
     && locale-gen en_US.UTF-8 \
-    && ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && echo "Asia/Shanghai" > /etc/timezone \
     && (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg) \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get install -y \
     build-essential ca-certificates gnupg lsb-release \
     libevent-core-2.1-7 libncursesw6 libtinfo6 \
     pkg-config bison libevent-dev libncurses-dev \
-    locales \
+    locales tzdata \
     && locale-gen en_US.UTF-8 \
+    && ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && echo "Asia/Shanghai" > /etc/timezone \
     && (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg) \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -230,6 +230,25 @@ test("composeDockerfile installs tmux for in-container session recovery", async 
   }
 });
 
+test("composeDockerfile installs tzdata for runtime TZ resolution", async () => {
+  const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tzdata-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /\btzdata\b/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("composeDockerfile bakes sandbox-tmux-entry script", async () => {
   const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmux-entry-"));
@@ -250,6 +269,7 @@ test("composeDockerfile bakes sandbox-tmux-entry script", async () => {
     assert.match(content, /tmux list-sessions -F '#\{session_name\}'/);
     assert.match(content, /case "\$name" in\s*"\$SESSION"-\*\)/);
     assert.match(content, /tmux kill-session -t "\$name"/);
+    assert.match(content, /tmux\s+set-environment\s+-t\s+"\$SESSION"\s+TZ/);
     assert.match(content, /exec tmux attach -d -t "\$SESSION"/);
     assert.match(content, /exec tmux new-session -s "\$SESSION"/);
   } finally {
@@ -326,7 +346,7 @@ test("composeDockerfile configures tmux extended keys and terminal env forwardin
     assert.match(content, /set -as terminal-features 'xterm\*:extkeys'/);
     assert.match(
       content,
-      /set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION'/
+      /set -ga update-environment 'TERM_PROGRAM TERM_PROGRAM_VERSION LC_TERMINAL LC_TERMINAL_VERSION TZ'/
     );
     assert.match(content, /set -g mouse on/);
     assert.match(content, /set -g status-interval 1/);

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -209,6 +209,27 @@ test("composeDockerfile includes gh CLI and bash_aliases sourcing", async () => 
   }
 });
 
+test("composeDockerfile wires Asia/Shanghai zoneinfo", async () => {
+  const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-zoneinfo-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node20"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /\btzdata\b/);
+    assert.match(content, /ln\s+-snf\s+\/usr\/share\/zoneinfo\/Asia\/Shanghai\s+\/etc\/localtime/);
+    assert.match(content, /echo\s+"Asia\/Shanghai"\s*>\s*\/etc\/timezone/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("composeDockerfile installs tmux for in-container session recovery", async () => {
   const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmux-"));

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -209,27 +209,6 @@ test("composeDockerfile includes gh CLI and bash_aliases sourcing", async () => 
   }
 });
 
-test("composeDockerfile wires Asia/Shanghai zoneinfo", async () => {
-  const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-zoneinfo-"));
-
-  try {
-    const dockerfilePath = sandboxDockerfile.composeDockerfile({
-      repoRoot: tmpDir,
-      project: "demo",
-      runtimes: ["node20"],
-      dockerfile: null
-    });
-    const content = fs.readFileSync(dockerfilePath, "utf8");
-
-    assert.match(content, /\btzdata\b/);
-    assert.match(content, /ln\s+-snf\s+\/usr\/share\/zoneinfo\/Asia\/Shanghai\s+\/etc\/localtime/);
-    assert.match(content, /echo\s+"Asia\/Shanghai"\s*>\s*\/etc\/timezone/);
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
 test("composeDockerfile installs tmux for in-container session recovery", async () => {
   const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmux-"));

--- a/tests/integration/cli/sandbox-timezone-injection.test.ts
+++ b/tests/integration/cli/sandbox-timezone-injection.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  cliArgs,
+  envWithPrependedPath,
+  gitSafeEnv,
+  onPlatforms,
+  writeSandboxEngineFixture
+} from "../../helpers.ts";
+
+function commitInitialFile(repoDir: string): void {
+  fs.writeFileSync(path.join(repoDir, "README.md"), "# demo\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=Test User", "-c", "user.email=test@example.com", "commit", "-m", "initial"],
+    { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" }
+  );
+}
+
+function spawnSandboxCli(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+  options: { timeout?: number } = {}
+) {
+  return spawnSync(process.execPath, cliArgs("sandbox", ...args), {
+    cwd: fixture.repoDir,
+    env: {
+      ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      DOCKER_LOG_PATH: fixture.logPath,
+      ...extraEnv
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: options.timeout ?? 15_000
+  });
+}
+
+test("sandbox create injects the detected host timezone into docker run", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-create-tz-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      sandbox: { tools: ["codex"] }
+    });
+    commitInitialFile(fixture.repoDir);
+
+    spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["create", "feature-x", "--cpu", "1", "--memory", "1"],
+      { DOCKER_EXIT_FOR_RUN: "1", TZ: "Europe/Paris" },
+      { timeout: 5_000 }
+    );
+
+    const runCall = fixture.readDockerCalls().find((call) => call[0] === "run");
+    assert.ok(runCall, "expected sandbox create to call docker run");
+    assert.ok(
+      runCall.some((arg, index) => arg === "-e" && runCall[index + 1] === "TZ=Europe/Paris"),
+      `expected docker run to receive TZ=Europe/Paris, got ${JSON.stringify(runCall)}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox exec injects the detected host timezone into docker exec", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-exec-tz-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      dockerStdoutForPs: "demo-dev-agent-infra-feature-cli-generic-sandbox"
+    });
+
+    const result = spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["exec", "agent-infra-feature-cli-generic-sandbox", "true"],
+      { TZ: "Europe/Paris" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const execCall = fixture.readDockerCalls().find((call) => call[0] === "exec");
+    assert.ok(execCall, "expected sandbox exec to call docker exec");
+    assert.ok(
+      execCall.some((arg, index) => arg === "-e" && execCall[index + 1] === "TZ=Europe/Paris"),
+      `expected docker exec to receive TZ=Europe/Paris, got ${JSON.stringify(execCall)}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -148,7 +148,8 @@ test("sandbox exec enters tmux automatically for interactive shells", onPlatform
           TERM_PROGRAM: "",
           TERM_PROGRAM_VERSION: "",
           LC_TERMINAL: "",
-          LC_TERMINAL_VERSION: ""
+          LC_TERMINAL_VERSION: "",
+          TZ: "Invalid Value"
         },
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"]

--- a/tests/unit/cli/host-timezone.test.ts
+++ b/tests/unit/cli/host-timezone.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadFreshEsm } from "../../helpers.ts";
+
+type HostTimezoneModule = {
+  detectHostTimezone(options?: {
+    platform?: NodeJS.Platform;
+    readlink?: (targetPath: string) => string;
+    env?: NodeJS.ProcessEnv;
+  }): string | null;
+};
+
+test("detectHostTimezone prefers an explicit TZ environment value", async () => {
+  const { detectHostTimezone } = await loadFreshEsm<HostTimezoneModule>("lib/sandbox/host-timezone.js");
+
+  assert.equal(
+    detectHostTimezone({
+      platform: "linux",
+      readlink() {
+        return "/usr/share/zoneinfo/Asia/Shanghai";
+      },
+      env: { TZ: "Europe/Paris" }
+    }),
+    "Europe/Paris"
+  );
+});
+
+test("detectHostTimezone extracts a macOS zoneinfo symlink target", async () => {
+  const { detectHostTimezone } = await loadFreshEsm<HostTimezoneModule>("lib/sandbox/host-timezone.js");
+
+  assert.equal(
+    detectHostTimezone({
+      platform: "darwin",
+      readlink() {
+        return "/var/db/timezone/zoneinfo/Asia/Shanghai";
+      },
+      env: {}
+    }),
+    "Asia/Shanghai"
+  );
+});
+
+test("detectHostTimezone extracts a Linux zoneinfo symlink target", async () => {
+  const { detectHostTimezone } = await loadFreshEsm<HostTimezoneModule>("lib/sandbox/host-timezone.js");
+
+  assert.equal(
+    detectHostTimezone({
+      platform: "linux",
+      readlink() {
+        return "/usr/share/zoneinfo/Asia/Shanghai";
+      },
+      env: {}
+    }),
+    "Asia/Shanghai"
+  );
+});
+
+test("detectHostTimezone returns null when no safe host timezone is available", async () => {
+  const { detectHostTimezone } = await loadFreshEsm<HostTimezoneModule>("lib/sandbox/host-timezone.js");
+
+  assert.equal(detectHostTimezone({ platform: "win32", env: {} }), null);
+  assert.equal(
+    detectHostTimezone({
+      platform: "linux",
+      readlink() {
+        throw new Error("ENOENT");
+      },
+      env: {}
+    }),
+    null
+  );
+  assert.equal(detectHostTimezone({ platform: "linux", env: { TZ: "Europe/Paris with space" } }), null);
+  assert.equal(
+    detectHostTimezone({
+      platform: "linux",
+      readlink() {
+        return "/usr/share/zoneinfo/../Europe/Paris";
+      },
+      env: {}
+    }),
+    null
+  );
+});

--- a/tests/unit/cli/sandbox-host-timezone-flags.test.ts
+++ b/tests/unit/cli/sandbox-host-timezone-flags.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadFreshEsm } from "../../helpers.ts";
+
+type EnterModule = {
+  hostTimezoneEnvFlags(detect?: () => string | null): string[];
+};
+
+test("hostTimezoneEnvFlags forwards the detected IANA timezone", async () => {
+  const sandboxEnter = await loadFreshEsm<EnterModule>("lib/sandbox/commands/enter.js");
+
+  assert.deepEqual(sandboxEnter.hostTimezoneEnvFlags(() => "Europe/Paris"), [
+    "-e",
+    "TZ=Europe/Paris"
+  ]);
+});
+
+test("hostTimezoneEnvFlags omits TZ when detection fails", async () => {
+  const sandboxEnter = await loadFreshEsm<EnterModule>("lib/sandbox/commands/enter.js");
+
+  assert.deepEqual(sandboxEnter.hostTimezoneEnvFlags(() => null), []);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #397

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

沙盒容器虽设置了 `ENV TZ=Asia/Shanghai`，但 `ubuntu:22.04` minimal image 不含 tzdata、`/etc/localtime` 是 broken symlink，glibc 解析 `TZ` 找不到 zoneinfo 文件后**静默 fallback 到 UTC**。后果：所有 AI 工作流通过 `date "+%Y-%m-%d %H:%M:%S%:z"` 拿到的时间戳都是 `+00:00` 而非项目惯例 `+08:00`，污染 `task.md` frontmatter、Activity Log、Issue/PR 同步评论与各类产物文档。

本次修复采用 **build-time 装 tzdata + runtime 注入 `-e TZ=<host-zone>`** 两层方案：镜像层只解决 zoneinfo 数据库可用性（一次性 rebuild），具体时区完全跟随**宿主机**，跨时区出差（+08 ↔ +09 ↔ ...）**不需要再 rebuild**。同时删除 Dockerfile 内硬编码 `ENV TZ=Asia/Shanghai`，让 sandbox 真正跨时区可移植。

> 本 PR 取代被 revert 的 commit `2e79fb4`（Round 1 实现把时区写死成 Asia/Shanghai 且全员触发 rebuild，与跨时区诉求冲突）。Round 2 设计与实施过程详见 Issue #397 的产物评论链。

## 📋 主要变更 / Brief Changelog

- **`lib/sandbox/runtimes/base.dockerfile`**：(a) 删除 `ENV TZ=Asia/Shanghai`、(b) `apt-get install` 列表加入 `tzdata`、(c) tmux `update-environment` 列表加入 `TZ`，并在 `sandbox-tmux-entry` 的 `has-session` 分支内 attach 前 `tmux set-environment -t "$SESSION" TZ "$TZ"`，让已存在 session 的新 windows/panes 立即拿到宿主当前 TZ
- **`lib/sandbox/host-timezone.ts`（新增）**：`detectHostTimezone()` 纯函数，env > `/etc/localtime` symlink > null 三段；IANA sanity regex `^[A-Za-z][A-Za-z0-9_+-]*(\/[A-Za-z0-9_+-]+)*$` 拒绝 `..` / 空格 / 前导斜杠等异常值，防止经 `process.env.TZ` 注入 docker 参数
- **`lib/sandbox/commands/create.ts`**：`docker run` 拼参时追加 `-e TZ=<host-zone>`（放在 `envFile.dockerArgs` 之后、`-w` 之前）
- **`lib/sandbox/commands/enter.ts`**：新增 `hostTimezoneEnvFlags(detect = detectHostTimezone)` helper，与 `terminalEnvFlags()` 合并到 `envFlags`；`docker exec` 每次重新探测宿主 TZ，让 `ai sandbox exec` 在跨时区切换时**免重建容器**即可在新 shell 内反映新 TZ
- **测试矩阵**（+8 用例 / 净 +24 测试）：
  - `tests/unit/cli/host-timezone.test.ts`：env 优先 / macOS / Linux / Windows / readlink ENOENT / IANA 正则拒绝 `..` 与空格
  - `tests/unit/cli/sandbox-host-timezone-flags.test.ts`：DI stub 覆盖 helper 的 detected / null 两条路径
  - `tests/integration/cli/sandbox-timezone-injection.test.ts`：用 `process.env.TZ='Europe/Paris'` 驱动真实探测，断言 `docker run` / `docker exec` 拼参含 `-e TZ=Europe/Paris`
  - `tests/integration/cli/sandbox-dockerfile.test.ts`：新增 `tzdata` 断言、`update-environment` 含 `TZ` 断言、`sandbox-tmux-entry` 含 `set-environment -t "$SESSION" TZ` 断言
  - `tests/integration/cli/sandbox-tools.test.ts`：原有 tmux entry 测试加 `TZ: "Invalid Value"` 中和宿主 TZ env 副作用，防止其严格 `dockerCalls` 断言被新功能污染

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. **自动化**：`npm test` 全套通过，586 用例 / 585 pass / 1 原有 skip / 0 fail
2. **手工镜像验证**（macOS 已实测）：

```bash
ai sandbox rebuild

# 关键负向：不带 -e TZ 必须输出 UTC（验证 ENV TZ=Asia/Shanghai 已真删除）
docker run --rm agent-infra-sandbox:latest sh -lc 'date "+%Y-%m-%d %H:%M:%S%:z"'
# → 2026-06-06 04:04:33+00:00 ✓

# 注入宿主时区
docker run --rm -e TZ=Asia/Shanghai agent-infra-sandbox:latest sh -lc 'date "+%Y-%m-%d %H:%M:%S%:z"'
# → 2026-06-06 12:04:34+08:00 ✓

# 跨时区切换（不重建镜像）
docker run --rm -e TZ=Asia/Tokyo agent-infra-sandbox:latest sh -lc 'date "+%Y-%m-%d %H:%M:%S%:z"'
# → 2026-06-06 13:04:34+09:00 ✓

docker run --rm -e TZ=Europe/London agent-infra-sandbox:latest sh -lc 'date "+%Y-%m-%d %H:%M:%S%:z"'
# → 2026-06-06 05:04:34+01:00 ✓ (BST)
```

3. **镜像内 tmux 配置 grep 验证**：

```bash
docker run --rm agent-infra-sandbox:latest sh -lc \
  "grep 'update-environment' /etc/tmux.conf && grep 'tmux set-environment -t \"\$SESSION\" TZ' /usr/local/bin/sandbox-tmux-entry"
# 两条 grep 都命中 ✓
```

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ⚠️ 待人工验证 / Pending Manual Verification

本 PR 由 macOS host 实施与端到端实测；以下场景**未在真实主机上跑过**，留给社区 reviewer 在不同 host 上覆盖：

- [ ] **Linux host**（Ubuntu / Debian / RHEL / Arch 任一）：验证 `ai sandbox create <branch>` 后 `docker inspect <container>` 的 Env 含 `TZ=<host-zone>`；切换宿主时区 `sudo timedatectl set-timezone Asia/Tokyo` 后 `ai sandbox exec <branch> date +%:z` 立即反映新偏移
- [ ] **Windows host（含 WSL2）**：宿主无 `TZ` env 时容器静默 fallback 到 UTC（不阻塞 sandbox 启动）；显式 `$env:TZ='Asia/Shanghai'` 后注入正常生效

**最差行为承诺**：探测失败时容器内 fallback 到 UTC，与本 PR 实施前的实际行为（`ENV TZ=Asia/Shanghai` 但 zoneinfo 缺失 → 同样 fallback UTC）完全一致——所以**任何平台都不会出现比实施前更差的行为**。

## 📋 附加信息 / Additional Notes

- **镜像签名变化触发一次性 rebuild**：用户首次启动当前签名的镜像时会被强制重建一次（必然代价）；**此后**无论宿主 TZ 如何切换都**不再** rebuild。这是本设计与被 revert 的 Round 1 方案的根本区别
- **已有容器的更新路径**：`ai sandbox exec` 每次重新探测宿主 TZ 注入，**新启动的 shell/工具进程**立即反映新 TZ；但容器主进程（`tail -f /dev/null`）的 TZ env 是 docker run 时快照，要让它也反映新 TZ 需要 `ai sandbox rm <branch> && ai sandbox create <branch>`
- **tmux 旧 pane 边界**：已 attach 的旧 pane 内的 shell 进程持有的 TZ env 是 fork 时快照，本次实现不强制 hot reload；用户需 exit 旧 pane 重开（`Ctrl-b c` 即获得新 TZ）
- **env-file 优先级**：自动探测的 TZ 注入位置在 `envFile.dockerArgs` 之后，会覆盖用户在 docker env-file 中可能放置的同名 `TZ`。这是本 PR 的设计选择（让宿主探测拥有最终决定权）；若未来需要让 env-file 优先，需单独讨论

---

**审查者注意事项 / Reviewer Notes:**

- `detectHostTimezone()` 的安全过滤（IANA sanity regex）和静默降级（探测失败返回 null、不注入 `-e TZ`）是本设计的安全边界，建议重点审查 `lib/sandbox/host-timezone.ts:11-42`
- `lib/sandbox/commands/create.ts` 中 `...tzFlags` 的拼参位置（line 1404，在 `...envFile.dockerArgs` 之后）决定优先级，已在「附加信息」声明
- tmux 路径：`lib/sandbox/runtimes/base.dockerfile:54` 的 `update-environment` 加 `TZ` 和 `:167-171` 的 `set-environment -t "$SESSION"` 是配对设计；缺一不可，否则 tmux session 内的新 pane 不会反映新 TZ
- 整 PR 是 net improvement / net 持平，无 net regression；回退路径单 commit revert 即可

Generated with AI assistance
