### PR TITLE
fix(skills): enforce specific milestone in code-task gate

### DIFF
--- a/.agents/rules/milestone-inference.md
+++ b/.agents/rules/milestone-inference.md
@@ -81,7 +81,11 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. 如果 `has_triage=false`、目标 milestone 不存在，或无法可靠判断 -> 保持原 milestone 不变
+6. 「无法收窄」的处理按模式和情形分流：
+   - 主干模式下版本线下**有** open 具体版本而未收窄属于规则违例，不再保留"保持原 milestone 不变"逃生口；执行步骤 5 即可。
+   - 主干模式下版本线下**没有** open 具体版本：保持原版本线 milestone 不变 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本。
+   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失时，保持原 milestone 不变。
+   - 任意模式下 `has_triage=false`：保持原 milestone 不变，由 bot 后补。
 
 具体版本查询建议：
 

--- a/.agents/rules/milestone-inference.md
+++ b/.agents/rules/milestone-inference.md
@@ -81,11 +81,10 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. 「无法收窄」的处理按模式和情形分流：
-   - 主干模式下版本线下**有** open 具体版本而未收窄属于规则违例，不再保留"保持原 milestone 不变"逃生口；执行步骤 5 即可。
-   - 主干模式下版本线下**没有** open 具体版本：保持原版本线 milestone 不变 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本。
-   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失时，保持原 milestone 不变。
-   - 任意模式下 `has_triage=false`：保持原 milestone 不变，由 bot 后补。
+6. 仅在以下情况保持原 milestone 不变（其余情形必须按步骤 5 收窄）：
+   - 主干模式下版本线下没有 open 具体版本 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本
+   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失
+   - 任意模式下 `has_triage=false`（由 bot 后补）
 
 具体版本查询建议：
 

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -5,6 +5,7 @@ import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+const VERSION_LINE_REGEX = /^[0-9]+\.[0-9]+\.x$/;
 const FRONTMATTER_FIELD_MAP = {
   priority: "Priority",
   effort: "Effort",
@@ -809,6 +810,22 @@ function checkMilestone(context, remoteData) {
       `PR #${context.prNumber} has no milestone set`,
       "check_failed"
     );
+  }
+
+  if (context.config.verify_milestone_specific) {
+    const issueTitle = remoteData.issue.milestone.title;
+    if (VERSION_LINE_REGEX.test(issueTitle)) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} milestone '${issueTitle}' is a release line; narrow to a specific version (e.g. ${issueTitle.replace(/\.x$/, ".N")}) before continuing`,
+        "check_failed"
+      );
+    }
+    if (context.prNumber && remoteData.prMilestone?.title && VERSION_LINE_REGEX.test(remoteData.prMilestone.title)) {
+      return failResult(CHECK_TYPE,
+        `PR #${context.prNumber} milestone '${remoteData.prMilestone.title}' is a release line; narrow to a specific version before continuing`,
+        "check_failed"
+      );
+    }
   }
 
   return null;

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -70,7 +70,9 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ### 3. 收窄里程碑
 
-如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测；再读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 2：`code-task`」收窄 Issue milestone；如果 `has_triage=false`，则保持原 milestone 不变。
+**必须执行，不得跳过。** 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测；再读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 2：`code-task`」收窄 Issue milestone；如果 `has_triage=false`，则保持原 milestone 不变。
+
+> 若此步骤被跳过或收窄后 Issue milestone 仍为 `X.Y.x` 版本线，步骤 11 的 `validate-artifact` gate 会通过 `verify_milestone_specific` 截停本轮 `code-task`，要求重新收窄到具体版本（如 `0.7.1`）后再继续。
 
 ### 4. 确定模式与轮次
 

--- a/.agents/skills/code-task/config/verify.json
+++ b/.agents/skills/code-task/config/verify.json
@@ -44,6 +44,7 @@
       "verify_issue_type": true,
       "verify_issue_fields": false,
       "verify_milestone": true,
+      "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"
     }

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -26,6 +26,7 @@
       "verify_pr_assignee": true,
       "verify_issue_fields": true,
       "verify_milestone": true,
+      "verify_milestone_specific": true,
       "expected_pr_comment_marker_key": "prSummary"
     }
   }

