### PR TITLE
fix(tests): drop execSync shell strings in CLI tests

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,5 @@
 export { filePath, exists, read, listFilesRecursive, listSkillNames } from "./helpers/paths.ts";
-export { CLI_PATH, cliArgs, cliCommand, pathWithPrependedBin, envWithPrependedPath } from "./helpers/cli.ts";
+export { CLI_PATH, cliArgs, pathWithPrependedBin, envWithPrependedPath } from "./helpers/cli.ts";
 export { gitSafeEnv, withGitSafeProcessEnv, initIsolatedGitRepo } from "./helpers/git.ts";
 export { onPlatforms, supportsPosixModeBits, assertModeBits } from "./helpers/platform.ts";
 export { writeSandboxEngineFixture, writeNodeCommandShim } from "./helpers/sandbox.ts";

--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -7,10 +7,6 @@ function cliArgs(...args: string[]): string[] {
   return [CLI_PATH, ...args];
 }
 
-function cliCommand(...args: string[]): string {
-  return [process.execPath, ...cliArgs(...args)].map((part) => JSON.stringify(part)).join(" ");
-}
-
 function pathWithPrependedBin(binDir: string, envPath: string = process.env.PATH || ""): string {
   return [binDir, envPath].filter(Boolean).join(path.delimiter);
 }
