### PR TITLE
feat(meta): active 任务全局短号系统

### DIFF
--- a/.agents/rules/task-short-id.md
+++ b/.agents/rules/task-short-id.md
@@ -1,21 +1,23 @@
 # 任务短号
 
-短号让所有 SKILL 在 active 任务生命周期内可以用 `#N` 替代完整的 22 字符
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 替代完整的 22 字符
 `TASK-YYYYMMDD-HHMMSS`。
 
 ## 语法
 
-- 格式：`^#\d+$`（如 `#1`、`#7`、`#42`）；纯数字、不引入字母。
-- `#0` 保留、永不分配。
-- 不允许前导零（`#01` 非法）。
-- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#N` 只是别名，不是持久化任务 ID。
+- 格式：`^#\d{shortIdLength}$`（**零填充到固定宽度**；默认 `shortIdLength=2` 时
+  形如 `#01`、`#07`、`#42`）。
+- **必须**零填充到 `shortIdLength` 位（默认 2 位：`#1` 视为格式错误，应输入
+  `#01`）。这是为了视觉对齐与盲打体验。
+- `#00`（或 `shortIdLength=1` 时 `#0`）保留、永不分配；纯数字、不引入字母。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` 只是别名，不是持久化任务 ID。
 
 ## 生命周期
 
 | 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
 |-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#N`，写入 task.md 的 `short_id` 字段。              |
-| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#N` → 完整 task id 查询，不分配。                              |
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入 task.md 的 `short_id` 字段。              |
+| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#NN` → 完整 task id 查询，不分配。                              |
 | release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
 | re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
 
@@ -28,34 +30,87 @@
 // .agents/.airc.json
 {
   "task": {
-    "shortIdLength": 1  // 默认；容量 = 9（#1–#9）。改为 2 时容量 = #1–#99。
+    "shortIdLength": 2  // 默认；容量 = 99（#01–#99）。改为 3 时容量 = #001–#999。
   }
 }
 ```
 
 当前位宽容量耗尽时，`alloc` 给出明确错误并建议「归档若干任务」或「调高
 `task.shortIdLength`」两种修复路径；不静默扩位、不静默截断。
+切换 `shortIdLength` 配置需要先归档所有 active 任务（注册表 key 宽度依赖配置）。
 
-## `#N` 解析作用域（按入口二分）
+## `#NN` 解析作用域（按入口二分）
 
 | 入口                                                       | 注册表命中            | 注册表未命中                                            |
 |-----------------------------------------------------------|----------------------|--------------------------------------------------------|
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
-| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`        | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`      | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
 
 `list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
 三者差异，但不修改任何状态。
 
+## SKILL 入参解析
+
+任意 SKILL（含 alloc / resolve / release / re-alloc 四类生命周期入口）在收到
+`{task-id}` 入参后，必须按以下契约处理：
+
+1. 如果 `{task-id}` 字面以 `#` 开头：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  # 脚本本身已输出完整错误（含「expected #NN (N-digit zero-padded; e.g. '#01')」）；
+  # 调用方只需透传退出码
+  task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
+else
+  task_id="{task-id}"
+fi
+```
+
+2. 后续所有命令把 `{task-id}` 视为 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）
+3. 解析失败的退出码语义参见「错误场景」段；不要在 SKILL 中重写错误处理
+
+## 存储位置
+
+短号系统跨两处持久化状态，二者在稳态时一一对应：
+
+| 位置 | 写入时机 | 读取时机 | 删除时机 |
+|---|---|---|---|
+| `.agents/workspace/active/.short-ids.json`（注册表） | `alloc` / 冷启动迁移 | `resolve` 唯一权威源 / `list` / `list --verify` | `release` / 冷启动 stale 清理 |
+| 各 task.md frontmatter 的 `short_id` 字段 | `alloc` / 冷启动迁移 | `list --verify`（比对一致性） | **永不删除**（归档后保留为历史值） |
+
+**注册表**：
+
+- 路径：`<repo-root>/.agents/workspace/active/.short-ids.json`
+- Schema：`{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
+- key 是零填充到 `task.shortIdLength` 位的字符串，value 是完整 `TASK-…` task id
+- 自动 git ignore（active 工作区整体 ignore；无需新增 ignore 条目）
+- 首次 `alloc` / `resolve` 时按需自动创建；不存在时按空注册表处理
+
+**task.md `short_id` 字段**：
+
+- 在 frontmatter 中、紧跟 `id` 字段之后；格式 `short_id: #01`
+- 与注册表 key 字面一致（含 `#` 前缀）
+- 归档（complete-task / cancel-task / block-task / close-*）后：注册表 entry 立即
+  删除（短号可被新任务复用），但 task.md `short_id` 字段保留作为历史值。解析器
+  只信任注册表
+- 冷启动迁移：升级 agent-infra 后首次 alloc / resolve 路径会扫描所有 active
+  目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
+  `updated_at` / `agent_infra_version`、不追加 Activity Log）
+
+`resolve('#NN')` 工作流：① 校验入参严格匹配 `^#\d{shortIdLength}$` → ② 直接以
+`NN` 作为 key 查注册表 `ids` → ③ 命中返回完整 task id，未命中按 `list --verify`
+给出修复指引退出 1。
+
 ## 错误场景
 
-- **短号不存在**：注册表中无 `#N`。可能是任务已归档（短号已释放）或输入错误。
+- **短号不存在**：注册表中无 `#NN`。可能是任务已归档（短号已释放）或输入错误。
 - **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
-- **参数格式错误**（如 `#0`、`#abc`、`#`）：退出码 1。
+- **参数格式错误**（如 `#00`、`#abc`、`#`、`#1` 当 `shortIdLength=2` 时）：退出码 1。
 
 ## 跨 TUI 引号要求
 
-bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#3' 'npm test'`。
-Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#N` 字面传递到
+bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#03' 'npm test'`。
+Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#NN` 字面传递到
 SKILL 的 `ARGUMENTS`。
 
 ## 冷启动迁移

--- a/.agents/rules/task-short-id.md
+++ b/.agents/rules/task-short-id.md
@@ -1,0 +1,69 @@
+# 任务短号
+
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#N` 替代完整的 22 字符
+`TASK-YYYYMMDD-HHMMSS`。
+
+## 语法
+
+- 格式：`^#\d+$`（如 `#1`、`#7`、`#42`）；纯数字、不引入字母。
+- `#0` 保留、永不分配。
+- 不允许前导零（`#01` 非法）。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#N` 只是别名，不是持久化任务 ID。
+
+## 生命周期
+
+| 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
+|-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#N`，写入 task.md 的 `short_id` 字段。              |
+| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#N` → 完整 task id 查询，不分配。                              |
+| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
+| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
+
+短号仅在任务处于 `.agents/workspace/active/` 期间有效；任务移动到
+`completed/` / `blocked/` / `archive/` 后短号立即释放，可被新任务复用。
+
+## 配置
+
+```jsonc
+// .agents/.airc.json
+{
+  "task": {
+    "shortIdLength": 1  // 默认；容量 = 9（#1–#9）。改为 2 时容量 = #1–#99。
+  }
+}
+```
+
+当前位宽容量耗尽时，`alloc` 给出明确错误并建议「归档若干任务」或「调高
+`task.shortIdLength`」两种修复路径；不静默扩位、不静默截断。
+
+## `#N` 解析作用域（按入口二分）
+
+| 入口                                                       | 注册表命中            | 注册表未命中                                            |
+|-----------------------------------------------------------|----------------------|--------------------------------------------------------|
+| SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
+| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`        | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+
+`list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
+三者差异，但不修改任何状态。
+
+## 错误场景
+
+- **短号不存在**：注册表中无 `#N`。可能是任务已归档（短号已释放）或输入错误。
+- **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
+- **参数格式错误**（如 `#0`、`#abc`、`#`）：退出码 1。
+
+## 跨 TUI 引号要求
+
+bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#3' 'npm test'`。
+Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#N` 字面传递到
+SKILL 的 `ARGUMENTS`。
+
+## 冷启动迁移
+
+升级 agent-infra 后，首次 `alloc` / `resolve` 调用会触发冷启动迁移：
+
+- 所有 active task.md 缺 `short_id` 字段时自动补发并回写（仅修改 `short_id`
+  一行，不刷新 `updated_at` / `agent_infra_version`，不追加 Activity Log）。
+- 若 active 任务总数超过 `shortIdLength` 容量，**在任何写入之前**报错退出 2。
+- 若 task.md 写入中途失败，`tx.commit()` 按缓存的原内容回滚所有已写文件（含
+  `mtime` / `atime` 恢复）。

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -669,11 +669,17 @@ function main(argv) {
   }
 }
 