--- a/templates/.agents/rules/milestone-inference.github.en.md
+++ b/templates/.agents/rules/milestone-inference.github.en.md
@@ -81,7 +81,11 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. If `has_triage=false`, the target milestone does not exist, or the branch ancestry cannot be determined reliably, keep the original milestone unchanged
+6. Handle "cannot narrow" by mode and circumstance:
+   - Trunk mode with an open concrete version available under the release line: failing to narrow is a rule violation; no "keep the original milestone" escape hatch is allowed - just apply step 5.
+   - Trunk mode with no open concrete version under the release line: keep the original release-line milestone unchanged - the `code-task` / `create-pr` `verify_milestone_specific` gate will fail and prompt maintainers to create the missing concrete version.
+   - Multi-release-line mode when both `git merge-base --is-ancestor` checks are unreliable or the remote refs are missing: keep the original milestone unchanged.
+   - In any mode, `has_triage=false`: keep the original milestone unchanged; the bot will reconcile later.
 
 Suggested concrete-version query:
 

--- a/templates/.agents/rules/milestone-inference.github.en.md
+++ b/templates/.agents/rules/milestone-inference.github.en.md
@@ -81,11 +81,10 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. Handle "cannot narrow" by mode and circumstance:
-   - Trunk mode with an open concrete version available under the release line: failing to narrow is a rule violation; no "keep the original milestone" escape hatch is allowed - just apply step 5.
-   - Trunk mode with no open concrete version under the release line: keep the original release-line milestone unchanged - the `code-task` / `create-pr` `verify_milestone_specific` gate will fail and prompt maintainers to create the missing concrete version.
-   - Multi-release-line mode when both `git merge-base --is-ancestor` checks are unreliable or the remote refs are missing: keep the original milestone unchanged.
-   - In any mode, `has_triage=false`: keep the original milestone unchanged; the bot will reconcile later.
+6. Keep the original milestone unchanged only in the following cases (otherwise narrow per step 5):
+   - Trunk mode with no open concrete version under the release line — the `code-task` / `create-pr` `verify_milestone_specific` gate will fail and prompt maintainers to create the missing concrete version
+   - Multi-release-line mode when both `git merge-base --is-ancestor` checks are unreliable or the remote refs are missing
+   - In any mode, `has_triage=false` (the bot will reconcile later)
 
 Suggested concrete-version query:
 

--- a/templates/.agents/rules/milestone-inference.github.zh-CN.md
+++ b/templates/.agents/rules/milestone-inference.github.zh-CN.md
@@ -81,7 +81,11 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. 如果 `has_triage=false`、目标 milestone 不存在，或无法可靠判断 -> 保持原 milestone 不变
+6. 「无法收窄」的处理按模式和情形分流：
+   - 主干模式下版本线下**有** open 具体版本而未收窄属于规则违例，不再保留"保持原 milestone 不变"逃生口；执行步骤 5 即可。
+   - 主干模式下版本线下**没有** open 具体版本：保持原版本线 milestone 不变 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本。
+   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失时，保持原 milestone 不变。
+   - 任意模式下 `has_triage=false`：保持原 milestone 不变，由 bot 后补。
 
 具体版本查询建议：
 

--- a/templates/.agents/rules/milestone-inference.github.zh-CN.md
+++ b/templates/.agents/rules/milestone-inference.github.zh-CN.md
@@ -81,11 +81,10 @@ if [ "$has_triage" = "true" ]; then
 fi
 ```
 
-6. 「无法收窄」的处理按模式和情形分流：
-   - 主干模式下版本线下**有** open 具体版本而未收窄属于规则违例，不再保留"保持原 milestone 不变"逃生口；执行步骤 5 即可。
-   - 主干模式下版本线下**没有** open 具体版本：保持原版本线 milestone 不变 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本。
-   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失时，保持原 milestone 不变。
-   - 任意模式下 `has_triage=false`：保持原 milestone 不变，由 bot 后补。
+6. 仅在以下情况保持原 milestone 不变（其余情形必须按步骤 5 收窄）：
+   - 主干模式下版本线下没有 open 具体版本 —— `code-task` / `create-pr` 的 `verify_milestone_specific` gate 会 FAIL，提醒维护者补建具体版本
+   - 多版本分支模式下 `git merge-base --is-ancestor` 两条判断都不可靠或远程引用缺失
+   - 任意模式下 `has_triage=false`（由 bot 后补）
 
 具体版本查询建议：
 

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -5,6 +5,7 @@ import spawn from "cross-spawn";
 
 const CHECK_TYPE = "platform-sync";
 const DEFAULT_RETRY_DELAYS_MS = [3000, 10000];
+const VERSION_LINE_REGEX = /^[0-9]+\.[0-9]+\.x$/;
 const FRONTMATTER_FIELD_MAP = {
   priority: "Priority",
   effort: "Effort",
@@ -809,6 +810,22 @@ function checkMilestone(context, remoteData) {
       `PR #${context.prNumber} has no milestone set`,
       "check_failed"
     );