@@ -28,7 +24,6 @@ function envWithPrependedPath(env: NodeJS.ProcessEnv, binDir: string): NodeJS.Pr
 export {
   CLI_PATH,
   cliArgs,
-  cliCommand,
   envWithPrependedPath,
   pathWithPrependedBin
 };

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -1,11 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync, execSync, spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { CLI_PATH, cliArgs, cliCommand, envWithPrependedPath, escapeRegExp, exists, filePath, read, supportsPosixModeBits, writeNodeCommandShim } from "../../helpers.ts";
+import { CLI_PATH, cliArgs, envWithPrependedPath, escapeRegExp, exists, filePath, read, supportsPosixModeBits, writeNodeCommandShim } from "../../helpers.ts";
 
 const PLATFORM_DEFAULT_ENGINES: Partial<Record<NodeJS.Platform, string>> = {
   linux: "native",
@@ -14,7 +14,7 @@ const PLATFORM_DEFAULT_ENGINES: Partial<Record<NodeJS.Platform, string>> = {
 };
 const CURRENT_PLATFORM = os.platform();
 const DEFAULT_SANDBOX_ENGINE = PLATFORM_DEFAULT_ENGINES[CURRENT_PLATFORM] ?? null;
-const ENGINE_NL = DEFAULT_SANDBOX_ENGINE ? "\\n" : "";
+const ENGINE_NL = DEFAULT_SANDBOX_ENGINE ? "\n" : "";
 
 test("bootstrap CLI files exist", () => {
   assert.ok(exists("install.sh"), "install.sh should exist");
@@ -112,10 +112,11 @@ test("agent-infra init generates seed files in a temp directory", () => {
   const cli = CLI_PATH;
 
   try {
-    execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}\n\n\n`,
+      stdio: "pipe"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -226,10 +227,12 @@ test("agent-infra init accepts a custom platform selected from the menu", () => 
   const cli = CLI_PATH;
 
   try {
-    const output = execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}2\\nmy-platform\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe", encoding: "utf8" }
-    );
+    const output = execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}2\nmy-platform\n\n\n`,
+      stdio: "pipe",
+      encoding: "utf8"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -250,10 +253,11 @@ test("agent-infra init remains compatible with direct platform input", () => {
   const cli = CLI_PATH;
 
   try {
-    execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}github\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n\n`,
+      stdio: "pipe"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -269,10 +273,12 @@ test("agent-infra init warns when a custom platform is entered directly", () => 
   const cli = CLI_PATH;
 
   try {
-    const output = execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}gitea\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe", encoding: "utf8" }
-    );
+    const output = execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}gitea\n\n\n`,
+      stdio: "pipe",
+      encoding: "utf8"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -293,10 +299,11 @@ test("agent-infra init records an optional external template source for any plat
   const cli = CLI_PATH;
 
   try {
-    execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}github\\n~/private-templates\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n~/private-templates\n\n`,
+      stdio: "pipe"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -317,10 +324,11 @@ test("agent-infra init omits optional source config when source prompts are blan
   const cli = CLI_PATH;
 
   try {
-    execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}gitea\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}gitea\n\n\n`,
+      stdio: "pipe"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -339,10 +347,11 @@ test("agent-infra init records optional external skill sources", () => {
   const cli = CLI_PATH;
 
   try {
-    execSync(
-      `printf 'testproj\\ntestorg\\n\\n${ENGINE_NL}github\\n\\n~/private-skills, ~/team-skills\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n~/private-skills, ~/team-skills\n`,
+      stdio: "pipe"
+    });
 
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
@@ -371,10 +380,11 @@ test("installed sync-templates.js executes inside a type=module project", () => 
       "utf8"
     );
 
-    execSync(
-      `printf 'esmproj\\nesmorg\\n\\n${ENGINE_NL}\\n\\n\\n' | ${cliCommand("init")}`,
-      { cwd: tmpDir, stdio: "pipe" }
-    );
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: `esmproj\nesmorg\n\n${ENGINE_NL}\n\n\n`,
+      stdio: "pipe"
+    });
     assert.equal(
       JSON.parse(fs.readFileSync(path.join(tmpDir, "package.json"), "utf8")).type,
       "module",
@@ -519,7 +529,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
       "utf8"
     );
 
-    const output = execSync(`${cliCommand("update")}`, {
+    const output = execFileSync(process.execPath, cliArgs("update"), {
       cwd: tmpDir,
       stdio: "pipe",
       encoding: "utf8"
@@ -581,7 +591,7 @@ test("agent-infra update requires .agents/.airc.json", () => {
 
   try {
     assert.throws(() => {
-      execSync(`${cliCommand("update")}`, {
+      execFileSync(process.execPath, cliArgs("update"), {
         cwd: tmpDir,
         stdio: "pipe"
       });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Code Scanning alerts #12-#21（同根因，无单独 GitHub Issue 跟踪）

- [ ] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

> 说明：本 PR 对应 CodeQL 安全告警 #12-#21（全部 `js/shell-command-injection-from-environment`），告警本身已是规范化跟踪入口（<https://github.com/fitlab-ai/agent-infra/security/code-scanning>），因此未额外创建 GitHub Issue。

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (security finding in test code)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

CodeQL 当前 open 状态的 10 条 `js/shell-command-injection-from-environment` 告警（**#12-#21**）全部位于 `tests/integration/cli/cli.test.ts`，根因相同：`tests/helpers/cli.ts` 的 `cliCommand()` 把 `process.execPath` 与 `import.meta.url` 派生的绝对路径 `CLI_PATH` 拼成 shell 命令字符串，再交给 `execSync` 执行（其中 8 处还前置 `printf | …` 管道）；环境派生路径若含空格或 shell 元字符会破坏 shell 解析（CWE-78 / CWE-88）。

本 PR 在源头消除「环境派生路径 → shell-string → `execSync`」这条污点链：把所有相关调用统一改写为 `execFileSync(process.execPath, cliArgs(...), { input })` 的安全 array-form（仓库内已有同形态样板，见 `init rejects invalid input` 与 `build output is up-to-date`）。改造后 `cliCommand()` 失去全部调用方，按外科手术原则一并删除该 helper 及其 re-export。

## 📋 主要变更 / Brief Changelog

- 把 `tests/integration/cli/cli.test.ts` 中 10 处 `execSync(cliCommand(...))`（其中 8 处含 `printf | …` 管道）改为 `execFileSync(process.execPath, cliArgs(...), { input })`；安全 array-form 不经任何 shell 解释。
- `ENGINE_NL` 由字面 `"\\n"` 改为真实换行 `"\n"`，所有 `input` 模板字符串中的 `\n` 也同步改为真实换行（不再依赖宿主 `printf` 翻译反斜杠转义）；逐 case 比对，stdin 字节序列与原 `printf` 解释后等价。
- 删除 `tests/helpers/cli.ts` 的 `cliCommand()` 函数与导出，以及 `tests/helpers.ts` 的对应 re-export；其它 helper（`CLI_PATH`、`cliArgs`、`envWithPrependedPath`、`pathWithPrependedBin`）保持不变。
- 不改动业务代码：`bin/`、`lib/`、`templates/`、`scripts/` 均未触碰。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run typecheck` —— `tsconfig.test.json` 覆盖 `tests/**`，验证 `cliCommand` 删除后 import / 类型完整性无未引用项。
2. `npm test` —— 全量测试套件 620 用例 / 619 pass / 1 skipped / 0 fail。
3. `rg "cliCommand|execSync\(" tests/integration/cli/cli.test.ts tests/helpers.ts tests/helpers/cli.ts` —— 期望 0 命中，确认 sink 全部消失。
4. `rg --glob '!.agents/workspace/**' --glob '!dist/**' --glob '!node_modules/**' 'cliCommand'` —— 期望 0 命中，确认 helper 在源码/测试入口范围内已彻底移除。

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests （本 PR 只修改测试，未新增独立单测）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue filed for the change（以 Code Scanning #12-#21 替代）
- [x] 你的 Pull Request 只解决一个 Issue / Single-purpose PR
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释（本 PR 为测试入口替换，无新增逻辑需注释）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性（沿用已有 `cli.test.ts` 用例，断言全部保留）
- [x] 当存在跨模块依赖时，我尽量使用了 mock（不涉及 mock，仅测试入口形态变更）
- [x] 代码检查通过 / `npm run typecheck`
- [x] 单元测试通过 / `npm test`

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / 仅删除内部测试 helper，无对外文档需要更新
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / 无破坏性变更
- [x] 我已经考虑了向后兼容性 / 改造后跨平台行为更一致（不再依赖宿主 `printf`）

## 📋 附加信息 / Additional Notes

**待人工验证 / Awaiting Human Verification**:

- [ ] 合并后等待 CodeQL workflow 重新扫描，确认 #12-#21 全部 10 条告警状态由 `open` 变为 `fixed`（同根因一次性消除）。AI agent 无法本地运行服务端 CodeQL 扫描，此为 env-blocked 项。

**审查者注意事项 / Reviewer Notes:**

- 重点关注 8 处 `init` 用例改造后的 `input` 字节序列是否与原 `printf` 解释结果一致（参见 PR 说明中的 ENGINE_NL 处理）。
- `update` 两处改为 `execFileSync(process.execPath, cliArgs("update"))` 后，stdout 捕获与非零退出抛错语义保持等价（`execFileSync` 在非零退出时同样抛 Error，`assert.throws` 仍能命中）。
- `tests/integration/cli/cli.test.ts` 中若干 `const cli = CLI_PATH;` 是预先存在的死代码，按计划本 PR 不顺手清理；如需清理建议另立任务。

---

Generated with AI assistance.