### PR TITLE
feat(cli): sandbox ls 增加序号列，exec 支持 #N 索引

### DIFF
--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from '../config.ts';
-import { assertValidBranchName, containerNameCandidates } from '../constants.ts';
+import { assertValidBranchName, containerNameCandidates, sandboxBranchLabel, sandboxLabel } from '../constants.ts';
 import { detectEngine } from '../engine.ts';
 import {
   formatCredentialWarnings,
@@ -13,8 +13,12 @@ import { resolveTaskBranch } from '../task-resolver.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
 import { runInteractiveWithClipboardBridge } from '../clipboard/bridge.ts';
 import { detectHostTimezone } from '../host-timezone.ts';
+import { fetchSandboxRows, isTaskShortRef, resolveTaskShortRef } from './list-running.ts';
 
-const USAGE = `Usage: ai sandbox exec <branch> [cmd...]`;
+const USAGE = `Usage: ai sandbox exec <branch | TASK-id | '#N'> [cmd...]
+
+'#N' references the N-th running sandbox in 'ai sandbox ls' order (1-based).
+Quote it as '#N' to avoid shell '#' comment handling.`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
 
 // Terminal-detection variables that interactive TUIs (e.g. claude-code)
@@ -115,8 +119,14 @@ export async function enter(args: string[]): Promise<number> {
   const config = loadConfig();
   validateClaudeCredentialsEnvOverride();
   const engine = detectEngine(config);
-  const [branchOrTaskId = '', ...cmd] = args;
-  const branch = resolveTaskBranch(branchOrTaskId, config.repoRoot);
+  const [firstArg = '', ...cmd] = args;
+  let branch: string;
+  if (isTaskShortRef(firstArg)) {
+    const { running } = fetchSandboxRows(engine, sandboxLabel(config), sandboxBranchLabel(config));
+    branch = resolveTaskShortRef(firstArg, { running });
+  } else {
+    branch = resolveTaskBranch(firstArg, config.repoRoot);
+  }
   assertValidBranchName(branch);
   const running = runSafeEngine(engine, 'docker', ['ps', '--format', '{{.Names}}']).split('\n');
   const container = containerNameCandidates(config, branch).find((name) => running.includes(name));

--- a/lib/sandbox/commands/list-running.ts
+++ b/lib/sandbox/commands/list-running.ts
@@ -1,0 +1,135 @@
+import { runSafeEngine } from '../shell.ts';
+
+export type SandboxRow = {
+  name: string;
+  status: string;
+  branch: string;
+  running: boolean;
+  index: number | null;
+};
+
+export function containerListFormat(): string {
+  return '{{.Names}}\t{{.Status}}\t{{.Labels}}';
+}
+
+export function parseLabels(csv: string): Record<string, string> {
+  if (!csv) {
+    return {};
+  }
+
+  const labels: Record<string, string> = {};
+  for (const pair of csv.split(',')) {
+    if (!pair) {
+      continue;
+    }
+    const eq = pair.indexOf('=');
+    if (eq < 0) {
+      continue;
+    }
+    labels[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+  return labels;
+}
+
+export function parseSandboxRows(rawOutput: string, branchKey: string): SandboxRow[] {
+  if (!rawOutput) {
+    return [];
+  }
+  return rawOutput.split('\n').map((line) => {
+    const [name = '', status = '', labelsCsv = ''] = line.split('\t');
+    const branch = parseLabels(labelsCsv)[branchKey] ?? '';
+    return {
+      name,
+      status,
+      branch,
+      running: status.startsWith('Up '),
+      index: null
+    };
+  });
+}
+
+export function sortAndIndexSandboxRows(rows: SandboxRow[]): {
+  running: SandboxRow[];
+  nonRunning: SandboxRow[];
+} {
+  const byName = (a: SandboxRow, b: SandboxRow): number => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  };
+  const running = rows.filter((row) => row.running).sort(byName).map((row, i) => ({
+    ...row,
+    index: i + 1
+  }));
+  const nonRunning = rows.filter((row) => !row.running).sort(byName).map((row) => ({
+    ...row,
+    index: null
+  }));
+  return { running, nonRunning };
+}
+
+export function fetchSandboxRows(
+  engine: string,
+  label: string,
+  branchKey: string
+): { running: SandboxRow[]; nonRunning: SandboxRow[] } {
+  const raw = runSafeEngine(engine, 'docker', [
+    'ps',
+    '-a',
+    '--filter',
+    `label=${label}`,
+    '--format',
+    containerListFormat()
+  ]);
+  return sortAndIndexSandboxRows(parseSandboxRows(raw, branchKey));
+}
+
+/**
+ * Returns true iff `arg` is a syntactically valid task short reference ('#N').
+ * Zero IO. Callers MUST use this as the gate before constructing any context
+ * for resolveTaskShortRef — that way non-matching arguments (e.g. '#abc',
+ * '#1.5', '#') never trigger sandbox list IO.
+ */
+export function isTaskShortRef(arg: string): boolean {
+  return /^#\d+$/.test(arg);
+}
+
+/**
+ * Resolve a task short reference ('#N') to a branch name.
+ *
+ * Current implementation: treats the digits as a 1-based index into the
+ * supplied running-sandbox list (ls view order). This is the *only*
+ * resolution path until the global task-short-id registry lands in a
+ * follow-up task; do NOT read task.md or scan .agents/workspace/ from this
+ * helper here.
+ *
+ * Precondition: callers MUST gate on isTaskShortRef(arg) === true before
+ * constructing ctx and calling this function. Throws when arg is a valid
+ * short ref but cannot be resolved (out of range, no running sandboxes,
+ * etc.); the caller surfaces the error to the user.
+ */
+export function resolveTaskShortRef(
+  arg: string,
+  ctx: { running: SandboxRow[] }
+): string {
+  const n = Number(arg.slice(1));
+  if (n < 1) {
+    throw new Error(`Invalid sandbox index '${arg}': must be >= 1`);
+  }
+  const { running } = ctx;
+  if (running.length === 0) {
+    throw new Error(`No running sandbox to reference with '${arg}'`);
+  }
+  if (n > running.length) {
+    throw new Error(
+      `No running sandbox at index '${arg}' (only ${running.length} running)`
+    );
+  }
+  const row = running[n - 1]!;
+  if (!row.branch) {
+    throw new Error(
+      `Cannot resolve branch for sandbox '${arg}' (container '${row.name}' missing branch label)`
+    );
+  }
+  return row.branch;
+}

--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -5,51 +5,36 @@ import pc from 'picocolors';
 import { loadConfig } from '../config.ts';
 import { sandboxBranchLabel, sandboxLabel } from '../constants.ts';
 import { detectEngine } from '../engine.ts';
-import { runSafeEngine } from '../shell.ts';
 import { resolveTools, toolProjectDirCandidates } from '../tools.ts';
+import { fetchSandboxRows } from './list-running.ts';
 
-const USAGE = 'Usage: ai sandbox ls';
-const CONTAINER_TABLE_HEADERS = ['NAMES', 'STATUS', 'BRANCH'] as const;
+export { containerListFormat, parseLabels } from './list-running.ts';
+
+const USAGE = `Usage: ai sandbox ls
+
+Lists all containers for the current project. The leftmost '#' column
+numbers running sandboxes; use it as "ai sandbox exec '#N'" to enter one.
+Quote '#N' to avoid shell '#' comment handling.`;
+
+const CONTAINER_TABLE_HEADERS = ['#', 'NAMES', 'STATUS', 'BRANCH'] as const;
 
 type ContainerTableRow = {
+  index: string;
   name: string;
   status: string;
   branch: string;
 };
 
-// Exported to lock the docker/podman-compatible format in unit tests.
-export function containerListFormat(): string {
-  return '{{.Names}}\t{{.Status}}\t{{.Labels}}';
-}
-
-export function parseLabels(csv: string): Record<string, string> {
-  if (!csv) {
-    return {};
-  }
-
-  const labels: Record<string, string> = {};
-  for (const pair of csv.split(',')) {
-    if (!pair) {
-      continue;
-    }
-    const eq = pair.indexOf('=');
-    if (eq < 0) {
-      continue;
-    }
-    labels[pair.slice(0, eq)] = pair.slice(eq + 1);
-  }
-  return labels;
-}
-
 export function formatContainerTable(rows: ContainerTableRow[]): string[] {
-  const columns = rows.map((row) => [row.name, row.status, row.branch] as const);
+  const columns = rows.map((row) => [row.index, row.name, row.status, row.branch] as const);
   const widths = [
-    Math.max(CONTAINER_TABLE_HEADERS[0].length, ...rows.map((row) => row.name.length)),
-    Math.max(CONTAINER_TABLE_HEADERS[1].length, ...rows.map((row) => row.status.length)),
-    Math.max(CONTAINER_TABLE_HEADERS[2].length, ...rows.map((row) => row.branch.length))
+    Math.max(CONTAINER_TABLE_HEADERS[0].length, ...rows.map((row) => row.index.length)),
+    Math.max(CONTAINER_TABLE_HEADERS[1].length, ...rows.map((row) => row.name.length)),
+    Math.max(CONTAINER_TABLE_HEADERS[2].length, ...rows.map((row) => row.status.length)),
+    Math.max(CONTAINER_TABLE_HEADERS[3].length, ...rows.map((row) => row.branch.length))
   ] as const;
-  const renderRow = (values: readonly [string, string, string]): string =>
-    `${values[0].padEnd(widths[0])}  ${values[1].padEnd(widths[1])}  ${values[2]}`.trimEnd();
+  const renderRow = (values: readonly [string, string, string, string]): string =>
+    `${values[0].padEnd(widths[0])}  ${values[1].padEnd(widths[1])}  ${values[2].padEnd(widths[2])}  ${values[3]}`.trimEnd();
 
   return [
     renderRow(CONTAINER_TABLE_HEADERS),
@@ -75,28 +60,22 @@ export function ls(args: string[] = []): void {
   const engine = detectEngine(config);
   const tools = resolveTools(config);
   const label = sandboxLabel(config);
-  const containers = runSafeEngine(engine, 'docker', [
-    'ps',
-    '-a',
-    '--filter',
-    `label=${label}`,
-    '--format',
-    containerListFormat()
-  ]);
+  const { running, nonRunning } = fetchSandboxRows(engine, label, sandboxBranchLabel(config));
 
   p.intro(pc.cyan(`Sandbox status for ${config.project}`));
 
   p.log.step('Containers');
-  if (!containers) {
+  const ordered = [...running, ...nonRunning];
+  if (ordered.length === 0) {
     p.log.warn('  No sandbox containers');
   } else {
-    const branchKey = sandboxBranchLabel(config);
-    const rows = containers.split('\n').map((line) => {
-      const [name = '', status = '', labelsCsv = ''] = line.split('\t');
-      const branch = parseLabels(labelsCsv)[branchKey] ?? '';
-      return { name, status, branch };
-    });
-    for (const line of formatContainerTable(rows)) {
+    const tableRows: ContainerTableRow[] = ordered.map((row) => ({
+      index: row.index === null ? '' : String(row.index),
+      name: row.name,
+      status: row.status,
+      branch: row.branch
+    }));
+    for (const line of formatContainerTable(tableRows)) {
       process.stdout.write(`  ${line}\n`);
     }
   }

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -2,7 +2,8 @@ const USAGE = `Usage: ai sandbox <command> [options]
 
 Commands:
   create <branch> [base]       Create a sandbox (VM + image + worktree + container)
-  exec <branch> [cmd...]       Enter sandbox or run a command
+  exec <branch | '#N'> [cmd...]
+                               Enter sandbox or run a command (use leftmost '#' column from 'ls')
   ls                           List sandboxes for the current project
   prune [--dry-run]            Remove orphaned per-branch state dirs
   rebuild [--quiet] [--refresh]

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -689,25 +689,151 @@ test("sandbox ls formatContainerTable aligns header and rows by column width", a
   const { formatContainerTable } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
 
   const rows = [
-    { name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
-    { name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
-    { name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
+    { index: "1", name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
+    { index: "", name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
+    { index: "", name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
   ];
   const lines = formatContainerTable(rows);
+  const hashColumn = lines[0]!.indexOf("#");
+  const namesColumn = lines[0]!.indexOf("NAMES");
   const statusColumn = lines[0]!.indexOf("STATUS");
   const branchColumn = lines[0]!.indexOf("BRANCH");
 
   assert.equal(lines.length, rows.length + 1);
-  assert.ok(statusColumn > 0);
+  assert.equal(hashColumn, 0);
+  assert.ok(namesColumn > hashColumn);
+  assert.ok(statusColumn > namesColumn);
   assert.ok(branchColumn > statusColumn);
   for (let i = 0; i < rows.length; i += 1) {
+    assert.equal(lines[i + 1]!.indexOf(rows[i]!.name), namesColumn);
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.status), statusColumn);
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.branch), branchColumn);
   }
+  assert.equal(lines[1]!.slice(0, namesColumn).trim(), "1");
+  assert.equal(lines[2]!.slice(0, namesColumn).trim(), "");
+  assert.equal(lines[3]!.slice(0, namesColumn).trim(), "");
   for (const line of lines) {
     assert.equal(line.includes("\t"), false);
     assert.doesNotMatch(line, /\s+$/);
   }
+});
+
+test("sandbox list-running parseSandboxRows tags running rows by 'Up ' prefix", async () => {
+  const { parseSandboxRows } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+
+  assert.deepEqual(parseSandboxRows("", "agent-infra.branch"), []);
+
+  const rows = parseSandboxRows(
+    [
+      "demo-a\tUp 5 minutes\tagent-infra.branch=feature/a",
+      "demo-b\tExited (0) 1 hour ago\tagent-infra.branch=feature/b",
+      "demo-c\tCreated\t",
+      "demo-d\tUp About a minute\tagent-infra.branch=main"
+    ].join("\n"),
+    "agent-infra.branch"
+  );
+  assert.equal(rows.length, 4);
+  assert.equal(rows[0]!.running, true);
+  assert.equal(rows[0]!.branch, "feature/a");
+  assert.equal(rows[1]!.running, false);
+  assert.equal(rows[1]!.branch, "feature/b");
+  assert.equal(rows[2]!.running, false);
+  assert.equal(rows[2]!.branch, "");
+  assert.equal(rows[3]!.running, true);
+});
+
+test("sandbox list-running sortAndIndexSandboxRows assigns 1-based index to running only", async () => {
+  const { sortAndIndexSandboxRows } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+
+  const input = [
+    { name: "demo-c", status: "Up 1 min", branch: "feature/c", running: true, index: null },
+    { name: "demo-a", status: "Exited (0)", branch: "feature/a", running: false, index: null },
+    { name: "Demo-A", status: "Up 1 min", branch: "feature/upper", running: true, index: null },
+    { name: "demo-a", status: "Up 1 min", branch: "feature/dup", running: true, index: null },
+    { name: "demo-z", status: "Created", branch: "feature/z", running: false, index: null }
+  ];
+  const { running, nonRunning } = sortAndIndexSandboxRows(input);
+
+  assert.deepEqual(running.map((r) => r.name), ["Demo-A", "demo-a", "demo-c"]);
+  assert.deepEqual(running.map((r) => r.index), [1, 2, 3]);
+  assert.deepEqual(nonRunning.map((r) => r.name), ["demo-a", "demo-z"]);
+  for (const r of nonRunning) {
+    assert.equal(r.index, null);
+  }
+});
+
+test("sandbox list-running isTaskShortRef matches only '#<digits>' syntactically", async () => {
+  const { isTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+
+  assert.equal(isTaskShortRef("#0"), true);
+  assert.equal(isTaskShortRef("#1"), true);
+  assert.equal(isTaskShortRef("#10"), true);
+  assert.equal(isTaskShortRef("#abc"), false);
+  assert.equal(isTaskShortRef("#1a"), false);
+  assert.equal(isTaskShortRef("#1.5"), false);
+  assert.equal(isTaskShortRef("#-1"), false);
+  assert.equal(isTaskShortRef("#"), false);
+  assert.equal(isTaskShortRef("1"), false);
+  assert.equal(isTaskShortRef("main"), false);
+  assert.equal(isTaskShortRef("TASK-20260609-084122"), false);
+  assert.equal(isTaskShortRef(""), false);
+});
+
+test("sandbox list-running resolveTaskShortRef returns branch for valid index", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const running = [
+    { name: "demo-a", status: "Up 1 min", branch: "feature/a", running: true, index: 1 },
+    { name: "demo-b", status: "Up 1 min", branch: "feature/b", running: true, index: 2 },
+    { name: "demo-c", status: "Up 1 min", branch: "main", running: true, index: 3 }
+  ];
+
+  assert.equal(resolveTaskShortRef("#1", { running }), "feature/a");
+  assert.equal(resolveTaskShortRef("#2", { running }), "feature/b");
+  assert.equal(resolveTaskShortRef("#3", { running }), "main");
+});
+
+test("sandbox list-running resolveTaskShortRef rejects '#0' with 'must be >= 1'", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+
+  assert.throws(
+    () => resolveTaskShortRef("#0", { running: [] }),
+    /must be >= 1/
+  );
+});
+
+test("sandbox list-running resolveTaskShortRef rejects out-of-range index with running count", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const running = [
+    { name: "demo-a", status: "Up 1 min", branch: "feature/a", running: true, index: 1 },
+    { name: "demo-b", status: "Up 1 min", branch: "feature/b", running: true, index: 2 },
+    { name: "demo-c", status: "Up 1 min", branch: "feature/c", running: true, index: 3 }
+  ];
+
+  assert.throws(
+    () => resolveTaskShortRef("#5", { running }),
+    /only 3 running/
+  );
+});
+
+test("sandbox list-running resolveTaskShortRef rejects when no running sandboxes", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+
+  assert.throws(
+    () => resolveTaskShortRef("#1", { running: [] }),
+    /No running sandbox to reference/
+  );
+});
+
+test("sandbox list-running resolveTaskShortRef rejects when running row has empty branch label", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const running = [
+    { name: "orphan", status: "Up 1 min", branch: "", running: true, index: 1 }
+  ];
+
+  assert.throws(
+    () => resolveTaskShortRef("#1", { running }),
+    /missing branch label/
+  );
 });
 
 test("sandbox ls parseLabels parses docker label CSV", async () => {

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -266,13 +266,16 @@ test("sandbox exec '#1' triggers fetchSandboxRows and reports no-running-sandbox
 
     const dockerCalls = fixture.readDockerCalls();
     assert.equal(dockerCalls.length, 1);
-    assert.deepEqual(dockerCalls[0], [
+    // Only assert the stable prefix: '--format' value contains literal tabs
+    // which a Windows .cmd shim retokenizes into separate args before the
+    // shim's node script sees them. The format string itself is covered by
+    // the containerListFormat() unit test.
+    assert.deepEqual(dockerCalls[0]!.slice(0, 5), [
       "ps",
       "-a",
       "--filter",
       "label=demo.sandbox",
-      "--format",
-      "{{.Names}}\t{{.Status}}\t{{.Labels}}"
+      "--format"
     ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -207,6 +207,78 @@ function spawnSandboxCli(
   });
 }
 
+test("sandbox exec '#abc' fails branch validation without triggering docker IO", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-bad-shortref-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+
+    const result = spawnSync(
+      process.execPath,
+      cliArgs("sandbox", "exec", "#abc"),
+      {
+        cwd: fixture.repoDir,
+        env: {
+          ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+          HOME: tmpDir,
+          USERPROFILE: tmpDir,
+          DOCKER_LOG_PATH: fixture.logPath
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 15_000
+      }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(String(result.stderr), /Invalid branch name '#abc'/);
+    assert.deepEqual(fixture.readDockerCalls(), []);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox exec '#1' triggers fetchSandboxRows and reports no-running-sandbox", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-shortref-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+
+    const result = spawnSync(
+      process.execPath,
+      cliArgs("sandbox", "exec", "#1"),
+      {
+        cwd: fixture.repoDir,
+        env: {
+          ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+          HOME: tmpDir,
+          USERPROFILE: tmpDir,
+          DOCKER_LOG_PATH: fixture.logPath
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 15_000
+      }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(String(result.stderr), /No running sandbox to reference with '#1'/);
+
+    const dockerCalls = fixture.readDockerCalls();
+    assert.equal(dockerCalls.length, 1);
+    assert.deepEqual(dockerCalls[0], [
+      "ps",
+      "-a",
+      "--filter",
+      "label=demo.sandbox",
+      "--format",
+      "{{.Names}}\t{{.Status}}\t{{.Labels}}"
+    ]);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("sandbox exec enters tmux automatically for interactive shells", onPlatforms("linux", "darwin", "win32"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-"));
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #414

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #414

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

在多沙箱场景下，用户通过 `ai sandbox ls` 看到列表后进入某个沙箱需要复制完整的容器名或分支名（往往二十多字符）。在手机终端、远程 SSH 等输入受限的场景下复制粘贴负担重。本 PR 引入「ls 表格序号列 + `ai sandbox exec '#N'` 引用」（类似 shell 历史的 `!N`），让用户可以用一两个字符进入第 N 个 running 沙箱。

排序在 CLI 层显式完成（按 `NAMES` 字典序），不依赖 docker / podman 的默认顺序，避免引擎升级或差异导致索引漂移。`#N` 解析路径还为后续「全局任务短号系统」（#419，独立任务）预留了零侵入扩展点。

In multi-sandbox scenarios, copying full container / branch names from `ai sandbox ls` to enter a sandbox is friction-heavy on mobile or constrained terminals. This PR adds a leftmost `#` index column to `ls` and lets `ai sandbox exec '#N'` jump into the N-th running sandbox. Sort is performed explicitly in CLI layer (by `NAMES` ascending), independent of docker / podman default ordering. The `#N` resolution path also leaves a zero-touch extension point for the upcoming global task short-id system (#419, separate task).

## 📋 主要变更 / Brief Changelog

- 新增 `lib/sandbox/commands/list-running.ts`：共享 helper，导出 `parseSandboxRows` / `sortAndIndexSandboxRows` / `fetchSandboxRows`（解析 + 按 NAMES 升序排序 + 1-based 索引），以及零 IO 的 `isTaskShortRef` 守卫和占位 `resolveTaskShortRef` 解析器（JSDoc 明确标注「不要读 task.md / 不要扫 active/」，为 #419 全局短号留扩展点）
- `lib/sandbox/commands/ls.ts`：表格新增最左 `#` 列（4 列布局：`#` / `NAMES` / `STATUS` / `BRANCH`），running 行 1-based 编号、non-running 行 `#` 列留空；`USAGE` 扩为多行并提示 `exec '#N'` 用法和加引号建议
- `lib/sandbox/commands/enter.ts`：入口分发改为「`isTaskShortRef(firstArg)` 判定 → 命中才 `fetchSandboxRows` + `resolveTaskShortRef`」两步接力，非数字 `#...` 入参零 docker IO 直接落到原 `assertValidBranchName` 错误路径；`USAGE` 同步扩展
- `lib/sandbox/index.ts`：子命令汇总 USAGE 中 `exec` 行升级为 `exec <branch | '#N'> [cmd...]`
- 单测：`tests/integration/cli/sandbox-core.test.ts` 增加 9 条 helper 单测覆盖 4 列对齐、sort 稳定性、`isTaskShortRef`/`resolveTaskShortRef` 正常与错误路径
- 集成测试：`tests/integration/cli/sandbox-tools.test.ts` 增加 2 条 `enter()` IO 守卫测试，分别验证 `exec '#abc'` 零 docker 调用 + `exec '#1'` 触发恰好 1 次 `docker ps -a --filter ...` 调用

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` — 全量 746 用例（745 pass / 1 skip / 0 fail）
2. `npm run build` 通过（TypeScript 编译无错）
3. 手动 dry-run（无 docker 环境也可）：
   - `node --experimental-strip-types ./bin/cli.ts sandbox ls --help` 输出含 `'#N'` 与 `Quote`
   - `node --experimental-strip-types ./bin/cli.ts sandbox exec --help` 输出含 `'#N'` 与 `1-based`
   - `node --experimental-strip-types ./bin/cli.ts sandbox --help` 中 `exec` 行展示 `<branch | '#N'>`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

向后兼容：`ls` 输出新增一列但保留 `NAMES` / `STATUS` / `BRANCH` 三列顺序与含义；`exec` 仍接受原 `<branch>` 与 `<TASK-id>` 入参；`#N` 是新增的入参形态，对旧调用无影响。

## 📋 附加信息 / Additional Notes

- 不在范围内：全局任务短号系统（注册表 + SKILL 入参解析改造）。已开 #419 独立任务跟进；本 PR 在 `lib/sandbox/commands/list-running.ts:111-132` 的 `resolveTaskShortRef` JSDoc 显式声明该 helper 是未来全局短号的扩展点
- 不在范围内：README / 文档中的 ls 表格样例更新；`grep -rn 'NAMES.*STATUS.*BRANCH' .` 当前无命中

---

**审查者注意事项 / Reviewer Notes:**

- `lib/sandbox/commands/enter.ts:121-128` 入口分发：`isTaskShortRef` 在 `fetchSandboxRows` 之前调用，非数字 `#...` 不会进入 IO 路径（C3 验收）
- `lib/sandbox/commands/list-running.ts:91-132` 的 JSDoc：「不要读 task.md / 不要扫 active/」的边界声明是否足以阻止后续 AI 在此处越界
- `tests/integration/cli/sandbox-tools.test.ts:210-279` 两条 IO 守卫测试是 C3 验收的最终观测点
- `tests/integration/cli/sandbox-core.test.ts` 中 `formatContainerTable` 测试的 4 列断言扩展，特别是 `lines[N].slice(0, namesColumn).trim()` 验证 non-running 行 `#` 列为空

Generated with AI assistance
