### PR TITLE
feat(sandbox): 支持沙箱内自定义 TUI 与自定义安装脚本

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -258,6 +258,76 @@ args: "<task-id>"   # 可选
 
 `customTUIs` 每个条目对应一个自定义 TUI。若希望 `update-agent-infra` 为自定义 skill 生成命令文件，请在 `dir` 中保留至少一个引用内置 skill 路径的既有命令文件，例如 `.agents/skills/analyze-task/SKILL.md`；agent-infra 会以该文件作为格式参考。
 
+## 沙箱自定义工具（Sandbox Custom Tools）
+
+上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
+
+| 字段 | 必填 | 含义 |
+|------|------|------|
+| `id` | 是 | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
+| `name` | 是 | 报告与提示中显示的名称。 |
+| `install` | 是 | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。 |
+| `containerMount` | 是 | 容器内绝对路径，工具的配置 / 状态目录挂载点。 |
+| `versionCmd` | 是 | 沙箱用来验证工具已安装的 shell 命令。 |
+| `setupHint` | 是 | 首次启动时显示的一行说明。 |
+| `envVars` | 否 | `Record<string, string>` 形式的环境变量，导出到容器中给该工具使用。 |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | 否 | 首次启动时从宿主复制到工具沙箱配置目录的文件 / 目录。 |
+| `pathRewriteFiles` | 否 | 工具配置内需要把宿主路径改写为容器路径的文件。 |
+| `hostLiveMounts` | 否 | 从宿主实时挂载（读写）到工具 `containerMount` 下的文件。 |
+| `postSetupCmds` | 否 | 首次安装完成后在容器内执行的命令。 |
+
+最小 npm 类自定义工具：
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "my-npm-tool"],
+    "customTools": [
+      {
+        "id": "my-npm-tool",
+        "name": "My Npm Tool",
+        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
+        "containerMount": "/home/devuser/.my-npm-tool",
+        "versionCmd": "my-npm-tool --version",
+        "setupHint": "首次使用前请在容器内完成认证。"
+      }
+    ]
+  }
+}
+```
+
+最小 shell 类自定义工具（非 npm 分发）：
+
+```json
+{
+  "sandbox": {
+    "tools": ["my-shell-tool"],
+    "customTools": [
+      {
+        "id": "my-shell-tool",
+        "name": "My Shell Tool",
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
+        "containerMount": "/home/devuser/.my-shell-tool",
+        "versionCmd": "my-shell-tool --version",
+        "setupHint": "首次使用前请在容器内完成认证。"
+      }
+    ]
+  }
+}
+```
+
+### 信任边界与执行身份
+
+- `install.cmd` 在 `docker build` 阶段以 `devuser`（非 root）身份执行，只能写容器内文件系统，不能逃逸到宿主。信任模型与现有 `sandbox.dockerfile` 一致：你是 `.airc.json` 的作者，本次构建做什么由你负责。
+- 因为不是 root，shell 安装无法 `sudo` / `apt-get`。非 npm 分发的几条可用路径：
+  - 用户态安装器，落到 `~/.local/bin`、`~/.cargo/bin`、`~/.npm-global/bin`（如 `pipx`、`cargo install`、`curl … | bash` 配合 `INSTALL_DIR=$HOME/.local/bin`）。
+  - 确实需要 root / 系统包时，仍走原有 `sandbox.dockerfile` 字段，接管整个 Dockerfile。
+- 修改 `install.cmd` 或任何参与镜像签名的字段，下次 `ai sandbox` 命令会触发一次镜像重建。
+
+### 与 `sandbox.dockerfile` 的交互
+
+当 `sandbox.dockerfile` 指向自定义 Dockerfile 时，agent-infra 仍会把 `AI_TOOL_PACKAGES`（空格分隔的 npm 包规范）和 `AI_TOOLS_SHELL_INSTALL_B64`（base64 编码的 shell 安装脚本）作为 `--build-arg` 传入。你的自定义 Dockerfile 若未声明对应 `ARG`，shell 安装路径会被 docker build 静默忽略——这是接管 Dockerfile 后的应有代价。
+
 ## Skill 编写规范
 
 编写或维护 `.agents/skills/*/SKILL.md` 及其模板时，步骤编号遵循以下规则：

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -262,41 +262,14 @@ args: "<task-id>"   # 可选
 
 上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
 
-| 字段 | 必填 | 含义 |
-|------|------|------|
-| `id` | 是 | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
-| `name` | 是 | 报告与提示中显示的名称。 |
-| `install` | 是 | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。 |
-| `containerMount` | 是 | 容器内绝对路径，工具的配置 / 状态目录挂载点。 |
-| `versionCmd` | 是 | 沙箱用来验证工具已安装的 shell 命令。 |
-| `setupHint` | 是 | 首次启动时显示的一行说明。 |
-| `envVars` | 否 | `Record<string, string>` 形式的环境变量，导出到容器中给该工具使用。 |
-| `hostPreSeedFiles` / `hostPreSeedDirs` | 否 | 首次启动时从宿主复制到工具沙箱配置目录的文件 / 目录。 |
-| `pathRewriteFiles` | 否 | 工具配置内需要把宿主路径改写为容器路径的文件。 |
-| `hostLiveMounts` | 否 | 从宿主实时挂载（读写）到工具 `containerMount` 下的文件。 |
-| `postSetupCmds` | 否 | 首次安装完成后在容器内执行的命令。 |
+### 必填字段
 
-最小 npm 类自定义工具：
+| 字段 | 含义 |
+|------|------|
+| `id` | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
+| `install` | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。`cmd` 必须非空。 |
 
-```json
-{
-  "sandbox": {
-    "tools": ["claude-code", "my-npm-tool"],
-    "customTools": [
-      {
-        "id": "my-npm-tool",
-        "name": "My Npm Tool",
-        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
-        "containerMount": "/home/devuser/.my-npm-tool",
-        "versionCmd": "my-npm-tool --version",
-        "setupHint": "首次使用前请在容器内完成认证。"
-      }
-    ]
-  }
-}
-```
-
-最小 shell 类自定义工具（非 npm 分发）：
+最小入口——把一个工具装进镜像所需的契约只有这两个字段：
 
 ```json
 {
@@ -305,11 +278,45 @@ args: "<task-id>"   # 可选
     "customTools": [
       {
         "id": "my-shell-tool",
-        "name": "My Shell Tool",
-        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
-        "containerMount": "/home/devuser/.my-shell-tool",
-        "versionCmd": "my-shell-tool --version",
-        "setupHint": "首次使用前请在容器内完成认证。"
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" }
+      }
+    ]
+  }
+}
+```
+
+### 可选集成字段
+
+只在你的工具真正需要时才加。**省略**则 loader 用合理默认值；**显式提供**则用你给的值；**显式给空串**会被拒绝（防止安装验证被绕过）。
+
+| 字段 | 省略时的默认值 | 什么时候应该提供 |
+|------|---------------|----------------|
+| `name` | `id` | 想在沙箱报告 / 提示里显示更友好的名称。 |
+| `containerMount` | `/home/devuser/.<id>` | 工具的配置 / 状态目录不在 `~/.<id>` 而在别处。必须是绝对路径。 |
+| `versionCmd` | `which <id>` | 安装后的可执行文件名与 `id` 不同（例如 id 是 `anthropic-claude`，二进制名是 `claude`）；填 `"claude --version"` 让 sandbox-create 能验证安装。 |
+| `setupHint` | `Run \`<id>\` inside the container to set up.` | setup 流程不一目了然，值得用一行说明。 |
+| `envVars` | （无） | 工具通过环境变量找配置（如 `XDG_CONFIG_HOME` 风格或自定义 `*_CONFIG` 变量）。形状：`Record<string, string>`。 |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | （无） | 首次启动时从宿主复制文件 / 目录到工具沙箱配置目录。 |
+| `pathRewriteFiles` | （无） | seed 进来的文件里有宿主绝对路径，需要改写为容器路径。 |
+| `hostLiveMounts` | （无） | 把宿主凭证（如 OAuth token）实时挂进容器，读写共享。 |
+| `postSetupCmds` | （无） | 首次安装完成后在容器内执行命令（如建符号链接）。 |
+
+> **`sandboxBase` 不由用户配置。** loader 永远使用 `~/.agent-infra/sandboxes/<id>`，这样 `ai sandbox rm` / `prune` 才能找到工具状态目录。`customTools` 条目里写的任何 `sandboxBase` 都会被静默忽略。
+
+实际场景示例——`anthropic-claude` 作为用户自定义 id，二进制名是 `claude`，并把宿主凭证 live-mount 进来：
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "anthropic-claude"],
+    "customTools": [
+      {
+        "id": "anthropic-claude",
+        "install": { "type": "npm", "cmd": "@anthropic-ai/claude-code@stable" },
+        "versionCmd": "claude --version",
+        "hostLiveMounts": [
+          { "hostPath": "~/.claude/.credentials.json", "containerSubpath": ".credentials.json" }
+        ]
       }
     ]
   }

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -36,7 +36,13 @@ import {
   runVerboseEngine
 } from '../shell.ts';
 import { resolveTaskBranch } from '../task-resolver.ts';
-import { resolveTools, toolConfigDirCandidates, toolNpmPackagesArg } from '../tools.ts';
+import {
+  imageSignatureFields,
+  resolveTools,
+  toolConfigDirCandidates,
+  toolNpmPackagesArg,
+  toolShellInstallScriptBase64
+} from '../tools.ts';
 import type { SandboxTool } from '../tools.ts';
 import { hostJoin, toEnginePath, volumeArg } from '../engines/wsl2-paths.ts';
 import { clipboardHostDir, CONTAINER_CLIPBOARD_MOUNT } from '../clipboard/paths.ts';
@@ -113,7 +119,7 @@ function buildSignature(preparedDockerfile: PreparedDockerfile, tools: SandboxTo
   return createHash('sha256')
     .update(JSON.stringify({
       dockerfile: preparedDockerfile.signature,
-      tools: tools.map((tool) => tool.npmPackage)
+      tools: imageSignatureFields(tools)
     }))
     .digest('hex')
     .slice(0, 12);
@@ -1063,6 +1069,8 @@ export function buildImage(
     `HOST_GID=${hostGid}`,
     '--build-arg',
     `AI_TOOL_PACKAGES=${toolNpmPackagesArg(tools)}`,
+    '--build-arg',
+    `AI_TOOLS_SHELL_INSTALL_B64=${toolShellInstallScriptBase64(tools)}`,
     '--label',
     sandboxLabel(config),
     '--label',

--- a/lib/sandbox/commands/rebuild.ts
+++ b/lib/sandbox/commands/rebuild.ts
@@ -8,7 +8,12 @@ import { prepareDockerfile } from '../dockerfile.ts';
 import { sandboxImageConfigLabel, sandboxLabel } from '../constants.ts';
 import { detectEngine, ensureDocker } from '../engine.ts';
 import { runEngine, runOkEngine, runSafeEngine, runVerboseEngine } from '../shell.ts';
-import { resolveTools, toolNpmPackagesArg } from '../tools.ts';
+import {
+  imageSignatureFields,
+  resolveTools,
+  toolNpmPackagesArg,
+  toolShellInstallScriptBase64
+} from '../tools.ts';
 import type { SandboxTool } from '../tools.ts';
 import { toEnginePath } from '../engines/wsl2-paths.ts';
 import { resolveBuildUid } from '../engines/native.ts';
@@ -23,7 +28,7 @@ function buildSignature(preparedDockerfile: PreparedDockerfile, tools: SandboxTo
   return createHash('sha256')
     .update(JSON.stringify({
       dockerfile: preparedDockerfile.signature,
-      tools: tools.map((tool) => tool.npmPackage)
+      tools: imageSignatureFields(tools)
     }))
     .digest('hex')
     .slice(0, 12);
@@ -66,6 +71,8 @@ export function buildArgs(
     `HOST_GID=${hostGid}`,
     '--build-arg',
     `AI_TOOL_PACKAGES=${toolNpmPackagesArg(tools)}`,
+    '--build-arg',
+    `AI_TOOLS_SHELL_INSTALL_B64=${toolShellInstallScriptBase64(tools)}`,
     '--label',
     sandboxLabel(config),
     '--label',

--- a/lib/sandbox/config.ts
+++ b/lib/sandbox/config.ts
@@ -6,6 +6,8 @@ import pc from 'picocolors';
 import { validateSandboxEngine } from './engine.ts';
 import { hostJoin } from './engines/wsl2-paths.ts';
 import { findRuntimeEngineMismatches } from './runtime-engines.ts';
+import { parseCustomTools } from './tools.ts';
+import type { SandboxTool } from './tools.ts';
 
 const DEFAULTS = Object.freeze({
   engine: null,
@@ -26,6 +28,7 @@ type SandboxConfigInput = {
   engine?: string | null;
   runtimes?: string[];
   tools?: string[];
+  customTools?: unknown;
   dockerfile?: string | null;
   vm?: Record<string, unknown>;
 };
@@ -51,6 +54,7 @@ export type SandboxConfig = {
   engine: string | null;
   runtimes: string[];
   tools: string[];
+  customTools: SandboxTool[];
   dockerfile: string | null;
   vm: SandboxVmConfig;
 };
@@ -136,6 +140,8 @@ export function loadConfig({
     }
   }
 
+  const customTools = parseCustomTools(sandbox.customTools, { home });
+
   return {
     repoRoot,
     configPath,
@@ -153,6 +159,7 @@ export function loadConfig({
     tools: Array.isArray(sandbox.tools) && sandbox.tools.length > 0
       ? [...sandbox.tools]
       : defaults.tools,
+    customTools,
     dockerfile,
     vm: {
       cpu: asPositiveNumberOrNull(sandbox.vm?.cpu) ?? defaults.vm.cpu,

--- a/lib/sandbox/runtimes/ai-tools.dockerfile
+++ b/lib/sandbox/runtimes/ai-tools.dockerfile
@@ -4,15 +4,19 @@ ENV OPENCODE_DISABLE_AUTOUPDATE=1
 ENV NPM_CONFIG_PREFIX=/home/devuser/.npm-global
 ENV PATH="/home/devuser/.npm-global/bin:${PATH}"
 
-ARG AI_TOOL_PACKAGES
-RUN if [ -z "${AI_TOOL_PACKAGES}" ]; then \
-      echo "AI_TOOL_PACKAGES build arg is required"; \
-      exit 1; \
-    fi && \
-    set -e && \
+ARG AI_TOOL_PACKAGES=
+RUN set -e && \
     for pkg in ${AI_TOOL_PACKAGES}; do \
       npm install -g "$pkg"; \
     done
+
+ARG AI_TOOLS_SHELL_INSTALL_B64=
+RUN if [ -n "${AI_TOOLS_SHELL_INSTALL_B64}" ]; then \
+      set -e && \
+      echo "${AI_TOOLS_SHELL_INSTALL_B64}" | base64 -d > /tmp/ai-tools-install.sh && \
+      bash /tmp/ai-tools-install.sh && \
+      rm /tmp/ai-tools-install.sh; \
+    fi
 
 RUN npm install -g pyright
 

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -123,9 +123,6 @@ function validateTool(tool: SandboxTool): void {
   if (!tool.id || !TOOL_ID_PATTERN.test(tool.id)) {
     throw new Error(`Invalid sandbox tool id: ${String(tool.id)}`);
   }
-  if (!tool.name) {
-    throw new Error(`Sandbox tool ${tool.id} is missing required field: name`);
-  }
   if (!tool.install || (tool.install.type !== 'npm' && tool.install.type !== 'shell')) {
     throw new Error(`Sandbox tool ${tool.id} has invalid install.type`);
   }
@@ -134,12 +131,6 @@ function validateTool(tool: SandboxTool): void {
   }
   if (!tool.containerMount || !tool.containerMount.startsWith('/')) {
     throw new Error(`Sandbox tool ${tool.id} containerMount must be an absolute path`);
-  }
-  if (!tool.versionCmd) {
-    throw new Error(`Sandbox tool ${tool.id} has empty versionCmd`);
-  }
-  if (!tool.setupHint) {
-    throw new Error(`Sandbox tool ${tool.id} has empty setupHint`);
   }
 }
 
@@ -154,12 +145,15 @@ function asString(value: unknown, field: string, context: string): string {
   return value;
 }
 
-function asOptionalString(value: unknown, field: string, context: string): string | undefined {
+function asOptionalNonEmptyString(value: unknown, field: string, context: string): string | undefined {
   if (value === undefined) {
     return undefined;
   }
   if (typeof value !== 'string') {
     throw new Error(`${context}: field "${field}" must be a string when provided`);
+  }
+  if (value.length === 0) {
+    throw new Error(`${context}: field "${field}" must be non-empty when provided`);
   }
   return value;
 }
@@ -280,14 +274,21 @@ export function parseCustomTool(
     throw new Error(`${context}: field "id" must match ${TOOL_ID_PATTERN.source}`);
   }
 
+  const containerMount = asOptionalNonEmptyString(entry.containerMount, 'containerMount', context)
+    ?? `/home/devuser/.${id}`;
+  if (!containerMount.startsWith('/')) {
+    throw new Error(`${context}: field "containerMount" must be an absolute path`);
+  }
+
   const tool: SandboxTool = {
     id,
-    name: asString(entry.name, 'name', context),
+    name: asOptionalNonEmptyString(entry.name, 'name', context) ?? id,
     install: parseInstall(entry.install, context),
     sandboxBase: hostJoin(options.home, '.agent-infra', 'sandboxes', id),
-    containerMount: asString(entry.containerMount, 'containerMount', context),
-    versionCmd: asString(entry.versionCmd, 'versionCmd', context),
-    setupHint: asString(entry.setupHint, 'setupHint', context),
+    containerMount,
+    versionCmd: asOptionalNonEmptyString(entry.versionCmd, 'versionCmd', context) ?? `which ${id}`,
+    setupHint: asOptionalNonEmptyString(entry.setupHint, 'setupHint', context)
+      ?? `Run \`${id}\` inside the container to set up.`,
     envVars: asStringRecord(entry.envVars, 'envVars', context),
     hostPreSeedFiles: parseHostPreSeedFiles(entry.hostPreSeedFiles, context),
     hostPreSeedDirs: parseHostPreSeedDirs(entry.hostPreSeedDirs, context),

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -1,10 +1,14 @@
 import { safeNameCandidates, sanitizeBranchName } from './constants.ts';
 import { hostJoin } from './engines/wsl2-paths.ts';
 
+export type SandboxToolInstall =
+  | { type: 'npm'; cmd: string }
+  | { type: 'shell'; cmd: string };
+
 export type SandboxTool = {
   id: string;
   name: string;
-  npmPackage: string;
+  install: SandboxToolInstall;
   sandboxBase: string;
   containerMount: string;
   versionCmd: string;
@@ -21,14 +25,17 @@ type ToolsConfig = {
   home: string;
   project: string;
   tools: string[];
+  customTools?: SandboxTool[];
 };
+
+const TOOL_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 function createBuiltinTools(home: string, project: string): Record<string, SandboxTool> {
   return {
     'claude-code': {
       id: 'claude-code',
       name: 'Claude Code',
-      npmPackage: '@anthropic-ai/claude-code@stable',
+      install: { type: 'npm', cmd: '@anthropic-ai/claude-code@stable' },
       sandboxBase: hostJoin(home, '.agent-infra', 'sandboxes', 'claude-code'),
       containerMount: '/home/devuser/.claude',
       versionCmd: 'claude --version',
@@ -58,7 +65,7 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
     codex: {
       id: 'codex',
       name: 'Codex',
-      npmPackage: '@openai/codex',
+      install: { type: 'npm', cmd: '@openai/codex' },
       sandboxBase: hostJoin(home, '.agent-infra', 'sandboxes', 'codex'),
       containerMount: '/home/devuser/.codex',
       versionCmd: 'codex --version',
@@ -73,7 +80,7 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
     opencode: {
       id: 'opencode',
       name: 'OpenCode',
-      npmPackage: 'opencode-ai',
+      install: { type: 'npm', cmd: 'opencode-ai' },
       sandboxBase: hostJoin(home, '.agent-infra', 'sandboxes', 'opencode'),
       containerMount: '/home/devuser/.local/share/opencode',
       versionCmd: 'opencode version',
@@ -92,7 +99,7 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
     'gemini-cli': {
       id: 'gemini-cli',
       name: 'Gemini CLI',
-      npmPackage: '@google/gemini-cli',
+      install: { type: 'npm', cmd: '@google/gemini-cli' },
       sandboxBase: hostJoin(home, '.agent-infra', 'sandboxes', 'gemini-cli'),
       containerMount: '/home/devuser/.gemini',
       versionCmd: 'gemini --version',
@@ -108,16 +115,223 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
   };
 }
 
+export function builtinToolIds(): string[] {
+  return Object.keys(createBuiltinTools('', ''));
+}
+
 function validateTool(tool: SandboxTool): void {
-  if (!tool.npmPackage || !tool.containerMount.startsWith('/')) {
-    throw new Error(`Invalid sandbox tool descriptor: ${tool.id}`);
+  if (!tool.id || !TOOL_ID_PATTERN.test(tool.id)) {
+    throw new Error(`Invalid sandbox tool id: ${String(tool.id)}`);
   }
+  if (!tool.name) {
+    throw new Error(`Sandbox tool ${tool.id} is missing required field: name`);
+  }
+  if (!tool.install || (tool.install.type !== 'npm' && tool.install.type !== 'shell')) {
+    throw new Error(`Sandbox tool ${tool.id} has invalid install.type`);
+  }
+  if (!tool.install.cmd) {
+    throw new Error(`Sandbox tool ${tool.id} has empty install.cmd`);
+  }
+  if (!tool.containerMount || !tool.containerMount.startsWith('/')) {
+    throw new Error(`Sandbox tool ${tool.id} containerMount must be an absolute path`);
+  }
+  if (!tool.versionCmd) {
+    throw new Error(`Sandbox tool ${tool.id} has empty versionCmd`);
+  }
+  if (!tool.setupHint) {
+    throw new Error(`Sandbox tool ${tool.id} has empty setupHint`);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown, field: string, context: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${context}: field "${field}" must be a string`);
+  }
+  return value;
+}
+
+function asOptionalString(value: unknown, field: string, context: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`${context}: field "${field}" must be a string when provided`);
+  }
+  return value;
+}
+
+function asStringRecord(value: unknown, field: string, context: string): Record<string, string> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(value)) {
+    throw new Error(`${context}: field "${field}" must be an object when provided`);
+  }
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof val !== 'string') {
+      throw new Error(`${context}: field "${field}.${key}" must be a string`);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function asStringArray(value: unknown, field: string, context: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${context}: field "${field}" must be an array when provided`);
+  }
+  return value.map((item, index) => {
+    if (typeof item !== 'string') {
+      throw new Error(`${context}: field "${field}[${index}]" must be a string`);
+    }
+    return item;
+  });
+}
+
+function parseInstall(value: unknown, context: string): SandboxToolInstall {
+  if (!isPlainObject(value)) {
+    throw new Error(`${context}: field "install" must be an object`);
+  }
+  const type = value.type;
+  if (type !== 'npm' && type !== 'shell') {
+    throw new Error(`${context}: field "install.type" must be "npm" or "shell"`);
+  }
+  const cmd = asString(value.cmd, 'install.cmd', context);
+  if (!cmd) {
+    throw new Error(`${context}: field "install.cmd" must be non-empty`);
+  }
+  return { type, cmd };
+}
+
+function parseHostPreSeedFiles(value: unknown, context: string): SandboxTool['hostPreSeedFiles'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${context}: field "hostPreSeedFiles" must be an array when provided`);
+  }
+  return value.map((item, index) => {
+    if (!isPlainObject(item)) {
+      throw new Error(`${context}: field "hostPreSeedFiles[${index}]" must be an object`);
+    }
+    return {
+      hostPath: asString(item.hostPath, `hostPreSeedFiles[${index}].hostPath`, context),
+      sandboxName: asString(item.sandboxName, `hostPreSeedFiles[${index}].sandboxName`, context)
+    };
+  });
+}
+
+function parseHostPreSeedDirs(value: unknown, context: string): SandboxTool['hostPreSeedDirs'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${context}: field "hostPreSeedDirs" must be an array when provided`);
+  }
+  return value.map((item, index) => {
+    if (!isPlainObject(item)) {
+      throw new Error(`${context}: field "hostPreSeedDirs[${index}]" must be an object`);
+    }
+    return {
+      hostDir: asString(item.hostDir, `hostPreSeedDirs[${index}].hostDir`, context),
+      sandboxSubdir: asString(item.sandboxSubdir, `hostPreSeedDirs[${index}].sandboxSubdir`, context)
+    };
+  });
+}
+
+function parseHostLiveMounts(value: unknown, context: string): SandboxTool['hostLiveMounts'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${context}: field "hostLiveMounts" must be an array when provided`);
+  }
+  return value.map((item, index) => {
+    if (!isPlainObject(item)) {
+      throw new Error(`${context}: field "hostLiveMounts[${index}]" must be an object`);
+    }
+    return {
+      hostPath: asString(item.hostPath, `hostLiveMounts[${index}].hostPath`, context),
+      containerSubpath: asString(item.containerSubpath, `hostLiveMounts[${index}].containerSubpath`, context)
+    };
+  });
+}
+
+export function parseCustomTool(
+  entry: unknown,
+  index: number,
+  options: { home: string }
+): SandboxTool {
+  const context = `customTools[${index}]`;
+  if (!isPlainObject(entry)) {
+    throw new Error(`${context} must be an object`);
+  }
+
+  const id = asString(entry.id, 'id', context);
+  if (!TOOL_ID_PATTERN.test(id)) {
+    throw new Error(`${context}: field "id" must match ${TOOL_ID_PATTERN.source}`);
+  }
+
+  const tool: SandboxTool = {
+    id,
+    name: asString(entry.name, 'name', context),
+    install: parseInstall(entry.install, context),
+    sandboxBase: hostJoin(options.home, '.agent-infra', 'sandboxes', id),
+    containerMount: asString(entry.containerMount, 'containerMount', context),
+    versionCmd: asString(entry.versionCmd, 'versionCmd', context),
+    setupHint: asString(entry.setupHint, 'setupHint', context),
+    envVars: asStringRecord(entry.envVars, 'envVars', context),
+    hostPreSeedFiles: parseHostPreSeedFiles(entry.hostPreSeedFiles, context),
+    hostPreSeedDirs: parseHostPreSeedDirs(entry.hostPreSeedDirs, context),
+    pathRewriteFiles: asStringArray(entry.pathRewriteFiles, 'pathRewriteFiles', context),
+    hostLiveMounts: parseHostLiveMounts(entry.hostLiveMounts, context),
+    postSetupCmds: asStringArray(entry.postSetupCmds, 'postSetupCmds', context)
+  };
+
+  validateTool(tool);
+  return tool;
+}
+
+export function parseCustomTools(value: unknown, options: { home: string }): SandboxTool[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('sandbox: "customTools" must be an array');
+  }
+  return value.map((entry, index) => parseCustomTool(entry, index, options));
 }
 
 export function resolveTools(config: ToolsConfig): SandboxTool[] {
   const builtins = createBuiltinTools(config.home, config.project);
+  const customs = config.customTools ?? [];
+
+  const seen = new Set<string>();
+  for (const tool of customs) {
+    if (builtins[tool.id]) {
+      throw new Error(`Custom sandbox tool id "${tool.id}" collides with a built-in tool`);
+    }
+    if (seen.has(tool.id)) {
+      throw new Error(`Duplicate sandbox tool id "${tool.id}" in customTools`);
+    }
+    seen.add(tool.id);
+  }
+
+  const merged: Record<string, SandboxTool> = { ...builtins };
+  for (const tool of customs) {
+    merged[tool.id] = tool;
+  }
+
   return config.tools.map((id) => {
-    const tool = builtins[id];
+    const tool = merged[id];
     if (!tool) {
       throw new Error(`Unknown sandbox tool: ${id}`);
     }
@@ -139,5 +353,29 @@ export function toolProjectDirCandidates(tool: SandboxTool, project: string): st
 }
 
 export function toolNpmPackagesArg(tools: SandboxTool[]): string {
-  return tools.map((tool) => tool.npmPackage).join(' ');
+  return tools
+    .filter((tool) => tool.install.type === 'npm')
+    .map((tool) => tool.install.cmd)
+    .join(' ');
+}
+
+export function toolShellInstallScript(tools: SandboxTool[]): string {
+  const blocks = tools
+    .filter((tool) => tool.install.type === 'shell')
+    .map((tool) => `# install: ${tool.id}\n${tool.install.cmd}`);
+
+  if (blocks.length === 0) {
+    return '';
+  }
+
+  return ['#!/bin/bash', 'set -e', '', ...blocks, ''].join('\n');
+}
+
+export function toolShellInstallScriptBase64(tools: SandboxTool[]): string {
+  const script = toolShellInstallScript(tools);
+  return script ? Buffer.from(script, 'utf8').toString('base64') : '';
+}
+
+export function imageSignatureFields(tools: SandboxTool[]): Array<{ id: string; install: SandboxToolInstall }> {
+  return tools.map((tool) => ({ id: tool.id, install: tool.install }));
 }

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -258,6 +258,76 @@ Namespaced custom TUI:
 
 `customTUIs` should contain one entry per custom TUI. To let `update-agent-infra` generate command files for custom skills, keep at least one existing command file in `dir` that references a built-in skill path such as `.agents/skills/analyze-task/SKILL.md`; agent-infra uses that file as the format reference.
 
+## Sandbox Custom Tools
+
+`customTUIs` (above) generates slash-command files but does not change the sandbox image. To install a non-npm TUI (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in tools (`claude-code`, `codex`, `opencode`, `gemini-cli`) keep working unchanged.
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `id` | Yes | Lowercase id matching `^[a-z0-9][a-z0-9-]*$`. Referenced from `sandbox.tools`. Must not collide with a built-in id. |
+| `name` | Yes | Display name shown in reports. |
+| `install` | Yes | Install descriptor. `{ "type": "npm", "cmd": "<npm package spec>" }` runs `npm install -g <cmd>`. `{ "type": "shell", "cmd": "<shell>" }` runs the shell command(s) as `devuser` during image build. |
+| `containerMount` | Yes | Absolute path inside the container that holds this tool's config / state directory. |
+| `versionCmd` | Yes | Shell command used by the sandbox to verify the tool is installed. |
+| `setupHint` | Yes | One-line hint shown to users during first launch. |
+| `envVars` | No | `Record<string, string>` of env vars exported into the container for this tool. |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | No | Files / directories copied from host into the tool's sandbox config on first launch. |
+| `pathRewriteFiles` | No | Files inside the tool config whose host paths should be rewritten to container paths. |
+| `hostLiveMounts` | No | Files mounted live (read-write) from host into the tool's containerMount. |
+| `postSetupCmds` | No | Commands run in the container after first setup. |
+
+Minimal npm-type custom tool:
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "my-npm-tool"],
+    "customTools": [
+      {
+        "id": "my-npm-tool",
+        "name": "My Npm Tool",
+        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
+        "containerMount": "/home/devuser/.my-npm-tool",
+        "versionCmd": "my-npm-tool --version",
+        "setupHint": "Authenticate inside the container before first use."
+      }
+    ]
+  }
+}
+```
+
+Minimal shell-type custom tool (non-npm distribution):
+
+```json
+{
+  "sandbox": {
+    "tools": ["my-shell-tool"],
+    "customTools": [
+      {
+        "id": "my-shell-tool",
+        "name": "My Shell Tool",
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
+        "containerMount": "/home/devuser/.my-shell-tool",
+        "versionCmd": "my-shell-tool --version",
+        "setupHint": "Authenticate inside the container before first use."
+      }
+    ]
+  }
+}
+```
+
+### Trust boundary and execution context
+
+- `install.cmd` runs as user `devuser` (non-root) during `docker build`. It can write to the container's filesystem but cannot escape to the host. The trust model is the same as for the `sandbox.dockerfile` escape hatch — you own the `.airc.json` in your repo, so you own what runs at build time.
+- Because the build runs as `devuser`, shell installs cannot `sudo` / `apt-get`. Available options for non-npm distributions:
+  - User-scope installers landing in `~/.local/bin`, `~/.cargo/bin`, `~/.npm-global/bin` (e.g. `pipx`, `cargo install`, `curl … | bash` with `INSTALL_DIR=$HOME/.local/bin`).
+  - When you genuinely need root or system packages, fall back to the existing `sandbox.dockerfile` field and own the full Dockerfile.
+- Changing `install.cmd` (or any field that participates in the image signature) triggers exactly one image rebuild on the next `ai sandbox` invocation.
+
+### Interaction with `sandbox.dockerfile`
+
+When you set `sandbox.dockerfile` to point at your own Dockerfile, agent-infra still passes both `AI_TOOL_PACKAGES` (space-separated npm package specs) and `AI_TOOLS_SHELL_INSTALL_B64` (base64-encoded shell install script) as `--build-arg`. Your custom Dockerfile decides whether to consume them; if it does not declare the matching `ARG`, the shell installs for `customTools` are silently skipped — taking over the Dockerfile means taking over the install path.
+
 ## Skill Authoring Conventions
 
 When writing or updating `.agents/skills/*/SKILL.md` files and their templates, keep step numbering consistent:

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -262,41 +262,14 @@ Namespaced custom TUI:
 
 `customTUIs` (above) generates slash-command files but does not change the sandbox image. To install a non-npm TUI (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in tools (`claude-code`, `codex`, `opencode`, `gemini-cli`) keep working unchanged.
 
-| Field | Required | Meaning |
-|-------|----------|---------|
-| `id` | Yes | Lowercase id matching `^[a-z0-9][a-z0-9-]*$`. Referenced from `sandbox.tools`. Must not collide with a built-in id. |
-| `name` | Yes | Display name shown in reports. |
-| `install` | Yes | Install descriptor. `{ "type": "npm", "cmd": "<npm package spec>" }` runs `npm install -g <cmd>`. `{ "type": "shell", "cmd": "<shell>" }` runs the shell command(s) as `devuser` during image build. |
-| `containerMount` | Yes | Absolute path inside the container that holds this tool's config / state directory. |
-| `versionCmd` | Yes | Shell command used by the sandbox to verify the tool is installed. |
-| `setupHint` | Yes | One-line hint shown to users during first launch. |
-| `envVars` | No | `Record<string, string>` of env vars exported into the container for this tool. |
-| `hostPreSeedFiles` / `hostPreSeedDirs` | No | Files / directories copied from host into the tool's sandbox config on first launch. |
-| `pathRewriteFiles` | No | Files inside the tool config whose host paths should be rewritten to container paths. |
-| `hostLiveMounts` | No | Files mounted live (read-write) from host into the tool's containerMount. |
-| `postSetupCmds` | No | Commands run in the container after first setup. |
+### Required fields
 
-Minimal npm-type custom tool:
+| Field | Meaning |
+|-------|---------|
+| `id` | Lowercase id matching `^[a-z0-9][a-z0-9-]*$`. Referenced from `sandbox.tools`. Must not collide with a built-in id. |
+| `install` | Install descriptor. `{ "type": "npm", "cmd": "<npm package spec>" }` runs `npm install -g <cmd>`. `{ "type": "shell", "cmd": "<shell>" }` runs the shell command(s) as `devuser` during image build. `cmd` must be non-empty. |
 
-```json
-{
-  "sandbox": {
-    "tools": ["claude-code", "my-npm-tool"],
-    "customTools": [
-      {
-        "id": "my-npm-tool",
-        "name": "My Npm Tool",
-        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
-        "containerMount": "/home/devuser/.my-npm-tool",
-        "versionCmd": "my-npm-tool --version",
-        "setupHint": "Authenticate inside the container before first use."
-      }
-    ]
-  }
-}
-```
-
-Minimal shell-type custom tool (non-npm distribution):
+Minimal entry — the contract for getting a tool into the image is just these two fields:
 
 ```json
 {
@@ -305,11 +278,45 @@ Minimal shell-type custom tool (non-npm distribution):
     "customTools": [
       {
         "id": "my-shell-tool",
-        "name": "My Shell Tool",
-        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
-        "containerMount": "/home/devuser/.my-shell-tool",
-        "versionCmd": "my-shell-tool --version",
-        "setupHint": "Authenticate inside the container before first use."
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" }
+      }
+    ]
+  }
+}
+```
+
+### Optional integration fields
+
+Add only the fields your tool actually needs. Omit them and the loader fills sensible defaults; provide them and the loader uses your value. Provide an explicit empty string and the loader rejects it (preventing silent install-verification bypass).
+
+| Field | Default when omitted | When to provide |
+|-------|---------------------|-----------------|
+| `name` | `id` | A friendlier display name in sandbox reports / hints. |
+| `containerMount` | `/home/devuser/.<id>` | Your tool stores its config / state somewhere other than `~/.<id>`. Must be an absolute path. |
+| `versionCmd` | `which <id>` | The installed binary name differs from `id` (e.g. id `anthropic-claude`, binary `claude`); set `"claude --version"` so sandbox-create can verify the install. |
+| `setupHint` | `Run \`<id>\` inside the container to set up.` | The setup story is non-obvious and worth a one-liner. |
+| `envVars` | (none) | Your tool reads config from a path the env points to (e.g. `XDG_CONFIG_HOME`-style or a custom `*_CONFIG` env). Shape: `Record<string, string>`. |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | (none) | Seed the tool's sandbox dir from host files / directories on first launch. |
+| `pathRewriteFiles` | (none) | Seeded files contain absolute host paths that need rewriting to container paths. |
+| `hostLiveMounts` | (none) | Share host credentials live (e.g. OAuth tokens) with the container. Read-write. |
+| `postSetupCmds` | (none) | Run commands inside the container after first setup (e.g. symlinks). |
+
+> **`sandboxBase` is not user-configurable.** The loader always assigns `~/.agent-infra/sandboxes/<id>` so `ai sandbox rm` / `prune` can find tool state. Any `sandboxBase` value in `customTools` entries is silently ignored.
+
+Real-world example — `anthropic-claude` as a user-defined id with binary name `claude` and host credential live-mount:
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "anthropic-claude"],
+    "customTools": [
+      {
+        "id": "anthropic-claude",
+        "install": { "type": "npm", "cmd": "@anthropic-ai/claude-code@stable" },
+        "versionCmd": "claude --version",
+        "hostLiveMounts": [
+          { "hostPath": "~/.claude/.credentials.json", "containerSubpath": ".credentials.json" }
+        ]
       }
     ]
   }

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -258,6 +258,76 @@ args: "<task-id>"   # 可选
 
 `customTUIs` 每个条目对应一个自定义 TUI。若希望 `update-agent-infra` 为自定义 skill 生成命令文件，请在 `dir` 中保留至少一个引用内置 skill 路径的既有命令文件，例如 `.agents/skills/analyze-task/SKILL.md`；agent-infra 会以该文件作为格式参考。
 