+  }
+
+  if (context.config.verify_milestone_specific) {
+    const issueTitle = remoteData.issue.milestone.title;
+    if (VERSION_LINE_REGEX.test(issueTitle)) {
+      return failResult(CHECK_TYPE,
+        `Issue #${context.issueNumber} milestone '${issueTitle}' is a release line; narrow to a specific version (e.g. ${issueTitle.replace(/\.x$/, ".N")}) before continuing`,
+        "check_failed"
+      );
+    }
+    if (context.prNumber && remoteData.prMilestone?.title && VERSION_LINE_REGEX.test(remoteData.prMilestone.title)) {
+      return failResult(CHECK_TYPE,
+        `PR #${context.prNumber} milestone '${remoteData.prMilestone.title}' is a release line; narrow to a specific version before continuing`,
+        "check_failed"
+      );
+    }
   }
 
   return null;

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -45,7 +45,9 @@ Read `reference/branch-management.md`, ensure the current branch matches the tas
 
 ### 3. Narrow the Milestone
 
-If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md` and `.agents/rules/milestone-inference.md`; follow Phase 2 for `code-task`.
+**Mandatory; do not skip.** If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md` first (upstream + permission detection), then `.agents/rules/milestone-inference.md` Phase 2 for `code-task` to narrow the Issue milestone. If `has_triage=false`, keep the existing milestone.
+
+> If this step is skipped or the Issue milestone is still a release line `X.Y.x` afterward, the step-11 `validate-artifact` gate will block the `code-task` round via `verify_milestone_specific` and require narrowing to a specific version (e.g. `0.7.1`) before proceeding.
 
 ### 4. Determine Mode and Round
 

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -70,7 +70,9 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ### 3. 收窄里程碑
 
-如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测；再读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 2：`code-task`」收窄 Issue milestone；如果 `has_triage=false`，则保持原 milestone 不变。
+**必须执行，不得跳过。** 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测；再读取 `.agents/rules/milestone-inference.md`，按其中的「阶段 2：`code-task`」收窄 Issue milestone；如果 `has_triage=false`，则保持原 milestone 不变。
+
+> 若此步骤被跳过或收窄后 Issue milestone 仍为 `X.Y.x` 版本线，步骤 11 的 `validate-artifact` gate 会通过 `verify_milestone_specific` 截停本轮 `code-task`，要求重新收窄到具体版本（如 `0.7.1`）后再继续。
 
 ### 4. 确定模式与轮次
 

--- a/templates/.agents/skills/code-task/config/verify.en.json
+++ b/templates/.agents/skills/code-task/config/verify.en.json
@@ -44,6 +44,7 @@
       "verify_issue_type": true,
       "verify_issue_fields": false,
       "verify_milestone": true,
+      "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"
     }

--- a/templates/.agents/skills/code-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/code-task/config/verify.zh-CN.json
@@ -44,6 +44,7 @@
       "verify_issue_type": true,
       "verify_issue_fields": false,
       "verify_milestone": true,
+      "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",
       "expected_comment_marker_key": "artifact"
     }

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -26,6 +26,7 @@
       "verify_pr_assignee": true,
       "verify_issue_fields": true,
       "verify_milestone": true,
+      "verify_milestone_specific": true,
       "expected_pr_comment_marker_key": "prSummary"
     }
   }

--- a/tests/e2e/core/validate-artifact-platform-sync.test.ts
+++ b/tests/e2e/core/validate-artifact-platform-sync.test.ts
@@ -205,6 +205,68 @@ const implementSyncCases = [
         message: /has no milestone set/
       });
     }
+  },
+  {
+    name: "validate-artifact platform-sync fails for code-task when Issue milestone is a release line",
+    skill: "code-task",
+    issuePayload: buildIssuePayload({
+      labels: [{ name: "status: in-progress" }],
+      body: "# Issue\n",
+      milestone: { title: "0.7.x" }
+    }),
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /milestone '0\.7\.x' is a release line/
+      });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync passes for code-task when Issue milestone is a specific version",
+    skill: "code-task",
+    issuePayload: buildIssuePayload({
+      labels: [{ name: "status: in-progress" }],
+      body: "# Issue\n",
+      milestone: { title: "0.7.1" }
+    }),
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync skips code-task milestone check without triage permission",
+    skill: "code-task",
+    issuePayload: buildIssuePayload({
+      labels: [{ name: "status: in-progress" }],
+      body: "# Issue\n",
+      milestone: { title: "0.7.x" }
+    }),
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    extraEnv: { GH_FAKE_PERMISSIONS: JSON.stringify({ triage: false, push: false }) },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+    }
   }
 ];
 