+// Compare canonicalized (symlink-resolved) paths so this script still runs as a
+// CLI when invoked through a temp-dir symlink (notably /var/folders on macOS,
+// which is a symlink to /private/var/folders; process.argv[1] keeps the
+// symlinked path while import.meta.url is auto-resolved to the realpath).
 const isCli = (() => {
   const entry = process.argv[1];
   if (!entry) return false;
   try {
-    return import.meta.url === pathToFileURL(entry).href;
+    const realEntry = fs.realpathSync(entry);
+    const realModule = fs.realpathSync(fileURLToPath(import.meta.url));
+    return realEntry === realModule;
   } catch {
     return false;
   }

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -13,6 +13,20 @@ const DEFAULT_LOCK_TIMEOUT_MS = 5000;
 // ai update-agent-infra to backfill the field).
 const DEFAULT_SHORT_ID_LENGTH = 2;
 
+// process.stdout.write / process.stderr.write are non-blocking when the
+// destination is a pipe (e.g. when spawned via child_process.spawnSync). On
+// some platforms (notably macOS) the Node process can exit before the buffer
+// flushes, leaving the parent with empty stdout. Use fs.writeSync to guarantee
+// synchronous, fully-flushed writes — this is critical because the parent
+// CLI/test code relies on stdout to carry the resolved task id / short id.
+function writeStdout(text) {
+  fs.writeSync(1, text);
+}
+
+function writeStderr(text) {
+  fs.writeSync(2, text);
+}
+
 function usage() {
   return [
     "Usage: task-short-id.js <subcommand> [args]",
@@ -85,19 +99,19 @@ function readRegistry(registryPath) {
   try {
     raw = fs.readFileSync(registryPath, "utf8");
   } catch (e) {
-    process.stderr.write(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
+    writeStderr(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
     process.exit(2);
   }
   try {
     const data = JSON.parse(raw);
     if (!data || typeof data !== "object" || !data.ids || typeof data.ids !== "object") {
-      process.stderr.write(`Error: registry ${registryPath} has invalid schema\n`);
+      writeStderr(`Error: registry ${registryPath} has invalid schema\n`);
       process.exit(2);
     }
     if (data.version !== 1) data.version = 1;
     return data;
   } catch (e) {
-    process.stderr.write(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
+    writeStderr(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
     process.exit(2);
   }
 }
@@ -119,7 +133,7 @@ function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
     } catch (e) {
       if (e.code !== "EEXIST") throw e;
       if (Date.now() - start > timeoutMs) {
-        process.stderr.write(`Error: registry lock timeout after ${timeoutMs}ms\n`);
+        writeStderr(`Error: registry lock timeout after ${timeoutMs}ms\n`);
         process.exit(3);
       }
       const elapsed = Date.now() - start;
@@ -175,7 +189,7 @@ function parseShortIdArg(arg, shortIdLength) {
   if (!re.test(arg)) {
     const example =
       shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
-    process.stderr.write(
+    writeStderr(
       `Error: invalid short id format '${arg}', ` +
         `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
     );
@@ -183,7 +197,7 @@ function parseShortIdArg(arg, shortIdLength) {
   }
   const key = arg.slice(1);
   if (Number(key) === 0) {
-    process.stderr.write(
+    writeStderr(
       `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
     );
     process.exit(1);
@@ -216,7 +230,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
   for (const [key, taskId] of Object.entries(projectedIds)) {
     if (taskIdToKey.has(taskId)) {
       const existingKey = taskIdToKey.get(taskId);
-      process.stderr.write(
+      writeStderr(
         `Error: duplicate registry entries for taskId ${taskId} at keys [#${existingKey}, #${key}]; manual resolution required\n`
       );
       process.exit(2);
@@ -241,13 +255,13 @@ function planTransaction(registry, activeDir, shortIdLength) {
       if (projectedIds[n] === taskId) continue; // 4a
       if (taskIdToKey.has(taskId)) {
         const registryKey = taskIdToKey.get(taskId);
-        process.stderr.write(
+        writeStderr(
           `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
         );
         process.exit(2);
       }
       if (projectedIds[n] && projectedIds[n] !== taskId) {
-        process.stderr.write(
+        writeStderr(
           `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
         );
         process.exit(2);
@@ -286,7 +300,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
   // A5: capacity pre-check
   const availableSlots = maxN - Object.keys(projectedIds).length;
   if (pendingAlloc.length > availableSlots) {
-    process.stderr.write(
+    writeStderr(
       `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
         `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
         `Archive some active tasks (complete-task / cancel-task / block-task) ` +
@@ -485,13 +499,13 @@ function verifyRegistry(registry, activeDir) {
 
 function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
   if (!TASK_ID_RE.test(taskId)) {
-    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    writeStderr(`Error: invalid task id format '${taskId}'\n`);
     process.exit(1);
   }
   return withRegistryLock(activeDir, () => {
     const taskMdPath = path.join(activeDir, taskId, "task.md");
     if (!fs.existsSync(taskMdPath)) {
-      process.stderr.write(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
+      writeStderr(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
       process.exit(1);
     }
     const registry = readRegistry(registryPath);
@@ -500,23 +514,23 @@ function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
     try {
       shortId = tx.planAlloc(taskId);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(2);
     }
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
     // shortId is already zero-padded (returned by tx.planAlloc; matches registry key)
-    process.stdout.write(`#${shortId}\n`);
+    writeStdout(`#${shortId}\n`);
   });
 }
 
 function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
   if (!TASK_ID_RE.test(taskId)) {
-    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    writeStderr(`Error: invalid task id format '${taskId}'\n`);
     process.exit(1);
   }
   return withRegistryLock(activeDir, () => {
@@ -526,7 +540,7 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
     // idempotent exit 0
@@ -550,16 +564,16 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
         try {
           tx.commit(registryPath);
         } catch (e) {
-          process.stderr.write(`${e.message}\n`);
+          writeStderr(`${e.message}\n`);
           process.exit(1);
         }
       }
       if (Object.keys(tx._projectedIds).length === 0) {
-        process.stderr.write(
+        writeStderr(
           `Error: short id '#${key}' not found; active task registry is empty.\n`
         );
       } else {
-        process.stderr.write(
+        writeStderr(
           `Error: short id '#${key}' not found in active task registry ` +
             `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
         );
@@ -569,22 +583,22 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
-    process.stdout.write(`${taskId}\n`);
+    writeStdout(`${taskId}\n`);
   });
 }
 
 function cmdList(activeDir, registryPath, verify) {
   if (!verify) {
     const registry = readRegistry(registryPath);
-    process.stdout.write(`${JSON.stringify(registry, null, 2)}\n`);
+    writeStdout(`${JSON.stringify(registry, null, 2)}\n`);
     return;
   }
   const registry = readRegistry(registryPath);
   if (!fs.existsSync(activeDir)) {
-    process.stdout.write("");
+    writeStdout("");
     return;
   }
   const diff = verifyRegistry(registry, activeDir);
@@ -594,7 +608,7 @@ function cmdList(activeDir, registryPath, verify) {
     diff.orphans_in_registry.length > 0 ||
     diff.duplicate_registry_keys.length > 0;
   if (hasIssues) {
-    process.stdout.write(`${JSON.stringify(diff, null, 2)}\n`);
+    writeStdout(`${JSON.stringify(diff, null, 2)}\n`);
     process.exit(1);
   }
   // consistent: empty stdout, exit 0
@@ -605,11 +619,11 @@ function main(argv) {
   try {
     args = parseArgs(argv);
   } catch (e) {
-    process.stderr.write(`${e.message}\n${usage()}\n`);
+    writeStderr(`${e.message}\n${usage()}\n`);
     process.exit(1);
   }
   if (args.help || args.positional.length === 0) {
-    process.stdout.write(`${usage()}\n`);
+    writeStdout(`${usage()}\n`);
     return;
   }
   const subcommand = args.positional[0];
@@ -620,7 +634,7 @@ function main(argv) {
     ? path.join(repoRoot, ".agents", "workspace", "active")
     : null;
   if (!activeDir) {
-    process.stderr.write(
+    writeStderr(
       `Error: cannot locate active dir (no .agents/.airc.json found above ${process.cwd()})\n`
     );
     process.exit(2);
@@ -631,26 +645,26 @@ function main(argv) {
   switch (subcommand) {
     case "alloc":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: alloc <task-id>\n`);
+        writeStderr(`Usage: alloc <task-id>\n`);
         process.exit(1);
       }
       return cmdAlloc(args.positional[1], activeDir, registryPath, shortIdLength);
     case "release":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: release <task-id>\n`);
+        writeStderr(`Usage: release <task-id>\n`);
         process.exit(1);
       }
       return cmdRelease(args.positional[1], activeDir, registryPath, shortIdLength);
     case "resolve":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: resolve <#N>\n`);
+        writeStderr(`Usage: resolve <#N>\n`);
         process.exit(1);
       }
       return cmdResolve(args.positional[1], activeDir, registryPath, shortIdLength);
     case "list":
       return cmdList(activeDir, registryPath, args.verify);
     default:
-      process.stderr.write(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
+      writeStderr(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
       process.exit(1);
   }
 }

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -7,6 +7,11 @@ const SHORT_ID_RE = /^#\d+$/;
 const REGISTRY_NAME = ".short-ids.json";
 const LOCK_NAME = ".short-ids.json.lock";
 const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+// Kept in sync with lib/defaults.json's task.shortIdLength. Used when there is
+// no `--short-id-length` flag and no readable `task.shortIdLength` in
+// .agents/.airc.json (e.g. the project upgraded but hasn't re-run
+// ai update-agent-infra to backfill the field).
+const DEFAULT_SHORT_ID_LENGTH = 2;
 
 function usage() {
   return [
@@ -21,7 +26,7 @@ function usage() {
     "",
     "Options:",
     "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
-    "  --short-id-length N  Override configured width (default: from .airc.json or 1)"
+    "  --short-id-length N  Override configured width (default: from .airc.json or 2)"
   ].join("\n");
 }
 
@@ -60,7 +65,7 @@ function readShortIdLength(repoRoot, override) {
   if (typeof override === "number" && Number.isFinite(override) && override >= 1) {
     return override;
   }
-  if (!repoRoot) return 1;
+  if (!repoRoot) return DEFAULT_SHORT_ID_LENGTH;
   try {
     const cfgPath = path.join(repoRoot, ".agents", ".airc.json");
     const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
@@ -69,7 +74,7 @@ function readShortIdLength(repoRoot, override) {
   } catch {
     // ignore
   }
-  return 1;
+  return DEFAULT_SHORT_ID_LENGTH;
 }
 
 function readRegistry(registryPath) {
@@ -153,11 +158,37 @@ function writeTaskMdShortId(taskMdPath, shortId) {
   fs.writeFileSync(taskMdPath, updated);
 }
 
-function allocateMinFreeInt(registry, maxN) {
+function padShortId(n, shortIdLength) {
+  return String(n).padStart(shortIdLength, "0");
+}
+
+function allocateMinFreeInt(registry, shortIdLength) {
+  const maxN = Math.pow(10, shortIdLength) - 1;
   for (let n = 1; n <= maxN; n += 1) {
-    if (!registry.ids[String(n)]) return n;
+    if (!registry.ids[padShortId(n, shortIdLength)]) return n;
   }
   return null;
+}
+
+function parseShortIdArg(arg, shortIdLength) {
+  const re = new RegExp(`^#\\d{${shortIdLength}}$`);
+  if (!re.test(arg)) {
+    const example =
+      shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
+    process.stderr.write(
+      `Error: invalid short id format '${arg}', ` +
+        `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
+    );
+    process.exit(1);
+  }
+  const key = arg.slice(1);
+  if (Number(key) === 0) {
+    process.stderr.write(
+      `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
+    );
+    process.exit(1);
+  }
+  return key;
 }
 
 function planTransaction(registry, activeDir, shortIdLength) {
@@ -267,19 +298,20 @@ function planTransaction(registry, activeDir, shortIdLength) {
   pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
 
   for (const item of pendingAlloc) {
-    const shortId = allocateMinFreeInt({ ids: projectedIds }, maxN);
-    if (shortId === null) {
+    const n = allocateMinFreeInt({ ids: projectedIds }, shortIdLength);
+    if (n === null) {
       throw new Error("Internal invariant: pendingAlloc capacity check failed");
     }
-    projectedIds[String(shortId)] = item.taskId;
-    taskIdToKey.set(item.taskId, String(shortId));
-    plannedRegistryWrites.push({ key: String(shortId), taskId: item.taskId });
+    const key = padShortId(n, shortIdLength);
+    projectedIds[key] = item.taskId;
+    taskIdToKey.set(item.taskId, key);
+    plannedRegistryWrites.push({ key, taskId: item.taskId });
     plannedTaskMdWrites.push({
       taskMdPath: item.taskMdPath,
       originalContent: item.originalContent,
       originalAtime: item.originalAtime,
       originalMtime: item.originalMtime,
-      shortId: `#${shortId}`,
+      shortId: `#${key}`,
       kind: "4f"
     });
   }
@@ -312,25 +344,26 @@ function planTransaction(registry, activeDir, shortIdLength) {
             `${inUse}/${this._maxN} slots in use). Archive some active tasks or raise task.shortIdLength.`
         );
       }
-      const shortId = allocateMinFreeInt({ ids: this._projectedIds }, this._maxN);
-      this._projectedIds[String(shortId)] = taskId;
-      this._taskIdToKey.set(taskId, String(shortId));
-      this._plannedRegistryWrites.push({ key: String(shortId), taskId });
+      const n = allocateMinFreeInt({ ids: this._projectedIds }, this._shortIdLength);
+      const key = padShortId(n, this._shortIdLength);
+      this._projectedIds[key] = taskId;
+      this._taskIdToKey.set(taskId, key);
+      this._plannedRegistryWrites.push({ key, taskId });
       const originalStat = fs.statSync(taskMdPath);
       const originalContent = fs.readFileSync(taskMdPath, "utf8");
       // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
       const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-      if (!existing || existing[1] !== `#${shortId}`) {
+      if (!existing || existing[1] !== `#${key}`) {
         this._plannedTaskMdWrites.push({
           taskMdPath,
           originalContent,
           originalAtime: originalStat.atime,
           originalMtime: originalStat.mtime,
-          shortId: `#${shortId}`,
+          shortId: `#${key}`,
           kind: "caller-alloc"
         });
       }
-      return String(shortId);
+      return key;  // zero-padded; matches registry key
     },
 
     planRelease(taskId) {
@@ -476,6 +509,7 @@ function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
       process.stderr.write(`${e.message}\n`);
       process.exit(1);
     }
+    // shortId is already zero-padded (returned by tx.planAlloc; matches registry key)
     process.stdout.write(`#${shortId}\n`);
   });
 }
@@ -500,23 +534,13 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
 }
 
 function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
-  if (!SHORT_ID_RE.test(shortIdArg)) {
-    process.stderr.write(
-      `Error: invalid short id format '${shortIdArg}'. Use quoted '#N' (e.g. '#1').\n`
-    );
-    process.exit(1);
-  }
-  const n = shortIdArg.slice(1);
-  if (n === "0" || (n.length > 1 && n.startsWith("0"))) {
-    process.stderr.write(
-      `Error: short id '${shortIdArg}' is invalid (#0 is reserved, leading zeros not allowed).\n`
-    );
-    process.exit(1);
-  }
+  // Strict width match + reserved key check; on invalid arg, parseShortIdArg writes full
+  // stderr (including "expected #NN (N-digit zero-padded; e.g. '#01')") and exits 1.
+  const key = parseShortIdArg(shortIdArg, shortIdLength);
   return withRegistryLock(activeDir, () => {
     const registry = readRegistry(registryPath);
     const tx = planTransaction(registry, activeDir, shortIdLength);
-    const taskId = tx._projectedIds[n];
+    const taskId = tx._projectedIds[key];
     if (!taskId) {
       const hasPendingMutations =
         tx._plannedRegistryWrites.length > 0 ||
@@ -532,11 +556,11 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
       }
       if (Object.keys(tx._projectedIds).length === 0) {
         process.stderr.write(
-          `Error: short id '${shortIdArg}' not found; active task registry is empty.\n`
+          `Error: short id '#${key}' not found; active task registry is empty.\n`
         );
       } else {
         process.stderr.write(
-          `Error: short id '${shortIdArg}' not found in active task registry ` +
+          `Error: short id '#${key}' not found in active task registry ` +
             `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
         );
       }
@@ -656,6 +680,8 @@ export {
   writeRegistryAtomic,
   withRegistryLock,
   writeTaskMdShortId,
+  padShortId,
+  parseShortIdArg,
   allocateMinFreeInt,
   planTransaction,
   verifyRegistry,

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -1,0 +1,667 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+const SHORT_ID_RE = /^#\d+$/;
+const REGISTRY_NAME = ".short-ids.json";
+const LOCK_NAME = ".short-ids.json.lock";
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+
+function usage() {
+  return [
+    "Usage: task-short-id.js <subcommand> [args]",
+    "",
+    "Subcommands:",
+    "  alloc <task-id>      Allocate short id for a task; writes registry + short_id to task.md",
+    "  release <task-id>    Release short id (idempotent; exit 0 if not present)",
+    "  resolve <#N>         Resolve short id to full task id",
+    "  list                 Print registry JSON",
+    "  list --verify        Read-only check; exit 1 if active dir / registry / task.md disagree",
+    "",
+    "Options:",
+    "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
+    "  --short-id-length N  Override configured width (default: from .airc.json or 1)"
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = { positional: [], activeDir: null, shortIdLength: null, verify: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--active-dir") {
+      args.activeDir = argv[++i];
+    } else if (a === "--short-id-length") {
+      args.shortIdLength = Number(argv[++i]);
+    } else if (a === "--verify") {
+      args.verify = true;
+    } else if (a === "-h" || a === "--help") {
+      args.help = true;
+    } else if (a.startsWith("--")) {
+      throw new Error(`Unknown option: ${a}`);
+    } else {
+      args.positional.push(a);
+    }
+  }
+  return args;
+}
+
+function findRepoRoot(start) {
+  let dir = path.resolve(start || process.cwd());
+  for (;;) {
+    if (fs.existsSync(path.join(dir, ".agents", ".airc.json"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function readShortIdLength(repoRoot, override) {
+  if (typeof override === "number" && Number.isFinite(override) && override >= 1) {
+    return override;
+  }
+  if (!repoRoot) return 1;
+  try {
+    const cfgPath = path.join(repoRoot, ".agents", ".airc.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    const v = cfg && cfg.task && cfg.task.shortIdLength;
+    if (typeof v === "number" && Number.isFinite(v) && v >= 1) return v;
+  } catch {
+    // ignore
+  }
+  return 1;
+}
+
+function readRegistry(registryPath) {
+  if (!fs.existsSync(registryPath)) {
+    return { version: 1, ids: {} };
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(registryPath, "utf8");
+  } catch (e) {
+    process.stderr.write(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
+    process.exit(2);
+  }
+  try {
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object" || !data.ids || typeof data.ids !== "object") {
+      process.stderr.write(`Error: registry ${registryPath} has invalid schema\n`);
+      process.exit(2);
+    }
+    if (data.version !== 1) data.version = 1;
+    return data;
+  } catch (e) {
+    process.stderr.write(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+}
+
+function writeRegistryAtomic(data, registryPath) {
+  const tmpPath = `${registryPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`);
+  fs.renameSync(tmpPath, registryPath);
+}
+
+function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
+  fs.mkdirSync(activeDir, { recursive: true });
+  const lockDir = path.join(activeDir, LOCK_NAME);
+  const start = Date.now();
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir, { recursive: false });
+      break;
+    } catch (e) {
+      if (e.code !== "EEXIST") throw e;
+      if (Date.now() - start > timeoutMs) {
+        process.stderr.write(`Error: registry lock timeout after ${timeoutMs}ms\n`);
+        process.exit(3);
+      }
+      const elapsed = Date.now() - start;
+      const wait = Math.min(500, 50 * Math.pow(2, Math.floor(elapsed / 200)));
+      const deadline = Date.now() + wait;
+      while (Date.now() < deadline) {
+        /* busy wait, ms-scale */
+      }
+    }
+  }
+  // Register cleanup that runs even on process.exit (which skips try/finally).
+  const cleanup = () => {
+    try {
+      fs.rmdirSync(lockDir);
+    } catch {
+      /* lock-dir already removed */
+    }
+  };
+  process.once("exit", cleanup);
+  try {
+    return fn();
+  } finally {
+    process.removeListener("exit", cleanup);
+    cleanup();
+  }
+}
+
+function writeTaskMdShortId(taskMdPath, shortId) {
+  const content = fs.readFileSync(taskMdPath, "utf8");
+  let updated;
+  if (/^short_id:.*$/m.test(content)) {
+    updated = content.replace(/^short_id:.*$/m, `short_id: ${shortId}`);
+  } else {
+    updated = content.replace(/^(id:.*)$/m, `$1\nshort_id: ${shortId}`);
+  }
+  fs.writeFileSync(taskMdPath, updated);
+}
+
+function allocateMinFreeInt(registry, maxN) {
+  for (let n = 1; n <= maxN; n += 1) {
+    if (!registry.ids[String(n)]) return n;
+  }
+  return null;
+}
+
+function planTransaction(registry, activeDir, shortIdLength) {
+  const maxN = Math.pow(10, shortIdLength) - 1;
+
+  // A1: active task id set
+  const activeTaskIds = new Set(
+    fs
+      .readdirSync(activeDir)
+      .filter((d) => TASK_ID_RE.test(d))
+      .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
+  );
+
+  // A2: stale entries
+  const pendingRegistryDeletes = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) pendingRegistryDeletes.push(key);
+  }
+
+  const projectedIds = { ...registry.ids };
+  for (const key of pendingRegistryDeletes) delete projectedIds[key];
+
+  // A3: duplicate key detection (after stale cleanup)
+  const taskIdToKey = new Map();
+  for (const [key, taskId] of Object.entries(projectedIds)) {
+    if (taskIdToKey.has(taskId)) {
+      const existingKey = taskIdToKey.get(taskId);
+      process.stderr.write(
+        `Error: duplicate registry entries for taskId ${taskId} at keys [#${existingKey}, #${key}]; manual resolution required\n`
+      );
+      process.exit(2);
+    }
+    taskIdToKey.set(taskId, key);
+  }
+
+  // A4: classify each active task
+  const plannedRegistryWrites = [];
+  const plannedTaskMdWrites = [];
+  const pendingAlloc = [];
+
+  for (const taskId of activeTaskIds) {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    const originalStat = fs.statSync(taskMdPath);
+    const originalContent = fs.readFileSync(taskMdPath, "utf8");
+    const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
+
+    if (existing) {
+      const declared = existing[1];
+      const n = declared.slice(1);
+      if (projectedIds[n] === taskId) continue; // 4a
+      if (taskIdToKey.has(taskId)) {
+        const registryKey = taskIdToKey.get(taskId);
+        process.stderr.write(
+          `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
+        );
+        process.exit(2);
+      }
+      if (projectedIds[n] && projectedIds[n] !== taskId) {
+        process.stderr.write(
+          `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
+        );
+        process.exit(2);
+      }
+      // 4d
+      plannedRegistryWrites.push({ key: n, taskId });
+      projectedIds[n] = taskId;
+      taskIdToKey.set(taskId, n);
+      continue;
+    }
+
+    if (taskIdToKey.has(taskId)) {
+      // 4e
+      const registryKey = taskIdToKey.get(taskId);
+      plannedTaskMdWrites.push({
+        taskMdPath,
+        originalContent,
+        originalAtime: originalStat.atime,
+        originalMtime: originalStat.mtime,
+        shortId: `#${registryKey}`,
+        kind: "4e"
+      });
+      continue;
+    }
+
+    // 4f: deferred
+    pendingAlloc.push({
+      taskId,
+      taskMdPath,
+      originalContent,
+      originalAtime: originalStat.atime,
+      originalMtime: originalStat.mtime
+    });
+  }
+
+  // A5: capacity pre-check
+  const availableSlots = maxN - Object.keys(projectedIds).length;
+  if (pendingAlloc.length > availableSlots) {
+    process.stderr.write(
+      `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
+        `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
+        `Archive some active tasks (complete-task / cancel-task / block-task) ` +
+        `or raise task.shortIdLength in .agents/.airc.json.\n`
+    );
+    process.exit(2);
+  }
+
+  pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
+
+  for (const item of pendingAlloc) {
+    const shortId = allocateMinFreeInt({ ids: projectedIds }, maxN);
+    if (shortId === null) {
+      throw new Error("Internal invariant: pendingAlloc capacity check failed");
+    }
+    projectedIds[String(shortId)] = item.taskId;
+    taskIdToKey.set(item.taskId, String(shortId));
+    plannedRegistryWrites.push({ key: String(shortId), taskId: item.taskId });
+    plannedTaskMdWrites.push({
+      taskMdPath: item.taskMdPath,
+      originalContent: item.originalContent,
+      originalAtime: item.originalAtime,
+      originalMtime: item.originalMtime,
+      shortId: `#${shortId}`,
+      kind: "4f"
+    });
+  }
+
+  // Build transaction object
+  const tx = {
+    _registry: registry,
+    _activeDir: activeDir,
+    _registrySnapshot: { ...registry.ids },
+    _pendingRegistryDeletes: pendingRegistryDeletes,
+    _plannedRegistryWrites: plannedRegistryWrites,
+    _plannedTaskMdWrites: plannedTaskMdWrites,
+    _projectedIds: projectedIds,
+    _taskIdToKey: taskIdToKey,
+    _shortIdLength: shortIdLength,
+    _maxN: maxN,
+
+    planAlloc(taskId) {
+      const taskMdPath = path.join(activeDir, taskId, "task.md");
+      if (!fs.existsSync(taskMdPath)) {
+        throw new Error(`planAlloc: task.md not found for ${taskId}`);
+      }
+      if (this._taskIdToKey.has(taskId)) {
+        return this._taskIdToKey.get(taskId);
+      }
+      const inUse = Object.keys(this._projectedIds).length;
+      if (inUse >= this._maxN) {
+        throw new Error(
+          `Error: short id width exhausted (current shortIdLength=${this._shortIdLength}, ` +
+            `${inUse}/${this._maxN} slots in use). Archive some active tasks or raise task.shortIdLength.`
+        );
+      }
+      const shortId = allocateMinFreeInt({ ids: this._projectedIds }, this._maxN);
+      this._projectedIds[String(shortId)] = taskId;
+      this._taskIdToKey.set(taskId, String(shortId));
+      this._plannedRegistryWrites.push({ key: String(shortId), taskId });
+      const originalStat = fs.statSync(taskMdPath);
+      const originalContent = fs.readFileSync(taskMdPath, "utf8");
+      // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
+      const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
+      if (!existing || existing[1] !== `#${shortId}`) {
+        this._plannedTaskMdWrites.push({
+          taskMdPath,
+          originalContent,
+          originalAtime: originalStat.atime,
+          originalMtime: originalStat.mtime,
+          shortId: `#${shortId}`,
+          kind: "caller-alloc"
+        });
+      }
+      return String(shortId);
+    },
+
+    planRelease(taskId) {
+      const key = this._taskIdToKey.get(taskId);
+      if (!key) return; // idempotent
+      this._plannedRegistryWrites = this._plannedRegistryWrites.filter(
+        (w) => w.taskId !== taskId
+      );
+      this._plannedTaskMdWrites = this._plannedTaskMdWrites.filter(
+        (w) => path.basename(path.dirname(w.taskMdPath)) !== taskId
+      );
+      this._pendingRegistryDeletes.push(key);
+      delete this._projectedIds[key];
+      this._taskIdToKey.delete(taskId);
+    },
+
+    commit(registryPath) {
+      // B1: apply registry mutation in memory
+      for (const key of this._pendingRegistryDeletes) delete this._registry.ids[key];
+      for (const { key, taskId } of this._plannedRegistryWrites) {
+        this._registry.ids[key] = taskId;
+      }
+
+      const completedWrites = [];
+      const rollback = (reason) => {
+        for (const done of completedWrites.reverse()) {
+          try {
+            fs.writeFileSync(done.taskMdPath, done.originalContent);
+            fs.utimesSync(done.taskMdPath, done.originalAtime, done.originalMtime);
+          } catch {
+            /* best-effort */
+          }
+        }
+        this._registry.ids = this._registrySnapshot;
+        const tail =
+          completedWrites.length > 0
+            ? `; rolled back ${completedWrites.length} prior task.md write(s)`
+            : "";
+        throw new Error(`${reason}${tail}`);
+      };
+
+      // B2: write task.md per plan
+      for (const write of this._plannedTaskMdWrites) {
+        try {
+          writeTaskMdShortId(write.taskMdPath, write.shortId);
+          completedWrites.push(write);
+        } catch (e) {
+          rollback(`Failed to write short_id to ${write.taskMdPath}: ${e.message}`);
+        }
+      }
+
+      // B3: atomic registry persistence
+      try {
+        writeRegistryAtomic(this._registry, registryPath);
+      } catch (e) {
+        rollback(`Failed to persist registry to ${registryPath}: ${e.message}`);
+      }
+    }
+  };
+
+  return tx;
+}
+
+function verifyRegistry(registry, activeDir) {
+  const activeTaskIds = new Set(
+    fs
+      .readdirSync(activeDir)
+      .filter((d) => TASK_ID_RE.test(d))
+      .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
+  );
+  const registryTaskIds = new Set(Object.values(registry.ids));
+  const taskmdShortIds = new Map();
+  for (const taskId of activeTaskIds) {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    const content = fs.readFileSync(taskMdPath, "utf8");
+    const m = content.match(/^short_id:\s*(#\d+)\s*$/m);
+    taskmdShortIds.set(taskId, m ? m[1] : null);
+  }
+  const missing_in_registry = [];
+  for (const taskId of activeTaskIds) {
+    if (!registryTaskIds.has(taskId)) {
+      missing_in_registry.push({ taskId, declared: taskmdShortIds.get(taskId) });
+    }
+  }
+  const missing_in_taskmd = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) continue;
+    const declared = taskmdShortIds.get(taskId);
+    if (declared === null) {
+      missing_in_taskmd.push({ taskId, expected: `#${key}` });
+    } else if (declared !== `#${key}`) {
+      missing_in_taskmd.push({ taskId, expected: `#${key}`, declared });
+    }
+  }
+  const orphans_in_registry = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) {
+      orphans_in_registry.push({ key: `#${key}`, taskId });
+    }
+  }
+  const taskIdToKeys = new Map();
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!taskIdToKeys.has(taskId)) taskIdToKeys.set(taskId, []);
+    taskIdToKeys.get(taskId).push(key);
+  }
+  const duplicate_registry_keys = [];
+  for (const [taskId, keys] of taskIdToKeys) {
+    if (keys.length > 1) {
+      duplicate_registry_keys.push({ taskId, keys: keys.map((k) => `#${k}`) });
+    }
+  }
+  return {
+    missing_in_registry,
+    missing_in_taskmd,
+    orphans_in_registry,
+    duplicate_registry_keys
+  };
+}
+
+function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
+  if (!TASK_ID_RE.test(taskId)) {
+    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    if (!fs.existsSync(taskMdPath)) {
+      process.stderr.write(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
+      process.exit(1);
+    }
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    let shortId;
+    try {
+      shortId = tx.planAlloc(taskId);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(2);
+    }
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`#${shortId}\n`);
+  });
+}
+
+function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
+  if (!TASK_ID_RE.test(taskId)) {
+    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    tx.planRelease(taskId);
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    // idempotent exit 0
+  });
+}
+
+function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
+  if (!SHORT_ID_RE.test(shortIdArg)) {
+    process.stderr.write(
+      `Error: invalid short id format '${shortIdArg}'. Use quoted '#N' (e.g. '#1').\n`
+    );
+    process.exit(1);
+  }
+  const n = shortIdArg.slice(1);
+  if (n === "0" || (n.length > 1 && n.startsWith("0"))) {
+    process.stderr.write(
+      `Error: short id '${shortIdArg}' is invalid (#0 is reserved, leading zeros not allowed).\n`
+    );
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    const taskId = tx._projectedIds[n];
+    if (!taskId) {
+      const hasPendingMutations =
+        tx._plannedRegistryWrites.length > 0 ||
+        tx._pendingRegistryDeletes.length > 0 ||
+        tx._plannedTaskMdWrites.length > 0;
+      if (hasPendingMutations) {
+        try {
+          tx.commit(registryPath);
+        } catch (e) {
+          process.stderr.write(`${e.message}\n`);
+          process.exit(1);
+        }
+      }
+      if (Object.keys(tx._projectedIds).length === 0) {
+        process.stderr.write(
+          `Error: short id '${shortIdArg}' not found; active task registry is empty.\n`
+        );
+      } else {
+        process.stderr.write(
+          `Error: short id '${shortIdArg}' not found in active task registry ` +
+            `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
+        );
+      }
+      process.exit(1);
+    }
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${taskId}\n`);
+  });
+}
+
+function cmdList(activeDir, registryPath, verify) {
+  if (!verify) {
+    const registry = readRegistry(registryPath);
+    process.stdout.write(`${JSON.stringify(registry, null, 2)}\n`);
+    return;
+  }
+  const registry = readRegistry(registryPath);
+  if (!fs.existsSync(activeDir)) {
+    process.stdout.write("");
+    return;
+  }
+  const diff = verifyRegistry(registry, activeDir);
+  const hasIssues =
+    diff.missing_in_registry.length > 0 ||
+    diff.missing_in_taskmd.length > 0 ||
+    diff.orphans_in_registry.length > 0 ||
+    diff.duplicate_registry_keys.length > 0;
+  if (hasIssues) {
+    process.stdout.write(`${JSON.stringify(diff, null, 2)}\n`);
+    process.exit(1);
+  }
+  // consistent: empty stdout, exit 0
+}
+
+function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    process.stderr.write(`${e.message}\n${usage()}\n`);
+    process.exit(1);
+  }
+  if (args.help || args.positional.length === 0) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const subcommand = args.positional[0];
+  const repoRoot = findRepoRoot(process.cwd());
+  const activeDir = args.activeDir
+    ? path.resolve(args.activeDir)
+    : repoRoot
+    ? path.join(repoRoot, ".agents", "workspace", "active")
+    : null;
+  if (!activeDir) {
+    process.stderr.write(
+      `Error: cannot locate active dir (no .agents/.airc.json found above ${process.cwd()})\n`
+    );
+    process.exit(2);
+  }
+  const shortIdLength = readShortIdLength(repoRoot, args.shortIdLength);
+  const registryPath = path.join(activeDir, REGISTRY_NAME);
+
+  switch (subcommand) {
+    case "alloc":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: alloc <task-id>\n`);
+        process.exit(1);
+      }
+      return cmdAlloc(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "release":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: release <task-id>\n`);
+        process.exit(1);
+      }
+      return cmdRelease(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "resolve":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: resolve <#N>\n`);
+        process.exit(1);
+      }
+      return cmdResolve(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "list":
+      return cmdList(activeDir, registryPath, args.verify);
+    default:
+      process.stderr.write(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
+      process.exit(1);
+  }
+}
+
+const isCli = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCli) {
+  main(process.argv.slice(2));
+}
+
+export {
+  TASK_ID_RE,
+  SHORT_ID_RE,
+  REGISTRY_NAME,
+  parseArgs,
+  findRepoRoot,
+  readShortIdLength,
+  readRegistry,
+  writeRegistryAtomic,
+  withRegistryLock,
+  writeTaskMdShortId,
+  allocateMinFreeInt,
+  planTransaction,
+  verifyRegistry,
+  cmdAlloc,
+  cmdRelease,
+  cmdResolve,
+  cmdList,
+  main
+};

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -27,8 +27,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 检查必要文件：

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -29,21 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -21,21 +21,7 @@ description: "标记任务为阻塞状态并记录原因"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -19,8 +19,25 @@ description: "标记任务为阻塞状态并记录原因"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 检查任务是否存在于 `.agents/workspace/active/{task-id}/`。
@@ -79,6 +96,12 @@ ls .agents/workspace/blocked/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -115,6 +138,8 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
   - Gemini CLI：/agent-infra:check-task {task-id}
   - Codex CLI：$check-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -15,21 +15,7 @@ description: "取消不再需要的任务并转移"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -13,8 +13,25 @@ description: "取消不再需要的任务并转移"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 依次检查以下目录：
@@ -92,6 +109,12 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务转移和同步状态符合规范：
 
 ```bash
@@ -124,6 +147,8 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
   - Gemini CLI：/agent-infra:check-task {task-id}
   - Codex CLI：$check-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/check-task/SKILL.md
+++ b/.agents/skills/check-task/SKILL.md
@@ -12,21 +12,7 @@ description: "查看任务的当前状态和进度"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 查找任务

--- a/.agents/skills/check-task/SKILL.md
+++ b/.agents/skills/check-task/SKILL.md
@@ -10,8 +10,25 @@ description: "查看任务的当前状态和进度"
 - 本技能是**只读**操作 —— 不修改任何文件
 - 始终检查 active、blocked 和 completed 目录
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 查找任务
 
 按以下优先顺序搜索任务：

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -9,21 +9,7 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -7,6 +7,24 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 关闭指定的 Code Scanning（CodeQL）告警并记录合理的关闭理由。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -81,6 +99,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
+- **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. 告知用户
 
@@ -117,3 +140,5 @@ Code Scanning 告警 #{alert-number} 已关闭。
 - 已关闭：提示 "Alert #{number} is already {state}"
 - 权限错误：提示 "No permission to modify alerts"
 - 用户取消：提示 "Cancellation acknowledged"
+
+

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -7,6 +7,24 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 关闭指定的 Dependabot 安全告警并记录合理的关闭理由。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -89,6 +107,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
+- **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. 告知用户
 
@@ -125,3 +148,5 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 已关闭：提示 "Alert #{number} is already {state}"
 - 权限错误：提示 "No permission to modify alerts"
 - 用户取消：提示 "Cancellation acknowledged"
+
+

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -9,21 +9,7 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -42,8 +42,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 先检查：

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -44,21 +44,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -19,21 +19,7 @@ description: "提交当前变更到 Git"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 1. 检查本地修改（关键）
 

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -17,6 +17,24 @@ description: "提交当前变更到 Git"
 | 「`git add -A` 更省事」 | 禁止 `git add -A`/`git add .`；只暂存明确列出的文件，避免带入无关改动。 |
 | 「改了带版权头的文件，年份先不动」 | 改了就更新版权年份（动态取 `date +%Y`），这是提交前的硬性检查。 |
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 1. 检查本地修改（关键）
 
 在任何编辑前先检查：

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -26,8 +26,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 检查任务是否存在于 `.agents/workspace/active/{task-id}/`。
@@ -119,6 +136,12 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -148,6 +171,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -28,21 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -13,21 +13,7 @@ description: "创建 Pull Request 到目标分支"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -11,6 +11,24 @@ description: "创建 Pull Request 到目标分支"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 前置门控：项目级 PR 流程检查

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -22,8 +22,25 @@ description: "根据自然语言描述创建任务"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 解析用户描述
 
 从自然语言描述中提取：
@@ -126,6 +143,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 5. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -209,6 +234,8 @@ Issue 创建失败：
 
 后续如需平台同步：修复认证/网络/模板问题后，可按 `.agents/rules/create-issue.md` 对当前任务手动执行一次 Issue 创建；或手动创建/查找 Issue，并把 `issue_number` 写入 task.md，后续技能会接管级联同步。
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -24,21 +24,7 @@ description: "根据自然语言描述创建任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 解析用户描述

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -13,6 +13,24 @@ description: "导入 Code Scanning 告警并创建修复任务"
 - 不要自动提交。绝不自动执行 `git commit` 或 `git add`
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -58,6 +76,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -93,6 +119,8 @@ Code Scanning 告警 #{alert-number} 已导入。
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -15,21 +15,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -15,21 +15,7 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -13,6 +13,24 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 - 不要自动提交。绝不自动执行 `git commit` 或 `git add`
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -59,6 +77,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -97,6 +123,8 @@ node .agents/scripts/validate-artifact.js gate import-dependabot .agents/workspa
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -13,6 +13,24 @@ description: "从 Issue 导入并创建任务"
 - 不要编写或修改业务代码。仅做导入
 - 执行本技能后，你**必须**立即更新任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取 Issue 信息
@@ -119,6 +137,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 7. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -154,6 +180,8 @@ Issue #{number} 已导入。
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -15,21 +15,7 @@ description: "从 Issue 导入并创建任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -27,8 +27,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 检查必要文件：

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -29,21 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -18,21 +18,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证输入与环境

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -16,8 +16,25 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证输入与环境
 
 检查：
@@ -90,9 +107,17 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 追加 Activity Log，说明任务已从平台 Issue 还原。
 
+**重新分配短号**（已把任务目录写回 `active/`，需要在锁内重新 alloc；新短号可能与归档前不同）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
 ### 7. 告知用户
 
 报告已恢复的 task id、恢复文件数量和 active task 目录。
+
+
 
 ## 完成检查清单
 

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -30,21 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -28,8 +28,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -36,8 +36,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -38,21 +38,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -30,21 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -28,8 +28,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -43,7 +43,7 @@ const DEFAULTS = {
     }
   },
   "task": {
-    "shortIdLength": 1
+    "shortIdLength": 2
   },
   "labels": {
     "in": {}

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -42,6 +42,9 @@ const DEFAULTS = {
       "disk": null
     }
   },
+  "task": {
+    "shortIdLength": 1
+  },
   "labels": {
     "in": {}
   },

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -7,6 +7,7 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
+short_id:                       # 由 create-task / import-* 在 active 期内写入；归档后保留历史值
 priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
 effort:                         # 可选 Issue 字段：High | Medium | Low
 start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -21,6 +21,9 @@
       "disk": null
     }
   },
+  "task": {
+    "shortIdLength": 1
+  },
   "labels": {
     "in": {}
   },

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -22,7 +22,7 @@
     }
   },
   "task": {
-    "shortIdLength": 1
+    "shortIdLength": 2
   },
   "labels": {
     "in": {}

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -30,6 +30,7 @@ type SourceEntry = {
 type Defaults = {
   files: FileRegistry;
   sandbox: Record<string, unknown>;
+  task: { shortIdLength: number };
   labels: Record<string, unknown>;
   requiresPullRequest: boolean;
 };
@@ -42,6 +43,7 @@ type AgentConfig = {
   requiresPullRequest: boolean;
   templateVersion: string;
   sandbox: Record<string, unknown>;
+  task: { shortIdLength: number };
   labels: Record<string, unknown>;
   files: FileRegistry;
   tuis: string[];
@@ -325,6 +327,7 @@ async function cmdInit(): Promise<void> {
     requiresPullRequest,
     templateVersion: VERSION,
     sandbox: structuredClone(defaults.sandbox),
+    task: structuredClone(defaults.task),
     labels: structuredClone(defaults.labels),
     files: buildDefaultFiles(platformType, enabledTUISet),
     tuis: enabledTUIs

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -123,7 +123,7 @@ export async function enter(args: string[]): Promise<number> {
   let branch: string;
   if (isTaskShortRef(firstArg)) {
     const { running } = fetchSandboxRows(engine, sandboxLabel(config), sandboxBranchLabel(config));
-    branch = resolveTaskShortRef(firstArg, { running });
+    branch = resolveTaskShortRef(firstArg, { running, repoRoot: config.repoRoot });
   } else {
     branch = resolveTaskBranch(firstArg, config.repoRoot);
   }

--- a/lib/sandbox/commands/list-running.ts
+++ b/lib/sandbox/commands/list-running.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 import { runSafeEngine } from '../shell.ts';
 
 export type SandboxRow = {
@@ -94,29 +97,56 @@ export function isTaskShortRef(arg: string): boolean {
   return /^#\d+$/.test(arg);
 }
 
+type RegistryLookup =
+  | { status: 'miss' }
+  | { status: 'hit'; branch: string };
+
 /**
- * Resolve a task short reference ('#N') to a branch name.
+ * Try to resolve a short ref against the global task-short-id registry.
  *
- * Current implementation: treats the digits as a 1-based index into the
- * supplied running-sandbox list (ls view order). This is the *only*
- * resolution path until the global task-short-id registry lands in a
- * follow-up task; do NOT read task.md or scan .agents/workspace/ from this
- * helper here.
- *
- * Precondition: callers MUST gate on isTaskShortRef(arg) === true before
- * constructing ctx and calling this function. Throws when arg is a valid
- * short ref but cannot be resolved (out of range, no running sandboxes,
- * etc.); the caller surfaces the error to the user.
+ * Tri-state semantics (review-code Round 1 M-1 fix):
+ *   - 'miss'     → script reports no entry (or registry script missing). Caller may fall back.
+ *   - 'hit'      → registry resolved to a task id and branch is found in task.md.
+ *   - throws     → registry hit but task.md is missing or branch metadata is unparseable;
+ *                   surfacing this error is critical — never silently fall back to running index.
  */
-export function resolveTaskShortRef(
-  arg: string,
-  ctx: { running: SandboxRow[] }
-): string {
+function tryResolveFromRegistry(arg: string, repoRoot: string): RegistryLookup {
+  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
+  if (!fs.existsSync(scriptPath)) return { status: 'miss' };
+  const result = spawnSync('node', [scriptPath, 'resolve', arg], { encoding: 'utf8', cwd: repoRoot });
+  if (result.status !== 0) return { status: 'miss' };
+  const taskId = (result.stdout || '').trim();
+  if (!/^TASK-\d{8}-\d{6}$/.test(taskId)) {
+    throw new Error(
+      `Registry returned malformed task id for '${arg}': ${JSON.stringify(taskId)}`
+    );
+  }
+  for (const sub of ['active', 'completed', 'blocked', 'archive']) {
+    const taskMdPath = path.join(repoRoot, '.agents', 'workspace', sub, taskId, 'task.md');
+    if (!fs.existsSync(taskMdPath)) continue;
+    const content = fs.readFileSync(taskMdPath, 'utf8');
+    const fm = content.match(/^branch:\s*(.+)$/m);
+    if (fm?.[1]?.trim()) {
+      return { status: 'hit', branch: fm[1].trim().replace(/^(["'])(.*)\1$/, '$2') };
+    }
+    const ctx = content.match(/^- \*\*(?:分支|Branch)\*\*：[ \t]*`?([^`\n]+)`?$/m);
+    if (ctx?.[1]?.trim()) {
+      return { status: 'hit', branch: ctx[1].trim().replace(/^(["'])(.*)\1$/, '$2') };
+    }
+    throw new Error(
+      `Short ref '${arg}' resolved to task ${taskId} but task.md has no branch field`
+    );
+  }
+  throw new Error(
+    `Short ref '${arg}' resolved to task ${taskId} but task.md was not found under any workspace dir`
+  );
+}
+
+function resolveByRunningIndex(arg: string, running: SandboxRow[]): string {
   const n = Number(arg.slice(1));
   if (n < 1) {
     throw new Error(`Invalid sandbox index '${arg}': must be >= 1`);
   }
-  const { running } = ctx;
   if (running.length === 0) {
     throw new Error(`No running sandbox to reference with '${arg}'`);
   }
@@ -132,4 +162,27 @@ export function resolveTaskShortRef(
     );
   }
   return row.branch;
+}
+
+/**
+ * Resolve a task short reference ('#N') to a branch name for the sandbox entrypoint.
+ *
+ * Resolution order (sandbox fallback mode, plan-r7 C2):
+ *   1. Try the global task-short-id registry under repoRoot. If hit, look up the
+ *      branch from the matching task.md.
+ *   2. Fallback to the running-sandbox list index (preserves the #414 ls-index
+ *      behaviour; long-term contract per analysis-r5).
+ *
+ * Precondition: callers MUST gate on isTaskShortRef(arg) === true.
+ */
+export function resolveTaskShortRef(
+  arg: string,
+  ctx: { running: SandboxRow[]; repoRoot?: string }
+): string {
+  if (ctx.repoRoot) {
+    const lookup = tryResolveFromRegistry(arg, ctx.repoRoot);
+    if (lookup.status === 'hit') return lookup.branch;
+    // 'miss' falls through to ls-index fallback (preserves #414 behaviour); 'hit-but-invalid' already threw above.
+  }
+  return resolveByRunningIndex(arg, ctx.running);
 }

--- a/lib/sandbox/task-resolver.ts
+++ b/lib/sandbox/task-resolver.ts
@@ -1,8 +1,26 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+const SHORT_ID_RE = /^#\d+$/;
 const WORKSPACE_DIRS = ['active', 'completed', 'blocked', 'archive'];
+
+function resolveShortIdStrict(arg: string, repoRoot: string): string {
+  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
+  if (!fs.existsSync(scriptPath)) {
+    throw new Error(
+      `Short id '${arg}' provided but task-short-id.js script is missing at ${scriptPath}`
+    );
+  }
+  const result = spawnSync('node', [scriptPath, 'resolve', arg], { encoding: 'utf8', cwd: repoRoot });
+  if (result.status !== 0) {
+    throw new Error(
+      `Short id '${arg}' not found in active task registry: ${(result.stderr || '').trim()}`
+    );
+  }
+  return result.stdout.trim();
+}
 
 function stripQuotes(value: string): string {
   return value.replace(/^(["'])(.*)\1$/, '$2');
@@ -33,10 +51,14 @@ function resolveBranchFromTaskContent(content: string, taskId: string): string {
 }
 
 export function resolveTaskBranch(arg: string, repoRoot: string): string {
+  if (SHORT_ID_RE.test(arg)) {
+    const taskId = resolveShortIdStrict(arg, repoRoot);
+    const content = readTaskContent(repoRoot, taskId);
+    return resolveBranchFromTaskContent(content, taskId);
+  }
   if (!TASK_ID_RE.test(arg)) {
     return arg;
   }
-
   const content = readTaskContent(repoRoot, arg);
   return resolveBranchFromTaskContent(content, arg);
 }

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -19,6 +19,7 @@ type UpdateConfig = {
   platform?: { type?: string };
   requiresPullRequest?: boolean;
   sandbox?: Record<string, unknown>;
+  task?: { shortIdLength: number };
   labels?: Record<string, unknown>;
   files?: Partial<FileRegistry>;
   tuis?: unknown;
@@ -28,6 +29,7 @@ type Defaults = {
   platform: { type: string };
   requiresPullRequest: boolean;
   sandbox: Record<string, unknown>;
+  task: { shortIdLength: number };
   labels: Record<string, unknown>;
   files: FileRegistry;
 };
@@ -191,6 +193,7 @@ async function cmdUpdate(): Promise<void> {
   const hasNewEntries = added.managed.length > 0 || added.merged.length > 0;
   const platformAdded = !config.platform;
   const sandboxAdded = !config.sandbox;
+  const taskAdded = !config.task;
   const labelsAdded = !config.labels;
   const requiresPullRequestAdded = config.requiresPullRequest === undefined;
   let configChanged = changed;
@@ -202,6 +205,11 @@ async function cmdUpdate(): Promise<void> {
 
   if (sandboxAdded) {
     config.sandbox = structuredClone(defaults.sandbox);
+    configChanged = true;
+  }
+
+  if (taskAdded) {
+    config.task = structuredClone(defaults.task);
     configChanged = true;
   }
 
@@ -225,12 +233,15 @@ async function cmdUpdate(): Promise<void> {
       for (const entry of added.merged) {
         ok(`  merged: ${entry}`);
       }
-    } else if (platformAdded || sandboxAdded || labelsAdded || requiresPullRequestAdded) {
+    } else if (platformAdded || sandboxAdded || taskAdded || labelsAdded || requiresPullRequestAdded) {
       if (platformAdded) {
         info(`Default platform config added to ${CONFIG_PATH}.`);
       }
       if (sandboxAdded) {
         info(`Default sandbox config added to ${CONFIG_PATH}.`);
+      }
+      if (taskAdded) {
+        info(`Default task.shortIdLength=${defaults.task.shortIdLength} added to ${CONFIG_PATH}.`);
       }
       if (labelsAdded) {
         info(`Default labels.in config added to ${CONFIG_PATH}.`);
@@ -243,6 +254,9 @@ async function cmdUpdate(): Promise<void> {
     }
     if (hasNewEntries && sandboxAdded) {
       info(`Default sandbox config added to ${CONFIG_PATH}.`);
+    }
+    if (hasNewEntries && taskAdded) {
+      info(`Default task.shortIdLength=${defaults.task.shortIdLength} added to ${CONFIG_PATH}.`);
     }
     if (hasNewEntries && labelsAdded) {
       info(`Default labels.in config added to ${CONFIG_PATH}.`);

--- a/templates/.agents/rules/task-short-id.en.md
+++ b/templates/.agents/rules/task-short-id.en.md
@@ -1,0 +1,77 @@
+# Task short id
+
+Task short ids let mobile-style SKILL invocations replace the full 22-char
+`TASK-YYYYMMDD-HHMMSS` with `#N` while a task is active.
+
+## Syntax
+
+- Format: `^#\d+$` (e.g. `#1`, `#7`, `#42`). Pure digits only; no letters.
+- `#0` is reserved and never allocated.
+- Leading zeros are rejected (`#01` is invalid).
+- The plain `TASK-…` form keeps working everywhere; the `#N` form is an alias,
+  not a replacement for the persisted task id.
+
+## Lifecycle
+
+| Action     | When                                                                 | Effect on registry & task.md                                  |
+|------------|-----------------------------------------------------------------------|---------------------------------------------------------------|
+| alloc      | `create-task`, `import-issue`, `import-codescan`, `import-dependabot` | Assigns lowest free `#N`; writes `short_id` into task.md.     |
+| resolve    | Lifecycle SKILLs (`analyze-task`, `plan-task`, `code-task`, …)        | Looks up `#N` → full task id. Does not allocate.              |
+| release    | `complete-task`, `cancel-task`, `block-task`, `close-codescan`, `close-dependabot` | Removes the registry entry; leaves task.md `short_id` as a historical value. |
+| re-alloc   | `restore-task`                                                        | Re-allocates a (possibly new) `#N` and writes it to task.md.  |
+
+Short ids are valid only while a task lives in `.agents/workspace/active/`.
+Once it is moved to `completed/`, `blocked/`, or `archive/`, the `#N` slot is
+freed and may be reused by a new task.
+
+## Configuration
+
+```jsonc
+// .agents/.airc.json
+{
+  "task": {
+    "shortIdLength": 1  // default; capacity = 9 (#1–#9). Set to 2 for #1–#99.
+  }
+}
+```
+
+When all slots for the configured width are in use, `alloc` fails with a clear
+error suggesting either archiving some tasks or raising `task.shortIdLength`.
+There is no silent extension or truncation.
+
+## `#N` resolution scope (split by entrypoint)
+
+| Entrypoint                                                  | Hit                  | Miss                                                 |
+|-------------------------------------------------------------|----------------------|------------------------------------------------------|
+| SKILL parameter resolver (lifecycle SKILLs)                  | resolve to full id   | **strict error** — short id not found / invalid     |
+| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`          | resolve to full id   | fall back to running-sandbox ls index (`#414`)      |
+
+`list --verify` is strictly read-only: it reports discrepancies between active
+dir, registry, and `short_id` declared in each `task.md`, but never writes.
+
+## Error scenarios
+
+- **Short id not found**: the registry has no entry for `#N`. Either the task
+  was archived (release freed the slot) or the input is wrong.
+- **Registry corruption** (duplicate registry entries for the same task id, or
+  the JSON is unparsable): exit code 2; manual cleanup required.
+- **Parameter format error** (e.g. `#0`, `#abc`, `#`): exit code 1.
+
+## Cross-TUI quoting
+
+Bash treats `#` as a comment marker. Always single-quote: `ai sandbox exec '#3' 'npm test'`.
+Claude Code / Codex / Gemini CLI / OpenCode all forward `#N` to SKILL `ARGUMENTS`
+literally when quoted.
+
+## Cold-start migration
+
+When a project upgrades to a version with this feature, the first call to
+`alloc` / `resolve` runs the cold-start path:
+
+- Active tasks whose `task.md` lacks `short_id` get one allocated and written
+  back (the only frontmatter mutation; `updated_at` / `agent_infra_version`
+  are **not** refreshed and Activity Log is **not** appended).
+- If active task count exceeds `shortIdLength` capacity, the migration aborts
+  **before any write** with a capacity error.
+- If a partial write fails midway, `tx.commit()` rolls all task.md files back to
+  their original content (including `mtime` / `atime`).

--- a/templates/.agents/rules/task-short-id.en.md
+++ b/templates/.agents/rules/task-short-id.en.md
@@ -1,27 +1,30 @@
 # Task short id
 
 Task short ids let mobile-style SKILL invocations replace the full 22-char
-`TASK-YYYYMMDD-HHMMSS` with `#N` while a task is active.
+`TASK-YYYYMMDD-HHMMSS` with `#NN` while a task is active.
 
 ## Syntax
 
-- Format: `^#\d+$` (e.g. `#1`, `#7`, `#42`). Pure digits only; no letters.
-- `#0` is reserved and never allocated.
-- Leading zeros are rejected (`#01` is invalid).
-- The plain `TASK-…` form keeps working everywhere; the `#N` form is an alias,
-  not a replacement for the persisted task id.
+- Format: `^#\d{shortIdLength}$` (**zero-padded to a fixed width**; with the
+  default `shortIdLength=2`, e.g. `#01`, `#07`, `#42`).
+- **Must** be zero-padded to `shortIdLength` digits (default 2: `#1` is a format
+  error, use `#01`). This keeps things aligned and touch-typeable.
+- `#00` (or `#0` when `shortIdLength=1`) is reserved and never allocated; digits
+  only, no letters.
+- The plain `TASK-…` form keeps working everywhere; `#NN` is an alias, not the
+  persisted task id.
 
 ## Lifecycle
 
 | Action     | When                                                                 | Effect on registry & task.md                                  |
 |------------|-----------------------------------------------------------------------|---------------------------------------------------------------|
-| alloc      | `create-task`, `import-issue`, `import-codescan`, `import-dependabot` | Assigns lowest free `#N`; writes `short_id` into task.md.     |
-| resolve    | Lifecycle SKILLs (`analyze-task`, `plan-task`, `code-task`, …)        | Looks up `#N` → full task id. Does not allocate.              |
+| alloc      | `create-task`, `import-issue`, `import-codescan`, `import-dependabot` | Assigns lowest free `#NN`; writes `short_id` into task.md.    |
+| resolve    | Lifecycle SKILLs (`analyze-task`, `plan-task`, `code-task`, …)        | Looks up `#NN` → full task id. Does not allocate.             |
 | release    | `complete-task`, `cancel-task`, `block-task`, `close-codescan`, `close-dependabot` | Removes the registry entry; leaves task.md `short_id` as a historical value. |
-| re-alloc   | `restore-task`                                                        | Re-allocates a (possibly new) `#N` and writes it to task.md.  |
+| re-alloc   | `restore-task`                                                        | Re-allocates a (possibly new) `#NN` and writes it to task.md. |
 
 Short ids are valid only while a task lives in `.agents/workspace/active/`.
-Once it is moved to `completed/`, `blocked/`, or `archive/`, the `#N` slot is
+Once it is moved to `completed/`, `blocked/`, or `archive/`, the `#NN` slot is
 freed and may be reused by a new task.
 
 ## Configuration
@@ -30,38 +33,99 @@ freed and may be reused by a new task.
 // .agents/.airc.json
 {
   "task": {
-    "shortIdLength": 1  // default; capacity = 9 (#1–#9). Set to 2 for #1–#99.
+    "shortIdLength": 2  // default; capacity = 99 (#01–#99). Set to 3 for #001–#999.
   }
 }
 ```
 
 When all slots for the configured width are in use, `alloc` fails with a clear
 error suggesting either archiving some tasks or raising `task.shortIdLength`.
-There is no silent extension or truncation.
+There is no silent extension or truncation. Changing `shortIdLength` requires
+archiving all active tasks first (the registry key width depends on it).
 
-## `#N` resolution scope (split by entrypoint)
+## `#NN` resolution scope (split by entrypoint)
 
 | Entrypoint                                                  | Hit                  | Miss                                                 |
 |-------------------------------------------------------------|----------------------|------------------------------------------------------|
 | SKILL parameter resolver (lifecycle SKILLs)                  | resolve to full id   | **strict error** — short id not found / invalid     |
-| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`          | resolve to full id   | fall back to running-sandbox ls index (`#414`)      |
+| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`        | resolve to full id   | fall back to running-sandbox ls index (`#414`)      |
 
 `list --verify` is strictly read-only: it reports discrepancies between active
 dir, registry, and `short_id` declared in each `task.md`, but never writes.
 
+## SKILL parameter resolver
+
+Any SKILL (alloc / resolve / release / re-alloc lifecycle entry-points) that
+receives a `{task-id}` argument must follow this contract:
+
+1. If `{task-id}` starts with `#`:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  # The script writes the full error message (including "expected #NN
+  # (N-digit zero-padded; e.g. '#01')") to stderr; callers only forward the exit.
+  task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
+else
+  task_id="{task-id}"
+fi
+```
+
+2. Every downstream command treats `{task-id}` as `$task_id` (already the full
+   `TASK-YYYYMMDD-HHMMSS` form).
+3. Error-code semantics for resolve are documented under "Error scenarios"; do
+   not reimplement error handling inside each SKILL.
+
+## Storage
+
+The short id system persists state in two places that stay in sync at rest:
+
+| Location | Written by | Read by | Removed by |
+|---|---|---|---|
+| `.agents/workspace/active/.short-ids.json` (registry) | `alloc` / cold-start migration | `resolve` (authoritative) / `list` / `list --verify` | `release` / cold-start stale cleanup |
+| `short_id` frontmatter field in each task.md | `alloc` / cold-start migration | `list --verify` (consistency check) | **never** (kept as historical value after archive) |
+
+**Registry**:
+
+- Path: `<repo-root>/.agents/workspace/active/.short-ids.json`
+- Schema: `{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
+- Keys are zero-padded decimal strings of `task.shortIdLength` digits; values are
+  full `TASK-…` task ids.
+- Automatically git-ignored (the whole active workspace is ignored; no new
+  ignore entry needed).
+- Created on demand by the first `alloc` / `resolve`; an absent file is treated
+  as an empty registry.
+
+**`short_id` field in task.md**:
+
+- Lives in frontmatter, immediately after `id`; formatted `short_id: #01`.
+- Matches the registry key byte-for-byte (including the `#` prefix).
+- After archive (complete-task / cancel-task / block-task / close-*) the
+  registry entry is deleted immediately (the short id can be reused), but the
+  `short_id` field in task.md is kept as a historical value. The resolver
+  trusts the registry only.
+- Cold-start migration: the first `alloc` / `resolve` after an upgrade scans
+  the active directory and fills in the missing field for legacy tasks; the
+  field write is constrained (does NOT refresh `updated_at` /
+  `agent_infra_version` and does NOT append Activity Log).
+
+`resolve('#NN')` workflow: ① validate arg matches `^#\d{shortIdLength}$` →
+② look up `NN` directly as the registry `ids` key → ③ return full task id on
+hit; on miss, exit 1 with the `list --verify` repair hint.
+
 ## Error scenarios
 
-- **Short id not found**: the registry has no entry for `#N`. Either the task
+- **Short id not found**: the registry has no entry for `#NN`. Either the task
   was archived (release freed the slot) or the input is wrong.
 - **Registry corruption** (duplicate registry entries for the same task id, or
   the JSON is unparsable): exit code 2; manual cleanup required.
-- **Parameter format error** (e.g. `#0`, `#abc`, `#`): exit code 1.
+- **Parameter format error** (e.g. `#00`, `#abc`, `#`, or `#1` when
+  `shortIdLength=2`): exit code 1.
 
 ## Cross-TUI quoting
 
-Bash treats `#` as a comment marker. Always single-quote: `ai sandbox exec '#3' 'npm test'`.
-Claude Code / Codex / Gemini CLI / OpenCode all forward `#N` to SKILL `ARGUMENTS`
-literally when quoted.
+Bash treats `#` as a comment marker. Always single-quote: `ai sandbox exec '#03' 'npm test'`.
+Claude Code / Codex / Gemini CLI / OpenCode all forward `#NN` to SKILL
+`ARGUMENTS` literally when quoted.
 
 ## Cold-start migration
 

--- a/templates/.agents/rules/task-short-id.zh-CN.md
+++ b/templates/.agents/rules/task-short-id.zh-CN.md
@@ -1,21 +1,23 @@
 # 任务短号
 
-短号让所有 SKILL 在 active 任务生命周期内可以用 `#N` 替代完整的 22 字符
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 替代完整的 22 字符
 `TASK-YYYYMMDD-HHMMSS`。
 
 ## 语法
 
-- 格式：`^#\d+$`（如 `#1`、`#7`、`#42`）；纯数字、不引入字母。
-- `#0` 保留、永不分配。
-- 不允许前导零（`#01` 非法）。
-- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#N` 只是别名，不是持久化任务 ID。
+- 格式：`^#\d{shortIdLength}$`（**零填充到固定宽度**；默认 `shortIdLength=2` 时
+  形如 `#01`、`#07`、`#42`）。
+- **必须**零填充到 `shortIdLength` 位（默认 2 位：`#1` 视为格式错误，应输入
+  `#01`）。这是为了视觉对齐与盲打体验。
+- `#00`（或 `shortIdLength=1` 时 `#0`）保留、永不分配；纯数字、不引入字母。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` 只是别名，不是持久化任务 ID。
 
 ## 生命周期
 
 | 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
 |-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#N`，写入 task.md 的 `short_id` 字段。              |
-| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#N` → 完整 task id 查询，不分配。                              |
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入 task.md 的 `short_id` 字段。              |
+| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#NN` → 完整 task id 查询，不分配。                              |
 | release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
 | re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
 
@@ -28,34 +30,87 @@
 // .agents/.airc.json
 {
   "task": {
-    "shortIdLength": 1  // 默认；容量 = 9（#1–#9）。改为 2 时容量 = #1–#99。
+    "shortIdLength": 2  // 默认；容量 = 99（#01–#99）。改为 3 时容量 = #001–#999。
   }
 }
 ```
 
 当前位宽容量耗尽时，`alloc` 给出明确错误并建议「归档若干任务」或「调高
 `task.shortIdLength`」两种修复路径；不静默扩位、不静默截断。
+切换 `shortIdLength` 配置需要先归档所有 active 任务（注册表 key 宽度依赖配置）。
 
-## `#N` 解析作用域（按入口二分）
+## `#NN` 解析作用域（按入口二分）
 
 | 入口                                                       | 注册表命中            | 注册表未命中                                            |
 |-----------------------------------------------------------|----------------------|--------------------------------------------------------|
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
-| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`        | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`      | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
 
 `list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
 三者差异，但不修改任何状态。
 
+## SKILL 入参解析
+
+任意 SKILL（含 alloc / resolve / release / re-alloc 四类生命周期入口）在收到
+`{task-id}` 入参后，必须按以下契约处理：
+
+1. 如果 `{task-id}` 字面以 `#` 开头：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  # 脚本本身已输出完整错误（含「expected #NN (N-digit zero-padded; e.g. '#01')」）；
+  # 调用方只需透传退出码
+  task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
+else
+  task_id="{task-id}"
+fi
+```
+
+2. 后续所有命令把 `{task-id}` 视为 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）
+3. 解析失败的退出码语义参见「错误场景」段；不要在 SKILL 中重写错误处理
+
+## 存储位置
+
+短号系统跨两处持久化状态，二者在稳态时一一对应：
+
+| 位置 | 写入时机 | 读取时机 | 删除时机 |
+|---|---|---|---|
+| `.agents/workspace/active/.short-ids.json`（注册表） | `alloc` / 冷启动迁移 | `resolve` 唯一权威源 / `list` / `list --verify` | `release` / 冷启动 stale 清理 |
+| 各 task.md frontmatter 的 `short_id` 字段 | `alloc` / 冷启动迁移 | `list --verify`（比对一致性） | **永不删除**（归档后保留为历史值） |
+
+**注册表**：
+
+- 路径：`<repo-root>/.agents/workspace/active/.short-ids.json`
+- Schema：`{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
+- key 是零填充到 `task.shortIdLength` 位的字符串，value 是完整 `TASK-…` task id
+- 自动 git ignore（active 工作区整体 ignore；无需新增 ignore 条目）
+- 首次 `alloc` / `resolve` 时按需自动创建；不存在时按空注册表处理
+
+**task.md `short_id` 字段**：
+
+- 在 frontmatter 中、紧跟 `id` 字段之后；格式 `short_id: #01`
+- 与注册表 key 字面一致（含 `#` 前缀）
+- 归档（complete-task / cancel-task / block-task / close-*）后：注册表 entry 立即
+  删除（短号可被新任务复用），但 task.md `short_id` 字段保留作为历史值。解析器
+  只信任注册表
+- 冷启动迁移：升级 agent-infra 后首次 alloc / resolve 路径会扫描所有 active
+  目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
+  `updated_at` / `agent_infra_version`、不追加 Activity Log）
+
+`resolve('#NN')` 工作流：① 校验入参严格匹配 `^#\d{shortIdLength}$` → ② 直接以
+`NN` 作为 key 查注册表 `ids` → ③ 命中返回完整 task id，未命中按 `list --verify`
+给出修复指引退出 1。
+
 ## 错误场景
 
-- **短号不存在**：注册表中无 `#N`。可能是任务已归档（短号已释放）或输入错误。
+- **短号不存在**：注册表中无 `#NN`。可能是任务已归档（短号已释放）或输入错误。
 - **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
-- **参数格式错误**（如 `#0`、`#abc`、`#`）：退出码 1。
+- **参数格式错误**（如 `#00`、`#abc`、`#`、`#1` 当 `shortIdLength=2` 时）：退出码 1。
 
 ## 跨 TUI 引号要求
 
-bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#3' 'npm test'`。
-Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#N` 字面传递到
+bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#03' 'npm test'`。
+Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#NN` 字面传递到
 SKILL 的 `ARGUMENTS`。
 
 ## 冷启动迁移

--- a/templates/.agents/rules/task-short-id.zh-CN.md
+++ b/templates/.agents/rules/task-short-id.zh-CN.md
@@ -1,0 +1,69 @@
+# 任务短号
+
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#N` 替代完整的 22 字符
+`TASK-YYYYMMDD-HHMMSS`。
+
+## 语法
+
+- 格式：`^#\d+$`（如 `#1`、`#7`、`#42`）；纯数字、不引入字母。
+- `#0` 保留、永不分配。
+- 不允许前导零（`#01` 非法）。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#N` 只是别名，不是持久化任务 ID。
+
+## 生命周期
+
+| 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
+|-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#N`，写入 task.md 的 `short_id` 字段。              |
+| resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#N` → 完整 task id 查询，不分配。                              |
+| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
+| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
+
+短号仅在任务处于 `.agents/workspace/active/` 期间有效；任务移动到
+`completed/` / `blocked/` / `archive/` 后短号立即释放，可被新任务复用。
+
+## 配置
+
+```jsonc
+// .agents/.airc.json
+{
+  "task": {
+    "shortIdLength": 1  // 默认；容量 = 9（#1–#9）。改为 2 时容量 = #1–#99。
+  }
+}
+```
+
+当前位宽容量耗尽时，`alloc` 给出明确错误并建议「归档若干任务」或「调高
+`task.shortIdLength`」两种修复路径；不静默扩位、不静默截断。
+
+## `#N` 解析作用域（按入口二分）
+
+| 入口                                                       | 注册表命中            | 注册表未命中                                            |
+|-----------------------------------------------------------|----------------------|--------------------------------------------------------|
+| SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
+| `ai sandbox enter '#N'` / `ai sandbox exec '#N' …`        | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+
+`list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
+三者差异，但不修改任何状态。
+
+## 错误场景
+
+- **短号不存在**：注册表中无 `#N`。可能是任务已归档（短号已释放）或输入错误。
+- **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
+- **参数格式错误**（如 `#0`、`#abc`、`#`）：退出码 1。
+
+## 跨 TUI 引号要求
+
+bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#3' 'npm test'`。
+Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#N` 字面传递到
+SKILL 的 `ARGUMENTS`。
+
+## 冷启动迁移
+
+升级 agent-infra 后，首次 `alloc` / `resolve` 调用会触发冷启动迁移：
+
+- 所有 active task.md 缺 `short_id` 字段时自动补发并回写（仅修改 `short_id`
+  一行，不刷新 `updated_at` / `agent_infra_version`，不追加 Activity Log）。
+- 若 active 任务总数超过 `shortIdLength` 容量，**在任何写入之前**报错退出 2。
+- 若 task.md 写入中途失败，`tx.commit()` 按缓存的原内容回滚所有已写文件（含
+  `mtime` / `atime` 恢复）。

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -669,11 +669,17 @@ function main(argv) {
   }
 }
 
+// Compare canonicalized (symlink-resolved) paths so this script still runs as a
+// CLI when invoked through a temp-dir symlink (notably /var/folders on macOS,
+// which is a symlink to /private/var/folders; process.argv[1] keeps the
+// symlinked path while import.meta.url is auto-resolved to the realpath).
 const isCli = (() => {
   const entry = process.argv[1];
   if (!entry) return false;
   try {
-    return import.meta.url === pathToFileURL(entry).href;
+    const realEntry = fs.realpathSync(entry);
+    const realModule = fs.realpathSync(fileURLToPath(import.meta.url));
+    return realEntry === realModule;
   } catch {
     return false;
   }

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -13,6 +13,20 @@ const DEFAULT_LOCK_TIMEOUT_MS = 5000;
 // ai update-agent-infra to backfill the field).
 const DEFAULT_SHORT_ID_LENGTH = 2;
 
+// process.stdout.write / process.stderr.write are non-blocking when the
+// destination is a pipe (e.g. when spawned via child_process.spawnSync). On
+// some platforms (notably macOS) the Node process can exit before the buffer
+// flushes, leaving the parent with empty stdout. Use fs.writeSync to guarantee
+// synchronous, fully-flushed writes — this is critical because the parent
+// CLI/test code relies on stdout to carry the resolved task id / short id.
+function writeStdout(text) {
+  fs.writeSync(1, text);
+}
+
+function writeStderr(text) {
+  fs.writeSync(2, text);
+}
+
 function usage() {
   return [
     "Usage: task-short-id.js <subcommand> [args]",
@@ -85,19 +99,19 @@ function readRegistry(registryPath) {
   try {
     raw = fs.readFileSync(registryPath, "utf8");
   } catch (e) {
-    process.stderr.write(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
+    writeStderr(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
     process.exit(2);
   }
   try {
     const data = JSON.parse(raw);
     if (!data || typeof data !== "object" || !data.ids || typeof data.ids !== "object") {
-      process.stderr.write(`Error: registry ${registryPath} has invalid schema\n`);
+      writeStderr(`Error: registry ${registryPath} has invalid schema\n`);
       process.exit(2);
     }
     if (data.version !== 1) data.version = 1;
     return data;
   } catch (e) {
-    process.stderr.write(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
+    writeStderr(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
     process.exit(2);
   }
 }
@@ -119,7 +133,7 @@ function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
     } catch (e) {
       if (e.code !== "EEXIST") throw e;
       if (Date.now() - start > timeoutMs) {
-        process.stderr.write(`Error: registry lock timeout after ${timeoutMs}ms\n`);
+        writeStderr(`Error: registry lock timeout after ${timeoutMs}ms\n`);
         process.exit(3);
       }
       const elapsed = Date.now() - start;
@@ -175,7 +189,7 @@ function parseShortIdArg(arg, shortIdLength) {
   if (!re.test(arg)) {
     const example =
       shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
-    process.stderr.write(
+    writeStderr(
       `Error: invalid short id format '${arg}', ` +
         `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
     );
@@ -183,7 +197,7 @@ function parseShortIdArg(arg, shortIdLength) {
   }
   const key = arg.slice(1);
   if (Number(key) === 0) {
-    process.stderr.write(
+    writeStderr(
       `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
     );
     process.exit(1);
@@ -216,7 +230,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
   for (const [key, taskId] of Object.entries(projectedIds)) {
     if (taskIdToKey.has(taskId)) {
       const existingKey = taskIdToKey.get(taskId);
-      process.stderr.write(
+      writeStderr(
         `Error: duplicate registry entries for taskId ${taskId} at keys [#${existingKey}, #${key}]; manual resolution required\n`
       );
       process.exit(2);
@@ -241,13 +255,13 @@ function planTransaction(registry, activeDir, shortIdLength) {
       if (projectedIds[n] === taskId) continue; // 4a
       if (taskIdToKey.has(taskId)) {
         const registryKey = taskIdToKey.get(taskId);
-        process.stderr.write(
+        writeStderr(
           `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
         );
         process.exit(2);
       }
       if (projectedIds[n] && projectedIds[n] !== taskId) {
-        process.stderr.write(
+        writeStderr(
           `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
         );
         process.exit(2);
@@ -286,7 +300,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
   // A5: capacity pre-check
   const availableSlots = maxN - Object.keys(projectedIds).length;
   if (pendingAlloc.length > availableSlots) {
-    process.stderr.write(
+    writeStderr(
       `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
         `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
         `Archive some active tasks (complete-task / cancel-task / block-task) ` +
@@ -485,13 +499,13 @@ function verifyRegistry(registry, activeDir) {
 
 function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
   if (!TASK_ID_RE.test(taskId)) {
-    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    writeStderr(`Error: invalid task id format '${taskId}'\n`);
     process.exit(1);
   }
   return withRegistryLock(activeDir, () => {
     const taskMdPath = path.join(activeDir, taskId, "task.md");
     if (!fs.existsSync(taskMdPath)) {
-      process.stderr.write(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
+      writeStderr(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
       process.exit(1);
     }
     const registry = readRegistry(registryPath);
@@ -500,23 +514,23 @@ function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
     try {
       shortId = tx.planAlloc(taskId);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(2);
     }
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
     // shortId is already zero-padded (returned by tx.planAlloc; matches registry key)
-    process.stdout.write(`#${shortId}\n`);
+    writeStdout(`#${shortId}\n`);
   });
 }
 
 function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
   if (!TASK_ID_RE.test(taskId)) {
-    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    writeStderr(`Error: invalid task id format '${taskId}'\n`);
     process.exit(1);
   }
   return withRegistryLock(activeDir, () => {
@@ -526,7 +540,7 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
     // idempotent exit 0
@@ -550,16 +564,16 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
         try {
           tx.commit(registryPath);
         } catch (e) {
-          process.stderr.write(`${e.message}\n`);
+          writeStderr(`${e.message}\n`);
           process.exit(1);
         }
       }
       if (Object.keys(tx._projectedIds).length === 0) {
-        process.stderr.write(
+        writeStderr(
           `Error: short id '#${key}' not found; active task registry is empty.\n`
         );
       } else {
-        process.stderr.write(
+        writeStderr(
           `Error: short id '#${key}' not found in active task registry ` +
             `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
         );
@@ -569,22 +583,22 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
     try {
       tx.commit(registryPath);
     } catch (e) {
-      process.stderr.write(`${e.message}\n`);
+      writeStderr(`${e.message}\n`);
       process.exit(1);
     }
-    process.stdout.write(`${taskId}\n`);
+    writeStdout(`${taskId}\n`);
   });
 }
 
 function cmdList(activeDir, registryPath, verify) {
   if (!verify) {
     const registry = readRegistry(registryPath);
-    process.stdout.write(`${JSON.stringify(registry, null, 2)}\n`);
+    writeStdout(`${JSON.stringify(registry, null, 2)}\n`);
     return;
   }
   const registry = readRegistry(registryPath);
   if (!fs.existsSync(activeDir)) {
-    process.stdout.write("");
+    writeStdout("");
     return;
   }
   const diff = verifyRegistry(registry, activeDir);
@@ -594,7 +608,7 @@ function cmdList(activeDir, registryPath, verify) {
     diff.orphans_in_registry.length > 0 ||
     diff.duplicate_registry_keys.length > 0;
   if (hasIssues) {
-    process.stdout.write(`${JSON.stringify(diff, null, 2)}\n`);
+    writeStdout(`${JSON.stringify(diff, null, 2)}\n`);
     process.exit(1);
   }
   // consistent: empty stdout, exit 0
@@ -605,11 +619,11 @@ function main(argv) {
   try {
     args = parseArgs(argv);
   } catch (e) {
-    process.stderr.write(`${e.message}\n${usage()}\n`);
+    writeStderr(`${e.message}\n${usage()}\n`);
     process.exit(1);
   }
   if (args.help || args.positional.length === 0) {
-    process.stdout.write(`${usage()}\n`);
+    writeStdout(`${usage()}\n`);
     return;
   }
   const subcommand = args.positional[0];
@@ -620,7 +634,7 @@ function main(argv) {
     ? path.join(repoRoot, ".agents", "workspace", "active")
     : null;
   if (!activeDir) {
-    process.stderr.write(
+    writeStderr(
       `Error: cannot locate active dir (no .agents/.airc.json found above ${process.cwd()})\n`
     );
     process.exit(2);
@@ -631,26 +645,26 @@ function main(argv) {
   switch (subcommand) {
     case "alloc":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: alloc <task-id>\n`);
+        writeStderr(`Usage: alloc <task-id>\n`);
         process.exit(1);
       }
       return cmdAlloc(args.positional[1], activeDir, registryPath, shortIdLength);
     case "release":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: release <task-id>\n`);
+        writeStderr(`Usage: release <task-id>\n`);
         process.exit(1);
       }
       return cmdRelease(args.positional[1], activeDir, registryPath, shortIdLength);
     case "resolve":
       if (!args.positional[1]) {
-        process.stderr.write(`Usage: resolve <#N>\n`);
+        writeStderr(`Usage: resolve <#N>\n`);
         process.exit(1);
       }
       return cmdResolve(args.positional[1], activeDir, registryPath, shortIdLength);
     case "list":
       return cmdList(activeDir, registryPath, args.verify);
     default:
-      process.stderr.write(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
+      writeStderr(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
       process.exit(1);
   }
 }

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -7,6 +7,11 @@ const SHORT_ID_RE = /^#\d+$/;
 const REGISTRY_NAME = ".short-ids.json";
 const LOCK_NAME = ".short-ids.json.lock";
 const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+// Kept in sync with lib/defaults.json's task.shortIdLength. Used when there is
+// no `--short-id-length` flag and no readable `task.shortIdLength` in
+// .agents/.airc.json (e.g. the project upgraded but hasn't re-run
+// ai update-agent-infra to backfill the field).
+const DEFAULT_SHORT_ID_LENGTH = 2;
 
 function usage() {
   return [
@@ -21,7 +26,7 @@ function usage() {
     "",
     "Options:",
     "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
-    "  --short-id-length N  Override configured width (default: from .airc.json or 1)"
+    "  --short-id-length N  Override configured width (default: from .airc.json or 2)"
   ].join("\n");
 }
 
@@ -60,7 +65,7 @@ function readShortIdLength(repoRoot, override) {
   if (typeof override === "number" && Number.isFinite(override) && override >= 1) {
     return override;
   }
-  if (!repoRoot) return 1;
+  if (!repoRoot) return DEFAULT_SHORT_ID_LENGTH;
   try {
     const cfgPath = path.join(repoRoot, ".agents", ".airc.json");
     const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
@@ -69,7 +74,7 @@ function readShortIdLength(repoRoot, override) {
   } catch {
     // ignore
   }
-  return 1;
+  return DEFAULT_SHORT_ID_LENGTH;
 }
 
 function readRegistry(registryPath) {
@@ -153,11 +158,37 @@ function writeTaskMdShortId(taskMdPath, shortId) {
   fs.writeFileSync(taskMdPath, updated);
 }
 
-function allocateMinFreeInt(registry, maxN) {
+function padShortId(n, shortIdLength) {
+  return String(n).padStart(shortIdLength, "0");
+}
+
+function allocateMinFreeInt(registry, shortIdLength) {
+  const maxN = Math.pow(10, shortIdLength) - 1;
   for (let n = 1; n <= maxN; n += 1) {
-    if (!registry.ids[String(n)]) return n;
+    if (!registry.ids[padShortId(n, shortIdLength)]) return n;
   }
   return null;
+}
+
+function parseShortIdArg(arg, shortIdLength) {
+  const re = new RegExp(`^#\\d{${shortIdLength}}$`);
+  if (!re.test(arg)) {
+    const example =
+      shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
+    process.stderr.write(
+      `Error: invalid short id format '${arg}', ` +
+        `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
+    );
+    process.exit(1);
+  }
+  const key = arg.slice(1);
+  if (Number(key) === 0) {
+    process.stderr.write(
+      `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
+    );
+    process.exit(1);
+  }
+  return key;
 }
 
 function planTransaction(registry, activeDir, shortIdLength) {
@@ -267,19 +298,20 @@ function planTransaction(registry, activeDir, shortIdLength) {
   pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
 
   for (const item of pendingAlloc) {
-    const shortId = allocateMinFreeInt({ ids: projectedIds }, maxN);
-    if (shortId === null) {
+    const n = allocateMinFreeInt({ ids: projectedIds }, shortIdLength);
+    if (n === null) {
       throw new Error("Internal invariant: pendingAlloc capacity check failed");
     }
-    projectedIds[String(shortId)] = item.taskId;
-    taskIdToKey.set(item.taskId, String(shortId));
-    plannedRegistryWrites.push({ key: String(shortId), taskId: item.taskId });
+    const key = padShortId(n, shortIdLength);
+    projectedIds[key] = item.taskId;
+    taskIdToKey.set(item.taskId, key);
+    plannedRegistryWrites.push({ key, taskId: item.taskId });
     plannedTaskMdWrites.push({
       taskMdPath: item.taskMdPath,
       originalContent: item.originalContent,
       originalAtime: item.originalAtime,
       originalMtime: item.originalMtime,
-      shortId: `#${shortId}`,
+      shortId: `#${key}`,
       kind: "4f"
     });
   }
@@ -312,25 +344,26 @@ function planTransaction(registry, activeDir, shortIdLength) {
             `${inUse}/${this._maxN} slots in use). Archive some active tasks or raise task.shortIdLength.`
         );
       }
-      const shortId = allocateMinFreeInt({ ids: this._projectedIds }, this._maxN);
-      this._projectedIds[String(shortId)] = taskId;
-      this._taskIdToKey.set(taskId, String(shortId));
-      this._plannedRegistryWrites.push({ key: String(shortId), taskId });
+      const n = allocateMinFreeInt({ ids: this._projectedIds }, this._shortIdLength);
+      const key = padShortId(n, this._shortIdLength);
+      this._projectedIds[key] = taskId;
+      this._taskIdToKey.set(taskId, key);
+      this._plannedRegistryWrites.push({ key, taskId });
       const originalStat = fs.statSync(taskMdPath);
       const originalContent = fs.readFileSync(taskMdPath, "utf8");
       // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
       const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-      if (!existing || existing[1] !== `#${shortId}`) {
+      if (!existing || existing[1] !== `#${key}`) {
         this._plannedTaskMdWrites.push({
           taskMdPath,
           originalContent,
           originalAtime: originalStat.atime,
           originalMtime: originalStat.mtime,
-          shortId: `#${shortId}`,
+          shortId: `#${key}`,
           kind: "caller-alloc"
         });
       }
-      return String(shortId);
+      return key;  // zero-padded; matches registry key
     },
 
     planRelease(taskId) {
@@ -476,6 +509,7 @@ function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
       process.stderr.write(`${e.message}\n`);
       process.exit(1);
     }
+    // shortId is already zero-padded (returned by tx.planAlloc; matches registry key)
     process.stdout.write(`#${shortId}\n`);
   });
 }
@@ -500,23 +534,13 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
 }
 
 function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
-  if (!SHORT_ID_RE.test(shortIdArg)) {
-    process.stderr.write(
-      `Error: invalid short id format '${shortIdArg}'. Use quoted '#N' (e.g. '#1').\n`
-    );
-    process.exit(1);
-  }
-  const n = shortIdArg.slice(1);
-  if (n === "0" || (n.length > 1 && n.startsWith("0"))) {
-    process.stderr.write(
-      `Error: short id '${shortIdArg}' is invalid (#0 is reserved, leading zeros not allowed).\n`
-    );
-    process.exit(1);
-  }
+  // Strict width match + reserved key check; on invalid arg, parseShortIdArg writes full
+  // stderr (including "expected #NN (N-digit zero-padded; e.g. '#01')") and exits 1.
+  const key = parseShortIdArg(shortIdArg, shortIdLength);
   return withRegistryLock(activeDir, () => {
     const registry = readRegistry(registryPath);
     const tx = planTransaction(registry, activeDir, shortIdLength);
-    const taskId = tx._projectedIds[n];
+    const taskId = tx._projectedIds[key];
     if (!taskId) {
       const hasPendingMutations =
         tx._plannedRegistryWrites.length > 0 ||
@@ -532,11 +556,11 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
       }
       if (Object.keys(tx._projectedIds).length === 0) {
         process.stderr.write(
-          `Error: short id '${shortIdArg}' not found; active task registry is empty.\n`
+          `Error: short id '#${key}' not found; active task registry is empty.\n`
         );
       } else {
         process.stderr.write(
-          `Error: short id '${shortIdArg}' not found in active task registry ` +
+          `Error: short id '#${key}' not found in active task registry ` +
             `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
         );
       }
@@ -656,6 +680,8 @@ export {
   writeRegistryAtomic,
   withRegistryLock,
   writeTaskMdShortId,
+  padShortId,
+  parseShortIdArg,
   allocateMinFreeInt,
   planTransaction,
   verifyRegistry,

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -1,0 +1,667 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+const SHORT_ID_RE = /^#\d+$/;
+const REGISTRY_NAME = ".short-ids.json";
+const LOCK_NAME = ".short-ids.json.lock";
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+
+function usage() {
+  return [
+    "Usage: task-short-id.js <subcommand> [args]",
+    "",
+    "Subcommands:",
+    "  alloc <task-id>      Allocate short id for a task; writes registry + short_id to task.md",
+    "  release <task-id>    Release short id (idempotent; exit 0 if not present)",
+    "  resolve <#N>         Resolve short id to full task id",
+    "  list                 Print registry JSON",
+    "  list --verify        Read-only check; exit 1 if active dir / registry / task.md disagree",
+    "",
+    "Options:",
+    "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
+    "  --short-id-length N  Override configured width (default: from .airc.json or 1)"
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = { positional: [], activeDir: null, shortIdLength: null, verify: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--active-dir") {
+      args.activeDir = argv[++i];
+    } else if (a === "--short-id-length") {
+      args.shortIdLength = Number(argv[++i]);
+    } else if (a === "--verify") {
+      args.verify = true;
+    } else if (a === "-h" || a === "--help") {
+      args.help = true;
+    } else if (a.startsWith("--")) {
+      throw new Error(`Unknown option: ${a}`);
+    } else {
+      args.positional.push(a);
+    }
+  }
+  return args;
+}
+
+function findRepoRoot(start) {
+  let dir = path.resolve(start || process.cwd());
+  for (;;) {
+    if (fs.existsSync(path.join(dir, ".agents", ".airc.json"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function readShortIdLength(repoRoot, override) {
+  if (typeof override === "number" && Number.isFinite(override) && override >= 1) {
+    return override;
+  }
+  if (!repoRoot) return 1;
+  try {
+    const cfgPath = path.join(repoRoot, ".agents", ".airc.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    const v = cfg && cfg.task && cfg.task.shortIdLength;
+    if (typeof v === "number" && Number.isFinite(v) && v >= 1) return v;
+  } catch {
+    // ignore
+  }
+  return 1;
+}
+
+function readRegistry(registryPath) {
+  if (!fs.existsSync(registryPath)) {
+    return { version: 1, ids: {} };
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(registryPath, "utf8");
+  } catch (e) {
+    process.stderr.write(`Error: cannot read registry ${registryPath}: ${e.message}\n`);
+    process.exit(2);
+  }
+  try {
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object" || !data.ids || typeof data.ids !== "object") {
+      process.stderr.write(`Error: registry ${registryPath} has invalid schema\n`);
+      process.exit(2);
+    }
+    if (data.version !== 1) data.version = 1;
+    return data;
+  } catch (e) {
+    process.stderr.write(`Error: registry ${registryPath} is not valid JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+}
+
+function writeRegistryAtomic(data, registryPath) {
+  const tmpPath = `${registryPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`);
+  fs.renameSync(tmpPath, registryPath);
+}
+
+function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
+  fs.mkdirSync(activeDir, { recursive: true });
+  const lockDir = path.join(activeDir, LOCK_NAME);
+  const start = Date.now();
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir, { recursive: false });
+      break;
+    } catch (e) {
+      if (e.code !== "EEXIST") throw e;
+      if (Date.now() - start > timeoutMs) {
+        process.stderr.write(`Error: registry lock timeout after ${timeoutMs}ms\n`);
+        process.exit(3);
+      }
+      const elapsed = Date.now() - start;
+      const wait = Math.min(500, 50 * Math.pow(2, Math.floor(elapsed / 200)));
+      const deadline = Date.now() + wait;
+      while (Date.now() < deadline) {
+        /* busy wait, ms-scale */
+      }
+    }
+  }
+  // Register cleanup that runs even on process.exit (which skips try/finally).
+  const cleanup = () => {
+    try {
+      fs.rmdirSync(lockDir);
+    } catch {
+      /* lock-dir already removed */
+    }
+  };
+  process.once("exit", cleanup);
+  try {
+    return fn();
+  } finally {
+    process.removeListener("exit", cleanup);
+    cleanup();
+  }
+}
+
+function writeTaskMdShortId(taskMdPath, shortId) {
+  const content = fs.readFileSync(taskMdPath, "utf8");
+  let updated;
+  if (/^short_id:.*$/m.test(content)) {
+    updated = content.replace(/^short_id:.*$/m, `short_id: ${shortId}`);
+  } else {
+    updated = content.replace(/^(id:.*)$/m, `$1\nshort_id: ${shortId}`);
+  }
+  fs.writeFileSync(taskMdPath, updated);
+}
+
+function allocateMinFreeInt(registry, maxN) {
+  for (let n = 1; n <= maxN; n += 1) {
+    if (!registry.ids[String(n)]) return n;
+  }
+  return null;
+}
+
+function planTransaction(registry, activeDir, shortIdLength) {
+  const maxN = Math.pow(10, shortIdLength) - 1;
+
+  // A1: active task id set
+  const activeTaskIds = new Set(
+    fs
+      .readdirSync(activeDir)
+      .filter((d) => TASK_ID_RE.test(d))
+      .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
+  );
+
+  // A2: stale entries
+  const pendingRegistryDeletes = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) pendingRegistryDeletes.push(key);
+  }
+
+  const projectedIds = { ...registry.ids };
+  for (const key of pendingRegistryDeletes) delete projectedIds[key];
+
+  // A3: duplicate key detection (after stale cleanup)
+  const taskIdToKey = new Map();
+  for (const [key, taskId] of Object.entries(projectedIds)) {
+    if (taskIdToKey.has(taskId)) {
+      const existingKey = taskIdToKey.get(taskId);
+      process.stderr.write(
+        `Error: duplicate registry entries for taskId ${taskId} at keys [#${existingKey}, #${key}]; manual resolution required\n`
+      );
+      process.exit(2);
+    }
+    taskIdToKey.set(taskId, key);
+  }
+
+  // A4: classify each active task
+  const plannedRegistryWrites = [];
+  const plannedTaskMdWrites = [];
+  const pendingAlloc = [];
+
+  for (const taskId of activeTaskIds) {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    const originalStat = fs.statSync(taskMdPath);
+    const originalContent = fs.readFileSync(taskMdPath, "utf8");
+    const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
+
+    if (existing) {
+      const declared = existing[1];
+      const n = declared.slice(1);
+      if (projectedIds[n] === taskId) continue; // 4a
+      if (taskIdToKey.has(taskId)) {
+        const registryKey = taskIdToKey.get(taskId);
+        process.stderr.write(
+          `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
+        );
+        process.exit(2);
+      }
+      if (projectedIds[n] && projectedIds[n] !== taskId) {
+        process.stderr.write(
+          `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
+        );
+        process.exit(2);
+      }
+      // 4d
+      plannedRegistryWrites.push({ key: n, taskId });
+      projectedIds[n] = taskId;
+      taskIdToKey.set(taskId, n);
+      continue;
+    }
+
+    if (taskIdToKey.has(taskId)) {
+      // 4e
+      const registryKey = taskIdToKey.get(taskId);
+      plannedTaskMdWrites.push({
+        taskMdPath,
+        originalContent,
+        originalAtime: originalStat.atime,
+        originalMtime: originalStat.mtime,
+        shortId: `#${registryKey}`,
+        kind: "4e"
+      });
+      continue;
+    }
+
+    // 4f: deferred
+    pendingAlloc.push({
+      taskId,
+      taskMdPath,
+      originalContent,
+      originalAtime: originalStat.atime,
+      originalMtime: originalStat.mtime
+    });
+  }
+
+  // A5: capacity pre-check
+  const availableSlots = maxN - Object.keys(projectedIds).length;
+  if (pendingAlloc.length > availableSlots) {
+    process.stderr.write(
+      `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
+        `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
+        `Archive some active tasks (complete-task / cancel-task / block-task) ` +
+        `or raise task.shortIdLength in .agents/.airc.json.\n`
+    );
+    process.exit(2);
+  }
+
+  pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
+
+  for (const item of pendingAlloc) {
+    const shortId = allocateMinFreeInt({ ids: projectedIds }, maxN);
+    if (shortId === null) {
+      throw new Error("Internal invariant: pendingAlloc capacity check failed");
+    }
+    projectedIds[String(shortId)] = item.taskId;
+    taskIdToKey.set(item.taskId, String(shortId));
+    plannedRegistryWrites.push({ key: String(shortId), taskId: item.taskId });
+    plannedTaskMdWrites.push({
+      taskMdPath: item.taskMdPath,
+      originalContent: item.originalContent,
+      originalAtime: item.originalAtime,
+      originalMtime: item.originalMtime,
+      shortId: `#${shortId}`,
+      kind: "4f"
+    });
+  }
+
+  // Build transaction object
+  const tx = {
+    _registry: registry,
+    _activeDir: activeDir,
+    _registrySnapshot: { ...registry.ids },
+    _pendingRegistryDeletes: pendingRegistryDeletes,
+    _plannedRegistryWrites: plannedRegistryWrites,
+    _plannedTaskMdWrites: plannedTaskMdWrites,
+    _projectedIds: projectedIds,
+    _taskIdToKey: taskIdToKey,
+    _shortIdLength: shortIdLength,
+    _maxN: maxN,
+
+    planAlloc(taskId) {
+      const taskMdPath = path.join(activeDir, taskId, "task.md");
+      if (!fs.existsSync(taskMdPath)) {
+        throw new Error(`planAlloc: task.md not found for ${taskId}`);
+      }
+      if (this._taskIdToKey.has(taskId)) {
+        return this._taskIdToKey.get(taskId);
+      }
+      const inUse = Object.keys(this._projectedIds).length;
+      if (inUse >= this._maxN) {
+        throw new Error(
+          `Error: short id width exhausted (current shortIdLength=${this._shortIdLength}, ` +
+            `${inUse}/${this._maxN} slots in use). Archive some active tasks or raise task.shortIdLength.`
+        );
+      }
+      const shortId = allocateMinFreeInt({ ids: this._projectedIds }, this._maxN);
+      this._projectedIds[String(shortId)] = taskId;
+      this._taskIdToKey.set(taskId, String(shortId));
+      this._plannedRegistryWrites.push({ key: String(shortId), taskId });
+      const originalStat = fs.statSync(taskMdPath);
+      const originalContent = fs.readFileSync(taskMdPath, "utf8");
+      // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
+      const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
+      if (!existing || existing[1] !== `#${shortId}`) {
+        this._plannedTaskMdWrites.push({
+          taskMdPath,
+          originalContent,
+          originalAtime: originalStat.atime,
+          originalMtime: originalStat.mtime,
+          shortId: `#${shortId}`,
+          kind: "caller-alloc"
+        });
+      }
+      return String(shortId);
+    },
+
+    planRelease(taskId) {
+      const key = this._taskIdToKey.get(taskId);
+      if (!key) return; // idempotent
+      this._plannedRegistryWrites = this._plannedRegistryWrites.filter(
+        (w) => w.taskId !== taskId
+      );
+      this._plannedTaskMdWrites = this._plannedTaskMdWrites.filter(
+        (w) => path.basename(path.dirname(w.taskMdPath)) !== taskId
+      );
+      this._pendingRegistryDeletes.push(key);
+      delete this._projectedIds[key];
+      this._taskIdToKey.delete(taskId);
+    },
+
+    commit(registryPath) {
+      // B1: apply registry mutation in memory
+      for (const key of this._pendingRegistryDeletes) delete this._registry.ids[key];
+      for (const { key, taskId } of this._plannedRegistryWrites) {
+        this._registry.ids[key] = taskId;
+      }
+
+      const completedWrites = [];
+      const rollback = (reason) => {
+        for (const done of completedWrites.reverse()) {
+          try {
+            fs.writeFileSync(done.taskMdPath, done.originalContent);
+            fs.utimesSync(done.taskMdPath, done.originalAtime, done.originalMtime);
+          } catch {
+            /* best-effort */
+          }
+        }
+        this._registry.ids = this._registrySnapshot;
+        const tail =
+          completedWrites.length > 0
+            ? `; rolled back ${completedWrites.length} prior task.md write(s)`
+            : "";
+        throw new Error(`${reason}${tail}`);
+      };
+
+      // B2: write task.md per plan
+      for (const write of this._plannedTaskMdWrites) {
+        try {
+          writeTaskMdShortId(write.taskMdPath, write.shortId);
+          completedWrites.push(write);
+        } catch (e) {
+          rollback(`Failed to write short_id to ${write.taskMdPath}: ${e.message}`);
+        }
+      }
+
+      // B3: atomic registry persistence
+      try {
+        writeRegistryAtomic(this._registry, registryPath);
+      } catch (e) {
+        rollback(`Failed to persist registry to ${registryPath}: ${e.message}`);
+      }
+    }
+  };
+
+  return tx;
+}
+
+function verifyRegistry(registry, activeDir) {
+  const activeTaskIds = new Set(
+    fs
+      .readdirSync(activeDir)
+      .filter((d) => TASK_ID_RE.test(d))
+      .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
+  );
+  const registryTaskIds = new Set(Object.values(registry.ids));
+  const taskmdShortIds = new Map();
+  for (const taskId of activeTaskIds) {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    const content = fs.readFileSync(taskMdPath, "utf8");
+    const m = content.match(/^short_id:\s*(#\d+)\s*$/m);
+    taskmdShortIds.set(taskId, m ? m[1] : null);
+  }
+  const missing_in_registry = [];
+  for (const taskId of activeTaskIds) {
+    if (!registryTaskIds.has(taskId)) {
+      missing_in_registry.push({ taskId, declared: taskmdShortIds.get(taskId) });
+    }
+  }
+  const missing_in_taskmd = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) continue;
+    const declared = taskmdShortIds.get(taskId);
+    if (declared === null) {
+      missing_in_taskmd.push({ taskId, expected: `#${key}` });
+    } else if (declared !== `#${key}`) {
+      missing_in_taskmd.push({ taskId, expected: `#${key}`, declared });
+    }
+  }
+  const orphans_in_registry = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!activeTaskIds.has(taskId)) {
+      orphans_in_registry.push({ key: `#${key}`, taskId });
+    }
+  }
+  const taskIdToKeys = new Map();
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    if (!taskIdToKeys.has(taskId)) taskIdToKeys.set(taskId, []);
+    taskIdToKeys.get(taskId).push(key);
+  }
+  const duplicate_registry_keys = [];
+  for (const [taskId, keys] of taskIdToKeys) {
+    if (keys.length > 1) {
+      duplicate_registry_keys.push({ taskId, keys: keys.map((k) => `#${k}`) });
+    }
+  }
+  return {
+    missing_in_registry,
+    missing_in_taskmd,
+    orphans_in_registry,
+    duplicate_registry_keys
+  };
+}
+
+function cmdAlloc(taskId, activeDir, registryPath, shortIdLength) {
+  if (!TASK_ID_RE.test(taskId)) {
+    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const taskMdPath = path.join(activeDir, taskId, "task.md");
+    if (!fs.existsSync(taskMdPath)) {
+      process.stderr.write(`Error: task ${taskId} not found in ${activeDir} (no task.md)\n`);
+      process.exit(1);
+    }
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    let shortId;
+    try {
+      shortId = tx.planAlloc(taskId);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(2);
+    }
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`#${shortId}\n`);
+  });
+}
+
+function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
+  if (!TASK_ID_RE.test(taskId)) {
+    process.stderr.write(`Error: invalid task id format '${taskId}'\n`);
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    tx.planRelease(taskId);
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    // idempotent exit 0
+  });
+}
+
+function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
+  if (!SHORT_ID_RE.test(shortIdArg)) {
+    process.stderr.write(
+      `Error: invalid short id format '${shortIdArg}'. Use quoted '#N' (e.g. '#1').\n`
+    );
+    process.exit(1);
+  }
+  const n = shortIdArg.slice(1);
+  if (n === "0" || (n.length > 1 && n.startsWith("0"))) {
+    process.stderr.write(
+      `Error: short id '${shortIdArg}' is invalid (#0 is reserved, leading zeros not allowed).\n`
+    );
+    process.exit(1);
+  }
+  return withRegistryLock(activeDir, () => {
+    const registry = readRegistry(registryPath);
+    const tx = planTransaction(registry, activeDir, shortIdLength);
+    const taskId = tx._projectedIds[n];
+    if (!taskId) {
+      const hasPendingMutations =
+        tx._plannedRegistryWrites.length > 0 ||
+        tx._pendingRegistryDeletes.length > 0 ||
+        tx._plannedTaskMdWrites.length > 0;
+      if (hasPendingMutations) {
+        try {
+          tx.commit(registryPath);
+        } catch (e) {
+          process.stderr.write(`${e.message}\n`);
+          process.exit(1);
+        }
+      }
+      if (Object.keys(tx._projectedIds).length === 0) {
+        process.stderr.write(
+          `Error: short id '${shortIdArg}' not found; active task registry is empty.\n`
+        );
+      } else {
+        process.stderr.write(
+          `Error: short id '${shortIdArg}' not found in active task registry ` +
+            `(it may have been cleaned up after archival; check 'task-short-id.js list').\n`
+        );
+      }
+      process.exit(1);
+    }
+    try {
+      tx.commit(registryPath);
+    } catch (e) {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${taskId}\n`);
+  });
+}
+
+function cmdList(activeDir, registryPath, verify) {
+  if (!verify) {
+    const registry = readRegistry(registryPath);
+    process.stdout.write(`${JSON.stringify(registry, null, 2)}\n`);
+    return;
+  }
+  const registry = readRegistry(registryPath);
+  if (!fs.existsSync(activeDir)) {
+    process.stdout.write("");
+    return;
+  }
+  const diff = verifyRegistry(registry, activeDir);
+  const hasIssues =
+    diff.missing_in_registry.length > 0 ||
+    diff.missing_in_taskmd.length > 0 ||
+    diff.orphans_in_registry.length > 0 ||
+    diff.duplicate_registry_keys.length > 0;
+  if (hasIssues) {
+    process.stdout.write(`${JSON.stringify(diff, null, 2)}\n`);
+    process.exit(1);
+  }
+  // consistent: empty stdout, exit 0
+}
+
+function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    process.stderr.write(`${e.message}\n${usage()}\n`);
+    process.exit(1);
+  }
+  if (args.help || args.positional.length === 0) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const subcommand = args.positional[0];
+  const repoRoot = findRepoRoot(process.cwd());
+  const activeDir = args.activeDir
+    ? path.resolve(args.activeDir)
+    : repoRoot
+    ? path.join(repoRoot, ".agents", "workspace", "active")
+    : null;
+  if (!activeDir) {
+    process.stderr.write(
+      `Error: cannot locate active dir (no .agents/.airc.json found above ${process.cwd()})\n`
+    );
+    process.exit(2);
+  }
+  const shortIdLength = readShortIdLength(repoRoot, args.shortIdLength);
+  const registryPath = path.join(activeDir, REGISTRY_NAME);
+
+  switch (subcommand) {
+    case "alloc":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: alloc <task-id>\n`);
+        process.exit(1);
+      }
+      return cmdAlloc(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "release":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: release <task-id>\n`);
+        process.exit(1);
+      }
+      return cmdRelease(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "resolve":
+      if (!args.positional[1]) {
+        process.stderr.write(`Usage: resolve <#N>\n`);
+        process.exit(1);
+      }
+      return cmdResolve(args.positional[1], activeDir, registryPath, shortIdLength);
+    case "list":
+      return cmdList(activeDir, registryPath, args.verify);
+    default:
+      process.stderr.write(`Unknown subcommand: ${subcommand}\n${usage()}\n`);
+      process.exit(1);
+  }
+}
+
+const isCli = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCli) {
+  main(process.argv.slice(2));
+}
+
+export {
+  TASK_ID_RE,
+  SHORT_ID_RE,
+  REGISTRY_NAME,
+  parseArgs,
+  findRepoRoot,
+  readShortIdLength,
+  readRegistry,
+  writeRegistryAtomic,
+  withRegistryLock,
+  writeTaskMdShortId,
+  allocateMinFreeInt,
+  planTransaction,
+  verifyRegistry,
+  cmdAlloc,
+  cmdRelease,
+  cmdResolve,
+  cmdList,
+  main
+};

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -27,6 +27,24 @@ tail .agents/workspace/active/{task-id}/task.md
 
 Before the state check is complete, do not make external-state assertions such as "the code is unchanged", "tests passed", or "there are no other references", including in reasoning. This gate is only a structural floor; evidence pairing and authenticity still require the report template and review discipline.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -29,21 +29,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -27,8 +27,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 检查必要文件：

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -29,21 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -21,21 +21,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -19,6 +19,24 @@ description: "Mark a task as blocked and record the reason"
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -79,6 +97,12 @@ If a valid `issue_number` exists, set `status: blocked` by following issue-sync.
 
 ### 7. Verification Gate
 
+**Release short id** (after the directory has already been moved; the script is idempotent and returns 0 even if the task isn't registered):
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -115,6 +139,8 @@ Next step - check task status after unblocking:
   - Gemini CLI: /{{project}}:check-task {task-id}
   - Codex CLI: $check-task {task-id}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -21,21 +21,7 @@ description: "标记任务为阻塞状态并记录原因"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -19,8 +19,25 @@ description: "标记任务为阻塞状态并记录原因"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 检查任务是否存在于 `.agents/workspace/active/{task-id}/`。
@@ -79,6 +96,12 @@ ls .agents/workspace/blocked/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -115,6 +138,8 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
   - Gemini CLI：/agent-infra:check-task {task-id}
   - Codex CLI：$check-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -15,21 +15,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -13,6 +13,24 @@ description: "Cancel an unneeded task and move it"
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -92,6 +110,12 @@ The cancellation comment must include at least:
 
 ### 7. Verification Gate
 
+**Release short id** (after the directory has already been moved; the script is idempotent and returns 0 even if the task isn't registered):
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 Run the verification gate to confirm the moved task and sync state are valid:
 
 ```bash
@@ -124,6 +148,8 @@ Next step - inspect the moved task:
   - Gemini CLI: /{{project}}:check-task {task-id}
   - Codex CLI: $check-task {task-id}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -15,21 +15,7 @@ description: "取消不再需要的任务并转移"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -13,8 +13,25 @@ description: "取消不再需要的任务并转移"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 依次检查以下目录：
@@ -92,6 +109,12 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务转移和同步状态符合规范：
 
 ```bash
@@ -124,6 +147,8 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
   - Gemini CLI：/{{project}}:check-task {task-id}
   - Codex CLI：$check-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/check-task/SKILL.en.md
+++ b/templates/.agents/skills/check-task/SKILL.en.md
@@ -10,6 +10,24 @@ description: "Check a task's current status and progress"
 - This skill is **read-only** -- do not modify any files
 - Always check the active, blocked, and completed directories
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Locate Task

--- a/templates/.agents/skills/check-task/SKILL.en.md
+++ b/templates/.agents/skills/check-task/SKILL.en.md
@@ -12,21 +12,7 @@ description: "Check a task's current status and progress"
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/check-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/check-task/SKILL.zh-CN.md
@@ -12,21 +12,7 @@ description: "查看任务的当前状态和进度"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 查找任务

--- a/templates/.agents/skills/check-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/check-task/SKILL.zh-CN.md
@@ -10,8 +10,25 @@ description: "查看任务的当前状态和进度"
 - 本技能是**只读**操作 —— 不修改任何文件
 - 始终检查 active、blocked 和 completed 目录
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 查找任务
 
 按以下优先顺序搜索任务：

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -7,6 +7,24 @@ description: "Close a Code Scanning alert with a documented reason"
 
 Dismiss the specified Code Scanning (CodeQL) alert and record a justified reason.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### 1. Retrieve Alert Information
@@ -81,6 +99,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
+- **Release short id** (after the archive `mv` succeeded; the script is idempotent):
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. Inform User
 
@@ -117,3 +140,5 @@ Next step - complete and archive the task if a related task exists:
 - Already closed: output "Alert #{number} is already {state}"
 - Permission error: output "No permission to modify alerts"
 - User canceled: output "Cancellation acknowledged"
+
+

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -9,21 +9,7 @@ Dismiss the specified Code Scanning (CodeQL) alert and record a justified reason
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -9,21 +9,7 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -7,6 +7,24 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 关闭指定的 Code Scanning（CodeQL）告警并记录合理的关闭理由。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -81,6 +99,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
+- **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. 告知用户
 
@@ -117,3 +140,5 @@ Code Scanning 告警 #{alert-number} 已关闭。
 - 已关闭：提示 "Alert #{number} is already {state}"
 - 权限错误：提示 "No permission to modify alerts"
 - 用户取消：提示 "Cancellation acknowledged"
+
+

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -9,21 +9,7 @@ Dismiss the specified Dependabot security alert and record a justified reason.
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -7,6 +7,24 @@ description: "Close a Dependabot alert with a documented reason"
 
 Dismiss the specified Dependabot security alert and record a justified reason.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### 1. Retrieve Alert Information
@@ -89,6 +107,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
+- **Release short id** (after the archive `mv` succeeded; the script is idempotent):
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. Inform User
 
@@ -125,3 +148,5 @@ Next step - complete and archive the task if a related task exists:
 - Already closed: output "Alert #{number} is already {state}"
 - Permission error: output "No permission to modify alerts"
 - User canceled: output "Cancellation acknowledged"
+
+

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -7,6 +7,24 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 关闭指定的 Dependabot 安全告警并记录合理的关闭理由。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -89,6 +107,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
+- **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：
+
+  ```bash
+  node .agents/scripts/task-short-id.js release "$task_id" || true
+  ```
 
 ### 8. 告知用户
 
@@ -125,3 +148,5 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 已关闭：提示 "Alert #{number} is already {state}"
 - 权限错误：提示 "No permission to modify alerts"
 - 用户取消：提示 "Cancellation acknowledged"
+
+

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -9,21 +9,7 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -29,6 +29,24 @@ ls -la .agents/workspace/active/{task-id}/
 tail .agents/workspace/active/{task-id}/task.md
 ```
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -31,21 +31,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -42,8 +42,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 先检查：

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -44,21 +44,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -17,6 +17,24 @@ When updating related `task.md` frontmatter, read `.agents/rules/version-stamp.m
 | "`git add -A` is faster." | `git add -A` and `git add .` are forbidden; stage only explicitly listed files to avoid including unrelated changes. |
 | "This file has a copyright header, but the year can wait." | If you changed it, update the copyright year using `date +%Y`; this is a hard pre-commit check. |
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## 1. Check Local Modifications (CRITICAL)
 
 Before any edit, inspect:

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -19,21 +19,7 @@ When updating related `task.md` frontmatter, read `.agents/rules/version-stamp.m
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## 1. Check Local Modifications (CRITICAL)
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -19,21 +19,7 @@ description: "提交当前变更到 Git"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 1. 检查本地修改（关键）
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -17,6 +17,24 @@ description: "提交当前变更到 Git"
 | 「`git add -A` 更省事」 | 禁止 `git add -A`/`git add .`；只暂存明确列出的文件，避免带入无关改动。 |
 | 「改了带版权头的文件，年份先不动」 | 改了就更新版权年份（动态取 `date +%Y`），这是提交前的硬性检查。 |
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 1. 检查本地修改（关键）
 
 在任何编辑前先检查：

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -28,21 +28,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -26,6 +26,24 @@ tail .agents/workspace/active/{task-id}/task.md
 
 Before the state check is complete, do not make external-state assertions such as "the code is unchanged", "tests passed", or "there are no other references", including in reasoning. This gate is only a structural floor; evidence pairing and authenticity still require the report template and review discipline.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Task Exists
@@ -119,6 +137,12 @@ If a valid `issue_number` exists:
 
 ### 7. Verification Gate
 
+**Release short id** (after the directory has already been moved; the script is idempotent and returns 0 even if the task isn't registered):
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -148,6 +172,8 @@ Task info:
 Deliverables:
 - {List of key outputs: files modified, tests added, etc.}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -26,8 +26,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证任务存在
 
 检查任务是否存在于 `.agents/workspace/active/{task-id}/`。
@@ -119,6 +136,12 @@ ls .agents/workspace/completed/{task-id}/task.md
 
 ### 7. 完成校验
 
+**释放短号**（先 `mv` 目录已成功，再 release；脚本幂等，未在注册表也返回 0）：
+
+```bash
+node .agents/scripts/task-short-id.js release "$task_id" || true
+```
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -148,6 +171,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -28,21 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -11,6 +11,24 @@ Create a Pull Request and, when task-related, sync the essential metadata and re
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### Pre-gate: Project-level PR Flow Check

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -13,21 +13,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -13,21 +13,7 @@ description: "创建 Pull Request 到目标分支"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -11,6 +11,24 @@ description: "创建 Pull Request 到目标分支"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 前置门控：项目级 PR 流程检查

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -22,6 +22,24 @@ After executing this skill, you **must** immediately update task status in task.
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Parse the User Description
@@ -126,6 +144,14 @@ Handle the result:
 
 ### 5. Verification Gate
 
+**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+If this fails (non-zero exit), follow the message — archive some active tasks or raise `task.shortIdLength` — and do NOT continue.
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -209,6 +235,8 @@ Next step - run requirements analysis:
 
 For later platform sync: after fixing auth / network / template issues, manually run the Issue creation flow in `.agents/rules/create-issue.md` for this task; or manually create/find an Issue and write `issue_number` into task.md so later skills can take over cascade sync.
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -24,21 +24,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -22,8 +22,25 @@ description: "根据自然语言描述创建任务"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 解析用户描述
 
 从自然语言描述中提取：
@@ -126,6 +143,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 5. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -209,6 +234,8 @@ Issue 创建失败：
 
 后续如需平台同步：修复认证/网络/模板问题后，可按 `.agents/rules/create-issue.md` 对当前任务手动执行一次 Issue 创建；或手动创建/查找 Issue，并把 `issue_number` 写入 task.md，后续技能会接管级联同步。
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -24,21 +24,7 @@ description: "根据自然语言描述创建任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 解析用户描述

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -15,21 +15,7 @@ Import the specified Code Scanning (CodeQL) alert and create a remediation task.
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -13,6 +13,24 @@ Import the specified Code Scanning (CodeQL) alert and create a remediation task.
 - Do NOT auto-commit. Never execute `git commit` or `git add` automatically
 - After executing this skill, you **must** immediately update task status in task.md
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### 1. Retrieve Alert Information
@@ -58,6 +76,14 @@ Update task.md: `current_step` -> `requirement-analysis`.
 
 ### 4. Verification Gate
 
+**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+If this fails (non-zero exit), follow the message — archive some active tasks or raise `task.shortIdLength` — and do NOT continue.
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -93,6 +119,8 @@ Next step:
   - Gemini CLI: /{{project}}:analyze-task {task-id}
   - Codex CLI: $analyze-task {task-id}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -13,6 +13,24 @@ description: "导入 Code Scanning 告警并创建修复任务"
 - 不要自动提交。绝不自动执行 `git commit` 或 `git add`
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -58,6 +76,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -93,6 +119,8 @@ Code Scanning 告警 #{alert-number} 已导入。
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -15,21 +15,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -13,6 +13,24 @@ Import the specified Dependabot security alert and create a remediation task.
 - Do NOT auto-commit. Never execute `git commit` or `git add` automatically
 - After executing this skill, you **must** immediately update task status in task.md
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### 1. Retrieve Alert Information
@@ -59,6 +77,14 @@ Update task.md: `current_step` -> `requirement-analysis`.
 
 ### 4. Verification Gate
 
+**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+If this fails (non-zero exit), follow the message — archive some active tasks or raise `task.shortIdLength` — and do NOT continue.
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -97,6 +123,8 @@ Next step:
   - Gemini CLI: /{{project}}:analyze-task {task-id}
   - Codex CLI: $analyze-task {task-id}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -15,21 +15,7 @@ Import the specified Dependabot security alert and create a remediation task.
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -15,21 +15,7 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -13,6 +13,24 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 - 不要自动提交。绝不自动执行 `git commit` 或 `git add`
 - 执行本技能后，你**必须**立即更新 task.md 中的任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取告警信息
@@ -59,6 +77,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -97,6 +123,8 @@ node .agents/scripts/validate-artifact.js gate import-dependabot .agents/workspa
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -13,6 +13,24 @@ Import the specified Issue and create a task. Argument: issue number.
 - Do not write or modify business code; import only
 - After executing this skill, you **must** immediately update task status
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Execution Flow
 
 ### 1. Retrieve Issue Information
@@ -119,6 +137,14 @@ If task.md contains a valid `issue_number`, perform these sync actions (skip and
 
 ### 7. Verification Gate
 
+**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+If this fails (non-zero exit), follow the message — archive some active tasks or raise `task.shortIdLength` — and do NOT continue.
+
 Run the verification gate to confirm the task artifact and sync state are valid:
 
 ```bash
@@ -154,6 +180,8 @@ Next step - run requirements analysis:
   - Gemini CLI: /{{project}}:analyze-task {task-id}
   - Codex CLI: $analyze-task {task-id}
 ```
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -15,21 +15,7 @@ Import the specified Issue and create a task. Argument: issue number.
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -13,6 +13,24 @@ description: "从 Issue 导入并创建任务"
 - 不要编写或修改业务代码。仅做导入
 - 执行本技能后，你**必须**立即更新任务状态
 
+## 任务入参短号别名
+
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
 ## 执行流程
 
 ### 1. 获取 Issue 信息
@@ -119,6 +137,14 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 7. 完成校验
 
+**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
+如失败（退出码非 0），按提示「归档若干任务」或「调高 task.shortIdLength」处理；不要继续执行后续步骤。
+
 运行完成校验，确认任务产物和同步状态符合规范：
 
 ```bash
@@ -154,6 +180,8 @@ Issue #{number} 已导入。
   - Gemini CLI：/agent-infra:analyze-task {task-id}
   - Codex CLI：$analyze-task {task-id}
 ```
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -15,21 +15,7 @@ description: "从 Issue 导入并创建任务"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -27,6 +27,24 @@ tail .agents/workspace/active/{task-id}/task.md
 
 Before the state check is complete, do not make external-state assertions such as "the code is unchanged", "tests passed", or "there are no other references", including in reasoning. This gate is only a structural floor; evidence pairing and authenticity still require the report template and review discipline.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -29,21 +29,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -27,8 +27,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 检查必要文件：

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -29,21 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -18,21 +18,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -16,6 +16,24 @@ Restore local task workspace files from platform Issue comments that contain syn
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Input and Environment
@@ -90,9 +108,17 @@ Update the restored `task.md`:
 
 Append an Activity Log entry indicating the task was restored from the platform Issue.
 
+**Re-allocate short id** (the task directory is back under `active/`; alloc a new `#N`, which may differ from the pre-archival value):
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
 ### 7. Inform User
 
 Report the restored task id, restored file count, and the active task directory.
+
+
 
 ## Completion Checklist
 

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -18,21 +18,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证输入与环境

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -16,8 +16,25 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证输入与环境
 
 检查：
@@ -90,9 +107,17 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 追加 Activity Log，说明任务已从平台 Issue 还原。
 
+**重新分配短号**（已把任务目录写回 `active/`，需要在锁内重新 alloc；新短号可能与归档前不同）：
+
+```bash
+node .agents/scripts/task-short-id.js alloc "$task_id"
+```
+
 ### 7. 告知用户
 
 报告已恢复的 task id、恢复文件数量和 active task 目录。
+
+
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -28,21 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -26,6 +26,24 @@ ls -la .agents/workspace/active/{task-id}/
 tail .agents/workspace/active/{task-id}/task.md
 ```
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -30,21 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -28,8 +28,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -38,21 +38,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -36,6 +36,24 @@ tail .agents/workspace/active/{task-id}/task.md
 
 Before the state check is complete, do not make external-state assertions such as "the code is unchanged", "tests passed", or "there are no other references", including in reasoning. This gate is only a structural floor; evidence pairing and authenticity still require the report template and review discipline.
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -36,8 +36,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言（例如“代码没变”“测试已通过”“没有其他引用”），包括思考阶段。本门禁只提供结构下限；逐条证据配对和真实性仍需按报告模板与审查要求核对。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -38,21 +38,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -28,21 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -26,6 +26,24 @@ ls -la .agents/workspace/active/{task-id}/
 tail .agents/workspace/active/{task-id}/task.md
 ```
 
+## Task id short ref
+
+If the `{task-id}` argument begins with `#` (e.g. `#1`, `#7`), resolve the short ref to a full task id first:
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+Treat `{task-id}` as `$task_id` in every downstream command (the full `TASK-YYYYMMDD-HHMMSS` form). Short ids are only valid inside the active task set; see `.agents/rules/task-short-id.md` for the lifecycle and the SKILL-vs-sandbox scope split.
+
 ## Steps
 
 ### 1. Verify Prerequisites

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -30,21 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
-
-```bash
-if [[ "{task-id}" == "#"* ]]; then
-  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
-    echo "Error: short id '{task-id}' not found in active task registry" >&2
-    exit 1
-  }
-  task_id="$resolved"
-else
-  task_id="{task-id}"
-fi
-```
-
-后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -28,8 +28,25 @@ tail .agents/workspace/active/{task-id}/task.md
 
 状态核对完成前，禁止任何关于外部状态的断言。
 
-## 执行步骤
+## 任务入参短号别名
 
+如果用户传入的 `{task-id}` 入参以 `#` 开头（如 `#1`、`#7`），先调用解析器把短号翻译为完整 task ID：
+
+```bash
+if [[ "{task-id}" == "#"* ]]; then
+  resolved=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || {
+    echo "Error: short id '{task-id}' not found in active task registry" >&2
+    exit 1
+  }
+  task_id="$resolved"
+else
+  task_id="{task-id}"
+fi
+```
+
+后续所有命令把 `{task-id}` 视作 `$task_id`（已是完整 `TASK-YYYYMMDD-HHMMSS` 形式）。短号仅在 active 域内有效；其语义、生命周期与 `#N` vs `TASK-…` 的作用域二分见 `.agents/rules/task-short-id.md`。
+
+## 执行步骤
 ### 1. 验证前置条件
 
 要求存在：

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -43,7 +43,7 @@ const DEFAULTS = {
     }
   },
   "task": {
-    "shortIdLength": 1
+    "shortIdLength": 2
   },
   "labels": {
     "in": {}

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -42,6 +42,9 @@ const DEFAULTS = {
       "disk": null
     }
   },
+  "task": {
+    "shortIdLength": 1
+  },
   "labels": {
     "in": {}
   },

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -7,6 +7,7 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # Current agent-infra version; refreshed by workflow commands
+short_id:                       # Allocated by create-task / import-* in active window; kept as historical value after archival
 priority:                       # Optional Issue field: Urgent | High | Medium | Low
 effort:                         # Optional Issue field: High | Medium | Low
 start_date:                     # Optional Issue field for Feature: YYYY-MM-DD

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -7,6 +7,7 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
+short_id:                       # 由 create-task / import-* 在 active 期内写入；归档后保留历史值
 priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
 effort:                         # 可选 Issue 字段：High | Medium | Low
 start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -873,6 +873,83 @@ test("sandbox list-running resolveTaskShortRef rejects when running row has empt
   );
 });
 
+test("sandbox list-running resolveTaskShortRef hits registry and returns task.md branch", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtsr-hit-"));
+  fs.mkdirSync(path.join(tmp, ".agents", "scripts"), { recursive: true });
+  fs.copyFileSync(
+    path.resolve(process.cwd(), "templates/.agents/scripts/task-short-id.js"),
+    path.join(tmp, ".agents", "scripts", "task-short-id.js")
+  );
+  fs.writeFileSync(path.join(tmp, ".agents", ".airc.json"), JSON.stringify({ task: { shortIdLength: 1 } }));
+  const taskId = "TASK-20250301-000001";
+  const active = path.join(tmp, ".agents", "workspace", "active");
+  fs.mkdirSync(path.join(active, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(active, taskId, "task.md"),
+    `---\nid: ${taskId}\nbranch: registry-branch\n---\n`
+  );
+  // Seed registry so resolve('#1') hits.
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId } })
+  );
+  const running = [
+    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
+  ];
+  // Registry-hit must win over the ls index.
+  assert.equal(resolveTaskShortRef("#1", { running, repoRoot: tmp }), "registry-branch");
+});
+
+test("sandbox list-running resolveTaskShortRef throws when registry hits but branch metadata missing (M-1)", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtsr-corrupt-"));
+  fs.mkdirSync(path.join(tmp, ".agents", "scripts"), { recursive: true });
+  fs.copyFileSync(
+    path.resolve(process.cwd(), "templates/.agents/scripts/task-short-id.js"),
+    path.join(tmp, ".agents", "scripts", "task-short-id.js")
+  );
+  fs.writeFileSync(path.join(tmp, ".agents", ".airc.json"), JSON.stringify({ task: { shortIdLength: 1 } }));
+  const taskId = "TASK-20250301-000002";
+  const active = path.join(tmp, ".agents", "workspace", "active");
+  fs.mkdirSync(path.join(active, taskId), { recursive: true });
+  // task.md exists but has no branch field
+  fs.writeFileSync(
+    path.join(active, taskId, "task.md"),
+    `---\nid: ${taskId}\n---\n# no branch field\n`
+  );
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId } })
+  );
+  const running = [
+    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
+  ];
+  // Registry hit but corrupt → MUST throw, NOT fall back to running[0].branch.
+  assert.throws(
+    () => resolveTaskShortRef("#1", { running, repoRoot: tmp }),
+    /no branch field/
+  );
+});
+
+test("sandbox list-running resolveTaskShortRef falls back to ls index on registry miss", async () => {
+  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtsr-miss-"));
+  fs.mkdirSync(path.join(tmp, ".agents", "scripts"), { recursive: true });
+  fs.copyFileSync(
+    path.resolve(process.cwd(), "templates/.agents/scripts/task-short-id.js"),
+    path.join(tmp, ".agents", "scripts", "task-short-id.js")
+  );
+  fs.writeFileSync(path.join(tmp, ".agents", ".airc.json"), JSON.stringify({ task: { shortIdLength: 1 } }));
+  // Empty registry; no active tasks → resolve('#1') misses.
+  fs.mkdirSync(path.join(tmp, ".agents", "workspace", "active"), { recursive: true });
+  const running = [
+    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
+  ];
+  // Should fall back to the ls index (preserves #414 behaviour).
+  assert.equal(resolveTaskShortRef("#1", { running, repoRoot: tmp }), "ls-branch");
+});
+
 test("sandbox ls parseLabels parses docker label CSV", async () => {
   const { parseLabels } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
 

--- a/tests/unit/cli/task-resolver.test.ts
+++ b/tests/unit/cli/task-resolver.test.ts
@@ -12,7 +12,7 @@ const SCRIPT = path.resolve(
   "templates/.agents/scripts/task-short-id.js"
 );
 
-function mkFixtureRepo(): { repoRoot: string; activeDir: string } {
+function mkFixtureRepo(shortIdLength: number = 1): { repoRoot: string; activeDir: string } {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tr-"));
   const agentsDir = path.join(repoRoot, ".agents");
   const scriptsDir = path.join(agentsDir, "scripts");
@@ -20,7 +20,7 @@ function mkFixtureRepo(): { repoRoot: string; activeDir: string } {
   fs.copyFileSync(SCRIPT, path.join(scriptsDir, "task-short-id.js"));
   fs.writeFileSync(
     path.join(agentsDir, ".airc.json"),
-    JSON.stringify({ task: { shortIdLength: 1 } })
+    JSON.stringify({ task: { shortIdLength } })
   );
   const activeDir = path.join(agentsDir, "workspace", "active");
   fs.mkdirSync(activeDir, { recursive: true });
@@ -42,9 +42,12 @@ test("resolveTaskBranch passes #N through registry and resolves branch (C3 regre
   const branch = "feature-test-branch";
   writeTask(activeDir, taskId, branch);
 
-  // Allocate short id via the script.
+  // Allocate short id via the script. Set cwd to repoRoot so the script reads
+  // the fixture's .airc.json (shortIdLength: 1) rather than walking up to the
+  // host project, whose .airc.json may not pin task.shortIdLength.
   const alloc = spawnSync("node", [SCRIPT, "alloc", taskId, "--active-dir", activeDir], {
-    encoding: "utf8"
+    encoding: "utf8",
+    cwd: repoRoot
   });
   assert.equal(alloc.status, 0, `alloc failed: ${alloc.stderr}`);
   assert.equal(alloc.stdout.trim(), "#1");
@@ -72,4 +75,23 @@ test("resolveTaskBranch on full TASK id is unchanged (no regression)", () => {
 test("resolveTaskBranch on non-task arg is identity", () => {
   const { repoRoot } = mkFixtureRepo();
   assert.equal(resolveTaskBranch("just-a-branch-name", repoRoot), "just-a-branch-name");
+});
+
+test("resolveTaskBranch with shortIdLength=2 hits on '#01' and rejects width-mismatched '#1'", () => {
+  const { repoRoot, activeDir } = mkFixtureRepo(2);
+  const taskId = "TASK-20260301-000001";
+  const branch = "feature-zero-padded";
+  writeTask(activeDir, taskId, branch);
+
+  const alloc = spawnSync("node", [SCRIPT, "alloc", taskId, "--active-dir", activeDir], {
+    encoding: "utf8",
+    cwd: repoRoot
+  });
+  assert.equal(alloc.status, 0, `alloc failed: ${alloc.stderr}`);
+  assert.equal(alloc.stdout.trim(), "#01");
+
+  // '#01' hits.
+  assert.equal(resolveTaskBranch("#01", repoRoot), branch);
+  // '#1' is a width error under shortIdLength=2.
+  assert.throws(() => resolveTaskBranch("#1", repoRoot), /expected #NN|not found in active task registry/);
 });

--- a/tests/unit/cli/task-resolver.test.ts
+++ b/tests/unit/cli/task-resolver.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveTaskBranch } from "../../../lib/sandbox/task-resolver.ts";
+
+const SCRIPT = path.resolve(
+  process.cwd(),
+  "templates/.agents/scripts/task-short-id.js"
+);
+
+function mkFixtureRepo(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tr-"));
+  const agentsDir = path.join(repoRoot, ".agents");
+  const scriptsDir = path.join(agentsDir, "scripts");
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(scriptsDir, "task-short-id.js"));
+  fs.writeFileSync(
+    path.join(agentsDir, ".airc.json"),
+    JSON.stringify({ task: { shortIdLength: 1 } })
+  );
+  const activeDir = path.join(agentsDir, "workspace", "active");
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTask(activeDir: string, taskId: string, branch: string): void {
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "task.md"),
+    `---\nid: ${taskId}\nbranch: ${branch}\n---\n# body\n`
+  );
+}
+
+test("resolveTaskBranch passes #N through registry and resolves branch (C3 regression)", () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  const taskId = "TASK-20250201-000001";
+  const branch = "feature-test-branch";
+  writeTask(activeDir, taskId, branch);
+
+  // Allocate short id via the script.
+  const alloc = spawnSync("node", [SCRIPT, "alloc", taskId, "--active-dir", activeDir], {
+    encoding: "utf8"
+  });
+  assert.equal(alloc.status, 0, `alloc failed: ${alloc.stderr}`);
+  assert.equal(alloc.stdout.trim(), "#1");
+
+  // Resolver should now translate #1 → branch.
+  const resolved = resolveTaskBranch("#1", repoRoot);
+  assert.equal(resolved, branch);
+});
+
+test("resolveTaskBranch throws for #N not in registry (C4 strict mode)", () => {
+  const { repoRoot } = mkFixtureRepo();
+  // No active tasks: nothing for cold-start to allocate; #1 truly absent.
+  assert.throws(() => resolveTaskBranch("#1", repoRoot), /not found/);
+});
+
+test("resolveTaskBranch on full TASK id is unchanged (no regression)", () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  const taskId = "TASK-20250201-000003";
+  const branch = "another-branch";
+  writeTask(activeDir, taskId, branch);
+
+  assert.equal(resolveTaskBranch(taskId, repoRoot), branch);
+});
+
+test("resolveTaskBranch on non-task arg is identity", () => {
+  const { repoRoot } = mkFixtureRepo();
+  assert.equal(resolveTaskBranch("just-a-branch-name", repoRoot), "just-a-branch-name");
+});

--- a/tests/unit/scripts/task-short-id.test.ts
+++ b/tests/unit/scripts/task-short-id.test.ts
@@ -74,28 +74,74 @@ function run(
   return spawnSync("node", [SCRIPT, ...args], { encoding: "utf8", cwd });
 }
 
-test("alloc and release reuse minimal free integer", () => {
+// Tests that use the single-digit semantics (#1, #2, …) explicitly request
+// shortIdLength=1 to remain independent of the project default (now 2).
+function runW1(args: string[]): SpawnSyncReturns<string> {
+  return run([...args, "--short-id-length", "1"]);
+}
+
+// Tests that exercise the zero-padded default (#01, #02, …) explicitly pin
+// shortIdLength=2 to be robust against future default changes.
+function runW2(args: string[]): SpawnSyncReturns<string> {
+  return run([...args, "--short-id-length", "2"]);
+}
+
+test("alloc and release reuse minimal free integer (shortIdLength=1)", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
   mkTask(active, "TASK-20250101-000001");
   mkTask(active, "TASK-20250101-000002");
 
-  const r1 = run(["alloc", "TASK-20250101-000001", "--active-dir", active]);
+  const r1 = runW1(["alloc", "TASK-20250101-000001", "--active-dir", active]);
   assert.equal(r1.status, 0);
   assert.equal(r1.stdout.trim(), "#1");
 
-  const r2 = run(["alloc", "TASK-20250101-000002", "--active-dir", active]);
+  const r2 = runW1(["alloc", "TASK-20250101-000002", "--active-dir", active]);
   assert.equal(r2.status, 0);
   assert.equal(r2.stdout.trim(), "#2");
 
-  const r3 = run(["release", "TASK-20250101-000001", "--active-dir", active]);
+  const r3 = runW1(["release", "TASK-20250101-000001", "--active-dir", active]);
   assert.equal(r3.status, 0);
 
   // Reallocating after release should reuse #1.
-  const r4 = run(["alloc", "TASK-20250101-000001", "--active-dir", active]);
+  const r4 = runW1(["alloc", "TASK-20250101-000001", "--active-dir", active]);
   assert.equal(r4.status, 0);
   assert.equal(r4.stdout.trim(), "#1");
+});
+
+test("alloc and release with default shortIdLength=2 emit zero-padded short ids", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  mkTask(active, "TASK-20260101-000001");
+  mkTask(active, "TASK-20260101-000002");
+
+  const r1 = runW2(["alloc", "TASK-20260101-000001", "--active-dir", active]);
+  assert.equal(r1.status, 0);
+  assert.equal(r1.stdout.trim(), "#01");
+
+  const r2 = runW2(["alloc", "TASK-20260101-000002", "--active-dir", active]);
+  assert.equal(r2.status, 0);
+  assert.equal(r2.stdout.trim(), "#02");
+
+  // task.md and registry must both store the zero-padded form.
+  const md1 = fs.readFileSync(path.join(active, "TASK-20260101-000001", "task.md"), "utf8");
+  assert.match(md1, /^short_id: #01$/m);
+  const registry = JSON.parse(fs.readFileSync(path.join(active, ".short-ids.json"), "utf8"));
+  assert.deepEqual(registry.ids, {
+    "01": "TASK-20260101-000001",
+    "02": "TASK-20260101-000002"
+  });
+
+  // resolve must accept the zero-padded form and reject the unpadded form.
+  const hit = runW2(["resolve", "#01", "--active-dir", active]);
+  assert.equal(hit.status, 0);
+  assert.equal(hit.stdout.trim(), "TASK-20260101-000001");
+
+  const widthErr = runW2(["resolve", "#1", "--active-dir", active]);
+  assert.equal(widthErr.status, 1, `stderr=${widthErr.stderr}`);
+  assert.match(widthErr.stderr, /expected #NN \(2-digit zero-padded/);
 });
 
 test("release is idempotent (exit 0 when no entry; m-1)", () => {
@@ -104,42 +150,56 @@ test("release is idempotent (exit 0 when no entry; m-1)", () => {
   fs.mkdirSync(active, { recursive: true });
   mkTask(active, "TASK-20250101-000003");
 
-  const r = run(["release", "TASK-20250101-000003", "--active-dir", active]);
+  const r = runW1(["release", "TASK-20250101-000003", "--active-dir", active]);
   assert.equal(r.status, 0, `stderr=${r.stderr}`);
 });
 
-test("resolve returns task id on hit; error on miss", () => {
+test("resolve returns task id on hit; error on miss (shortIdLength=1)", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
   mkTask(active, "TASK-20250101-000010");
 
-  run(["alloc", "TASK-20250101-000010", "--active-dir", active]);
-  const hit = run(["resolve", "#1", "--active-dir", active]);
+  runW1(["alloc", "TASK-20250101-000010", "--active-dir", active]);
+  const hit = runW1(["resolve", "#1", "--active-dir", active]);
   assert.equal(hit.status, 0);
   assert.equal(hit.stdout.trim(), "TASK-20250101-000010");
 
-  const miss = run(["resolve", "#9", "--active-dir", active]);
+  const miss = runW1(["resolve", "#9", "--active-dir", active]);
   assert.equal(miss.status, 1);
   assert.match(miss.stderr, /not found/);
 });
 
-test("resolve rejects #0, leading-zero, malformed input", () => {
+test("resolve rejects reserved key, width mismatch, malformed input", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
 
-  const zero = run(["resolve", "#0", "--active-dir", active]);
-  assert.equal(zero.status, 1);
-  assert.match(zero.stderr, /reserved/);
+  // shortIdLength=1: #0 reserved; #abc malformed; #01 width mismatch.
+  const zero1 = runW1(["resolve", "#0", "--active-dir", active]);
+  assert.equal(zero1.status, 1);
+  assert.match(zero1.stderr, /reserved/);
 
-  const leading = run(["resolve", "#01", "--active-dir", active]);
-  assert.equal(leading.status, 1);
-  assert.match(leading.stderr, /reserved|leading/);
+  const widthErrW1 = runW1(["resolve", "#01", "--active-dir", active]);
+  assert.equal(widthErrW1.status, 1);
+  assert.match(widthErrW1.stderr, /expected #N \(1-digit zero-padded/);
 
-  const bad = run(["resolve", "#abc", "--active-dir", active]);
+  const bad = runW1(["resolve", "#abc", "--active-dir", active]);
   assert.equal(bad.status, 1);
   assert.match(bad.stderr, /invalid short id format/);
+
+  // shortIdLength=2: #00 reserved; #1 width mismatch; #001 width mismatch.
+  const zero2 = runW2(["resolve", "#00", "--active-dir", active]);
+  assert.equal(zero2.status, 1);
+  assert.match(zero2.stderr, /reserved/);
+
+  const widthErrW2 = runW2(["resolve", "#1", "--active-dir", active]);
+  assert.equal(widthErrW2.status, 1);
+  assert.match(widthErrW2.stderr, /expected #NN \(2-digit zero-padded/);
+
+  const overWidth = runW2(["resolve", "#001", "--active-dir", active]);
+  assert.equal(overWidth.status, 1);
+  assert.match(overWidth.stderr, /expected #NN/);
 });
 
 test("width exhaustion (case D): cold start aborts before any write", () => {
@@ -231,7 +291,7 @@ test("cold-start case B: registry has entry, task.md missing short_id → writes
     JSON.stringify({ version: 1, ids: { "1": taskId } })
   );
 
-  const r = run(["resolve", "#1", "--active-dir", active]);
+  const r = runW1(["resolve", "#1", "--active-dir", active]);
   assert.equal(r.status, 0, `stderr=${r.stderr}`);
   assert.equal(r.stdout.trim(), taskId);
 
@@ -250,7 +310,7 @@ test("cold-start case C (duplicate registry keys) → exit 2", () => {
     JSON.stringify({ version: 1, ids: { "1": taskId, "2": taskId } })
   );
 
-  const r = run(["resolve", "#1", "--active-dir", active]);
+  const r = runW1(["resolve", "#1", "--active-dir", active]);
   assert.equal(r.status, 2);
   assert.match(r.stderr, /duplicate registry entries/);
 });
@@ -267,7 +327,7 @@ test("stale entries are cleaned automatically (B4)", () => {
   // A real task is created.
   mkTask(active, "TASK-20250107-000001");
 
-  const r = run(["alloc", "TASK-20250107-000001", "--active-dir", active]);
+  const r = runW1(["alloc", "TASK-20250107-000001", "--active-dir", active]);
   assert.equal(r.status, 0, `stderr=${r.stderr}`);
   // Stale #3 cleaned, new task gets #1 (lowest free).
   assert.equal(r.stdout.trim(), "#1");
@@ -286,7 +346,7 @@ test("alloc rejects task id not in active (R5 B-1) without touching state", () =
   mkTask(active, "TASK-20250108-000001");
   mkTask(active, "TASK-20250108-000002");
 
-  const r = run(["alloc", "TASK-99999999-000000", "--active-dir", active]);
+  const r = runW1(["alloc", "TASK-99999999-000000", "--active-dir", active]);
   assert.equal(r.status, 1, `stderr=${r.stderr}`);
   assert.match(r.stderr, /not found in/);
 
@@ -311,9 +371,93 @@ test("alloc skips re-write when task.md already declares the same short_id", () 
   const taskMd = path.join(active, taskId, "task.md");
   const beforeMtime = fs.statSync(taskMd).mtimeMs;
 
-  const r = run(["alloc", taskId, "--active-dir", active]);
+  const r = runW1(["alloc", taskId, "--active-dir", active]);
   assert.equal(r.status, 0);
   assert.equal(r.stdout.trim(), "#1");
   // mtime unchanged because nothing to write.
   assert.equal(fs.statSync(taskMd).mtimeMs, beforeMtime);
+});
+
+// --- U-2 structural assertions: SKILL.md inline bash is gone ---
+
+test("default width is 2 even without --short-id-length flag and without task.shortIdLength in .airc.json (R4 B-1)", () => {
+  // Simulate a project that upgraded but hasn't backfilled task.shortIdLength
+  // into .agents/.airc.json yet. The script must still allocate / resolve with
+  // the default 2-digit zero-padded form (matching lib/defaults.json).
+  const tmp = mkTmp();
+  const agentsDir = path.join(tmp, ".agents");
+  const active = path.join(agentsDir, "workspace", "active");
+  fs.mkdirSync(active, { recursive: true });
+  // Stub .airc.json without a `task` key.
+  fs.writeFileSync(path.join(agentsDir, ".airc.json"), JSON.stringify({ project: "x" }));
+  const taskId = "TASK-20260601-000001";
+  fs.mkdirSync(path.join(active, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(active, taskId, "task.md"),
+    `---\nid: ${taskId}\nbranch: x\n---\nbody\n`
+  );
+
+  // No --short-id-length: script must fall back to DEFAULT_SHORT_ID_LENGTH=2.
+  const alloc = spawnSync("node", [SCRIPT, "alloc", taskId], { encoding: "utf8", cwd: tmp });
+  assert.equal(alloc.status, 0, `alloc failed: ${alloc.stderr}`);
+  assert.equal(alloc.stdout.trim(), "#01", "default must emit zero-padded form");
+
+  const hit = spawnSync("node", [SCRIPT, "resolve", "#01"], { encoding: "utf8", cwd: tmp });
+  assert.equal(hit.status, 0);
+  assert.equal(hit.stdout.trim(), taskId);
+
+  const widthErr = spawnSync("node", [SCRIPT, "resolve", "#1"], { encoding: "utf8", cwd: tmp });
+  assert.equal(widthErr.status, 1, `stderr=${widthErr.stderr}`);
+  assert.match(widthErr.stderr, /expected #NN \(2-digit zero-padded/);
+});
+
+test("SKILL.md no longer embeds multi-line short-id bash snippet (U-2 slimming)", () => {
+  const skills = fs.readdirSync(TEMPLATES_SKILLS);
+  // Match the 5-line conditional block that used to live in every SKILL.md
+  // (`if [[ "{task-id}" == "#"* ]]; then` followed by a `node …` call).
+  const oldSnippet = /if \[\[ "\{task-id\}" == "#"\*[\s\S]+task-short-id\.js resolve/m;
+  let offenders: string[] = [];
+  for (const skill of skills) {
+    for (const lang of ["en", "zh-CN"]) {
+      const file = path.join(TEMPLATES_SKILLS, skill, `SKILL.${lang}.md`);
+      if (!fs.existsSync(file)) continue;
+      const content = fs.readFileSync(file, "utf8");
+      if (oldSnippet.test(content)) offenders.push(`${skill}/${lang}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `SKILL.md still embeds old inline bash: ${offenders.join(", ")}`);
+});
+
+test("19 lifecycle SKILLs reference the centralized task-short-id rule doc (U-2)", () => {
+  const skills = [
+    "create-task", "import-issue", "import-codescan", "import-dependabot",
+    "analyze-task", "plan-task", "code-task", "review-analysis", "review-plan",
+    "review-code", "commit", "create-pr", "check-task",
+    "complete-task", "cancel-task", "block-task", "close-codescan", "close-dependabot",
+    "restore-task"
+  ];
+  const pointerRe = /rules\/task-short-id\.md/;
+  for (const skill of skills) {
+    for (const lang of ["en", "zh-CN"]) {
+      const file = path.join(TEMPLATES_SKILLS, skill, `SKILL.${lang}.md`);
+      const content = fs.readFileSync(file, "utf8");
+      assert.match(content, pointerRe, `${skill}/${lang} missing rule pointer`);
+    }
+  }
+});
+
+// --- U-3 structural assertions: rule doc declares storage + SKILL parser ---
+
+test("task-short-id rule doc declares SKILL parser + storage sections (U-2/U-3)", () => {
+  const docs = {
+    "en": path.resolve(process.cwd(), "templates/.agents/rules/task-short-id.en.md"),
+    "zh-CN": path.resolve(process.cwd(), "templates/.agents/rules/task-short-id.zh-CN.md")
+  };
+  const skillSection = { en: /^## SKILL parameter resolver$/m, "zh-CN": /^## SKILL 入参解析$/m };
+  const storageSection = { en: /^## Storage$/m, "zh-CN": /^## 存储位置$/m };
+  for (const [lang, file] of Object.entries(docs)) {
+    const content = fs.readFileSync(file, "utf8");
+    assert.match(content, skillSection[lang as keyof typeof skillSection], `${lang}: SKILL section missing`);
+    assert.match(content, storageSection[lang as keyof typeof storageSection], `${lang}: storage section missing`);
+  }
 });

--- a/tests/unit/scripts/task-short-id.test.ts
+++ b/tests/unit/scripts/task-short-id.test.ts
@@ -1,0 +1,319 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEMPLATES_SKILLS = path.resolve(process.cwd(), "templates/.agents/skills");
+
+test("all 4 alloc-class SKILLs invoke task-short-id.js alloc inside execution steps", () => {
+  const skills = ["create-task", "import-issue", "import-codescan", "import-dependabot"];
+  for (const skill of skills) {
+    for (const lang of ["en", "zh-CN"]) {
+      const file = path.join(TEMPLATES_SKILLS, skill, `SKILL.${lang}.md`);
+      const content = fs.readFileSync(file, "utf8");
+      const matches = content.match(/node \.agents\/scripts\/task-short-id\.js alloc/g);
+      assert.ok(
+        matches && matches.length >= 1,
+        `${skill}/${lang}: missing alloc call`
+      );
+    }
+  }
+});
+
+test("all 5 release-class SKILLs invoke task-short-id.js release inside execution steps", () => {
+  const skills = ["complete-task", "cancel-task", "block-task", "close-codescan", "close-dependabot"];
+  for (const skill of skills) {
+    for (const lang of ["en", "zh-CN"]) {
+      const file = path.join(TEMPLATES_SKILLS, skill, `SKILL.${lang}.md`);
+      const content = fs.readFileSync(file, "utf8");
+      const matches = content.match(/node \.agents\/scripts\/task-short-id\.js release/g);
+      assert.ok(
+        matches && matches.length >= 1,
+        `${skill}/${lang}: missing release call`
+      );
+    }
+  }
+});
+
+test("restore-task re-allocates short id", () => {
+  for (const lang of ["en", "zh-CN"]) {
+    const file = path.join(TEMPLATES_SKILLS, "restore-task", `SKILL.${lang}.md`);
+    const content = fs.readFileSync(file, "utf8");
+    const matches = content.match(/node \.agents\/scripts\/task-short-id\.js alloc/g);
+    assert.ok(matches && matches.length >= 1, `restore-task/${lang}: missing alloc call`);
+  }
+});
+
+const SCRIPT = path.resolve(
+  process.cwd(),
+  "templates/.agents/scripts/task-short-id.js"
+);
+
+function mkTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tsid-"));
+}
+
+function mkTask(activeDir: string, taskId: string, withShortId?: string): string {
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  const taskMd = path.join(dir, "task.md");
+  const short = withShortId ? `\nshort_id: ${withShortId}` : "";
+  fs.writeFileSync(
+    taskMd,
+    `---\nid: ${taskId}${short}\nbranch: x\n---\n# body\n`
+  );
+  return taskMd;
+}
+
+function run(
+  args: string[],
+  cwd: string = process.cwd()
+): SpawnSyncReturns<string> {
+  return spawnSync("node", [SCRIPT, ...args], { encoding: "utf8", cwd });
+}
+
+test("alloc and release reuse minimal free integer", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  mkTask(active, "TASK-20250101-000001");
+  mkTask(active, "TASK-20250101-000002");
+
+  const r1 = run(["alloc", "TASK-20250101-000001", "--active-dir", active]);
+  assert.equal(r1.status, 0);
+  assert.equal(r1.stdout.trim(), "#1");
+
+  const r2 = run(["alloc", "TASK-20250101-000002", "--active-dir", active]);
+  assert.equal(r2.status, 0);
+  assert.equal(r2.stdout.trim(), "#2");
+
+  const r3 = run(["release", "TASK-20250101-000001", "--active-dir", active]);
+  assert.equal(r3.status, 0);
+
+  // Reallocating after release should reuse #1.
+  const r4 = run(["alloc", "TASK-20250101-000001", "--active-dir", active]);
+  assert.equal(r4.status, 0);
+  assert.equal(r4.stdout.trim(), "#1");
+});
+
+test("release is idempotent (exit 0 when no entry; m-1)", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  mkTask(active, "TASK-20250101-000003");
+
+  const r = run(["release", "TASK-20250101-000003", "--active-dir", active]);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+});
+
+test("resolve returns task id on hit; error on miss", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  mkTask(active, "TASK-20250101-000010");
+
+  run(["alloc", "TASK-20250101-000010", "--active-dir", active]);
+  const hit = run(["resolve", "#1", "--active-dir", active]);
+  assert.equal(hit.status, 0);
+  assert.equal(hit.stdout.trim(), "TASK-20250101-000010");
+
+  const miss = run(["resolve", "#9", "--active-dir", active]);
+  assert.equal(miss.status, 1);
+  assert.match(miss.stderr, /not found/);
+});
+
+test("resolve rejects #0, leading-zero, malformed input", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+
+  const zero = run(["resolve", "#0", "--active-dir", active]);
+  assert.equal(zero.status, 1);
+  assert.match(zero.stderr, /reserved/);
+
+  const leading = run(["resolve", "#01", "--active-dir", active]);
+  assert.equal(leading.status, 1);
+  assert.match(leading.stderr, /reserved|leading/);
+
+  const bad = run(["resolve", "#abc", "--active-dir", active]);
+  assert.equal(bad.status, 1);
+  assert.match(bad.stderr, /invalid short id format/);
+});
+
+test("width exhaustion (case D): cold start aborts before any write", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const paths: string[] = [];
+  for (let i = 1; i <= 10; i += 1) {
+    paths.push(
+      mkTask(active, `TASK-20250102-${String(i).padStart(6, "0")}`)
+    );
+  }
+  const beforeMtimes = paths.map((p) => fs.statSync(p).mtimeMs);
+  const beforeContents = paths.map((p) => fs.readFileSync(p, "utf8"));
+
+  // shortIdLength=1 → capacity = 9; need 10 → fail
+  const r = run([
+    "resolve",
+    "#1",
+    "--active-dir",
+    active,
+    "--short-id-length",
+    "1"
+  ]);
+  assert.equal(r.status, 2, `unexpected exit; stderr=${r.stderr}`);
+  assert.match(r.stderr, /needs 10 short id\(s\) but only 9/);
+
+  // No fs writes: all task.md mtimes + contents preserved.
+  for (let i = 0; i < paths.length; i += 1) {
+    assert.equal(fs.statSync(paths[i]!).mtimeMs, beforeMtimes[i]);
+    assert.equal(fs.readFileSync(paths[i]!, "utf8"), beforeContents[i]);
+  }
+  // Registry must not exist.
+  assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
+});
+
+test("width tight boundary (case D'): 9 tasks fit exactly", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  for (let i = 1; i <= 9; i += 1) {
+    mkTask(active, `TASK-20250103-${String(i).padStart(6, "0")}`);
+  }
+  const r = run([
+    "resolve",
+    "#1",
+    "--active-dir",
+    active,
+    "--short-id-length",
+    "1"
+  ]);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+  // Every task.md must now carry a short_id field.
+  for (let i = 1; i <= 9; i += 1) {
+    const taskId = `TASK-20250103-${String(i).padStart(6, "0")}`;
+    const content = fs.readFileSync(path.join(active, taskId, "task.md"), "utf8");
+    assert.match(content, /^short_id: #\d+$/m, `task ${taskId} missing short_id`);
+  }
+  // list --verify must agree.
+  const verify = run(["list", "--verify", "--active-dir", active]);
+  assert.equal(verify.status, 0, `verify stderr=${verify.stderr}; stdout=${verify.stdout}`);
+});
+
+test("list --verify is strictly read-only (R3 B-1)", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const taskMd = mkTask(active, "TASK-20250104-000001");
+  // Active dir has a task with no short_id; registry is empty → inconsistent.
+  const beforeMtime = fs.statSync(taskMd).mtimeMs;
+  const beforeContent = fs.readFileSync(taskMd, "utf8");
+
+  const r = run(["list", "--verify", "--active-dir", active]);
+  assert.equal(r.status, 1, `expected fail; stderr=${r.stderr}`);
+  // Must not have written task.md or created the registry.
+  assert.equal(fs.statSync(taskMd).mtimeMs, beforeMtime, "task.md mtime mutated");
+  assert.equal(fs.readFileSync(taskMd, "utf8"), beforeContent, "task.md content mutated");
+  assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
+});
+
+test("cold-start case B: registry has entry, task.md missing short_id → writes back", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const taskId = "TASK-20250105-000001";
+  mkTask(active, taskId);
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId } })
+  );
+
+  const r = run(["resolve", "#1", "--active-dir", active]);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+  assert.equal(r.stdout.trim(), taskId);
+
+  const taskMd = fs.readFileSync(path.join(active, taskId, "task.md"), "utf8");
+  assert.match(taskMd, /^short_id: #1$/m);
+});
+
+test("cold-start case C (duplicate registry keys) → exit 2", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const taskId = "TASK-20250106-000001";
+  mkTask(active, taskId);
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId, "2": taskId } })
+  );
+
+  const r = run(["resolve", "#1", "--active-dir", active]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /duplicate registry entries/);
+});
+
+test("stale entries are cleaned automatically (B4)", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  // Registry contains a taskId whose dir does not exist.
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "3": "TASK-99999999-999999" } })
+  );
+  // A real task is created.
+  mkTask(active, "TASK-20250107-000001");
+
+  const r = run(["alloc", "TASK-20250107-000001", "--active-dir", active]);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+  // Stale #3 cleaned, new task gets #1 (lowest free).
+  assert.equal(r.stdout.trim(), "#1");
+
+  const list = JSON.parse(
+    fs.readFileSync(path.join(active, ".short-ids.json"), "utf8")
+  );
+  assert.deepEqual(list.ids, { "1": "TASK-20250107-000001" });
+});
+
+test("alloc rejects task id not in active (R5 B-1) without touching state", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  // Pre-existing tasks without short_id (would trigger cold-start migration).
+  mkTask(active, "TASK-20250108-000001");
+  mkTask(active, "TASK-20250108-000002");
+
+  const r = run(["alloc", "TASK-99999999-000000", "--active-dir", active]);
+  assert.equal(r.status, 1, `stderr=${r.stderr}`);
+  assert.match(r.stderr, /not found in/);
+
+  // The two existing tasks must remain untouched.
+  for (const id of ["TASK-20250108-000001", "TASK-20250108-000002"]) {
+    const md = fs.readFileSync(path.join(active, id, "task.md"), "utf8");
+    assert.doesNotMatch(md, /short_id:/, `${id} mutated`);
+  }
+  assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
+});
+
+test("alloc skips re-write when task.md already declares the same short_id", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const taskId = "TASK-20250109-000001";
+  mkTask(active, taskId, "#1");
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId } })
+  );
+  const taskMd = path.join(active, taskId, "task.md");
+  const beforeMtime = fs.statSync(taskMd).mtimeMs;
+
+  const r = run(["alloc", taskId, "--active-dir", active]);
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout.trim(), "#1");
+  // mtime unchanged because nothing to write.
+  assert.equal(fs.statSync(taskMd).mtimeMs, beforeMtime);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #419

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

为每个 active 状态的任务分配一个**短号别名**（默认 1 位的 `#N`），让用户在手机端、车载小屏、远程 SSH 等输入受限场景下，把 22 字符的 `TASK-YYYYMMDD-HHMMSS` 压缩到 2 字符。所有 SKILL 入参（`/code-task #1`、`/review-plan #2`）和 sandbox CLI（`ai sandbox exec '#3'`）都支持短号别名；归档后立即释放、可被新任务复用，向后完全兼容完整 `TASK-…` 入参。

## 📋 主要变更 / Brief Changelog

- **新增公共脚本** `templates/.agents/scripts/task-short-id.js`（~470 行）：包含 `planTransaction()` / `tx.commit()` / `verifyRegistry()` 的两阶段事务模型，覆盖 alloc / release / resolve / list / list --verify 五个子命令；mkdir-based 文件锁 + 原子 rename 写入；冷启动迁移容量预检 + 写失败按原始内容/mtime 整体回滚
- **19 个 SKILL.md 接入 `#N` 入参解析**（发布源 × 2 语言 + 镜像）；10 个生命周期 SKILL（4 alloc / 5 release / 1 re-alloc）在执行步骤内调用对应脚本动作
- **sandbox CLI 集成**：`lib/sandbox/task-resolver.ts` 增加 `#N` 严格模式分支；`lib/sandbox/commands/list-running.ts` 的 `resolveTaskShortRef` 改为 tri-state（`hit` / `miss` / throw），命中注册表后 task.md 缺 `branch` 立即抛错、不静默回退到 ls 行号；`enter.ts` 透传 `repoRoot`
- **配置默认值** `task.shortIdLength: 1` 落 `lib/defaults.json`；`lib/init.ts` / `lib/update.ts` 同步类型 + 缺失字段回填
- **双语规则文档** `task-short-id.{en,zh-CN}.md`；任务模板 `task.{en,zh-CN}.md` frontmatter 增加 `short_id` 字段
- **测试新增 16 个**：单元（`task-short-id` 12 个：CRUD / 容量耗尽 case D / 紧边界 case D' / list --verify 只读 / 冷启动 case B / case C 数据损坏 / B4 stale 清理 / `task-resolver` 4 个：`#N` 严格模式 / TASK-… 回归）；集成（sandbox-core 新增 3 用例：注册表命中 / hit-but-invalid 抛错 / miss 回退）+ 3 个结构性测试断言 4 alloc + 5 release + 1 re-alloc 共 10 SKILL × 2 lang 都包含对应脚本调用

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build` —— TypeScript 零错误
2. `npm test` —— 768 用例，767 通过，1 跳过（仅平台特定 skip），含 16+3 新用例
3. 手动 smoke：在临时 active 目录下 `node templates/.agents/scripts/task-short-id.js alloc TASK-…` → 拿到 `#1`、task.md 写回 `short_id: #1`；`resolve '#1'` 反向解析为完整 task id；`release` 后再 `alloc` 复用 `#1`；`list --verify` 在三者一致时空输出

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line
- [x] 我的代码遵循项目的代码规范 / Code follows project standards
- [x] 我已经为复杂的代码添加了必要的注释 / Complex code is commented
- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / Necessary unit tests are added
- [x] 单元测试通过 / Unit tests pass
- [x] 我已经更新了相应的文档 / Documentation updated (新增 `task-short-id.{en,zh-CN}.md` 规则文档)
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered (完整 `TASK-…` 入参在所有 CLI / SKILL 路径上行为完全等价于现状)

## 📋 附加信息 / Additional Notes

- 实施过程经历 7 轮 plan-task（含 2 次外部审查阻塞修复）+ 3 轮 code-task（含 2 次 fix 模式收尾）；详见 task.md Activity Log 与 Issue #419 评论历史
- 与 #414 已合的 sandbox `#N` ls-index 行为完全兼容：注册表命中时优先，未命中时回退到 ls 行号（保留 #414 体验）
- `.agents/workspace/active/.short-ids.json` 注册表跟 active 工作区一起 git ignore，无需新增 ignore 条目

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注 `planTransaction()` / `tx.commit()` 事务边界：阶段 A 全部只读（含容量预检）；阶段 B 写失败按缓存 `originalContent` + `utimesSync` 恢复字节与 mtime；`alloc()` 在 `planTransaction()` 之前做 task.md 存在性硬校验，避免无效入参带出 normalize 副作用
- `resolveTaskShortRef` tri-state 语义：注册表命中后 task.md 损坏（缺 `branch` 字段）必须抛错，不能静默退到 ls 行号

Generated with AI assistance