+## 沙箱自定义工具（Sandbox Custom Tools）
+
+上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
+
+| 字段 | 必填 | 含义 |
+|------|------|------|
+| `id` | 是 | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
+| `name` | 是 | 报告与提示中显示的名称。 |
+| `install` | 是 | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。 |
+| `containerMount` | 是 | 容器内绝对路径，工具的配置 / 状态目录挂载点。 |
+| `versionCmd` | 是 | 沙箱用来验证工具已安装的 shell 命令。 |
+| `setupHint` | 是 | 首次启动时显示的一行说明。 |
+| `envVars` | 否 | `Record<string, string>` 形式的环境变量，导出到容器中给该工具使用。 |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | 否 | 首次启动时从宿主复制到工具沙箱配置目录的文件 / 目录。 |
+| `pathRewriteFiles` | 否 | 工具配置内需要把宿主路径改写为容器路径的文件。 |
+| `hostLiveMounts` | 否 | 从宿主实时挂载（读写）到工具 `containerMount` 下的文件。 |
+| `postSetupCmds` | 否 | 首次安装完成后在容器内执行的命令。 |
+
+最小 npm 类自定义工具：
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "my-npm-tool"],
+    "customTools": [
+      {
+        "id": "my-npm-tool",
+        "name": "My Npm Tool",
+        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
+        "containerMount": "/home/devuser/.my-npm-tool",
+        "versionCmd": "my-npm-tool --version",
+        "setupHint": "首次使用前请在容器内完成认证。"
+      }
+    ]
+  }
+}
+```
+
+最小 shell 类自定义工具（非 npm 分发）：
+
+```json
+{
+  "sandbox": {
+    "tools": ["my-shell-tool"],
+    "customTools": [
+      {
+        "id": "my-shell-tool",
+        "name": "My Shell Tool",
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
+        "containerMount": "/home/devuser/.my-shell-tool",
+        "versionCmd": "my-shell-tool --version",
+        "setupHint": "首次使用前请在容器内完成认证。"
+      }
+    ]
+  }
+}
+```
+
+### 信任边界与执行身份
+
+- `install.cmd` 在 `docker build` 阶段以 `devuser`（非 root）身份执行，只能写容器内文件系统，不能逃逸到宿主。信任模型与现有 `sandbox.dockerfile` 一致：你是 `.airc.json` 的作者，本次构建做什么由你负责。
+- 因为不是 root，shell 安装无法 `sudo` / `apt-get`。非 npm 分发的几条可用路径：
+  - 用户态安装器，落到 `~/.local/bin`、`~/.cargo/bin`、`~/.npm-global/bin`（如 `pipx`、`cargo install`、`curl … | bash` 配合 `INSTALL_DIR=$HOME/.local/bin`）。
+  - 确实需要 root / 系统包时，仍走原有 `sandbox.dockerfile` 字段，接管整个 Dockerfile。
+- 修改 `install.cmd` 或任何参与镜像签名的字段，下次 `ai sandbox` 命令会触发一次镜像重建。
+
+### 与 `sandbox.dockerfile` 的交互
+
+当 `sandbox.dockerfile` 指向自定义 Dockerfile 时，agent-infra 仍会把 `AI_TOOL_PACKAGES`（空格分隔的 npm 包规范）和 `AI_TOOLS_SHELL_INSTALL_B64`（base64 编码的 shell 安装脚本）作为 `--build-arg` 传入。你的自定义 Dockerfile 若未声明对应 `ARG`，shell 安装路径会被 docker build 静默忽略——这是接管 Dockerfile 后的应有代价。
+
 ## Skill 编写规范
 
 编写或维护 `.agents/skills/*/SKILL.md` 及其模板时，步骤编号遵循以下规则：

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -262,41 +262,14 @@ args: "<task-id>"   # 可选
 
 上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
 
-| 字段 | 必填 | 含义 |
-|------|------|------|
-| `id` | 是 | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
-| `name` | 是 | 报告与提示中显示的名称。 |
-| `install` | 是 | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。 |
-| `containerMount` | 是 | 容器内绝对路径，工具的配置 / 状态目录挂载点。 |
-| `versionCmd` | 是 | 沙箱用来验证工具已安装的 shell 命令。 |
-| `setupHint` | 是 | 首次启动时显示的一行说明。 |
-| `envVars` | 否 | `Record<string, string>` 形式的环境变量，导出到容器中给该工具使用。 |
-| `hostPreSeedFiles` / `hostPreSeedDirs` | 否 | 首次启动时从宿主复制到工具沙箱配置目录的文件 / 目录。 |
-| `pathRewriteFiles` | 否 | 工具配置内需要把宿主路径改写为容器路径的文件。 |
-| `hostLiveMounts` | 否 | 从宿主实时挂载（读写）到工具 `containerMount` 下的文件。 |
-| `postSetupCmds` | 否 | 首次安装完成后在容器内执行的命令。 |
+### 必填字段
 
-最小 npm 类自定义工具：
+| 字段 | 含义 |
+|------|------|
+| `id` | 小写 id，匹配 `^[a-z0-9][a-z0-9-]*$`；由 `sandbox.tools` 引用；不可与内建 id 冲突。 |
+| `install` | 安装描述符。`{ "type": "npm", "cmd": "<npm 包规范>" }` 执行 `npm install -g <cmd>`；`{ "type": "shell", "cmd": "<shell>" }` 在镜像构建阶段以 `devuser` 执行 shell。`cmd` 必须非空。 |
 
-```json
-{
-  "sandbox": {
-    "tools": ["claude-code", "my-npm-tool"],
-    "customTools": [
-      {
-        "id": "my-npm-tool",
-        "name": "My Npm Tool",
-        "install": { "type": "npm", "cmd": "my-npm-tool@latest" },
-        "containerMount": "/home/devuser/.my-npm-tool",
-        "versionCmd": "my-npm-tool --version",
-        "setupHint": "首次使用前请在容器内完成认证。"
-      }
-    ]
-  }
-}
-```
-
-最小 shell 类自定义工具（非 npm 分发）：
+最小入口——把一个工具装进镜像所需的契约只有这两个字段：
 
 ```json
 {
@@ -305,11 +278,45 @@ args: "<task-id>"   # 可选
     "customTools": [
       {
         "id": "my-shell-tool",
-        "name": "My Shell Tool",
-        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" },
-        "containerMount": "/home/devuser/.my-shell-tool",
-        "versionCmd": "my-shell-tool --version",
-        "setupHint": "首次使用前请在容器内完成认证。"
+        "install": { "type": "shell", "cmd": "curl -fsSL https://example.com/install.sh | bash" }
+      }
+    ]
+  }
+}
+```
+
+### 可选集成字段
+
+只在你的工具真正需要时才加。**省略**则 loader 用合理默认值；**显式提供**则用你给的值；**显式给空串**会被拒绝（防止安装验证被绕过）。
+
+| 字段 | 省略时的默认值 | 什么时候应该提供 |
+|------|---------------|----------------|
+| `name` | `id` | 想在沙箱报告 / 提示里显示更友好的名称。 |
+| `containerMount` | `/home/devuser/.<id>` | 工具的配置 / 状态目录不在 `~/.<id>` 而在别处。必须是绝对路径。 |
+| `versionCmd` | `which <id>` | 安装后的可执行文件名与 `id` 不同（例如 id 是 `anthropic-claude`，二进制名是 `claude`）；填 `"claude --version"` 让 sandbox-create 能验证安装。 |
+| `setupHint` | `Run \`<id>\` inside the container to set up.` | setup 流程不一目了然，值得用一行说明。 |
+| `envVars` | （无） | 工具通过环境变量找配置（如 `XDG_CONFIG_HOME` 风格或自定义 `*_CONFIG` 变量）。形状：`Record<string, string>`。 |
+| `hostPreSeedFiles` / `hostPreSeedDirs` | （无） | 首次启动时从宿主复制文件 / 目录到工具沙箱配置目录。 |
+| `pathRewriteFiles` | （无） | seed 进来的文件里有宿主绝对路径，需要改写为容器路径。 |
+| `hostLiveMounts` | （无） | 把宿主凭证（如 OAuth token）实时挂进容器，读写共享。 |
+| `postSetupCmds` | （无） | 首次安装完成后在容器内执行命令（如建符号链接）。 |
+
+> **`sandboxBase` 不由用户配置。** loader 永远使用 `~/.agent-infra/sandboxes/<id>`，这样 `ai sandbox rm` / `prune` 才能找到工具状态目录。`customTools` 条目里写的任何 `sandboxBase` 都会被静默忽略。
+
+实际场景示例——`anthropic-claude` 作为用户自定义 id，二进制名是 `claude`，并把宿主凭证 live-mount 进来：
+
+```json
+{
+  "sandbox": {
+    "tools": ["claude-code", "anthropic-claude"],
+    "customTools": [
+      {
+        "id": "anthropic-claude",
+        "install": { "type": "npm", "cmd": "@anthropic-ai/claude-code@stable" },
+        "versionCmd": "claude --version",
+        "hostLiveMounts": [
+          { "hostPath": "~/.claude/.credentials.json", "containerSubpath": ".credentials.json" }
+        ]
       }
     ]
   }

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -735,7 +735,7 @@ test("sandbox prune collects orphaned per-branch dirs while preserving active an
   const tool = {
     id: "codex",
     name: "Codex",
-    npmPackage: "@openai/codex",
+    install: { type: "npm", cmd: "@openai/codex" },
     sandboxBase: path.join(tmpDir, ".agent-infra", "sandboxes", "codex"),
     containerMount: "/home/devuser/.codex",
     versionCmd: "codex --version",

--- a/tests/integration/cli/sandbox-custom-tools.test.ts
+++ b/tests/integration/cli/sandbox-custom-tools.test.ts
@@ -1,0 +1,433 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  gitSafeEnv,
+  loadFreshEsm,
+  withGitSafeProcessEnv
+} from "../../helpers.ts";
+
+type SandboxConfigModule = typeof import("../../../lib/sandbox/config.ts");
+type SandboxToolsModule = typeof import("../../../lib/sandbox/tools.ts");
+type SandboxCreateModule = typeof import("../../../lib/sandbox/commands/create.ts");
+
+type VerboseCall = {
+  type: "run" | "verbose";
+  engine?: string;
+  cmd: string;
+  args: string[];
+  opts?: { cwd?: string };
+};
+
+const SHELL_INSTALL_CMD = 'curl -fsSL https://example.com/install.sh | bash';
+
+function writeAirc(repoRoot: string, body: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(repoRoot, ".agents"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoRoot, ".agents", ".airc.json"),
+    JSON.stringify(body, null, 2) + "\n",
+    "utf8"
+  );
+}
+
+test("loadConfig parses sandbox.customTools and fills sandboxBase under ~/.agent-infra/sandboxes", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-tools-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        tools: ["claude-code", "my-tool"],
+        customTools: [
+          {
+            id: "my-tool",
+            name: "My Custom Tool",
+            install: { type: "shell", cmd: SHELL_INSTALL_CMD },
+            containerMount: "/home/devuser/.mytool",
+            versionCmd: "mytool --version",
+            setupHint: "fixture"
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig());
+
+    assert.equal(config.customTools.length, 1);
+    const tool = config.customTools[0];
+    assert.equal(tool?.id, "my-tool");
+    assert.deepEqual(tool?.install, { type: "shell", cmd: SHELL_INSTALL_CMD });
+    assert.equal(
+      tool?.sandboxBase,
+      path.join(process.env.HOME ?? "", ".agent-infra", "sandboxes", "my-tool")
+    );
+    // tools array preserves user order, including non-builtin id
+    assert.deepEqual(config.tools, ["claude-code", "my-tool"]);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects customTools entries with relative containerMount", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-bad-mount-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        customTools: [
+          {
+            id: "bad-tool",
+            name: "Bad",
+            install: { type: "shell", cmd: "echo hi" },
+            containerMount: "relative/path",
+            versionCmd: "bad --version",
+            setupHint: "fixture"
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    assert.throws(
+      () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
+      /containerMount must be an absolute path/
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects customTools entries with empty versionCmd", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-empty-version-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        customTools: [
+          {
+            id: "no-version",
+            name: "Empty Version",
+            install: { type: "shell", cmd: "echo hi" },
+            containerMount: "/home/devuser/.no-version",
+            versionCmd: "",
+            setupHint: "fixture"
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    // Empty versionCmd would otherwise pass through to `bash -lc ""`, which
+    // exits 0 — silently masking install failures during sandbox creation.
+    assert.throws(
+      () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
+      /empty versionCmd/
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects customTools entries with empty setupHint", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-empty-hint-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        customTools: [
+          {
+            id: "no-hint",
+            name: "Empty Hint",
+            install: { type: "shell", cmd: "echo hi" },
+            containerMount: "/home/devuser/.no-hint",
+            versionCmd: "no-hint --version",
+            setupHint: ""
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    assert.throws(
+      () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
+      /empty setupHint/
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig always assigns the default sandboxBase and ignores user-supplied overrides", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-base-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        customTools: [
+          {
+            id: "fixed-base",
+            name: "Fixed Base",
+            install: { type: "shell", cmd: "echo hi" },
+            containerMount: "/home/devuser/.fixed-base",
+            // User attempts to override sandboxBase — the loader must ignore
+            // it so `ai sandbox rm` / `prune` keep finding the canonical path.
+            sandboxBase: "/some/unexpected/host/path",
+            versionCmd: "fixed-base --version",
+            setupHint: "fixture"
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig());
+    assert.equal(
+      config.customTools[0]?.sandboxBase,
+      path.join(process.env.HOME ?? "", ".agent-infra", "sandboxes", "fixed-base")
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects customTools entries with empty install.cmd", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-empty-cmd-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        customTools: [
+          {
+            id: "empty-cmd",
+            name: "Empty",
+            install: { type: "shell", cmd: "" },
+            containerMount: "/home/devuser/.empty",
+            versionCmd: "v",
+            setupHint: "f"
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    assert.throws(
+      () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
+      /install\.cmd/
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveTools merges builtin and customTools, preserving sandbox.tools ordering", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const tools = sandboxTools.resolveTools({
+    home: "/home/host-user",
+    project: "demo",
+    tools: ["my-shell-tool", "claude-code"],
+    customTools: [
+      {
+        id: "my-shell-tool",
+        name: "My Shell Tool",
+        install: { type: "shell", cmd: SHELL_INSTALL_CMD },
+        sandboxBase: "/home/host-user/.agent-infra/sandboxes/my-shell-tool",
+        containerMount: "/home/devuser/.my-shell-tool",
+        versionCmd: "my-shell-tool --version",
+        setupHint: "fixture"
+      }
+    ]
+  });
+
+  assert.deepEqual(
+    tools.map((tool) => tool.id),
+    ["my-shell-tool", "claude-code"]
+  );
+  assert.deepEqual(tools[0]?.install, { type: "shell", cmd: SHELL_INSTALL_CMD });
+});
+
+test("resolveTools throws when customTools id collides with a built-in tool", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  assert.throws(
+    () =>
+      sandboxTools.resolveTools({
+        home: "/home/host-user",
+        project: "demo",
+        tools: ["claude-code"],
+        customTools: [
+          {
+            id: "claude-code",
+            name: "Imposter",
+            install: { type: "shell", cmd: "echo override" },
+            sandboxBase: "/home/host-user/.agent-infra/sandboxes/claude-code",
+            containerMount: "/home/devuser/.claude",
+            versionCmd: "claude --version",
+            setupHint: "fixture"
+          }
+        ]
+      }),
+    /collides with a built-in tool/
+  );
+});
+
+test("resolveTools throws when two customTools share the same id", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const dup = {
+    id: "dup-tool",
+    name: "Dup",
+    install: { type: "shell" as const, cmd: "echo dup" },
+    sandboxBase: "/home/host-user/.agent-infra/sandboxes/dup-tool",
+    containerMount: "/home/devuser/.dup",
+    versionCmd: "dup --version",
+    setupHint: "fixture"
+  };
+
+  assert.throws(
+    () =>
+      sandboxTools.resolveTools({
+        home: "/home/host-user",
+        project: "demo",
+        tools: ["dup-tool"],
+        customTools: [dup, { ...dup }]
+      }),
+    /Duplicate sandbox tool id/
+  );
+});
+
+test("resolveTools still throws Unknown sandbox tool when sandbox.tools references a missing id", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  assert.throws(
+    () =>
+      sandboxTools.resolveTools({
+        home: "/home/host-user",
+        project: "demo",
+        tools: ["does-not-exist"],
+        customTools: []
+      }),
+    /Unknown sandbox tool: does-not-exist/
+  );
+});
+
+test("buildImage forwards AI_TOOL_PACKAGES= empty and a non-empty AI_TOOLS_SHELL_INSTALL_B64 for shell-only configs", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const calls: VerboseCall[] = [];
+
+  sandboxCreate.buildImage(
+    { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
+    [
+      {
+        id: "shell-only",
+        name: "Shell Only",
+        install: { type: "shell", cmd: SHELL_INSTALL_CMD },
+        sandboxBase: "/home/host-user/.agent-infra/sandboxes/shell-only",
+        containerMount: "/home/devuser/.shell-only",
+        versionCmd: "shell-only --version",
+        setupHint: "fixture"
+      }
+    ],
+    "/tmp/Dockerfile",
+    "sig-shell-only",
+    {
+      engine: "native",
+      runFn(_engine: string, cmd: string, args: string[]) {
+        calls.push({ type: "run", cmd, args });
+        if (cmd === "id" && args[0] === "-u") return "1000";
+        if (cmd === "id" && args[0] === "-g") return "1000";
+        throw new Error(`unexpected quiet command: ${cmd} ${args.join(" ")}`);
+      },
+      runSafeFn() {
+        return "";
+      },
+      runVerboseFn(engine: string, cmd: string, args: string[], opts?: { cwd?: string }) {
+        calls.push({ type: "verbose", engine, cmd, args, opts });
+      }
+    }
+  );
+
+  const verbose = calls.find((c) => c.type === "verbose");
+  assert.ok(verbose, "expected a verbose docker build call");
+  const argString = verbose.args.join("\n");
+  assert.match(argString, /AI_TOOL_PACKAGES=$/m);
+  const shellArgIdx = verbose.args.findIndex((arg) => arg.startsWith("AI_TOOLS_SHELL_INSTALL_B64="));
+  assert.ok(shellArgIdx >= 0, "expected AI_TOOLS_SHELL_INSTALL_B64 build arg");
+  const shellArgValue = (verbose.args[shellArgIdx] ?? "").slice("AI_TOOLS_SHELL_INSTALL_B64=".length);
+  assert.notEqual(shellArgValue, "");
+  const decoded = Buffer.from(shellArgValue, "base64").toString("utf8");
+  assert.match(decoded, /# install: shell-only/);
+  assert.match(decoded, /curl -fsSL https:\/\/example\.com\/install\.sh \| bash/);
+});
+
+test("buildImage forwards AI_TOOLS_SHELL_INSTALL_B64= empty for the default npm-only configuration", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const calls: VerboseCall[] = [];
+
+  sandboxCreate.buildImage(
+    { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
+    "/tmp/Dockerfile",
+    "sig-npm-only",
+    {
+      engine: "native",
+      runFn(_engine: string, cmd: string, args: string[]) {
+        calls.push({ type: "run", cmd, args });
+        if (cmd === "id" && args[0] === "-u") return "1000";
+        if (cmd === "id" && args[0] === "-g") return "1000";
+        throw new Error(`unexpected quiet command: ${cmd} ${args.join(" ")}`);
+      },
+      runSafeFn() {
+        return "";
+      },
+      runVerboseFn(engine: string, cmd: string, args: string[], opts?: { cwd?: string }) {
+        calls.push({ type: "verbose", engine, cmd, args, opts });
+      }
+    }
+  );
+
+  const verbose = calls.find((c) => c.type === "verbose");
+  assert.ok(verbose, "expected a verbose docker build call");
+  assert.ok(
+    verbose.args.includes("AI_TOOLS_SHELL_INSTALL_B64="),
+    "expected empty AI_TOOLS_SHELL_INSTALL_B64 for npm-only build"
+  );
+  assert.ok(
+    verbose.args.includes("AI_TOOL_PACKAGES=@acme/tool"),
+    "expected AI_TOOL_PACKAGES to carry the npm-type tool"
+  );
+});

--- a/tests/integration/cli/sandbox-custom-tools.test.ts
+++ b/tests/integration/cli/sandbox-custom-tools.test.ts
@@ -34,13 +34,15 @@ function writeAirc(repoRoot: string, body: Record<string, unknown>): void {
   );
 }
 
-test("loadConfig parses sandbox.customTools and fills sandboxBase under ~/.agent-infra/sandboxes", async () => {
+test("loadConfig parses the minimal {id, install} customTools entry and fills all other fields with defaults", async () => {
   const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-tools-"));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-tools-minimal-"));
   const previousCwd = process.cwd();
 
   try {
     execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    // The minimal entry is the contract that documentation promises: 2 fields
+    // (id + install) are required; everything else gets a sensible default.
     writeAirc(tmpDir, {
       project: "demo",
       sandbox: {
@@ -48,11 +50,7 @@ test("loadConfig parses sandbox.customTools and fills sandboxBase under ~/.agent
         customTools: [
           {
             id: "my-tool",
-            name: "My Custom Tool",
-            install: { type: "shell", cmd: SHELL_INSTALL_CMD },
-            containerMount: "/home/devuser/.mytool",
-            versionCmd: "mytool --version",
-            setupHint: "fixture"
+            install: { type: "shell", cmd: SHELL_INSTALL_CMD }
           }
         ]
       }
@@ -65,10 +63,23 @@ test("loadConfig parses sandbox.customTools and fills sandboxBase under ~/.agent
     const tool = config.customTools[0];
     assert.equal(tool?.id, "my-tool");
     assert.deepEqual(tool?.install, { type: "shell", cmd: SHELL_INSTALL_CMD });
+    // Defaults derived from id
+    assert.equal(tool?.name, "my-tool");
+    assert.equal(tool?.containerMount, "/home/devuser/.my-tool");
+    assert.equal(tool?.versionCmd, "which my-tool");
+    assert.match(tool?.setupHint ?? "", /^Run/);
+    // sandboxBase is always derived; not user-configurable
     assert.equal(
       tool?.sandboxBase,
       path.join(process.env.HOME ?? "", ".agent-infra", "sandboxes", "my-tool")
     );
+    // Optional integration fields stay undefined when omitted
+    assert.equal(tool?.envVars, undefined);
+    assert.equal(tool?.hostLiveMounts, undefined);
+    assert.equal(tool?.hostPreSeedFiles, undefined);
+    assert.equal(tool?.hostPreSeedDirs, undefined);
+    assert.equal(tool?.pathRewriteFiles, undefined);
+    assert.equal(tool?.postSetupCmds, undefined);
     // tools array preserves user order, including non-builtin id
     assert.deepEqual(config.tools, ["claude-code", "my-tool"]);
   } finally {
@@ -77,7 +88,48 @@ test("loadConfig parses sandbox.customTools and fills sandboxBase under ~/.agent
   }
 });
 
-test("loadConfig rejects customTools entries with relative containerMount", async () => {
+test("loadConfig honours user-supplied versionCmd to support binary names that differ from the tool id", async () => {
+  const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-tools-versioncmd-"));
+  const previousCwd = process.cwd();
+
+  try {
+    execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    // Realistic case: npm package is @anthropic-ai/claude-code, binary is
+    // `claude`, user picks `anthropic-claude` as a disambiguated id.
+    // The default `which anthropic-claude` would fail; user must override.
+    writeAirc(tmpDir, {
+      project: "demo",
+      sandbox: {
+        tools: ["anthropic-claude"],
+        customTools: [
+          {
+            id: "anthropic-claude",
+            install: { type: "npm", cmd: "@anthropic-ai/claude-code@stable" },
+            versionCmd: "claude --version",
+            hostLiveMounts: [
+              { hostPath: "/home/u/.claude/.credentials.json", containerSubpath: ".credentials.json" }
+            ]
+          }
+        ]
+      }
+    });
+
+    process.chdir(tmpDir);
+    const config = withGitSafeProcessEnv(() => sandboxConfig.loadConfig());
+
+    const tool = config.customTools[0];
+    assert.equal(tool?.versionCmd, "claude --version");
+    assert.deepEqual(tool?.hostLiveMounts, [
+      { hostPath: "/home/u/.claude/.credentials.json", containerSubpath: ".credentials.json" }
+    ]);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects an explicit relative containerMount even though the field is now optional", async () => {
   const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-bad-mount-"));
   const previousCwd = process.cwd();
@@ -90,11 +142,8 @@ test("loadConfig rejects customTools entries with relative containerMount", asyn
         customTools: [
           {
             id: "bad-tool",
-            name: "Bad",
             install: { type: "shell", cmd: "echo hi" },
-            containerMount: "relative/path",
-            versionCmd: "bad --version",
-            setupHint: "fixture"
+            containerMount: "relative/path"
           }
         ]
       }
@@ -103,7 +152,7 @@ test("loadConfig rejects customTools entries with relative containerMount", asyn
     process.chdir(tmpDir);
     assert.throws(
       () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
-      /containerMount must be an absolute path/
+      /"containerMount" must be an absolute path/
     );
   } finally {
     process.chdir(previousCwd);
@@ -111,35 +160,33 @@ test("loadConfig rejects customTools entries with relative containerMount", asyn
   }
 });
 
-test("loadConfig rejects customTools entries with empty versionCmd", async () => {
+test("loadConfig rejects an explicit empty versionCmd to prevent bash -lc '' from silently passing", async () => {
   const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-empty-version-"));
   const previousCwd = process.cwd();
 
   try {
     execSync("git init", { cwd: tmpDir, env: gitSafeEnv(), stdio: "pipe" });
+    // Round 4 distinguishes "omitted" (legal, use default) from "explicit empty
+    // string" (illegal). The explicit empty case would, if accepted, run
+    // `bash -lc ""` which exits 0 — silently masking install failures.
     writeAirc(tmpDir, {
       project: "demo",
       sandbox: {
         customTools: [
           {
             id: "no-version",
-            name: "Empty Version",
             install: { type: "shell", cmd: "echo hi" },
-            containerMount: "/home/devuser/.no-version",
-            versionCmd: "",
-            setupHint: "fixture"
+            versionCmd: ""
           }
         ]
       }
     });
 
     process.chdir(tmpDir);
-    // Empty versionCmd would otherwise pass through to `bash -lc ""`, which
-    // exits 0 — silently masking install failures during sandbox creation.
     assert.throws(
       () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
-      /empty versionCmd/
+      /"versionCmd" must be non-empty when provided/
     );
   } finally {
     process.chdir(previousCwd);
@@ -147,7 +194,7 @@ test("loadConfig rejects customTools entries with empty versionCmd", async () =>
   }
 });
 
-test("loadConfig rejects customTools entries with empty setupHint", async () => {
+test("loadConfig rejects an explicit empty setupHint while accepting omission", async () => {
   const sandboxConfig = await loadFreshEsm<SandboxConfigModule>("lib/sandbox/config.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-custom-empty-hint-"));
   const previousCwd = process.cwd();
@@ -160,10 +207,7 @@ test("loadConfig rejects customTools entries with empty setupHint", async () => 
         customTools: [
           {
             id: "no-hint",
-            name: "Empty Hint",
             install: { type: "shell", cmd: "echo hi" },
-            containerMount: "/home/devuser/.no-hint",
-            versionCmd: "no-hint --version",
             setupHint: ""
           }
         ]
@@ -173,7 +217,7 @@ test("loadConfig rejects customTools entries with empty setupHint", async () => 
     process.chdir(tmpDir);
     assert.throws(
       () => withGitSafeProcessEnv(() => sandboxConfig.loadConfig()),
-      /empty setupHint/
+      /"setupHint" must be non-empty when provided/
     );
   } finally {
     process.chdir(previousCwd);
@@ -194,14 +238,10 @@ test("loadConfig always assigns the default sandboxBase and ignores user-supplie
         customTools: [
           {
             id: "fixed-base",
-            name: "Fixed Base",
             install: { type: "shell", cmd: "echo hi" },
-            containerMount: "/home/devuser/.fixed-base",
             // User attempts to override sandboxBase — the loader must ignore
             // it so `ai sandbox rm` / `prune` keep finding the canonical path.
-            sandboxBase: "/some/unexpected/host/path",
-            versionCmd: "fixed-base --version",
-            setupHint: "fixture"
+            sandboxBase: "/some/unexpected/host/path"
           }
         ]
       }
@@ -232,11 +272,7 @@ test("loadConfig rejects customTools entries with empty install.cmd", async () =
         customTools: [
           {
             id: "empty-cmd",
-            name: "Empty",
-            install: { type: "shell", cmd: "" },
-            containerMount: "/home/devuser/.empty",
-            versionCmd: "v",
-            setupHint: "f"
+            install: { type: "shell", cmd: "" }
           }
         ]
       }

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -119,7 +119,8 @@ test("composeDockerfile joins runtime fragments in order", async () => {
     assert.match(content, /^FROM ubuntu:24\.04/m);
     assert.match(content, /setup_20\.x/);
     assert.match(content, /python3 python3-pip python3-venv/);
-    assert.match(content, /AI_TOOL_PACKAGES build arg is required/);
+    assert.match(content, /ARG AI_TOOL_PACKAGES=/);
+    assert.match(content, /ARG AI_TOOLS_SHELL_INSTALL_B64=/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -363,7 +364,7 @@ test("buildImage uses verbose docker build output while keeping host UID/GID loo
 
   sandboxCreate.buildImage(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "/tmp/Dockerfile",
     "sig-123",
     {
@@ -407,6 +408,8 @@ test("buildImage uses verbose docker build output while keeping host UID/GID loo
     "HOST_GID=20",
     "--build-arg",
     "AI_TOOL_PACKAGES=@acme/tool",
+    "--build-arg",
+    "AI_TOOLS_SHELL_INSTALL_B64=",
     "--label",
     "demo.sandbox",
     "--label",
@@ -423,7 +426,7 @@ test("buildImage forwards HOST_UID=0 and HOST_GID=0 unchanged when host runs as 
 
   sandboxCreate.buildImage(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "/tmp/Dockerfile",
     "sig-123",
     {
@@ -499,7 +502,7 @@ test("buildImage rewrites HOST_UID and HOST_GID to 0 when Docker is rootless", a
 
   sandboxCreate.buildImage(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "/repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "/tmp/Dockerfile",
     "sig-123",
     {

--- a/tests/integration/cli/sandbox-engine.test.ts
+++ b/tests/integration/cli/sandbox-engine.test.ts
@@ -298,7 +298,7 @@ test("buildImage converts Docker build paths for WSL2", async () => {
 
   sandboxCreate.buildImage(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "F:\\repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "F:\\tmp\\Dockerfile",
     "sig-123",
     {
@@ -427,7 +427,7 @@ test("rebuild buildArgs converts Docker build paths for WSL2", async () => {
 
   const args = sandboxRebuild.buildArgs(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "F:\\repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "F:\\tmp\\Dockerfile",
     "sig-123",
     { engine: "wsl2", runFn: () => "1000" }
@@ -443,7 +443,7 @@ test("rebuild buildArgs adds refresh build flags after docker build", async () =
 
   const args = sandboxRebuild.buildArgs(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "F:\\repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "F:\\tmp\\Dockerfile",
     "sig-123",
     { engine: "wsl2", runFn: () => "1000", refresh: true }
@@ -460,7 +460,7 @@ test("rebuild buildArgs keeps Docker build cache by default", async () => {
 
   const args = sandboxRebuild.buildArgs(
     { project: "demo", imageName: "demo-sandbox:latest", repoRoot: "F:\\repo" },
-    [{ npmPackage: "@acme/tool" }],
+    [{ install: { type: "npm", cmd: "@acme/tool" } }],
     "F:\\tmp\\Dockerfile",
     "sig-123",
     { engine: "wsl2", runFn: () => "1000" }

--- a/tests/integration/cli/sandbox-install-script.test.ts
+++ b/tests/integration/cli/sandbox-install-script.test.ts
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadFreshEsm } from "../../helpers.ts";
+
+type SandboxToolsModule = typeof import("../../../lib/sandbox/tools.ts");
+
+const FAKE_HOST_PATH = "/home/host-user/.acme/auth.json";
+
+const NPM_TOOL = {
+  id: "demo-npm",
+  name: "Demo Npm",
+  install: { type: "npm" as const, cmd: "@demo/npm-tool@1.0.0" },
+  sandboxBase: "/home/host-user/.agent-infra/sandboxes/demo-npm",
+  containerMount: "/home/devuser/.demo-npm",
+  versionCmd: "demo-npm --version",
+  setupHint: "fixture"
+};
+
+const SHELL_TOOL = {
+  id: "demo-shell",
+  name: "Demo Shell",
+  install: { type: "shell" as const, cmd: 'curl -fsSL https://example.com/install.sh | bash' },
+  sandboxBase: "/home/host-user/.agent-infra/sandboxes/demo-shell",
+  containerMount: "/home/devuser/.demo-shell",
+  versionCmd: "demo-shell --version",
+  setupHint: "fixture"
+};
+
+test("toolNpmPackagesArg returns space-separated npm packages and ignores shell tools", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  assert.equal(sandboxTools.toolNpmPackagesArg([NPM_TOOL, SHELL_TOOL]), "@demo/npm-tool@1.0.0");
+  assert.equal(sandboxTools.toolNpmPackagesArg([SHELL_TOOL]), "");
+});
+
+test("toolShellInstallScript returns empty string when no shell tools are present", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  assert.equal(sandboxTools.toolShellInstallScript([]), "");
+  assert.equal(sandboxTools.toolShellInstallScript([NPM_TOOL]), "");
+});
+
+test("toolShellInstallScript composes per-tool shebang + set -e + comment header + cmd", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const script = sandboxTools.toolShellInstallScript([NPM_TOOL, SHELL_TOOL]);
+
+  assert.match(script, /^#!\/bin\/bash\nset -e\n/);
+  assert.match(script, /# install: demo-shell\ncurl -fsSL https:\/\/example\.com\/install\.sh \| bash/);
+  // npm tool is excluded from the shell script
+  assert.equal(script.includes("@demo/npm-tool"), false);
+});
+
+test("toolShellInstallScript handles multi-line shell commands without escaping", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+  const multiline = {
+    ...SHELL_TOOL,
+    id: "multi",
+    install: { type: "shell" as const, cmd: "echo step-1\necho step-2" }
+  };
+
+  const script = sandboxTools.toolShellInstallScript([multiline]);
+
+  assert.ok(script.includes("# install: multi\necho step-1\necho step-2"));
+});
+
+test("toolShellInstallScriptBase64 round-trips back to the script via base64 decode", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const b64 = sandboxTools.toolShellInstallScriptBase64([SHELL_TOOL]);
+  assert.notEqual(b64, "");
+  const decoded = Buffer.from(b64, "base64").toString("utf8");
+  assert.equal(decoded, sandboxTools.toolShellInstallScript([SHELL_TOOL]));
+});
+
+test("toolShellInstallScriptBase64 returns empty string when no shell tools are present", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  assert.equal(sandboxTools.toolShellInstallScriptBase64([]), "");
+  assert.equal(sandboxTools.toolShellInstallScriptBase64([NPM_TOOL]), "");
+});
+
+test("imageSignatureFields exposes only id and install — mount/env fields are excluded", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const withMountA = { ...SHELL_TOOL, containerMount: "/home/devuser/.a", hostLiveMounts: [{ hostPath: FAKE_HOST_PATH, containerSubpath: "auth.json" }] };
+  const withMountB = { ...SHELL_TOOL, containerMount: "/home/devuser/.b", hostLiveMounts: [{ hostPath: "/other/path", containerSubpath: "other.json" }] };
+
+  assert.deepEqual(
+    sandboxTools.imageSignatureFields([withMountA]),
+    sandboxTools.imageSignatureFields([withMountB])
+  );
+});
+
+test("imageSignatureFields changes when install.cmd changes — drives docker image rebuild", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const v1 = { ...SHELL_TOOL, install: { type: "shell" as const, cmd: "install v1" } };
+  const v2 = { ...SHELL_TOOL, install: { type: "shell" as const, cmd: "install v2" } };
+
+  assert.notDeepEqual(
+    sandboxTools.imageSignatureFields([v1]),
+    sandboxTools.imageSignatureFields([v2])
+  );
+});
+
+test("imageSignatureFields changes when install.type switches from npm to shell", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+
+  const npm = { ...NPM_TOOL, id: "swap", install: { type: "npm" as const, cmd: "same-cmd" } };
+  const shell = { ...NPM_TOOL, id: "swap", install: { type: "shell" as const, cmd: "same-cmd" } };
+
+  assert.notDeepEqual(
+    sandboxTools.imageSignatureFields([npm]),
+    sandboxTools.imageSignatureFields([shell])
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #410

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #410

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature（沙箱自定义 TUI 与安装脚本）
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update（README en/zh-CN 沙箱章节）
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

让用户能在 `.airc.json` 里声明自定义沙箱 TUI，并支持**任意安装脚本**（不限于 `npm install -g`），从而把非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制等）也接入沙箱镜像。在此之前 `lib/sandbox/tools.ts` 硬编码 4 个内建 TUI（Claude Code / Codex / OpenCode / Gemini CLI），`resolveTools()` 遇到未知 id 直接抛 `Unknown sandbox tool`；镜像层 `ai-tools.dockerfile:7-15` 是固定的 `for pkg in ${AI_TOOL_PACKAGES}; do npm install -g "$pkg"; done` 只能装 npm 包——非 npm 分发的 TUI 完全无法支持。

设计在 4 轮 plan / 3 轮 code review 中逐步收敛到「最低入门成本 + 按需深化」原则：必填字段只有 `id` 和 `install`，其它字段全部可选并由 loader 提供合理默认值；同时保留 Issue #410 列举的全部集成能力（凭证 live-mount、配置 seeding、env 变量、安装钩子等）。

## 📋 主要变更 / Brief Changelog

**数据模型与安装管线**

- `SandboxTool` 描述符以 `install: { type: 'npm' | 'shell'; cmd: string }` union 替换原 `npmPackage` 字段；4 个内建 TUI 平移到新字段，行为零变化。
- `ai-tools.dockerfile` 新增 base64 编码的 shell 安装路径（build arg `AI_TOOLS_SHELL_INSTALL_B64`），并把 `AI_TOOL_PACKAGES` 默认改为空字符串、移除非空 guard，让 shell-only 配置也能 build。
- 镜像签名（rebuild.ts/create.ts 的 `buildSignature`）抽出 `imageSignatureFields` helper，rebuild 与 create 共享同一签名输入，避免漂移；签名对 install 内容敏感、对 mount 字段不敏感。

**用户暴露面（customTools schema）**

- 在 `.airc.json` 的 `sandbox` 子树新增 `customTools` 数组。**必填字段只有 2 个**：`id` 和 `install`。
- 其它 10 个字段（`name` / `containerMount` / `versionCmd` / `setupHint` / `envVars` / `hostPreSeedFiles` / `hostPreSeedDirs` / `pathRewriteFiles` / `hostLiveMounts` / `postSetupCmds`）均为可选，loader 自动填合理默认值。
- `asOptionalNonEmptyString` helper 提供三态语义：**省略**字段使用默认值；**显式非空**使用用户值；**显式空字符串**抛错（防止 `bash -lc ""` 静默通过 install 验证）。
- `sandboxBase` 始终由 loader 计算为 `~/.agent-infra/sandboxes/<id>`，**不允许**用户在 `.airc.json` 中覆盖，保证 `ai sandbox rm` / `prune` 能找到状态目录。
- id 冲突检测：自定义 id 与内建冲突 / customTools 内部 id 重复 → 直接抛错。

**测试**

- 新增 `tests/integration/cli/sandbox-install-script.test.ts`（10 个单元用例，覆盖 `toolNpmPackagesArg` / `toolShellInstallScript` / `toolShellInstallScriptBase64` / `imageSignatureFields`）。
- 新增 `tests/integration/cli/sandbox-custom-tools.test.ts`（11 个集成用例，覆盖最小 entry 默认值、自定义 versionCmd 覆盖、显式空串拒绝、id 冲突 / 重复 / 未知、shell-only buildImage args、npm-only buildImage args）。
- 修复既有 sandbox-engine / sandbox-dockerfile / sandbox-core 测试中的 `npmPackage` fixture 迁移；`composeDockerfile` 断言更新到 Round 2 / Round 3 的 dockerfile 文本。

**文档**

- `templates/.agents/README.en.md`、`README.zh-CN.md`、`.agents/README.md`（工作副本）新增 `Sandbox Custom Tools` 章节，含必填表（2 字段）/ 可选表（10 字段，含默认值）/ 最小 entry 示例 / 真实场景示例（`anthropic-claude` 含 `hostLiveMounts`） / 信任边界说明 / 与 `sandbox.dockerfile` 交互说明。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build` —— 验证 TypeScript 编译通过。
2. `npm test` —— 全量项目测试套件 654 用例 / 653 pass / 1 skipped（与本任务无关，平台守卫 skip）/ 0 fail。
3. `grep -rn "\\.npmPackage" lib bin` —— 期望 0 命中，确认旧字段全量迁移。
4. 在有 Docker 的环境用本 PR 分支跑 `ai sandbox rebuild` 三组冒烟（详见下方「待人工验证」）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（21 个新增用例 + 多个 fixture 迁移）
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（本机无 docker daemon，端到端 `docker build` 由维护者承接）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue filed for the change（#410）
- [x] 你的 Pull Request 只解决一个 Issue / Single-purpose PR
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范（TypeScript erasable syntax / 测试纪律 / 外科手术式修改）
- [x] 我已经进行了自我代码审查（3 轮 codex review，最新 review-code-r3.md Approved 0/0/0）
- [x] 我已经为复杂的代码添加了必要的注释（`asOptionalNonEmptyString` 三态语义 / `parseCustomTool` 默认值逻辑）

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过 / `npm run build`（tsc -p tsconfig.json 全绿）
- [x] 单元测试通过 / `npm test`（654/654，1 skipped 无关）

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（3 份 README 同步新增 Sandbox Custom Tools 章节）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更——内建 4 个 TUI 行为零变化；用户首次升级会触发**一次**镜像重建，因为 buildSignature 字段从 `npmPackage` 改为 `{id, install}`，JSON 序列化结果不同；功能等价）
- [x] 我已经考虑了向后兼容性（`AI_TOOL_PACKAGES` build arg 保留，现有用户的自定义 Dockerfile 不破坏）

## 📋 附加信息 / Additional Notes

**待人工验证 / Awaiting Human Verification（env-blocked）**:

本机无 docker daemon，dockerfile 双安装通道真实构建冒烟无法在 AI 侧跑。维护者合并前请在有 Docker / OrbStack / Docker Desktop / WSL2 Docker 的机器上跑下面三组 `ai sandbox rebuild`。任务目录里准备好了配置文件（gitignored，不进 PR）：`.agents/workspace/active/TASK-20260608-162509/sandbox-verify/` 含 `airc.original.backup.json` / `airc.scenario-2-mixed.json` / `airc.scenario-3-shell-only.json` 三个文件 + 操作 README。

- [x] **先决条件**：`docker run --rm ubuntu:24.04 sh -lc 'which base64 bash'` 应输出两个二进制路径（dockerfile 的 base64 解码块依赖这两个）。
- [x] **场景 1（默认 npm-only 回归）**：保持原 `.airc.json`，跑 `ai sandbox rebuild`；构建日志能看到 4 次 `npm install -g <pkg>`，**没有**「`AI_TOOL_PACKAGES build arg is required`」错误。
- [x] **场景 2（npm + shell 混合）**：把 scenario-2 配置 cp 到 `.airc.json` 跑 rebuild；4 次 npm install + 1 个 shell-demo 工具装上；进容器 `shell-demo` 输出 `shell-demo 1.0.0 (installed via shell)`。
- [x] **场景 3（shell-only，关键修复点）**：把 scenario-3 配置 cp 到 `.airc.json` 跑 rebuild；构建成功（不再因 `AI_TOOL_PACKAGES=` 空而 `exit 1`，这是 Round 1 → Round 2 阻塞项的核心修复）。

任一失败：贴失败日志到本 PR comment，决定走「分支再修一轮」还是「合并后 hotfix」。

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `lib/sandbox/tools.ts` 的 `asOptionalNonEmptyString` 三态语义和 `parseCustomTool` 的默认值组合，这是 4 轮 plan + 3 轮 code review 收敛后的 schema 设计。
- `containerMount` 绝对路径校验现在在两处：parseCustomTool（给自定义工具用，错误信息带 `customTools[<index>]` 上下文）和 validateTool（给内建工具兜底，永远不会触发因为内建是写死的）。
- 镜像构建期间 shell 安装命令在 `USER devuser` 上下文执行（非 root），与 `sandbox.dockerfile` 信任边界一致——用户对自己仓库的 `.airc.json` 完全负责。
- Round 4 plan 解决了 Round 3 plan 的两个 review finding：(1) 不再删除 Issue #410 明确要求的集成字段（`hostLiveMounts` 等），改为可选保留；(2) `versionCmd` 不强制等于 `which <id>`，用户可覆盖以支持「binary 名 ≠ id」场景（如 npm 包 `@anthropic-ai/claude-code` 装出的 binary 是 `claude`）。
- 流程上踩到 2 个技能链路盲区：(a) review-code verdict 字段值域不受 review-code verify gate 约束；(b) detect-mode 不感知 plan 在 code 之后被改过。两个盲区都已绕过当前 PR 推进，并合并到 #413（标题已改为「加固技能链路工作流的边界假设」）单独跟踪。

---

Generated with AI assistance.