@@ -351,6 +413,13 @@ const createPrCases = [
     prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }], milestone: null }),
     expectedStatus: 1,
     message: [/PR #77 has no milestone set/]
+  },
+  {
+    name: "validate-artifact platform-sync fails when create-pr PR milestone is a release line",
+    issuePayload: buildIssuePayload({ labels: [], body: "# Issue\n", milestone: { title: "0.7.1" } }),
+    prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }], milestone: { title: "0.7.x" } }),
+    expectedStatus: 1,
+    message: [/PR #77 milestone '0\.7\.x' is a release line/]
   },
   {
     name: "validate-artifact platform-sync fails when PR and Issue in: labels diverge",


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #432

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 `code-task` 阶段 2 milestone 收窄静默失效（#432）。

v0.7.0 之后 `code-task` 步骤 3「收窄里程碑」被 AI 跳过且 `platform-sync` gate 仅检查 milestone 非空，导致 0.7.1 周期所有 Issue/PR milestone 都停留在版本线 `0.7.x`，依赖人工 demilestone + 重新 milestone 到具体版本。本 PR 在 gate / SKILL / 规则三层同时收紧，让漏做必被截停并提示如何修复。

## 📋 主要变更 / Brief Changelog

- 在 `checkMilestone()` 中新增由 `verify_milestone_specific` 控制的版本线拒绝分支（Issue 与 PR milestone 同阈值）；同步到 `templates/.agents/scripts/platform-adapters/platform-sync.github.js` 保持 byte-identical。
- `code-task` / `create-pr` 的 `verify.json`（含双语模板）启用 `verify_milestone_specific: true`；`create-task` 保持原状（阶段 1 仍允许 `X.Y.x`）。
- `code-task/SKILL.md` 步骤 3 升级为「**必须执行，不得跳过**」加粗强约束，并明文告知漏做会被步骤 11 gate 截停；模板双语同改。
- `milestone-inference.md` 阶段 2 步骤 6 拆分为 4 种情形分流，关闭主干模式「版本线下有 open 具体版本却保持原 milestone 不变」的逃生口；运行态 + 双语 GitHub 模板同改。
- `tests/e2e/core/validate-artifact-platform-sync.test.ts` 新增 4 个用例：code-task release line FAIL / specific version PASS / `has_triage=false` 早返回 PASS / create-pr PR milestone release line FAIL。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` 全量回归（含新增 4 用例）。
2. `diff -u .agents/scripts/platform-adapters/platform-sync.js templates/.agents/scripts/platform-adapters/platform-sync.github.js` 应为空（既有 `tests/e2e/core/validate-artifact.test.ts:407-416` 同源断言兜底）。
3. 端到端正向验证：本 PR 关联 Issue #432 的 milestone 已由本任务 `code-task` 步骤 3 从 `0.7.x` 收窄到 `0.7.2`（`gh issue view 432 --json milestone --jq '.milestone.title'` 应输出 `0.7.2`）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue filed for the change (#432)
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / Comments added where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / Mocks used for cross-module dependencies
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / Documentation updated (SKILL.md + milestone-inference.md + templates)
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered (`verify_milestone_specific` 缺省为 false 时行为与现状等价)

## 📋 附加信息 / Additional Notes

- 运行态 `.agents/...` 与 `templates/.agents/...` 严格双源同改（13 文件配对 + 1 测试），由 `tests/e2e/core/validate-artifact.test.ts:407-416` 的 byte-identical 断言保护。
- `create-task` 阶段 1 故意**不**启用新 gate，保持创建 Issue 时粗粒度版本线 `X.Y.x` 的行为；阶段 2/3 同步收紧。
- 仓库未建对应具体版本 milestone 时，新 gate 会 FAIL —— 这是有意为之的"提醒发版准备"行为，文案给出收窄建议（`0.7.x` → `0.7.N`）。

Closes #432

---

**审查者注意事项 / Reviewer Notes:**

- `checkMilestone()` 新分支条件顺序须在 milestone 非空检查通过后才执行版本线判定。
- `verify_milestone_specific` 在 `create-task/verify.json` 必须保持缺省（false），否则会回归 Issue #432 阶段 1 行为；本 PR 已 grep 确认未启用。
- milestone-inference 阶段 2 步骤 6 改写后 4 种情形覆盖：主干模式可收窄不留逃生口 / 主干模式无具体版本保留版本线由 gate 兜底 / 多版本分支不可靠时保留 / 任意模式 `has_triage=false` 保留。

Generated with AI assistance