### PR TITLE
feat(cli): add ai task command and bare-numeric task short ids

### DIFF
--- a/.agents/rules/task-short-id.md
+++ b/.agents/rules/task-short-id.md
@@ -1,16 +1,18 @@
 # 任务短号
 
-短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 替代完整的 22 字符
-`TASK-YYYYMMDD-HHMMSS`。
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 或裸数字 `N`（推荐）替代
+完整的 22 字符 `TASK-YYYYMMDD-HHMMSS`。
 
 ## 语法
 
-- 格式：`^#\d{shortIdLength}$`（**零填充到固定宽度**；默认 `shortIdLength=2` 时
-  形如 `#01`、`#07`、`#42`）。
-- **必须**零填充到 `shortIdLength` 位（默认 2 位：`#1` 视为格式错误，应输入
-  `#01`）。这是为了视觉对齐与盲打体验。
+- 字面接受两种等价形式：
+  - **裸数字 `N`**（推荐，无需 shell 引号）：如 `1`、`7`、`42`。
+  - **`#`-前缀 `#N` / `#NN`**（兼容旧写法）：如 `#1`、`#01`、`#42`。
+- 解析规则：去前导零后取数值 `n`，若 `n == 0` 报错（保留）；若 `n > 10^shortIdLength - 1`
+  报错（超容量）；否则归一化为 `#${n.padStart(shortIdLength, '0')}`，作为注册表 key。
+- 默认 `shortIdLength=2` 时容量 `n ∈ [1, 99]`，注册表 key 形如 `01`、`07`、`42`。
 - `#00`（或 `shortIdLength=1` 时 `#0`）保留、永不分配；纯数字、不引入字母。
-- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` 只是别名，不是持久化任务 ID。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` / 裸数字只是别名，不是持久化任务 ID。
 
 ## 生命周期
 
@@ -44,7 +46,7 @@
 | 入口                                                       | 注册表命中            | 注册表未命中                                            |
 |-----------------------------------------------------------|----------------------|--------------------------------------------------------|
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
-| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`      | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+| `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | 解析为完整 task id 后查 task.md 取 `branch` | **严格报错** —— 不再回退到 ls 行号或字面分支名；提示用任务短号 / `TASK-id` / 分支名 |
 
 `list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
 三者差异，但不修改任何状态。
@@ -54,11 +56,11 @@
 任意 SKILL（含 alloc / resolve / release / re-alloc 四类生命周期入口）在收到
 `{task-id}` 入参后，必须按以下契约处理：
 
-1. 如果 `{task-id}` 字面以 `#` 开头：
+1. 如果 `{task-id}` 字面匹配 `^[#]?[0-9]+$`（裸数字 `N` 或 `#`-前缀 `#N`）：
 
 ```bash
-if [[ "{task-id}" == "#"* ]]; then
-  # 脚本本身已输出完整错误（含「expected #NN (N-digit zero-padded; e.g. '#01')」）；
+if [[ "{task-id}" =~ ^[#]?[0-9]+$ ]]; then
+  # 脚本本身已输出完整错误（含 reserved / exceeds shortIdLength capacity 等场景）；
   # 调用方只需透传退出码
   task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
 else
@@ -97,21 +99,27 @@ fi
   目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
   `updated_at` / `agent_infra_version`、不追加 Activity Log）
 
-`resolve('#NN')` 工作流：① 校验入参严格匹配 `^#\d{shortIdLength}$` → ② 直接以
-`NN` 作为 key 查注册表 `ids` → ③ 命中返回完整 task id，未命中按 `list --verify`
-给出修复指引退出 1。
+`resolve(<N|'#N'>)` 工作流：① 校验入参匹配 `^[#]?[0-9]+$` → ② 去前导零取
+数值 `n`，按 `n` 是否 `== 0`（保留）/ `> 10^shortIdLength - 1`（超容量）/
+正常 三类处理 → ③ 正常时以 `n.padStart(shortIdLength, '0')` 作为 key 查
+注册表 `ids` → ④ 命中返回完整 task id，未命中按 `list --verify` 给出修复指引退出 1。
 
 ## 错误场景
 
-- **短号不存在**：注册表中无 `#NN`。可能是任务已归档（短号已释放）或输入错误。
+- **短号不存在**：注册表中无对应 key。可能是任务已归档（短号已释放）或输入错误。退出码 1。
 - **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
-- **参数格式错误**（如 `#00`、`#abc`、`#`、`#1` 当 `shortIdLength=2` 时）：退出码 1。
+- **保留键**：解析后 `n == 0`（输入如 `0`、`#0`、`#00`）。退出码 1。
+- **超容量**：解析后 `n > 10^shortIdLength - 1`（如 `shortIdLength=2` 下 `100` 或 `#100`）。退出码 1。
+- **参数格式错误**：入参既不是 `^[#]?[0-9]+$` 也不是 `TASK-id`（如 `#abc`、`#`、`5.5`）。退出码 1。
 
 ## 跨 TUI 引号要求
 
-bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#03' 'npm test'`。
-Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#NN` 字面传递到
-SKILL 的 `ARGUMENTS`。
+裸数字 `N` 在所有 shell 与 TUI 中都安全无需引号，推荐写法：
+`ai sandbox exec 11 'npm test'`、`/review-analysis 11`。
+
+`#N` / `#NN` 写法仍然兼容；但 bash 中 `#` 是注释起始符，必须单引号：
+`ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
+在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
 
 ## 冷启动迁移
 

--- a/.agents/rules/task-short-id.md
+++ b/.agents/rules/task-short-id.md
@@ -7,7 +7,7 @@
 
 - 字面接受两种等价形式：
   - **裸数字 `N`**（推荐，无需 shell 引号）：如 `1`、`7`、`42`。
-  - **`#`-前缀 `#N` / `#NN`**（兼容旧写法）：如 `#1`、`#01`、`#42`。
+  - **`#`-前缀 `#N` / `#NN`**（也接受；但 bash 需 `'...'` 引号）：如 `#1`、`#01`、`#42`。
 - 解析规则：去前导零后取数值 `n`，若 `n == 0` 报错（保留）；若 `n > 10^shortIdLength - 1`
   报错（超容量）；否则归一化为 `#${n.padStart(shortIdLength, '0')}`，作为注册表 key。
 - 默认 `shortIdLength=2` 时容量 `n ∈ [1, 99]`，注册表 key 形如 `01`、`07`、`42`。
@@ -117,7 +117,7 @@ fi
 裸数字 `N` 在所有 shell 与 TUI 中都安全无需引号，推荐写法：
 `ai sandbox exec 11 'npm test'`、`/review-analysis 11`。
 
-`#N` / `#NN` 写法仍然兼容；但 bash 中 `#` 是注释起始符，必须单引号：
+`#N` / `#NN` 写法也接受；但 bash 中 `#` 是注释起始符，必须单引号：
 `ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
 在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
 

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -185,24 +185,34 @@ function allocateMinFreeInt(registry, shortIdLength) {
 }
 
 function parseShortIdArg(arg, shortIdLength) {
-  const re = new RegExp(`^#\\d{${shortIdLength}}$`);
-  if (!re.test(arg)) {
-    const example =
-      shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
+  const L = shortIdLength;
+  const max = Math.pow(10, L) - 1;
+  // Accept bare numeric or '#'-prefixed; canonicalize to zero-padded key.
+  // Bare numeric is the recommended form (no shell quoting needed).
+  const m = /^#?(\d+)$/.exec(arg);
+  if (!m) {
     writeStderr(
       `Error: invalid short id format '${arg}', ` +
-        `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
+        `expected bare digits (recommended) or '#'-prefixed digits; ` +
+        `e.g. '11' or '#11' (shortIdLength=${L}, max=${max})\n`
     );
     process.exit(1);
   }
-  const key = arg.slice(1);
-  if (Number(key) === 0) {
+  const n = Number(m[1]);
+  if (n === 0) {
     writeStderr(
-      `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
+      `Error: short id '${arg}' is invalid (#${"0".repeat(L)} is reserved)\n`
     );
     process.exit(1);
   }
-  return key;
+  if (n > max) {
+    writeStderr(
+      `Error: short id ${n} exceeds shortIdLength=${L} capacity (max=${max}); ` +
+        `archive tasks or raise task.shortIdLength in .agents/.airc.json\n`
+    );
+    process.exit(1);
+  }
+  return String(n).padStart(L, "0");
 }
 
 function planTransaction(registry, activeDir, shortIdLength) {
@@ -548,8 +558,8 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
 }
 
 function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
-  // Strict width match + reserved key check; on invalid arg, parseShortIdArg writes full
-  // stderr (including "expected #NN (N-digit zero-padded; e.g. '#01')") and exits 1.
+  // Accepts bare digits ('11') or '#'-prefixed form ('#11', '#11', '#005'); normalized by
+  // numeric value with capacity check (n > 10^L-1) and reserved-zero rejection.
   const key = parseShortIdArg(shortIdArg, shortIdLength);
   return withRegistryLock(activeDir, () => {
     const registry = readRegistry(registryPath);

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -29,7 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -21,7 +21,7 @@ description: "标记任务为阻塞状态并记录原因"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -15,7 +15,7 @@ description: "取消不再需要的任务并转移"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/check-task/SKILL.md
+++ b/.agents/skills/check-task/SKILL.md
@@ -12,7 +12,7 @@ description: "查看任务的当前状态和进度"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 查找任务

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -9,7 +9,7 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -9,7 +9,7 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -44,7 +44,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -176,7 +176,9 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > 仅在校验通过后执行本步骤。
 
-> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`。
+> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/code-task/reference/fix-mode.md
+++ b/.agents/skills/code-task/reference/fix-mode.md
@@ -66,9 +66,9 @@ env-blocked 项不在修复范围。处理规则：
 
 下一步 - 重新审查或提交：
 - 重新审查（始终推荐）：
-  - Claude Code / OpenCode：/review-code {task-id}
-  - Gemini CLI：/agent-infra:review-code {task-id}
-  - Codex CLI：$review-code {task-id}
+  - Claude Code / OpenCode：/review-code {task-ref}
+  - Gemini CLI：/agent-infra:review-code {task-ref}
+  - Codex CLI：$review-code {task-ref}
 - 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit

--- a/.agents/skills/code-task/reference/output-template.md
+++ b/.agents/skills/code-task/reference/output-template.md
@@ -14,7 +14,7 @@
 - 实现报告：.agents/workspace/active/{task-id}/{code-artifact}
 
 下一步 - 代码审查：
-  - Claude Code / OpenCode：/review-code {task-id}
-  - Gemini CLI：/agent-infra:review-code {task-id}
-  - Codex CLI：$review-code {task-id}
+  - Claude Code / OpenCode：/review-code {task-ref}
+  - Gemini CLI：/agent-infra:review-code {task-ref}
+  - Codex CLI：$review-code {task-ref}
 ```

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -19,7 +19,7 @@ description: "提交当前变更到 Git"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 1. 检查本地修改（关键）
 

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -28,7 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -13,7 +13,7 @@ description: "创建 Pull Request 到目标分支"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -24,7 +24,7 @@ description: "根据自然语言描述创建任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 解析用户描述

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -15,7 +15,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -15,7 +15,7 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -15,7 +15,7 @@ description: "从 Issue 导入并创建任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -29,7 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/.agents/skills/restore-task/SKILL.md
+++ b/.agents/skills/restore-task/SKILL.md
@@ -18,7 +18,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证输入与环境

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -30,7 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -91,6 +91,8 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 ### 8. 告知用户
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/review-analysis/reference/output-templates.md
+++ b/.agents/skills/review-analysis/reference/output-templates.md
@@ -25,9 +25,9 @@
 [- 审查报告：.agents/workspace/active/{task-id}/{review-artifact}]
 
 下一步 - 编写技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -41,14 +41,14 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订分析后继续（推荐）：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 或直接进入方案设计：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -62,9 +62,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订需求分析：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -78,9 +78,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新分析：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -38,7 +38,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -123,6 +123,8 @@ node .agents/scripts/validate-artifact.js gate review-code .agents/workspace/act
 env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显示。
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/.agents/skills/review-code/reference/output-templates.md
+++ b/.agents/skills/review-code/reference/output-templates.md
@@ -43,9 +43,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修复问题后提交（推荐）：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 或直接提交（跳过修复）：
   - Claude Code / OpenCode：/commit
@@ -64,9 +64,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修复问题：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /code-task。
@@ -80,9 +80,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新设计技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 > 注意：Rejected 表示实现方向需要整体重做，不是局部修复。`code-task/scripts/detect-mode.js` 分支 #7 会拒绝直接 `/code-task`，要求先重新方案设计。
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -30,7 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -91,6 +91,8 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 ### 8. 告知用户
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/review-plan/reference/output-templates.md
+++ b/.agents/skills/review-plan/reference/output-templates.md
@@ -25,9 +25,9 @@
 [- 审查报告：.agents/workspace/active/{task-id}/{review-artifact}]
 
 下一步 - 编写代码：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -41,14 +41,14 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订方案后编码（推荐）：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 或直接进入编码：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -62,9 +62,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -78,9 +78,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新设计：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,6 +18,7 @@ Usage:
   agent-infra init            Initialize a new project with update-agent-infra seed command
   agent-infra merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   agent-infra sandbox         Manage Docker-based AI sandboxes
+  agent-infra task            Read-only views over .agents/workspace tasks (ls / show)
   agent-infra update          Update seed files and sync file registry for an existing project
   agent-infra version         Show version
 
@@ -92,6 +93,16 @@ switch (command) {
     if (!imported) break;
     const { runSandbox } = imported;
     await runSandbox(process.argv.slice(3)).catch((e: unknown) => {
+      process.stderr.write(`Error: ${errorMessage(e)}\n`);
+      process.exit(1);
+    });
+    break;
+  }
+  case 'task': {
+    const imported = await importCommand('../lib/task/index.ts');
+    if (!imported) break;
+    const { runTask } = imported;
+    await runTask(process.argv.slice(3)).catch((e: unknown) => {
       process.stderr.write(`Error: ${errorMessage(e)}\n`);
       process.exit(1);
     });

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from '../config.ts';
-import { assertValidBranchName, containerNameCandidates, sandboxBranchLabel, sandboxLabel } from '../constants.ts';
+import { assertValidBranchName, containerNameCandidates } from '../constants.ts';
 import { detectEngine } from '../engine.ts';
 import {
   formatCredentialWarnings,
@@ -13,12 +13,14 @@ import { resolveTaskBranch } from '../task-resolver.ts';
 import { dotfilesCacheDir, materializeDotfiles } from '../dotfiles.ts';
 import { runInteractiveWithClipboardBridge } from '../clipboard/bridge.ts';
 import { detectHostTimezone } from '../host-timezone.ts';
-import { fetchSandboxRows, isTaskShortRef, resolveTaskShortRef } from './list-running.ts';
+import { isTaskShortRef, resolveTaskShortRef } from './list-running.ts';
 
-const USAGE = `Usage: ai sandbox exec <branch | TASK-id | '#N'> [cmd...]
+const USAGE = `Usage: ai sandbox exec <branch | TASK-id | N | '#N'> [cmd...]
 
-'#N' references the N-th running sandbox in 'ai sandbox ls' order (1-based).
-Quote it as '#N' to avoid shell '#' comment handling.`;
+N (bare) and '#N' both reference the same active task short id from
+.agents/workspace/active/.short-ids.json. The legacy "#N = N-th running
+sandbox" semantics from #414 has been removed; '#N' or bare N always
+resolves to a task short id, never to a container row index.`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
 
 // Terminal-detection variables that interactive TUIs (e.g. claude-code)
@@ -122,8 +124,7 @@ export async function enter(args: string[]): Promise<number> {
   const [firstArg = '', ...cmd] = args;
   let branch: string;
   if (isTaskShortRef(firstArg)) {
-    const { running } = fetchSandboxRows(engine, sandboxLabel(config), sandboxBranchLabel(config));
-    branch = resolveTaskShortRef(firstArg, { running, repoRoot: config.repoRoot });
+    branch = resolveTaskShortRef(firstArg, { repoRoot: config.repoRoot });
   } else {
     branch = resolveTaskBranch(firstArg, config.repoRoot);
   }

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -18,9 +18,9 @@ import { isTaskShortRef, resolveTaskShortRef } from './list-running.ts';
 const USAGE = `Usage: ai sandbox exec <branch | TASK-id | N | '#N'> [cmd...]
 
 N (bare) and '#N' both reference the same active task short id from
-.agents/workspace/active/.short-ids.json. The legacy "#N = N-th running
-sandbox" semantics from #414 has been removed; '#N' or bare N always
-resolves to a task short id, never to a container row index.`;
+.agents/workspace/active/.short-ids.json. The "#N = N-th running sandbox"
+semantics from #414 has been removed; '#N' or bare N always resolves to a
+task short id, never to a container row index.`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
 
 // Terminal-detection variables that interactive TUIs (e.g. claude-code)

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -18,9 +18,9 @@ import { isTaskShortRef, resolveTaskShortRef } from './list-running.ts';
 const USAGE = `Usage: ai sandbox exec <branch | TASK-id | N | '#N'> [cmd...]
 
 N (bare) and '#N' both reference the same active task short id from
-.agents/workspace/active/.short-ids.json. The "#N = N-th running sandbox"
-semantics from #414 has been removed; '#N' or bare N always resolves to a
-task short id, never to a container row index.`;
+.agents/workspace/active/.short-ids.json. They resolve only via that
+registry — they do not reference a container's row position in
+'ai sandbox ls' output.`;
 const TMUX_ENTRY_PATH = '/usr/local/bin/sandbox-tmux-entry';
 
 // Terminal-detection variables that interactive TUIs (e.g. claude-code)

--- a/lib/sandbox/commands/list-running.ts
+++ b/lib/sandbox/commands/list-running.ts
@@ -147,15 +147,16 @@ function tryResolveFromRegistry(arg: string, repoRoot: string): RegistryLookup {
 }
 
 /**
+/**
  * Resolve a task short reference (bare 'N' or '#N') to a branch name for the
  * sandbox entrypoint.
  *
- * Resolution order:
- *   1. Resolve via the global task-short-id registry under repoRoot. If hit,
- *      look up the branch from the matching task.md.
- *   2. On miss (registry empty or short id absent), throw with an actionable
- *      message — the "#N = N-th running sandbox" fallback (#414) was removed
- *      in favour of unambiguous short-id-only semantics.
+ * Resolution: registry-only. Look up the short id in the global task-short-id
+ * registry under repoRoot; if hit, read the branch from the matching task.md.
+ * On miss (registry empty or short id absent), throw with an actionable
+ * message instead of falling back to a container's row position in
+ * 'ai sandbox ls' output — that fallback would make the same syntax mean
+ * different things depending on `docker ps` state.
  *
  * Precondition: callers MUST gate on isTaskShortRef(arg) === true.
  */
@@ -167,7 +168,7 @@ export function resolveTaskShortRef(
   if (lookup.status === 'hit') return lookup.branch;
   throw new Error(
     `short ref '${arg}' is not in the active task registry. ` +
-      `The '#N' = N-th running sandbox semantics from #414 has been removed; ` +
+      `'#N' and bare N resolve only via the registry (not by row position in 'ai sandbox ls'); ` +
       `use a task short id (e.g. 'ai sandbox exec 11'), a TASK-id, or a branch name.`
   );
 }

--- a/lib/sandbox/commands/list-running.ts
+++ b/lib/sandbox/commands/list-running.ts
@@ -88,13 +88,14 @@ export function fetchSandboxRows(
 }
 
 /**
- * Returns true iff `arg` is a syntactically valid task short reference ('#N').
+ * Returns true iff `arg` is a syntactically valid task short reference.
+ * Accepts both bare numeric ('11') and '#'-prefixed ('#11') forms.
  * Zero IO. Callers MUST use this as the gate before constructing any context
  * for resolveTaskShortRef — that way non-matching arguments (e.g. '#abc',
  * '#1.5', '#') never trigger sandbox list IO.
  */
 export function isTaskShortRef(arg: string): boolean {
-  return /^#\d+$/.test(arg);
+  return /^#?\d+$/.test(arg);
 }
 
 type RegistryLookup =
@@ -113,6 +114,9 @@ type RegistryLookup =
 function tryResolveFromRegistry(arg: string, repoRoot: string): RegistryLookup {
   const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
   if (!fs.existsSync(scriptPath)) return { status: 'miss' };
+  // Strip leading '#' when forwarding bare-numeric input through the script's CLI.
+  // (Script accepts both forms, but this avoids shell quoting confusion in error
+  // messages echoed back to the user.)
   const result = spawnSync('node', [scriptPath, 'resolve', arg], { encoding: 'utf8', cwd: repoRoot });
   if (result.status !== 0) return { status: 'miss' };
   const taskId = (result.stdout || '').trim();
@@ -142,47 +146,28 @@ function tryResolveFromRegistry(arg: string, repoRoot: string): RegistryLookup {
   );
 }
 
-function resolveByRunningIndex(arg: string, running: SandboxRow[]): string {
-  const n = Number(arg.slice(1));
-  if (n < 1) {
-    throw new Error(`Invalid sandbox index '${arg}': must be >= 1`);
-  }
-  if (running.length === 0) {
-    throw new Error(`No running sandbox to reference with '${arg}'`);
-  }
-  if (n > running.length) {
-    throw new Error(
-      `No running sandbox at index '${arg}' (only ${running.length} running)`
-    );
-  }
-  const row = running[n - 1]!;
-  if (!row.branch) {
-    throw new Error(
-      `Cannot resolve branch for sandbox '${arg}' (container '${row.name}' missing branch label)`
-    );
-  }
-  return row.branch;
-}
-
 /**
- * Resolve a task short reference ('#N') to a branch name for the sandbox entrypoint.
+ * Resolve a task short reference (bare 'N' or '#N') to a branch name for the
+ * sandbox entrypoint.
  *
- * Resolution order (sandbox fallback mode, plan-r7 C2):
- *   1. Try the global task-short-id registry under repoRoot. If hit, look up the
- *      branch from the matching task.md.
- *   2. Fallback to the running-sandbox list index (preserves the #414 ls-index
- *      behaviour; long-term contract per analysis-r5).
+ * Resolution order:
+ *   1. Resolve via the global task-short-id registry under repoRoot. If hit,
+ *      look up the branch from the matching task.md.
+ *   2. On miss (registry empty or short id absent), throw with an actionable
+ *      message — the legacy "#N = N-th running sandbox" fallback (#414) was
+ *      removed in favour of unambiguous short-id-only semantics.
  *
  * Precondition: callers MUST gate on isTaskShortRef(arg) === true.
  */
 export function resolveTaskShortRef(
   arg: string,
-  ctx: { running: SandboxRow[]; repoRoot?: string }
+  ctx: { repoRoot: string }
 ): string {
-  if (ctx.repoRoot) {
-    const lookup = tryResolveFromRegistry(arg, ctx.repoRoot);
-    if (lookup.status === 'hit') return lookup.branch;
-    // 'miss' falls through to ls-index fallback (preserves #414 behaviour); 'hit-but-invalid' already threw above.
-  }
-  return resolveByRunningIndex(arg, ctx.running);
+  const lookup = tryResolveFromRegistry(arg, ctx.repoRoot);
+  if (lookup.status === 'hit') return lookup.branch;
+  throw new Error(
+    `short ref '${arg}' is not in the active task registry. ` +
+      `The legacy '#N' = N-th running sandbox semantics has been removed; ` +
+      `use a task short id (e.g. 'ai sandbox exec 11'), a TASK-id, or a branch name.`
+  );
 }

--- a/lib/sandbox/commands/list-running.ts
+++ b/lib/sandbox/commands/list-running.ts
@@ -154,8 +154,8 @@ function tryResolveFromRegistry(arg: string, repoRoot: string): RegistryLookup {
  *   1. Resolve via the global task-short-id registry under repoRoot. If hit,
  *      look up the branch from the matching task.md.
  *   2. On miss (registry empty or short id absent), throw with an actionable
- *      message — the legacy "#N = N-th running sandbox" fallback (#414) was
- *      removed in favour of unambiguous short-id-only semantics.
+ *      message — the "#N = N-th running sandbox" fallback (#414) was removed
+ *      in favour of unambiguous short-id-only semantics.
  *
  * Precondition: callers MUST gate on isTaskShortRef(arg) === true.
  */
@@ -167,7 +167,7 @@ export function resolveTaskShortRef(
   if (lookup.status === 'hit') return lookup.branch;
   throw new Error(
     `short ref '${arg}' is not in the active task registry. ` +
-      `The legacy '#N' = N-th running sandbox semantics has been removed; ` +
+      `The '#N' = N-th running sandbox semantics from #414 has been removed; ` +
       `use a task short id (e.g. 'ai sandbox exec 11'), a TASK-id, or a branch name.`
   );
 }

--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -6,6 +6,8 @@ import { loadConfig } from '../config.ts';
 import { sandboxBranchLabel, sandboxLabel } from '../constants.ts';
 import { detectEngine } from '../engine.ts';
 import { resolveTools, toolProjectDirCandidates } from '../tools.ts';
+import { formatTable } from '../../table.ts';
+import { lookupShortIdByBranch } from '../../task/short-id.ts';
 import { fetchSandboxRows } from './list-running.ts';
 
 export { containerListFormat, parseLabels } from './list-running.ts';
@@ -13,8 +15,10 @@ export { containerListFormat, parseLabels } from './list-running.ts';
 const USAGE = `Usage: ai sandbox ls
 
 Lists all containers for the current project. The leftmost '#' column
-numbers running sandboxes; use it as "ai sandbox exec '#N'" to enter one.
-Quote '#N' to avoid shell '#' comment handling.`;
+shows the active task short id bound to each container's branch (via
+.agents/workspace/active/.short-ids.json); '-' means no active task is
+bound to the branch. Use it as "ai sandbox exec N" or "ai sandbox exec
+'#N'" to enter the sandbox of that task.`;
 
 const CONTAINER_TABLE_HEADERS = ['#', 'NAMES', 'STATUS', 'BRANCH'] as const;
 
@@ -26,20 +30,10 @@ type ContainerTableRow = {
 };
 
 export function formatContainerTable(rows: ContainerTableRow[]): string[] {
-  const columns = rows.map((row) => [row.index, row.name, row.status, row.branch] as const);
-  const widths = [
-    Math.max(CONTAINER_TABLE_HEADERS[0].length, ...rows.map((row) => row.index.length)),
-    Math.max(CONTAINER_TABLE_HEADERS[1].length, ...rows.map((row) => row.name.length)),
-    Math.max(CONTAINER_TABLE_HEADERS[2].length, ...rows.map((row) => row.status.length)),
-    Math.max(CONTAINER_TABLE_HEADERS[3].length, ...rows.map((row) => row.branch.length))
-  ] as const;
-  const renderRow = (values: readonly [string, string, string, string]): string =>
-    `${values[0].padEnd(widths[0])}  ${values[1].padEnd(widths[1])}  ${values[2].padEnd(widths[2])}  ${values[3]}`.trimEnd();
-
-  return [
-    renderRow(CONTAINER_TABLE_HEADERS),
-    ...columns.map((column) => renderRow(column))
-  ];
+  return formatTable(
+    CONTAINER_TABLE_HEADERS,
+    rows.map((row) => [row.index, row.name, row.status, row.branch])
+  );
 }
 
 function listChildren(dir: string): string[] {
@@ -69,12 +63,15 @@ export function ls(args: string[] = []): void {
   if (ordered.length === 0) {
     p.log.warn('  No sandbox containers');
   } else {
-    const tableRows: ContainerTableRow[] = ordered.map((row) => ({
-      index: row.index === null ? '' : String(row.index),
-      name: row.name,
-      status: row.status,
-      branch: row.branch
-    }));
+    const tableRows: ContainerTableRow[] = ordered.map((row) => {
+      const shortId = row.branch ? lookupShortIdByBranch(row.branch, config.repoRoot) : null;
+      return {
+        index: shortId ?? '-',
+        name: row.name,
+        status: row.status,
+        branch: row.branch
+      };
+    });
     for (const line of formatContainerTable(tableRows)) {
       process.stdout.write(`  ${line}\n`);
     }

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -2,9 +2,13 @@ const USAGE = `Usage: ai sandbox <command> [options]
 
 Commands:
   create <branch> [base]       Create a sandbox (VM + image + worktree + container)
-  exec <branch | '#N'> [cmd...]
-                               Enter sandbox or run a command (use leftmost '#' column from 'ls')
-  ls                           List sandboxes for the current project
+  exec <branch | TASK-id | N | '#N'> [cmd...]
+                               Enter sandbox or run a command. N (bare) is the
+                               recommended form for task short ids (e.g.
+                               'ai sandbox exec 11'); '#N' is also accepted.
+  ls                           List sandboxes for the current project (the '#'
+                               column shows the active task short id; '-' if no
+                               active task is bound to the container's branch)
   prune [--dry-run]            Remove orphaned per-branch state dirs
   rebuild [--quiet] [--refresh]
                                Rebuild the sandbox image (--refresh pulls base + tools)

--- a/lib/sandbox/task-resolver.ts
+++ b/lib/sandbox/task-resolver.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
-const SHORT_ID_RE = /^#\d+$/;
+const SHORT_ID_RE = /^#?\d+$/;
 const WORKSPACE_DIRS = ['active', 'completed', 'blocked', 'archive'];
 
 function resolveShortIdStrict(arg: string, repoRoot: string): string {

--- a/lib/table.ts
+++ b/lib/table.ts
@@ -1,0 +1,32 @@
+function formatTable(
+  headers: readonly string[],
+  rows: readonly (readonly string[])[]
+): string[] {
+  const columnCount = headers.length;
+  const widths = headers.map((header, i) => {
+    const headerLen = header.length;
+    let max = headerLen;
+    for (const row of rows) {
+      const cell = row[i] ?? '';
+      if (cell.length > max) max = cell.length;
+    }
+    return max;
+  });
+
+  const renderRow = (values: readonly string[]): string => {
+    const parts: string[] = [];
+    for (let i = 0; i < columnCount; i += 1) {
+      const cell = values[i] ?? '';
+      if (i === columnCount - 1) {
+        parts.push(cell);
+      } else {
+        parts.push(cell.padEnd(widths[i]!));
+      }
+    }
+    return parts.join('  ').trimEnd();
+  };
+
+  return [renderRow(headers), ...rows.map((row) => renderRow(row))];
+}
+
+export { formatTable };

--- a/lib/task/commands/ls.ts
+++ b/lib/task/commands/ls.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { formatTable } from '../../table.ts';
+import { parseTaskFrontmatter, extractTitle } from '../frontmatter.ts';
+
+const USAGE = `Usage: ai task ls [--all | --blocked | --completed]
+
+Lists tasks under .agents/workspace/. Defaults to active tasks only.
+  --all         Include active + blocked + completed (excludes archive)
+  --blocked     Only blocked tasks
+  --completed   Only completed tasks
+
+Columns: # / short_id / type / status / current_step / branch / title
+`;
+
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+const TABLE_HEADERS = ['#', 'SHORT', 'TYPE', 'STATUS', 'STEP', 'BRANCH', 'TITLE'] as const;
+
+type Selection = ('active' | 'blocked' | 'completed')[];
+
+function detectRepoRoot(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    throw new Error('ai task: current directory is not inside a git repository');
+  }
+}
+
+type ParseResult =
+  | { ok: true; selection: Selection }
+  | { ok: false; message: string };
+
+function parseSelection(args: string[]): ParseResult {
+  const positional = args.filter((a) => !a.startsWith('--'));
+  if (positional.length > 0) {
+    return {
+      ok: false,
+      message: `ai task ls: unexpected positional argument(s): ${positional.join(' ')}`
+    };
+  }
+  const flags = args.filter((a) => a.startsWith('--'));
+  if (flags.length === 0) return { ok: true, selection: ['active'] };
+  if (flags.length > 1) {
+    return {
+      ok: false,
+      message: 'ai task ls: pass at most one of --all / --blocked / --completed'
+    };
+  }
+  switch (flags[0]) {
+    case '--all':
+      return { ok: true, selection: ['active', 'blocked', 'completed'] };
+    case '--blocked':
+      return { ok: true, selection: ['blocked'] };
+    case '--completed':
+      return { ok: true, selection: ['completed'] };
+    default:
+      return { ok: false, message: `ai task ls: unknown flag: ${flags[0]}` };
+  }
+}
+
+type TaskRow = {
+  shortIdNumeric: string;
+  shortId: string;
+  type: string;
+  status: string;
+  step: string;
+  branch: string;
+  title: string;
+};
+
+function collectTasks(repoRoot: string, state: 'active' | 'blocked' | 'completed'): TaskRow[] {
+  const dir = path.join(repoRoot, '.agents', 'workspace', state);
+  if (!fs.existsSync(dir)) return [];
+  const rows: TaskRow[] = [];
+  for (const entry of fs.readdirSync(dir).sort()) {
+    if (!TASK_ID_RE.test(entry)) continue;
+    const taskMdPath = path.join(dir, entry, 'task.md');
+    if (!fs.existsSync(taskMdPath)) continue;
+    const content = fs.readFileSync(taskMdPath, 'utf8');
+    const fm = parseTaskFrontmatter(content);
+    const title = extractTitle(content);
+    const shortId = (fm.short_id ?? '').trim() || '-';
+    const shortIdNumeric = shortId.startsWith('#') ? String(Number(shortId.slice(1)) || 0) : '';
+    rows.push({
+      shortIdNumeric,
+      shortId,
+      type: fm.type ?? '-',
+      status: fm.status ?? state,
+      step: fm.current_step ?? '-',
+      branch: fm.branch ?? '-',
+      title: title || fm.id || entry
+    });
+  }
+  return rows;
+}
+
+function ls(args: string[] = []): void {
+  if (args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    return;
+  }
+  const result = parseSelection(args);
+  if (!result.ok) {
+    process.stderr.write(`${result.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const { selection } = result;
+  const repoRoot = detectRepoRoot();
+  const rows: TaskRow[] = [];
+  for (const state of selection) {
+    rows.push(...collectTasks(repoRoot, state));
+  }
+  if (rows.length === 0) {
+    process.stdout.write(`No tasks under .agents/workspace/${selection.join('|')}\n`);
+    return;
+  }
+  const tableRows = rows.map((r) => [
+    r.shortIdNumeric,
+    r.shortId,
+    r.type,
+    r.status,
+    r.step,
+    r.branch,
+    r.title
+  ]);
+  for (const line of formatTable(TABLE_HEADERS, tableRows)) {
+    process.stdout.write(`${line}\n`);
+  }
+}
+
+export { ls };

--- a/lib/task/commands/show.ts
+++ b/lib/task/commands/show.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { normalizeShortIdInput } from '../short-id.ts';
+
+const USAGE = `Usage: ai task show <N | #N | TASK-id>
+
+Prints the task.md content for the matching task.
+  N (bare numeric)   Recommended; resolves the active short id via the registry.
+  '#N'               Compatibility form for old commands.
+  TASK-YYYYMMDD-HHMMSS  Locates a task in active / blocked / completed / archive.
+`;
+
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+// Flat-structured workspace dirs that hold tasks under `{dir}/{taskId}/task.md`.
+// Note: `archive` uses a three-level YYYY/MM/DD layout and is handled separately.
+const FLAT_WORKSPACE_DIRS = ['active', 'blocked', 'completed'] as const;
+
+function detectRepoRoot(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    throw new Error('ai task: current directory is not inside a git repository');
+  }
+}
+
+function readShortIdLength(repoRoot: string): number {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8'));
+    const v = cfg?.task?.shortIdLength;
+    if (typeof v === 'number' && Number.isFinite(v) && v >= 1) return v;
+  } catch {
+    // fall through to default
+  }
+  return 2;
+}
+
+function resolveShortIdToTaskId(arg: string, repoRoot: string): string {
+  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
+  if (!fs.existsSync(scriptPath)) {
+    throw new Error(`task-short-id.js not found at ${scriptPath}`);
+  }
+  const result = spawnSync('node', [scriptPath, 'resolve', arg], {
+    encoding: 'utf8',
+    cwd: repoRoot
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `failed to resolve '${arg}'`);
+  }
+  return result.stdout.trim();
+}
+
+function listSortedNumeric(dir: string, width: number): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const pattern = new RegExp(`^\\d{${width}}$`);
+  return fs
+    .readdirSync(dir)
+    .filter((entry) => pattern.test(entry))
+    .sort()
+    .reverse();
+}
+
+function findInArchive(repoRoot: string, taskId: string): string | null {
+  // archive-tasks SKILL writes to .agents/workspace/archive/YYYY/MM/DD/{taskId}/task.md
+  // where YYYY/MM/DD comes from completed_at (or updated_at fallback) — NOT from
+  // the task id's creation date. So we cannot derive the path from taskId alone;
+  // walk the bounded YYYY/MM/DD tree instead. Newest-first to favor recent archives.
+  const archiveDir = path.join(repoRoot, '.agents', 'workspace', 'archive');
+  for (const year of listSortedNumeric(archiveDir, 4)) {
+    const yearDir = path.join(archiveDir, year);
+    for (const month of listSortedNumeric(yearDir, 2)) {
+      const monthDir = path.join(yearDir, month);
+      for (const day of listSortedNumeric(monthDir, 2)) {
+        const candidate = path.join(monthDir, day, taskId, 'task.md');
+        if (fs.existsSync(candidate)) return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function findTaskMd(repoRoot: string, taskId: string): string | null {
+  for (const sub of FLAT_WORKSPACE_DIRS) {
+    const candidate = path.join(repoRoot, '.agents', 'workspace', sub, taskId, 'task.md');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return findInArchive(repoRoot, taskId);
+}
+
+function show(args: string[] = []): void {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    if (args.length === 0) process.exitCode = 1;
+    return;
+  }
+  const repoRoot = detectRepoRoot();
+  const arg = args[0]!;
+  let taskId: string;
+  if (TASK_ID_RE.test(arg)) {
+    taskId = arg;
+  } else {
+    const shortIdLength = readShortIdLength(repoRoot);
+    const normalized = normalizeShortIdInput(arg, { shortIdLength });
+    if (normalized.kind === 'error') {
+      process.stderr.write(`ai task show: ${normalized.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    if (normalized.kind === 'pass') {
+      process.stderr.write(
+        `ai task show: '${arg}' is not a valid short id or TASK-id; ` +
+          `expected bare digits, '#N', or 'TASK-YYYYMMDD-HHMMSS'\n`
+      );
+      process.exitCode = 1;
+      return;
+    }
+    try {
+      taskId = resolveShortIdToTaskId(normalized.value, repoRoot);
+    } catch (e) {
+      process.stderr.write(`ai task show: ${(e as Error).message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+  const taskMdPath = findTaskMd(repoRoot, taskId);
+  if (!taskMdPath) {
+    process.stderr.write(
+      `ai task show: task ${taskId} not found in active / blocked / completed / archive\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(fs.readFileSync(taskMdPath, 'utf8'));
+}
+
+export { show };

--- a/lib/task/frontmatter.ts
+++ b/lib/task/frontmatter.ts
@@ -1,0 +1,30 @@
+type Frontmatter = Record<string, string>;
+
+function parseTaskFrontmatter(content: string): Frontmatter {
+  const result: Frontmatter = {};
+  if (!content.startsWith('---')) return result;
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) return result;
+  const body = content.slice(3, end);
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line.trim()) continue;
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+function extractTitle(content: string): string {
+  for (const line of content.split('\n')) {
+    const m = /^#\s+(?:任务[:：]?\s*)?(.+)$/.exec(line.trim());
+    if (m && m[1]) return m[1].trim();
+  }
+  return '';
+}
+
+export { parseTaskFrontmatter, extractTitle };
+export type { Frontmatter };

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -1,0 +1,44 @@
+const USAGE = `Usage: ai task <command> [options]
+
+Commands:
+  ls [--all | --blocked | --completed]   List tasks (default: active)
+  show <N | #N | TASK-id>                Print a task.md
+
+Examples:
+  ai task ls
+  ai task show 11
+  ai task show TASK-20260612-162737
+
+Run 'ai task <command> --help' for details.`;
+
+export async function runTask(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+
+  if (!subcommand) {
+    process.stdout.write(`${USAGE}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  switch (subcommand) {
+    case 'ls': {
+      const { ls } = await import('./commands/ls.ts');
+      ls(rest);
+      break;
+    }
+    case 'show': {
+      const { show } = await import('./commands/show.ts');
+      show(rest);
+      break;
+    }
+    default:
+      process.stderr.write(`Unknown task command: ${subcommand}\n\n`);
+      process.stdout.write(`${USAGE}\n`);
+      process.exitCode = 1;
+  }
+}

--- a/lib/task/short-id.ts
+++ b/lib/task/short-id.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REGISTRY_NAME = '.short-ids.json';
+
+type NormalizeResult =
+  | { kind: 'shortId'; value: string }
+  | { kind: 'pass'; value: string }
+  | { kind: 'error'; message: string };
+
+type NormalizeOpts = { shortIdLength: number };
+
+function normalizeShortIdInput(input: string, opts: NormalizeOpts): NormalizeResult {
+  const L = opts.shortIdLength;
+  const m = /^#?(\d+)$/.exec(input);
+  if (!m) {
+    return { kind: 'pass', value: input };
+  }
+  const n = Number(m[1]);
+  if (n === 0) {
+    return {
+      kind: 'error',
+      message: `short id '${input}' is invalid (#${'0'.repeat(L)} is reserved)`
+    };
+  }
+  const max = Math.pow(10, L) - 1;
+  if (n > max) {
+    return {
+      kind: 'error',
+      message: `short id ${n} exceeds shortIdLength=${L} capacity (max=${max}); archive tasks or raise task.shortIdLength in .agents/.airc.json`
+    };
+  }
+  return { kind: 'shortId', value: `#${String(n).padStart(L, '0')}` };
+}
+
+type RegistrySchema = {
+  version: number;
+  ids: Record<string, string>;
+};
+
+function readRegistry(repoRoot: string): RegistrySchema | null {
+  const registryPath = path.join(repoRoot, '.agents', 'workspace', 'active', REGISTRY_NAME);
+  if (!fs.existsSync(registryPath)) return null;
+  try {
+    const raw = fs.readFileSync(registryPath, 'utf8');
+    const data = JSON.parse(raw) as RegistrySchema;
+    if (!data || typeof data !== 'object' || !data.ids) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+function readBranchFromTaskMd(repoRoot: string, taskId: string): string | null {
+  const taskMdPath = path.join(repoRoot, '.agents', 'workspace', 'active', taskId, 'task.md');
+  if (!fs.existsSync(taskMdPath)) return null;
+  const content = fs.readFileSync(taskMdPath, 'utf8');
+  const m = content.match(/^branch:\s*(.+)$/m);
+  if (!m || !m[1]) return null;
+  return m[1].trim().replace(/^(["'])(.*)\1$/, '$2');
+}
+
+function lookupShortIdByBranch(
+  branch: string,
+  repoRoot: string,
+  _opts?: { shortIdLength?: number }
+): string | null {
+  const registry = readRegistry(repoRoot);
+  if (!registry) return null;
+  const matches: string[] = [];
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    const taskBranch = readBranchFromTaskMd(repoRoot, taskId);
+    if (taskBranch && taskBranch === branch) {
+      matches.push(`#${key}`);
+    }
+  }
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    process.stderr.write(
+      `Warning: branch '${branch}' is bound to multiple active tasks: ${matches.join(', ')}; using ${matches[0]}\n`
+    );
+  }
+  return matches[0]!;
+}
+
+export { normalizeShortIdInput, lookupShortIdByBranch };
+export type { NormalizeResult, NormalizeOpts };

--- a/templates/.agents/rules/task-short-id.en.md
+++ b/templates/.agents/rules/task-short-id.en.md
@@ -8,7 +8,7 @@ task is active.
 
 - Two equivalent literal forms are accepted:
   - **Bare numeric `N`** (recommended; no shell quoting needed): e.g. `1`, `7`, `42`.
-  - **`#`-prefixed `#N` / `#NN`** (compat with legacy commands): e.g. `#1`, `#01`, `#42`.
+  - **`#`-prefixed `#N` / `#NN`** (also accepted; bash needs `'...'` quoting): e.g. `#1`, `#01`, `#42`.
 - Resolution: drop leading zeros and take the numeric value `n`; if `n == 0`,
   reject (reserved); if `n > 10^shortIdLength - 1`, reject (over capacity);
   otherwise canonicalize to `#${n.padStart(shortIdLength, '0')}` as the
@@ -140,7 +140,7 @@ repair hint.
 Bare numeric `N` is safe in every shell and TUI without quoting (recommended):
 `ai sandbox exec 11 'npm test'`, `/review-analysis 11`.
 
-The `#N` / `#NN` form is still accepted; but bash treats `#` as a comment
+The `#N` / `#NN` form is also accepted; but bash treats `#` as a comment
 marker, so it must be single-quoted: `ai sandbox exec '#03' 'npm test'`.
 Claude Code / Codex / Gemini CLI / OpenCode all forward `#NN` to SKILL
 `ARGUMENTS` literally when quoted.

--- a/templates/.agents/rules/task-short-id.en.md
+++ b/templates/.agents/rules/task-short-id.en.md
@@ -1,18 +1,24 @@
 # Task short id
 
 Task short ids let mobile-style SKILL invocations replace the full 22-char
-`TASK-YYYYMMDD-HHMMSS` with `#NN` while a task is active.
+`TASK-YYYYMMDD-HHMMSS` with bare numeric `N` (recommended) or `#NN` while a
+task is active.
 
 ## Syntax
 
-- Format: `^#\d{shortIdLength}$` (**zero-padded to a fixed width**; with the
-  default `shortIdLength=2`, e.g. `#01`, `#07`, `#42`).
-- **Must** be zero-padded to `shortIdLength` digits (default 2: `#1` is a format
-  error, use `#01`). This keeps things aligned and touch-typeable.
+- Two equivalent literal forms are accepted:
+  - **Bare numeric `N`** (recommended; no shell quoting needed): e.g. `1`, `7`, `42`.
+  - **`#`-prefixed `#N` / `#NN`** (compat with legacy commands): e.g. `#1`, `#01`, `#42`.
+- Resolution: drop leading zeros and take the numeric value `n`; if `n == 0`,
+  reject (reserved); if `n > 10^shortIdLength - 1`, reject (over capacity);
+  otherwise canonicalize to `#${n.padStart(shortIdLength, '0')}` as the
+  registry key.
+- With the default `shortIdLength=2`, capacity is `n ∈ [1, 99]`; registry keys
+  look like `01`, `07`, `42`.
 - `#00` (or `#0` when `shortIdLength=1`) is reserved and never allocated; digits
   only, no letters.
-- The plain `TASK-…` form keeps working everywhere; `#NN` is an alias, not the
-  persisted task id.
+- The plain `TASK-…` form keeps working everywhere; bare numeric / `#NN` is an
+  alias, not the persisted task id.
 
 ## Lifecycle
 
@@ -48,7 +54,7 @@ archiving all active tasks first (the registry key width depends on it).
 | Entrypoint                                                  | Hit                  | Miss                                                 |
 |-------------------------------------------------------------|----------------------|------------------------------------------------------|
 | SKILL parameter resolver (lifecycle SKILLs)                  | resolve to full id   | **strict error** — short id not found / invalid     |
-| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`        | resolve to full id   | fall back to running-sandbox ls index (`#414`)      |
+| `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | resolve to full id, then read `branch` from task.md | **strict error** — no ls-index fallback, no literal-branch fallback; hint the user to pass a short id / `TASK-id` / branch name |
 
 `list --verify` is strictly read-only: it reports discrepancies between active
 dir, registry, and `short_id` declared in each `task.md`, but never writes.
@@ -58,12 +64,13 @@ dir, registry, and `short_id` declared in each `task.md`, but never writes.
 Any SKILL (alloc / resolve / release / re-alloc lifecycle entry-points) that
 receives a `{task-id}` argument must follow this contract:
 
-1. If `{task-id}` starts with `#`:
+1. If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric `N` or `#`-prefixed `#N`):
 
 ```bash
-if [[ "{task-id}" == "#"* ]]; then
-  # The script writes the full error message (including "expected #NN
-  # (N-digit zero-padded; e.g. '#01')") to stderr; callers only forward the exit.
+if [[ "{task-id}" =~ ^[#]?[0-9]+$ ]]; then
+  # The script writes the full error message (covering reserved / exceeds
+  # shortIdLength capacity / malformed input) to stderr; callers only forward
+  # the exit.
   task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
 else
   task_id="{task-id}"
@@ -108,22 +115,33 @@ The short id system persists state in two places that stay in sync at rest:
   field write is constrained (does NOT refresh `updated_at` /
   `agent_infra_version` and does NOT append Activity Log).
 
-`resolve('#NN')` workflow: ① validate arg matches `^#\d{shortIdLength}$` →
-② look up `NN` directly as the registry `ids` key → ③ return full task id on
-hit; on miss, exit 1 with the `list --verify` repair hint.
+`resolve(<N|'#N'>)` workflow: ① validate arg matches `^[#]?[0-9]+$` →
+② strip leading zeros and take the numeric value `n`; classify as reserved
+(`n == 0`) / over capacity (`n > 10^shortIdLength - 1`) / normal → ③ on
+normal, use `n.padStart(shortIdLength, '0')` as the registry `ids` key
+→ ④ return full task id on hit; on miss, exit 1 with the `list --verify`
+repair hint.
 
 ## Error scenarios
 
-- **Short id not found**: the registry has no entry for `#NN`. Either the task
-  was archived (release freed the slot) or the input is wrong.
+- **Short id not found**: the registry has no entry for the resolved key.
+  Either the task was archived (release freed the slot) or the input is
+  wrong. Exit code 1.
 - **Registry corruption** (duplicate registry entries for the same task id, or
   the JSON is unparsable): exit code 2; manual cleanup required.
-- **Parameter format error** (e.g. `#00`, `#abc`, `#`, or `#1` when
-  `shortIdLength=2`): exit code 1.
+- **Reserved key**: the resolved `n == 0` (inputs like `0`, `#0`, `#00`). Exit code 1.
+- **Over capacity**: the resolved `n > 10^shortIdLength - 1` (e.g. `100` or
+  `#100` when `shortIdLength=2`). Exit code 1.
+- **Parameter format error**: input matches neither `^[#]?[0-9]+$` nor a
+  `TASK-id` (e.g. `#abc`, `#`, `5.5`). Exit code 1.
 
 ## Cross-TUI quoting
 
-Bash treats `#` as a comment marker. Always single-quote: `ai sandbox exec '#03' 'npm test'`.
+Bare numeric `N` is safe in every shell and TUI without quoting (recommended):
+`ai sandbox exec 11 'npm test'`, `/review-analysis 11`.
+
+The `#N` / `#NN` form is still accepted; but bash treats `#` as a comment
+marker, so it must be single-quoted: `ai sandbox exec '#03' 'npm test'`.
 Claude Code / Codex / Gemini CLI / OpenCode all forward `#NN` to SKILL
 `ARGUMENTS` literally when quoted.
 

--- a/templates/.agents/rules/task-short-id.zh-CN.md
+++ b/templates/.agents/rules/task-short-id.zh-CN.md
@@ -1,16 +1,18 @@
 # 任务短号
 
-短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 替代完整的 22 字符
-`TASK-YYYYMMDD-HHMMSS`。
+短号让所有 SKILL 在 active 任务生命周期内可以用 `#NN` 或裸数字 `N`（推荐）替代
+完整的 22 字符 `TASK-YYYYMMDD-HHMMSS`。
 
 ## 语法
 
-- 格式：`^#\d{shortIdLength}$`（**零填充到固定宽度**；默认 `shortIdLength=2` 时
-  形如 `#01`、`#07`、`#42`）。
-- **必须**零填充到 `shortIdLength` 位（默认 2 位：`#1` 视为格式错误，应输入
-  `#01`）。这是为了视觉对齐与盲打体验。
+- 字面接受两种等价形式：
+  - **裸数字 `N`**（推荐，无需 shell 引号）：如 `1`、`7`、`42`。
+  - **`#`-前缀 `#N` / `#NN`**（兼容旧写法）：如 `#1`、`#01`、`#42`。
+- 解析规则：去前导零后取数值 `n`，若 `n == 0` 报错（保留）；若 `n > 10^shortIdLength - 1`
+  报错（超容量）；否则归一化为 `#${n.padStart(shortIdLength, '0')}`，作为注册表 key。
+- 默认 `shortIdLength=2` 时容量 `n ∈ [1, 99]`，注册表 key 形如 `01`、`07`、`42`。
 - `#00`（或 `shortIdLength=1` 时 `#0`）保留、永不分配；纯数字、不引入字母。
-- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` 只是别名，不是持久化任务 ID。
+- 完整 `TASK-…` 入参在所有路径下行为与现状等价；`#NN` / 裸数字只是别名，不是持久化任务 ID。
 
 ## 生命周期
 
@@ -44,7 +46,7 @@
 | 入口                                                       | 注册表命中            | 注册表未命中                                            |
 |-----------------------------------------------------------|----------------------|--------------------------------------------------------|
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
-| `ai sandbox enter '#NN'` / `ai sandbox exec '#NN' …`      | 解析为完整 task id    | 回退到 running sandbox 的 ls 行号语义（保留 #414 行为）|
+| `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | 解析为完整 task id 后查 task.md 取 `branch` | **严格报错** —— 不再回退到 ls 行号或字面分支名；提示用任务短号 / `TASK-id` / 分支名 |
 
 `list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
 三者差异，但不修改任何状态。
@@ -54,11 +56,11 @@
 任意 SKILL（含 alloc / resolve / release / re-alloc 四类生命周期入口）在收到
 `{task-id}` 入参后，必须按以下契约处理：
 
-1. 如果 `{task-id}` 字面以 `#` 开头：
+1. 如果 `{task-id}` 字面匹配 `^[#]?[0-9]+$`（裸数字 `N` 或 `#`-前缀 `#N`）：
 
 ```bash
-if [[ "{task-id}" == "#"* ]]; then
-  # 脚本本身已输出完整错误（含「expected #NN (N-digit zero-padded; e.g. '#01')」）；
+if [[ "{task-id}" =~ ^[#]?[0-9]+$ ]]; then
+  # 脚本本身已输出完整错误（含 reserved / exceeds shortIdLength capacity 等场景）；
   # 调用方只需透传退出码
   task_id=$(node .agents/scripts/task-short-id.js resolve "{task-id}") || exit 1
 else
@@ -97,21 +99,27 @@ fi
   目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
   `updated_at` / `agent_infra_version`、不追加 Activity Log）
 
-`resolve('#NN')` 工作流：① 校验入参严格匹配 `^#\d{shortIdLength}$` → ② 直接以
-`NN` 作为 key 查注册表 `ids` → ③ 命中返回完整 task id，未命中按 `list --verify`
-给出修复指引退出 1。
+`resolve(<N|'#N'>)` 工作流：① 校验入参匹配 `^[#]?[0-9]+$` → ② 去前导零取
+数值 `n`，按 `n` 是否 `== 0`（保留）/ `> 10^shortIdLength - 1`（超容量）/
+正常 三类处理 → ③ 正常时以 `n.padStart(shortIdLength, '0')` 作为 key 查
+注册表 `ids` → ④ 命中返回完整 task id，未命中按 `list --verify` 给出修复指引退出 1。
 
 ## 错误场景
 
-- **短号不存在**：注册表中无 `#NN`。可能是任务已归档（短号已释放）或输入错误。
+- **短号不存在**：注册表中无对应 key。可能是任务已归档（短号已释放）或输入错误。退出码 1。
 - **注册表损坏**（同一 taskId 出现多次或 JSON 无法解析）：退出码 2，需人工处理。
-- **参数格式错误**（如 `#00`、`#abc`、`#`、`#1` 当 `shortIdLength=2` 时）：退出码 1。
+- **保留键**：解析后 `n == 0`（输入如 `0`、`#0`、`#00`）。退出码 1。
+- **超容量**：解析后 `n > 10^shortIdLength - 1`（如 `shortIdLength=2` 下 `100` 或 `#100`）。退出码 1。
+- **参数格式错误**：入参既不是 `^[#]?[0-9]+$` 也不是 `TASK-id`（如 `#abc`、`#`、`5.5`）。退出码 1。
 
 ## 跨 TUI 引号要求
 
-bash 中 `#` 是注释起始符，必须单引号：`ai sandbox exec '#03' 'npm test'`。
-Claude Code / Codex / Gemini CLI / OpenCode 在加引号时都能把 `#NN` 字面传递到
-SKILL 的 `ARGUMENTS`。
+裸数字 `N` 在所有 shell 与 TUI 中都安全无需引号，推荐写法：
+`ai sandbox exec 11 'npm test'`、`/review-analysis 11`。
+
+`#N` / `#NN` 写法仍然兼容；但 bash 中 `#` 是注释起始符，必须单引号：
+`ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
+在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
 
 ## 冷启动迁移
 

--- a/templates/.agents/rules/task-short-id.zh-CN.md
+++ b/templates/.agents/rules/task-short-id.zh-CN.md
@@ -7,7 +7,7 @@
 
 - 字面接受两种等价形式：
   - **裸数字 `N`**（推荐，无需 shell 引号）：如 `1`、`7`、`42`。
-  - **`#`-前缀 `#N` / `#NN`**（兼容旧写法）：如 `#1`、`#01`、`#42`。
+  - **`#`-前缀 `#N` / `#NN`**（也接受；但 bash 需 `'...'` 引号）：如 `#1`、`#01`、`#42`。
 - 解析规则：去前导零后取数值 `n`，若 `n == 0` 报错（保留）；若 `n > 10^shortIdLength - 1`
   报错（超容量）；否则归一化为 `#${n.padStart(shortIdLength, '0')}`，作为注册表 key。
 - 默认 `shortIdLength=2` 时容量 `n ∈ [1, 99]`，注册表 key 形如 `01`、`07`、`42`。
@@ -117,7 +117,7 @@ fi
 裸数字 `N` 在所有 shell 与 TUI 中都安全无需引号，推荐写法：
 `ai sandbox exec 11 'npm test'`、`/review-analysis 11`。
 
-`#N` / `#NN` 写法仍然兼容；但 bash 中 `#` 是注释起始符，必须单引号：
+`#N` / `#NN` 写法也接受；但 bash 中 `#` 是注释起始符，必须单引号：
 `ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
 在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
 

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -185,24 +185,34 @@ function allocateMinFreeInt(registry, shortIdLength) {
 }
 
 function parseShortIdArg(arg, shortIdLength) {
-  const re = new RegExp(`^#\\d{${shortIdLength}}$`);
-  if (!re.test(arg)) {
-    const example =
-      shortIdLength === 1 ? "'#1'" : shortIdLength === 2 ? "'#01'" : `'#${"0".repeat(shortIdLength - 1)}1'`;
+  const L = shortIdLength;
+  const max = Math.pow(10, L) - 1;
+  // Accept bare numeric or '#'-prefixed; canonicalize to zero-padded key.
+  // Bare numeric is the recommended form (no shell quoting needed).
+  const m = /^#?(\d+)$/.exec(arg);
+  if (!m) {
     writeStderr(
       `Error: invalid short id format '${arg}', ` +
-        `expected #${"N".repeat(shortIdLength)} (${shortIdLength}-digit zero-padded; e.g. ${example})\n`
+        `expected bare digits (recommended) or '#'-prefixed digits; ` +
+        `e.g. '11' or '#11' (shortIdLength=${L}, max=${max})\n`
     );
     process.exit(1);
   }
-  const key = arg.slice(1);
-  if (Number(key) === 0) {
+  const n = Number(m[1]);
+  if (n === 0) {
     writeStderr(
-      `Error: short id '${arg}' is invalid (#${"0".repeat(shortIdLength)} is reserved)\n`
+      `Error: short id '${arg}' is invalid (#${"0".repeat(L)} is reserved)\n`
     );
     process.exit(1);
   }
-  return key;
+  if (n > max) {
+    writeStderr(
+      `Error: short id ${n} exceeds shortIdLength=${L} capacity (max=${max}); ` +
+        `archive tasks or raise task.shortIdLength in .agents/.airc.json\n`
+    );
+    process.exit(1);
+  }
+  return String(n).padStart(L, "0");
 }
 
 function planTransaction(registry, activeDir, shortIdLength) {
@@ -548,8 +558,8 @@ function cmdRelease(taskId, activeDir, registryPath, shortIdLength) {
 }
 
 function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
-  // Strict width match + reserved key check; on invalid arg, parseShortIdArg writes full
-  // stderr (including "expected #NN (N-digit zero-padded; e.g. '#01')") and exits 1.
+  // Accepts bare digits ('11') or '#'-prefixed form ('#11', '#11', '#005'); normalized by
+  // numeric value with capacity check (n > 10^L-1) and reserved-zero rejection.
   const key = parseShortIdArg(shortIdArg, shortIdLength);
   return withRegistryLock(activeDir, () => {
     const registry = readRegistry(registryPath);

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -29,7 +29,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -29,7 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -21,7 +21,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -21,7 +21,7 @@ description: "标记任务为阻塞状态并记录原因"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -15,7 +15,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -15,7 +15,7 @@ description: "取消不再需要的任务并转移"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/check-task/SKILL.en.md
+++ b/templates/.agents/skills/check-task/SKILL.en.md
@@ -12,7 +12,7 @@ description: "Check a task's current status and progress"
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/check-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/check-task/SKILL.zh-CN.md
@@ -12,7 +12,7 @@ description: "查看任务的当前状态和进度"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 查找任务

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -9,7 +9,7 @@ Dismiss the specified Code Scanning (CodeQL) alert and record a justified reason
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -9,7 +9,7 @@ description: "关闭 Code Scanning 告警并记录理由"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -9,7 +9,7 @@ Dismiss the specified Dependabot security alert and record a justified reason.
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -9,7 +9,7 @@ description: "关闭 Dependabot 安全告警并记录理由"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -31,7 +31,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 
@@ -118,4 +118,6 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 ### 12. Tell the User
 
-Use `reference/output-template.md` and show all TUI command formats.
+Use `reference/output-template.md` (or `reference/fix-mode.md` in fix mode) and show all TUI command formats.
+
+> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -44,7 +44,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -176,7 +176,9 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > 仅在校验通过后执行本步骤。
 
-> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`。
+> **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/code-task/reference/fix-mode.en.md
+++ b/templates/.agents/skills/code-task/reference/fix-mode.en.md
@@ -66,9 +66,9 @@ Fix status:
 
 Next step - re-review or commit:
 - Re-review (always recommended):
-  - Claude Code / OpenCode: /review-code {task-id}
-  - Gemini CLI: /agent-infra:review-code {task-id}
-  - Codex CLI: $review-code {task-id}
+  - Claude Code / OpenCode: /review-code {task-ref}
+  - Gemini CLI: /agent-infra:review-code {task-ref}
+  - Codex CLI: $review-code {task-ref}
 - Commit directly (optional; only when all issues are resolved and changes are low risk):
   - Claude Code / OpenCode: /commit
   - Gemini CLI: /agent-infra:commit

--- a/templates/.agents/skills/code-task/reference/fix-mode.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/fix-mode.zh-CN.md
@@ -66,9 +66,9 @@ env-blocked 项不在修复范围。处理规则：
 
 下一步 - 重新审查或提交：
 - 重新审查（始终推荐）：
-  - Claude Code / OpenCode：/review-code {task-id}
-  - Gemini CLI：/agent-infra:review-code {task-id}
-  - Codex CLI：$review-code {task-id}
+  - Claude Code / OpenCode：/review-code {task-ref}
+  - Gemini CLI：/agent-infra:review-code {task-ref}
+  - Codex CLI：$review-code {task-ref}
 - 直接提交（可选；仅在所有问题已解决且风险可控时）：
   - Claude Code / OpenCode：/commit
   - Gemini CLI：/agent-infra:commit

--- a/templates/.agents/skills/code-task/reference/output-template.en.md
+++ b/templates/.agents/skills/code-task/reference/output-template.en.md
@@ -14,7 +14,7 @@ Output files:
 - Code report: .agents/workspace/active/{task-id}/{code-artifact}
 
 Next step - code review:
-  - Claude Code / OpenCode: /review-code {task-id}
-  - Gemini CLI: /{{project}}:review-code {task-id}
-  - Codex CLI: $review-code {task-id}
+  - Claude Code / OpenCode: /review-code {task-ref}
+  - Gemini CLI: /{{project}}:review-code {task-ref}
+  - Codex CLI: $review-code {task-ref}
 ```

--- a/templates/.agents/skills/code-task/reference/output-template.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/output-template.zh-CN.md
@@ -14,7 +14,7 @@
 - 实现报告：.agents/workspace/active/{task-id}/{code-artifact}
 
 下一步 - 代码审查：
-  - Claude Code / OpenCode：/review-code {task-id}
-  - Gemini CLI：/agent-infra:review-code {task-id}
-  - Codex CLI：$review-code {task-id}
+  - Claude Code / OpenCode：/review-code {task-ref}
+  - Gemini CLI：/agent-infra:review-code {task-ref}
+  - Codex CLI：$review-code {task-ref}
 ```

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -19,7 +19,7 @@ When updating related `task.md` frontmatter, read `.agents/rules/version-stamp.m
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## 1. Check Local Modifications (CRITICAL)
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -19,7 +19,7 @@ description: "提交当前变更到 Git"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 1. 检查本地修改（关键）
 

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -28,7 +28,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -28,7 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证任务存在

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -13,7 +13,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -13,7 +13,7 @@ description: "创建 Pull Request 到目标分支"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -24,7 +24,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -24,7 +24,7 @@ description: "根据自然语言描述创建任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 解析用户描述

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -15,7 +15,7 @@ Import the specified Code Scanning (CodeQL) alert and create a remediation task.
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -15,7 +15,7 @@ description: "导入 Code Scanning 告警并创建修复任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -15,7 +15,7 @@ Import the specified Dependabot security alert and create a remediation task.
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -15,7 +15,7 @@ description: "导入 Dependabot 安全告警并创建修复任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -15,7 +15,7 @@ Import the specified Issue and create a task. Argument: issue number.
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Execution Flow
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -15,7 +15,7 @@ description: "从 Issue 导入并创建任务"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行流程
 

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -29,7 +29,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -29,7 +29,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件

--- a/templates/.agents/skills/restore-task/SKILL.en.md
+++ b/templates/.agents/skills/restore-task/SKILL.en.md
@@ -18,7 +18,7 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 

--- a/templates/.agents/skills/restore-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/restore-task/SKILL.zh-CN.md
@@ -18,7 +18,7 @@ description: "从平台 Issue 评论还原本地任务文件"
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证输入与环境

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -28,7 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 
@@ -78,3 +78,5 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 ### 8. Tell the User
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
+
+> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -30,7 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -91,6 +91,8 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 ### 8. 告知用户
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-analysis/reference/output-templates.en.md
+++ b/templates/.agents/skills/review-analysis/reference/output-templates.en.md
@@ -25,9 +25,9 @@ Task {task-id} requirement analysis review completed. Verdict: approved.
 [- Review report: .agents/workspace/active/{task-id}/{review-artifact}]
 
 Next step - write the technical plan:
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /analyze-task.
@@ -41,14 +41,14 @@ Task {task-id} requirement analysis review completed. Verdict: approved.
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - revise analysis before continuing (recommended):
-  - Claude Code / OpenCode: /analyze-task {task-id}
-  - Gemini CLI: /agent-infra:analyze-task {task-id}
-  - Codex CLI: $analyze-task {task-id}
+  - Claude Code / OpenCode: /analyze-task {task-ref}
+  - Gemini CLI: /agent-infra:analyze-task {task-ref}
+  - Codex CLI: $analyze-task {task-ref}
 
 Or proceed directly to planning:
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /analyze-task.
@@ -62,9 +62,9 @@ Task {task-id} requirement analysis review completed. Verdict: changes requested
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - revise requirement analysis:
-  - Claude Code / OpenCode: /analyze-task {task-id}
-  - Gemini CLI: /agent-infra:analyze-task {task-id}
-  - Codex CLI: $analyze-task {task-id}
+  - Claude Code / OpenCode: /analyze-task {task-ref}
+  - Gemini CLI: /agent-infra:analyze-task {task-ref}
+  - Codex CLI: $analyze-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /analyze-task.
@@ -78,9 +78,9 @@ Task {task-id} requirement analysis review completed. Verdict: rejected, fresh a
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - re-analyze:
-  - Claude Code / OpenCode: /analyze-task {task-id}
-  - Gemini CLI: /agent-infra:analyze-task {task-id}
-  - Codex CLI: $analyze-task {task-id}
+  - Claude Code / OpenCode: /analyze-task {task-ref}
+  - Gemini CLI: /agent-infra:analyze-task {task-ref}
+  - Codex CLI: $analyze-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /analyze-task.

--- a/templates/.agents/skills/review-analysis/reference/output-templates.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/reference/output-templates.zh-CN.md
@@ -25,9 +25,9 @@
 [- 审查报告：.agents/workspace/active/{task-id}/{review-artifact}]
 
 下一步 - 编写技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -41,14 +41,14 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订分析后继续（推荐）：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 或直接进入方案设计：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -62,9 +62,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订需求分析：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。
@@ -78,9 +78,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新分析：
-  - Claude Code / OpenCode：/analyze-task {task-id}
-  - Gemini CLI：/agent-infra:analyze-task {task-id}
-  - Codex CLI：$analyze-task {task-id}
+  - Claude Code / OpenCode：/analyze-task {task-ref}
+  - Gemini CLI：/agent-infra:analyze-task {task-ref}
+  - Codex CLI：$analyze-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /analyze-task。

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -38,7 +38,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 
@@ -120,6 +120,8 @@ Choose exactly one branch based on the findings:
 env-blocked counts do not influence branch selection; they are appended to the summary line only.
 
 > The full four-branch output templates, selection rules, and prohibition clauses live in `reference/output-templates.md`. Read `reference/output-templates.md` before reporting the review result.
+
+> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
 
 Include all TUI command formats in the next-step output. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name).
 

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -38,7 +38,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -123,6 +123,8 @@ node .agents/scripts/validate-artifact.js gate review-code .agents/workspace/act
 env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显示。
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/templates/.agents/skills/review-code/reference/output-templates.en.md
+++ b/templates/.agents/skills/review-code/reference/output-templates.en.md
@@ -43,9 +43,9 @@ Task {task-id} review completed. Verdict: approved.
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - fix before commit (recommended):
-  - Claude Code / OpenCode: /code-task {task-id}
-  - Gemini CLI: /agent-infra:code-task {task-id}
-  - Codex CLI: $code-task {task-id}
+  - Claude Code / OpenCode: /code-task {task-ref}
+  - Gemini CLI: /agent-infra:code-task {task-ref}
+  - Codex CLI: $code-task {task-ref}
 
 Or commit directly (skip fix):
   - Claude Code / OpenCode: /commit
@@ -64,9 +64,9 @@ Task {task-id} review completed. Verdict: changes requested.
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - fix the findings:
-  - Claude Code / OpenCode: /code-task {task-id}
-  - Gemini CLI: /agent-infra:code-task {task-id}
-  - Codex CLI: $code-task {task-id}
+  - Claude Code / OpenCode: /code-task {task-ref}
+  - Gemini CLI: /agent-infra:code-task {task-ref}
+  - Codex CLI: $code-task {task-ref}
 
 [When env-blocked > 0, append this final line:]
 Reminder: env-blocked findings must be carried in the PR description as a "manual verification required" checklist and should not trigger /code-task.
@@ -80,9 +80,9 @@ Task {task-id} review completed. Verdict: rejected, re-design the technical plan
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - re-design the technical plan:
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 > Note: Rejected means the implementation direction needs to be reworked end-to-end, not patched locally. `code-task/scripts/detect-mode.js` branch #7 refuses a direct `/code-task` and requires a fresh plan first.
 

--- a/templates/.agents/skills/review-code/reference/output-templates.zh-CN.md
+++ b/templates/.agents/skills/review-code/reference/output-templates.zh-CN.md
@@ -43,9 +43,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修复问题后提交（推荐）：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 或直接提交（跳过修复）：
   - Claude Code / OpenCode：/commit
@@ -64,9 +64,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修复问题：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /code-task。
@@ -80,9 +80,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新设计技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 > 注意：Rejected 表示实现方向需要整体重做，不是局部修复。`code-task/scripts/detect-mode.js` 分支 #7 会拒绝直接 `/code-task`，要求先重新方案设计。
 

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -28,7 +28,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## Task id short ref
 
-> If `{task-id}` begins with `#`, follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
+> If `{task-id}` matches `^[#]?[0-9]+$` (bare numeric or `#`-prefixed), follow the "SKILL parameter resolver" section of `.agents/rules/task-short-id.md`; treat `{task-id}` as the resolved full `TASK-YYYYMMDD-HHMMSS` form for every downstream command.
 
 ## Steps
 
@@ -78,3 +78,5 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 ### 8. Tell the User
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
+
+> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -30,7 +30,7 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ## 任务入参短号别名
 
-> 如果 `{task-id}` 入参以 `#` 开头，先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
+> 如果 `{task-id}` 入参匹配 `^[#]?[0-9]+$`（裸数字或带 `#` 前缀），先读取 `.agents/rules/task-short-id.md` 的「SKILL 入参解析」段执行解析；后续命令视 `{task-id}` 为解析后的全长 `TASK-YYYYMMDD-HHMMSS` 形式。
 
 ## 执行步骤
 ### 1. 验证前置条件
@@ -91,6 +91,8 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 ### 8. 告知用户
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
+
+> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-plan/reference/output-templates.en.md
+++ b/templates/.agents/skills/review-plan/reference/output-templates.en.md
@@ -25,9 +25,9 @@ Task {task-id} technical plan review completed. Verdict: approved.
 [- Review report: .agents/workspace/active/{task-id}/{review-artifact}]
 
 Next step - write code:
-  - Claude Code / OpenCode: /code-task {task-id}
-  - Gemini CLI: /agent-infra:code-task {task-id}
-  - Codex CLI: $code-task {task-id}
+  - Claude Code / OpenCode: /code-task {task-ref}
+  - Gemini CLI: /agent-infra:code-task {task-ref}
+  - Codex CLI: $code-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /plan-task.
@@ -41,14 +41,14 @@ Task {task-id} technical plan review completed. Verdict: approved.
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - revise plan before coding (recommended):
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 Or proceed directly to coding:
-  - Claude Code / OpenCode: /code-task {task-id}
-  - Gemini CLI: /agent-infra:code-task {task-id}
-  - Codex CLI: $code-task {task-id}
+  - Claude Code / OpenCode: /code-task {task-ref}
+  - Gemini CLI: /agent-infra:code-task {task-ref}
+  - Codex CLI: $code-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /plan-task.
@@ -62,9 +62,9 @@ Task {task-id} technical plan review completed. Verdict: changes requested.
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - revise technical plan:
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /plan-task.
@@ -78,9 +78,9 @@ Task {task-id} technical plan review completed. Verdict: rejected, redesign requ
 - Review report: .agents/workspace/active/{task-id}/{review-artifact}
 
 Next step - redesign:
-  - Claude Code / OpenCode: /plan-task {task-id}
-  - Gemini CLI: /agent-infra:plan-task {task-id}
-  - Codex CLI: $plan-task {task-id}
+  - Claude Code / OpenCode: /plan-task {task-ref}
+  - Gemini CLI: /agent-infra:plan-task {task-ref}
+  - Codex CLI: $plan-task {task-ref}
 
 [When env-blocked > 0, append:]
 Reminder: env-blocked items belong in the PR description manual verification checklist and should not trigger /plan-task.

--- a/templates/.agents/skills/review-plan/reference/output-templates.zh-CN.md
+++ b/templates/.agents/skills/review-plan/reference/output-templates.zh-CN.md
@@ -25,9 +25,9 @@
 [- 审查报告：.agents/workspace/active/{task-id}/{review-artifact}]
 
 下一步 - 编写代码：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -41,14 +41,14 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订方案后编码（推荐）：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 或直接进入编码：
-  - Claude Code / OpenCode：/code-task {task-id}
-  - Gemini CLI：/agent-infra:code-task {task-id}
-  - Codex CLI：$code-task {task-id}
+  - Claude Code / OpenCode：/code-task {task-ref}
+  - Gemini CLI：/agent-infra:code-task {task-ref}
+  - Codex CLI：$code-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -62,9 +62,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 修订技术方案：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。
@@ -78,9 +78,9 @@
 - 审查报告：.agents/workspace/active/{task-id}/{review-artifact}
 
 下一步 - 重新设计：
-  - Claude Code / OpenCode：/plan-task {task-id}
-  - Gemini CLI：/agent-infra:plan-task {task-id}
-  - Codex CLI：$plan-task {task-id}
+  - Claude Code / OpenCode：/plan-task {task-ref}
+  - Gemini CLI：/agent-infra:plan-task {task-ref}
+  - Codex CLI：$plan-task {task-ref}
 
 [当 env-blocked > 0 时，在最后附加一行：]
 提醒：env-blocked 项需在 PR description 的「待人工验证」清单中承接，不应触发 /plan-task。

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -726,9 +726,9 @@ test("sandbox ls formatContainerTable aligns header and rows by column width", a
   const { formatContainerTable } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
 
   const rows = [
-    { index: "1", name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
-    { index: "", name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
-    { index: "", name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
+    { index: "#01", name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
+    { index: "-", name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
+    { index: "-", name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
   ];
   const lines = formatContainerTable(rows);
   const hashColumn = lines[0]!.indexOf("#");
@@ -746,9 +746,9 @@ test("sandbox ls formatContainerTable aligns header and rows by column width", a
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.status), statusColumn);
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.branch), branchColumn);
   }
-  assert.equal(lines[1]!.slice(0, namesColumn).trim(), "1");
-  assert.equal(lines[2]!.slice(0, namesColumn).trim(), "");
-  assert.equal(lines[3]!.slice(0, namesColumn).trim(), "");
+  assert.equal(lines[1]!.slice(0, namesColumn).trim(), "#01");
+  assert.equal(lines[2]!.slice(0, namesColumn).trim(), "-");
+  assert.equal(lines[3]!.slice(0, namesColumn).trim(), "-");
   for (const line of lines) {
     assert.equal(line.includes("\t"), false);
     assert.doesNotMatch(line, /\s+$/);
@@ -799,78 +799,24 @@ test("sandbox list-running sortAndIndexSandboxRows assigns 1-based index to runn
   }
 });
 
-test("sandbox list-running isTaskShortRef matches only '#<digits>' syntactically", async () => {
+test("sandbox list-running isTaskShortRef matches '#<digits>' and bare numeric (Round 4 contract)", async () => {
   const { isTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
 
   assert.equal(isTaskShortRef("#0"), true);
   assert.equal(isTaskShortRef("#1"), true);
   assert.equal(isTaskShortRef("#10"), true);
+  assert.equal(isTaskShortRef("0"), true);
+  assert.equal(isTaskShortRef("1"), true);
+  assert.equal(isTaskShortRef("11"), true);
   assert.equal(isTaskShortRef("#abc"), false);
   assert.equal(isTaskShortRef("#1a"), false);
   assert.equal(isTaskShortRef("#1.5"), false);
   assert.equal(isTaskShortRef("#-1"), false);
   assert.equal(isTaskShortRef("#"), false);
-  assert.equal(isTaskShortRef("1"), false);
+  assert.equal(isTaskShortRef("1.5"), false);
   assert.equal(isTaskShortRef("main"), false);
   assert.equal(isTaskShortRef("TASK-20260609-084122"), false);
   assert.equal(isTaskShortRef(""), false);
-});
-
-test("sandbox list-running resolveTaskShortRef returns branch for valid index", async () => {
-  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
-  const running = [
-    { name: "demo-a", status: "Up 1 min", branch: "feature/a", running: true, index: 1 },
-    { name: "demo-b", status: "Up 1 min", branch: "feature/b", running: true, index: 2 },
-    { name: "demo-c", status: "Up 1 min", branch: "main", running: true, index: 3 }
-  ];
-
-  assert.equal(resolveTaskShortRef("#1", { running }), "feature/a");
-  assert.equal(resolveTaskShortRef("#2", { running }), "feature/b");
-  assert.equal(resolveTaskShortRef("#3", { running }), "main");
-});
-
-test("sandbox list-running resolveTaskShortRef rejects '#0' with 'must be >= 1'", async () => {
-  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
-
-  assert.throws(
-    () => resolveTaskShortRef("#0", { running: [] }),
-    /must be >= 1/
-  );
-});
-
-test("sandbox list-running resolveTaskShortRef rejects out-of-range index with running count", async () => {
-  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
-  const running = [
-    { name: "demo-a", status: "Up 1 min", branch: "feature/a", running: true, index: 1 },
-    { name: "demo-b", status: "Up 1 min", branch: "feature/b", running: true, index: 2 },
-    { name: "demo-c", status: "Up 1 min", branch: "feature/c", running: true, index: 3 }
-  ];
-
-  assert.throws(
-    () => resolveTaskShortRef("#5", { running }),
-    /only 3 running/
-  );
-});
-
-test("sandbox list-running resolveTaskShortRef rejects when no running sandboxes", async () => {
-  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
-
-  assert.throws(
-    () => resolveTaskShortRef("#1", { running: [] }),
-    /No running sandbox to reference/
-  );
-});
-
-test("sandbox list-running resolveTaskShortRef rejects when running row has empty branch label", async () => {
-  const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
-  const running = [
-    { name: "orphan", status: "Up 1 min", branch: "", running: true, index: 1 }
-  ];
-
-  assert.throws(
-    () => resolveTaskShortRef("#1", { running }),
-    /missing branch label/
-  );
 });
 
 test("sandbox list-running resolveTaskShortRef hits registry and returns task.md branch", async () => {
@@ -894,11 +840,9 @@ test("sandbox list-running resolveTaskShortRef hits registry and returns task.md
     path.join(active, ".short-ids.json"),
     JSON.stringify({ version: 1, ids: { "1": taskId } })
   );
-  const running = [
-    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
-  ];
-  // Registry-hit must win over the ls index.
-  assert.equal(resolveTaskShortRef("#1", { running, repoRoot: tmp }), "registry-branch");
+  // Both '#1' and bare '1' resolve to the registry-mapped branch (Round 4).
+  assert.equal(resolveTaskShortRef("#1", { repoRoot: tmp }), "registry-branch");
+  assert.equal(resolveTaskShortRef("1", { repoRoot: tmp }), "registry-branch");
 });
 
 test("sandbox list-running resolveTaskShortRef throws when registry hits but branch metadata missing (M-1)", async () => {
@@ -922,17 +866,14 @@ test("sandbox list-running resolveTaskShortRef throws when registry hits but bra
     path.join(active, ".short-ids.json"),
     JSON.stringify({ version: 1, ids: { "1": taskId } })
   );
-  const running = [
-    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
-  ];
-  // Registry hit but corrupt → MUST throw, NOT fall back to running[0].branch.
+  // Registry hit but corrupt → MUST throw.
   assert.throws(
-    () => resolveTaskShortRef("#1", { running, repoRoot: tmp }),
+    () => resolveTaskShortRef("#1", { repoRoot: tmp }),
     /no branch field/
   );
 });
 
-test("sandbox list-running resolveTaskShortRef falls back to ls index on registry miss", async () => {
+test("sandbox list-running resolveTaskShortRef throws on registry miss (Round 4: no ls-index fallback)", async () => {
   const { resolveTaskShortRef } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/list-running.ts")>("lib/sandbox/commands/list-running.js");
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtsr-miss-"));
   fs.mkdirSync(path.join(tmp, ".agents", "scripts"), { recursive: true });
@@ -943,11 +884,11 @@ test("sandbox list-running resolveTaskShortRef falls back to ls index on registr
   fs.writeFileSync(path.join(tmp, ".agents", ".airc.json"), JSON.stringify({ task: { shortIdLength: 1 } }));
   // Empty registry; no active tasks → resolve('#1') misses.
   fs.mkdirSync(path.join(tmp, ".agents", "workspace", "active"), { recursive: true });
-  const running = [
-    { name: "demo-a", status: "Up 1 min", branch: "ls-branch", running: true, index: 1 }
-  ];
-  // Should fall back to the ls index (preserves #414 behaviour).
-  assert.equal(resolveTaskShortRef("#1", { running, repoRoot: tmp }), "ls-branch");
+  // The legacy ls-index fallback has been removed. miss → throw, not run[0].branch.
+  assert.throws(
+    () => resolveTaskShortRef("#1", { repoRoot: tmp }),
+    /not in the active task registry/
+  );
 });
 
 test("sandbox ls parseLabels parses docker label CSV", async () => {

--- a/tests/integration/cli/sandbox-ls-short-id-column.test.ts
+++ b/tests/integration/cli/sandbox-ls-short-id-column.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadFreshEsm } from '../../helpers.ts';
+import { lookupShortIdByBranch } from '../../../lib/task/short-id.ts';
+
+function mkFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-ls-shortid-'));
+  const activeDir = path.join(repoRoot, '.agents', 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTaskWithBranch(activeDir: string, taskId: string, branch: string): void {
+  fs.mkdirSync(path.join(activeDir, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(activeDir, taskId, 'task.md'),
+    `---\nid: ${taskId}\nbranch: ${branch}\n---\n# body\n`
+  );
+}
+
+function writeRegistry(activeDir: string, ids: Record<string, string>): void {
+  fs.writeFileSync(
+    path.join(activeDir, '.short-ids.json'),
+    JSON.stringify({ version: 1, ids }, null, 2)
+  );
+}
+
+test('lookupShortIdByBranch returns #NN for a branch bound to an active task', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000001', 'feature-bound');
+  writeRegistry(activeDir, { '07': 'TASK-20260101-000001' });
+  assert.equal(lookupShortIdByBranch('feature-bound', repoRoot), '#07');
+});
+
+test("lookupShortIdByBranch returns null for branches without an active task", () => {
+  const { repoRoot, activeDir } = mkFixture();
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000001', 'feature-bound');
+  writeRegistry(activeDir, { '07': 'TASK-20260101-000001' });
+  assert.equal(lookupShortIdByBranch('main', repoRoot), null);
+});
+
+test('formatContainerTable now uses short id / "-" instead of running-index', async () => {
+  const { formatContainerTable } = await loadFreshEsm<typeof import('../../../lib/sandbox/commands/ls.ts')>(
+    'lib/sandbox/commands/ls.js'
+  );
+  const rows = [
+    { index: '#11', name: 'sb-feature-eleven', status: 'Up 1 min', branch: 'feature-eleven' },
+    { index: '-', name: 'sb-feature-orphan', status: 'Up 2 hours', branch: 'orphan-branch' }
+  ];
+  const lines = formatContainerTable(rows);
+  const namesColumn = lines[0]!.indexOf('NAMES');
+  assert.equal(lines[1]!.slice(0, namesColumn).trim(), '#11');
+  assert.equal(lines[2]!.slice(0, namesColumn).trim(), '-');
+});

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -238,7 +238,7 @@ test("sandbox exec '#abc' fails branch validation without triggering docker IO",
   }
 });
 
-test("sandbox exec '#1' triggers fetchSandboxRows and reports no-running-sandbox", onPlatforms("linux", "darwin", "win32"), () => {
+test("sandbox exec '#1' on registry miss throws short-ref error (Round 4: no ls-index fallback)", onPlatforms("linux", "darwin", "win32"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-enter-shortref-"));
 
   try {
@@ -262,21 +262,14 @@ test("sandbox exec '#1' triggers fetchSandboxRows and reports no-running-sandbox
     );
 
     assert.notEqual(result.status, 0);
-    assert.match(String(result.stderr), /No running sandbox to reference with '#1'/);
+    // Round 4: '#1' no longer falls back to "N-th running sandbox"; missing
+    // registry entry throws a short-ref-not-found error before any docker call.
+    assert.match(String(result.stderr), /not in the active task registry/);
 
+    // No docker calls should have happened — resolution failed before listing
+    // sandboxes.
     const dockerCalls = fixture.readDockerCalls();
-    assert.equal(dockerCalls.length, 1);
-    // Only assert the stable prefix: '--format' value contains literal tabs
-    // which a Windows .cmd shim retokenizes into separate args before the
-    // shim's node script sees them. The format string itself is covered by
-    // the containerListFormat() unit test.
-    assert.deepEqual(dockerCalls[0]!.slice(0, 5), [
-      "ps",
-      "-a",
-      "--filter",
-      "label=demo.sandbox",
-      "--format"
-    ]);
+    assert.equal(dockerCalls.length, 0);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+function runCli(args: string[]) {
+  return spawnSync('node', [CLI_PATH, ...args], { encoding: 'utf8' });
+}
+
+test('ai task without subcommand prints USAGE and exits non-zero', () => {
+  const out = runCli(['task']);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task <command>/);
+  assert.match(out.stdout, /ls \[--all/);
+  assert.match(out.stdout, /show <N \| #N \| TASK-id>/);
+});
+
+test('ai task --help prints USAGE and exits zero', () => {
+  const out = runCli(['task', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task <command>/);
+});
+
+test('ai task ls --help prints subcommand USAGE', () => {
+  const out = runCli(['task', 'ls', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task ls/);
+});
+
+test('ai task show --help prints subcommand USAGE', () => {
+  const out = runCli(['task', 'show', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task show/);
+});
+
+test('ai task <unknown> reports error', () => {
+  const out = runCli(['task', 'wat']);
+  assert.equal(out.status, 1);
+  assert.match(out.stderr, /Unknown task command: wat/);
+});
+
+test('agent-infra USAGE mentions the task subcommand', () => {
+  const out = runCli(['help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /agent-infra task/);
+});

--- a/tests/integration/cli/task-ls.test.ts
+++ b/tests/integration/cli/task-ls.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+function mkFixtureRepo(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-ls-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  const activeDir = path.join(agentsDir, 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  fs.mkdirSync(path.join(agentsDir, 'workspace', 'blocked'), { recursive: true });
+  fs.mkdirSync(path.join(agentsDir, 'workspace', 'completed'), { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTask(
+  baseDir: string,
+  taskId: string,
+  fields: { short_id?: string; type?: string; status?: string; current_step?: string; branch?: string; title?: string }
+): void {
+  fs.mkdirSync(path.join(baseDir, taskId), { recursive: true });
+  const fm: string[] = [`id: ${taskId}`];
+  if (fields.short_id) fm.push(`short_id: ${fields.short_id}`);
+  if (fields.type) fm.push(`type: ${fields.type}`);
+  if (fields.status) fm.push(`status: ${fields.status}`);
+  if (fields.current_step) fm.push(`current_step: ${fields.current_step}`);
+  if (fields.branch) fm.push(`branch: ${fields.branch}`);
+  const title = fields.title ?? `# ${taskId}`;
+  fs.writeFileSync(
+    path.join(baseDir, taskId, 'task.md'),
+    `---\n${fm.join('\n')}\n---\n\n${title}\n`
+  );
+}
+
+function runCli(args: string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+test('ai task ls defaults to active state', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#01', type: 'feature', status: 'active', current_step: 'plan', branch: 'feature-one' });
+  writeTask(
+    path.join(repoRoot, '.agents', 'workspace', 'blocked'),
+    'TASK-20260101-000002',
+    { short_id: '#02', type: 'bugfix', status: 'blocked', current_step: 'blocked', branch: 'bug-two' }
+  );
+  const out = runCli(['task', 'ls'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /TASK-20260101-000001|feature-one/);
+  assert.doesNotMatch(out.stdout, /feature-?two|bug-two/);
+});
+
+test('ai task ls --all spans active + blocked + completed (not archive)', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#01', branch: 'feature-active' });
+  writeTask(path.join(repoRoot, '.agents', 'workspace', 'blocked'), 'TASK-20260101-000002', { short_id: '#02', branch: 'feature-blocked' });
+  writeTask(path.join(repoRoot, '.agents', 'workspace', 'completed'), 'TASK-20260101-000003', { short_id: '#03', branch: 'feature-completed' });
+  const archiveDir = path.join(repoRoot, '.agents', 'workspace', 'archive');
+  fs.mkdirSync(archiveDir, { recursive: true });
+  writeTask(archiveDir, 'TASK-20250101-000099', { short_id: '#99', branch: 'feature-archive' });
+
+  const out = runCli(['task', 'ls', '--all'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /feature-active/);
+  assert.match(out.stdout, /feature-blocked/);
+  assert.match(out.stdout, /feature-completed/);
+  assert.doesNotMatch(out.stdout, /feature-archive/);
+});
+
+test('ai task ls --blocked filters to blocked state only', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#01', branch: 'feature-active' });
+  writeTask(path.join(repoRoot, '.agents', 'workspace', 'blocked'), 'TASK-20260101-000002', { short_id: '#02', branch: 'feature-blocked' });
+
+  const out = runCli(['task', 'ls', '--blocked'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /feature-blocked/);
+  assert.doesNotMatch(out.stdout, /feature-active/);
+});
+
+test('ai task ls rejects mutually exclusive flag combos', () => {
+  const { repoRoot } = mkFixtureRepo();
+  const out = runCli(['task', 'ls', '--all', '--blocked'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /at most one of/i);
+});
+
+test('ai task ls rejects unexpected positional arguments', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#01', branch: 'feature-one' });
+  const out = runCli(['task', 'ls', 'ignored-positional'], repoRoot);
+  assert.notEqual(out.status, 0, 'positional arg should fail, not silently succeed');
+  assert.match(out.stderr, /unexpected positional argument/);
+});
+
+test('ai task ls rejects unknown flags', () => {
+  const { repoRoot } = mkFixtureRepo();
+  const out = runCli(['task', 'ls', '--bogus'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /unknown flag/i);
+});
+
+test('ai task ls prints empty-state message when no tasks present', () => {
+  const { repoRoot } = mkFixtureRepo();
+  const out = runCli(['task', 'ls'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /No tasks under/);
+});

--- a/tests/integration/cli/task-show.test.ts
+++ b/tests/integration/cli/task-show.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-show-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
+  // Stub script: copy from runtime to fixture so resolve subcommand works under cwd.
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  const activeDir = path.join(agentsDir, 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTask(activeDir: string, taskId: string, branch: string): void {
+  fs.mkdirSync(path.join(activeDir, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(activeDir, taskId, 'task.md'),
+    `---\nid: ${taskId}\nbranch: ${branch}\n---\n# 任务：${taskId}\n\nbody for ${taskId}\n`
+  );
+}
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('ai task show <bare-numeric> prints task.md', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTask(activeDir, taskId, 'feature-seven');
+  // Allocate short id via script (first slot is #01 with empty registry).
+  const alloc = spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+  assert.equal(alloc.status, 0, alloc.stderr);
+  assert.equal(alloc.stdout.trim(), '#01');
+
+  const out = runCli(['task', 'show', '1'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /TASK-20260101-000007/);
+  assert.match(out.stdout, /body for TASK-20260101-000007/);
+});
+
+test('ai task show #1 (hash form) is equivalent to bare numeric', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTask(activeDir, taskId, 'feature-seven');
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const out = runCli(['task', 'show', '#1'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /TASK-20260101-000007/);
+});
+
+test('ai task show <TASK-id> resolves a completed task (flat layout)', () => {
+  const { repoRoot } = mkFixture();
+  const completedDir = path.join(repoRoot, '.agents', 'workspace', 'completed');
+  fs.mkdirSync(completedDir, { recursive: true });
+  const taskId = 'TASK-20250101-000099';
+  writeTask(completedDir, taskId, 'feature-completed');
+
+  const out = runCli(['task', 'show', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /feature-completed/);
+});
+
+test('ai task show <TASK-id> resolves an archived task under archive/YYYY/MM/DD/', () => {
+  const { repoRoot } = mkFixture();
+  // archive-tasks SKILL moves completed tasks into
+  //   .agents/workspace/archive/YYYY/MM/DD/TASK-YYYYMMDD-HHMMSS/task.md
+  // where YYYY/MM/DD comes from completed_at (NOT from the task id timestamp).
+  const taskId = 'TASK-20260613-120000';
+  const datedDir = path.join(
+    repoRoot,
+    '.agents',
+    'workspace',
+    'archive',
+    '2026',
+    '06',
+    '13',
+    taskId
+  );
+  fs.mkdirSync(datedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(datedDir, 'task.md'),
+    `---\nid: ${taskId}\nbranch: archived-demo\n---\n# Archived\nbody for archived\n`
+  );
+
+  const out = runCli(['task', 'show', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /archived-demo/);
+  assert.match(out.stdout, /body for archived/);
+});
+
+test('ai task show <TASK-id> resolves an archived task whose archive date differs from task id (cross-day)', () => {
+  const { repoRoot } = mkFixture();
+  // archive-tasks uses completed_at/updated_at, which can fall on a different
+  // calendar day than the task id timestamp (e.g. task created Jun 12, completed
+  // Jun 13). The lookup must NOT derive the path from the task id date.
+  const taskId = 'TASK-20260612-120000';
+  const datedDir = path.join(
+    repoRoot,
+    '.agents',
+    'workspace',
+    'archive',
+    '2026',
+    '06',
+    '13', // archive date != task id date (Jun 13 vs Jun 12)
+    taskId
+  );
+  fs.mkdirSync(datedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(datedDir, 'task.md'),
+    `---\nid: ${taskId}\ncompleted_at: 2026-06-13 09:00:00+08:00\nbranch: archived-cross-day\n---\n# Archived Cross Day\n`
+  );
+
+  const out = runCli(['task', 'show', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /archived-cross-day/);
+});
+
+test('ai task show <reserved> rejects 0', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'show', '0'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /reserved/);
+});
+
+test('ai task show <over-capacity> rejects 100 under shortIdLength=2', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'show', '100'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /exceeds/);
+});
+
+test('ai task show <non-numeric> rejects garbage input', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'show', 'not-a-task'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /not a valid short id or TASK-id/);
+});
+
+test('ai task show requires an argument', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'show'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task show/);
+});

--- a/tests/unit/cli/render-table.test.ts
+++ b/tests/unit/cli/render-table.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatTable } from '../../../lib/table.ts';
+
+test('formatTable renders header + rows with padded columns', () => {
+  const out = formatTable(['#', 'NAME', 'STATUS'], [
+    ['1', 'alpha', 'Up 10m'],
+    ['10', 'beta-longer', 'Exited']
+  ]);
+  assert.equal(out.length, 3);
+  assert.equal(out[0], '#   NAME         STATUS');
+  assert.equal(out[1], '1   alpha        Up 10m');
+  assert.equal(out[2], '10  beta-longer  Exited');
+});
+
+test('formatTable handles header-only rendering', () => {
+  const out = formatTable(['A', 'B'], []);
+  assert.deepEqual(out, ['A  B']);
+});
+
+test('formatTable trims trailing whitespace on each row', () => {
+  const out = formatTable(['A', 'B'], [['hello', '']]);
+  assert.equal(out[1], 'hello');
+  assert.ok(!out[1]!.endsWith(' '), 'trailing whitespace should be trimmed');
+});
+
+test('formatTable column widths track widest header or row cell', () => {
+  const out = formatTable(['short', 'h'], [['a', 'verylong']]);
+  // header "short" (len 5) wider than cell "a" → first col padded to 5.
+  assert.equal(out[0], 'short  h');
+  assert.equal(out[1], 'a      verylong');
+});

--- a/tests/unit/cli/task-frontmatter.test.ts
+++ b/tests/unit/cli/task-frontmatter.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseTaskFrontmatter, extractTitle } from '../../../lib/task/frontmatter.ts';
+
+test('parseTaskFrontmatter returns key/value map', () => {
+  const fm = parseTaskFrontmatter('---\nid: TASK-1\ntype: feature\n---\nbody\n');
+  assert.deepEqual(fm, { id: 'TASK-1', type: 'feature' });
+});
+
+test('parseTaskFrontmatter preserves empty values', () => {
+  const fm = parseTaskFrontmatter('---\nstart_date:\ntarget_date: 2026-06-15\n---\n');
+  assert.equal(fm.start_date, '');
+  assert.equal(fm.target_date, '2026-06-15');
+});
+
+test('parseTaskFrontmatter handles values containing colons', () => {
+  const fm = parseTaskFrontmatter('---\ncreated_at: 2026-06-12 16:27:37+08:00\n---\n');
+  assert.equal(fm.created_at, '2026-06-12 16:27:37+08:00');
+});
+
+test('parseTaskFrontmatter ignores body content after closing ---', () => {
+  const fm = parseTaskFrontmatter('---\nid: x\n---\n# Title: with colon\nbody: should be ignored\n');
+  assert.deepEqual(fm, { id: 'x' });
+});
+
+test('parseTaskFrontmatter returns {} when no frontmatter present', () => {
+  assert.deepEqual(parseTaskFrontmatter('no frontmatter here\n'), {});
+});
+
+test('parseTaskFrontmatter returns {} when frontmatter block is unclosed', () => {
+  assert.deepEqual(parseTaskFrontmatter('---\nid: orphan\nstill here\n'), {});
+});
+
+test('extractTitle pulls the first H1 (Chinese 任务 prefix)', () => {
+  const t = extractTitle('---\nid: x\n---\n# 任务：新增 ai task CLI\n\n## 描述\n');
+  assert.equal(t, '新增 ai task CLI');
+});
+
+test('extractTitle pulls the first H1 (plain English)', () => {
+  const t = extractTitle('# Add bare numeric short ids\n\nbody\n');
+  assert.equal(t, 'Add bare numeric short ids');
+});
+
+test('extractTitle returns empty string when no H1 found', () => {
+  assert.equal(extractTitle('## not h1\nbody\n'), '');
+});

--- a/tests/unit/cli/task-resolver.test.ts
+++ b/tests/unit/cli/task-resolver.test.ts
@@ -77,7 +77,7 @@ test("resolveTaskBranch on non-task arg is identity", () => {
   assert.equal(resolveTaskBranch("just-a-branch-name", repoRoot), "just-a-branch-name");
 });
 
-test("resolveTaskBranch with shortIdLength=2 hits on '#01' and rejects width-mismatched '#1'", () => {
+test("resolveTaskBranch with shortIdLength=2: '#01', '#1', '1' all resolve to the same branch", () => {
   const { repoRoot, activeDir } = mkFixtureRepo(2);
   const taskId = "TASK-20260301-000001";
   const branch = "feature-zero-padded";
@@ -90,8 +90,12 @@ test("resolveTaskBranch with shortIdLength=2 hits on '#01' and rejects width-mis
   assert.equal(alloc.status, 0, `alloc failed: ${alloc.stderr}`);
   assert.equal(alloc.stdout.trim(), "#01");
 
-  // '#01' hits.
+  // Round 4 contract: bare numeric, non-padded '#N', and zero-padded '#NN' are all aliases.
   assert.equal(resolveTaskBranch("#01", repoRoot), branch);
-  // '#1' is a width error under shortIdLength=2.
-  assert.throws(() => resolveTaskBranch("#1", repoRoot), /expected #NN|not found in active task registry/);
+  assert.equal(resolveTaskBranch("#1", repoRoot), branch);
+  assert.equal(resolveTaskBranch("1", repoRoot), branch);
+  // Reserved key still rejects.
+  assert.throws(() => resolveTaskBranch("#0", repoRoot), /reserved|not found/);
+  // Over capacity still rejects.
+  assert.throws(() => resolveTaskBranch("#100", repoRoot), /exceeds|not found/);
 });

--- a/tests/unit/cli/task-short-id.test.ts
+++ b/tests/unit/cli/task-short-id.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  normalizeShortIdInput,
+  lookupShortIdByBranch
+} from '../../../lib/task/short-id.ts';
+
+type ShortIdCase = {
+  input: string;
+  L: number;
+  expectKind: 'shortId' | 'error' | 'pass';
+  expectValue?: string;
+  expectErrorMatch?: RegExp;
+};
+
+const NORMALIZE_CASES: ShortIdCase[] = [
+  // bare numeric, L=2
+  { input: '5', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  { input: '05', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  { input: '005', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  // hash-prefixed, L=2
+  { input: '#5', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  { input: '#05', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  { input: '#005', L: 2, expectKind: 'shortId', expectValue: '#05' },
+  // boundary at capacity, L=2
+  { input: '99', L: 2, expectKind: 'shortId', expectValue: '#99' },
+  { input: '#099', L: 2, expectKind: 'shortId', expectValue: '#99' },
+  // over capacity, L=2
+  { input: '100', L: 2, expectKind: 'error', expectErrorMatch: /exceeds shortIdLength=2/ },
+  { input: '#100', L: 2, expectKind: 'error', expectErrorMatch: /exceeds shortIdLength=2/ },
+  // reserved zero, L=2
+  { input: '0', L: 2, expectKind: 'error', expectErrorMatch: /reserved/ },
+  { input: '00', L: 2, expectKind: 'error', expectErrorMatch: /reserved/ },
+  { input: '#0', L: 2, expectKind: 'error', expectErrorMatch: /reserved/ },
+  { input: '#00', L: 2, expectKind: 'error', expectErrorMatch: /reserved/ },
+  { input: '#000', L: 2, expectKind: 'error', expectErrorMatch: /reserved/ },
+  // L=1
+  { input: '5', L: 1, expectKind: 'shortId', expectValue: '#5' },
+  { input: '9', L: 1, expectKind: 'shortId', expectValue: '#9' },
+  { input: '10', L: 1, expectKind: 'error', expectErrorMatch: /exceeds shortIdLength=1/ },
+  // L=3
+  { input: '#5', L: 3, expectKind: 'shortId', expectValue: '#005' },
+  { input: '999', L: 3, expectKind: 'shortId', expectValue: '#999' },
+  { input: '1000', L: 3, expectKind: 'error', expectErrorMatch: /exceeds shortIdLength=3/ },
+  // pass-through
+  { input: 'TASK-20260612-162737', L: 2, expectKind: 'pass', expectValue: 'TASK-20260612-162737' },
+  { input: 'my-branch', L: 2, expectKind: 'pass', expectValue: 'my-branch' },
+  { input: '#abc', L: 2, expectKind: 'pass', expectValue: '#abc' },
+  { input: '5.5', L: 2, expectKind: 'pass', expectValue: '5.5' }
+];
+
+for (const c of NORMALIZE_CASES) {
+  test(`normalizeShortIdInput('${c.input}', L=${c.L}) -> ${c.expectKind}${c.expectValue ? ` ${c.expectValue}` : ''}`, () => {
+    const result = normalizeShortIdInput(c.input, { shortIdLength: c.L });
+    assert.equal(result.kind, c.expectKind);
+    if (c.expectKind === 'shortId' || c.expectKind === 'pass') {
+      assert.equal((result as { value: string }).value, c.expectValue);
+    }
+    if (c.expectKind === 'error' && c.expectErrorMatch) {
+      assert.match((result as { message: string }).message, c.expectErrorMatch);
+    }
+  });
+}
+
+function mkRegistryFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'shortid-lookup-'));
+  const activeDir = path.join(repoRoot, '.agents', 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTaskWithBranch(activeDir: string, taskId: string, branch: string): void {
+  fs.mkdirSync(path.join(activeDir, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(activeDir, taskId, 'task.md'),
+    `---\nid: ${taskId}\nbranch: ${branch}\n---\n# body\n`
+  );
+}
+
+function writeRegistry(activeDir: string, ids: Record<string, string>): void {
+  fs.writeFileSync(
+    path.join(activeDir, '.short-ids.json'),
+    JSON.stringify({ version: 1, ids }, null, 2)
+  );
+}
+
+test('lookupShortIdByBranch returns #NN when branch matches one active task', () => {
+  const { repoRoot, activeDir } = mkRegistryFixture();
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000001', 'feature-foo');
+  writeRegistry(activeDir, { '07': 'TASK-20260101-000001' });
+  assert.equal(lookupShortIdByBranch('feature-foo', repoRoot), '#07');
+});
+
+test('lookupShortIdByBranch returns null when no match', () => {
+  const { repoRoot, activeDir } = mkRegistryFixture();
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000002', 'feature-foo');
+  writeRegistry(activeDir, { '07': 'TASK-20260101-000002' });
+  assert.equal(lookupShortIdByBranch('feature-other', repoRoot), null);
+});
+
+test('lookupShortIdByBranch warns and returns first when multiple tasks share a branch', () => {
+  const { repoRoot, activeDir } = mkRegistryFixture();
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000003', 'shared');
+  writeTaskWithBranch(activeDir, 'TASK-20260101-000004', 'shared');
+  writeRegistry(activeDir, {
+    '03': 'TASK-20260101-000003',
+    '04': 'TASK-20260101-000004'
+  });
+  const original = process.stderr.write.bind(process.stderr);
+  const captured: string[] = [];
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = lookupShortIdByBranch('shared', repoRoot);
+    assert.ok(result === '#03' || result === '#04');
+    assert.ok(
+      captured.some((line) => /multiple active tasks/.test(line)),
+      'expected stderr warning about multiple tasks'
+    );
+  } finally {
+    process.stderr.write = original;
+  }
+});
+
+test('lookupShortIdByBranch returns null when registry missing', () => {
+  const { repoRoot } = mkRegistryFixture();
+  assert.equal(lookupShortIdByBranch('anything', repoRoot), null);
+});

--- a/tests/unit/scripts/task-short-id.test.ts
+++ b/tests/unit/scripts/task-short-id.test.ts
@@ -134,14 +134,18 @@ test("alloc and release with default shortIdLength=2 emit zero-padded short ids"
     "02": "TASK-20260101-000002"
   });
 
-  // resolve must accept the zero-padded form and reject the unpadded form.
+  // resolve accepts both zero-padded and non-padded forms (numeric-value contract).
   const hit = runW2(["resolve", "#01", "--active-dir", active]);
   assert.equal(hit.status, 0);
   assert.equal(hit.stdout.trim(), "TASK-20260101-000001");
 
-  const widthErr = runW2(["resolve", "#1", "--active-dir", active]);
-  assert.equal(widthErr.status, 1, `stderr=${widthErr.stderr}`);
-  assert.match(widthErr.stderr, /expected #NN \(2-digit zero-padded/);
+  const unpaddedHit = runW2(["resolve", "#1", "--active-dir", active]);
+  assert.equal(unpaddedHit.status, 0, `stderr=${unpaddedHit.stderr}`);
+  assert.equal(unpaddedHit.stdout.trim(), "TASK-20260101-000001");
+
+  const bareHit = runW2(["resolve", "1", "--active-dir", active]);
+  assert.equal(bareHit.status, 0, `stderr=${bareHit.stderr}`);
+  assert.equal(bareHit.stdout.trim(), "TASK-20260101-000001");
 });
 
 test("release is idempotent (exit 0 when no entry; m-1)", () => {
@@ -170,36 +174,45 @@ test("resolve returns task id on hit; error on miss (shortIdLength=1)", () => {
   assert.match(miss.stderr, /not found/);
 });
 
-test("resolve rejects reserved key, width mismatch, malformed input", () => {
+test("resolve rejects reserved key, over capacity, malformed input", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
 
-  // shortIdLength=1: #0 reserved; #abc malformed; #01 width mismatch.
+  // shortIdLength=1: #0 and bare 0 are reserved; #abc malformed.
   const zero1 = runW1(["resolve", "#0", "--active-dir", active]);
   assert.equal(zero1.status, 1);
   assert.match(zero1.stderr, /reserved/);
 
-  const widthErrW1 = runW1(["resolve", "#01", "--active-dir", active]);
-  assert.equal(widthErrW1.status, 1);
-  assert.match(widthErrW1.stderr, /expected #N \(1-digit zero-padded/);
+  const bareZero1 = runW1(["resolve", "0", "--active-dir", active]);
+  assert.equal(bareZero1.status, 1);
+  assert.match(bareZero1.stderr, /reserved/);
+
+  // #10 exceeds shortIdLength=1 capacity (max=9).
+  const overW1 = runW1(["resolve", "#10", "--active-dir", active]);
+  assert.equal(overW1.status, 1);
+  assert.match(overW1.stderr, /exceeds shortIdLength=1 capacity/);
 
   const bad = runW1(["resolve", "#abc", "--active-dir", active]);
   assert.equal(bad.status, 1);
   assert.match(bad.stderr, /invalid short id format/);
 
-  // shortIdLength=2: #00 reserved; #1 width mismatch; #001 width mismatch.
+  // shortIdLength=2: #00 and bare 00 reserved.
   const zero2 = runW2(["resolve", "#00", "--active-dir", active]);
   assert.equal(zero2.status, 1);
   assert.match(zero2.stderr, /reserved/);
 
-  const widthErrW2 = runW2(["resolve", "#1", "--active-dir", active]);
-  assert.equal(widthErrW2.status, 1);
-  assert.match(widthErrW2.stderr, /expected #NN \(2-digit zero-padded/);
+  // #100 exceeds shortIdLength=2 capacity (max=99).
+  const overW2 = runW2(["resolve", "#100", "--active-dir", active]);
+  assert.equal(overW2.status, 1);
+  assert.match(overW2.stderr, /exceeds shortIdLength=2 capacity/);
 
-  const overWidth = runW2(["resolve", "#001", "--active-dir", active]);
-  assert.equal(overWidth.status, 1);
-  assert.match(overWidth.stderr, /expected #NN/);
+  // #001 in L=2 is now valid (numeric value=1, ≤ max=99) — registry just won't have it.
+  // Confirm format pass-through doesn't itself error.
+  const okFormat = runW2(["resolve", "#001", "--active-dir", active]);
+  // Registry empty here → exit 1 with "not found", NOT "invalid format".
+  assert.equal(okFormat.status, 1);
+  assert.doesNotMatch(okFormat.stderr, /invalid short id format/);
 });
 
 test("width exhaustion (case D): cold start aborts before any write", () => {
@@ -406,9 +419,19 @@ test("default width is 2 even without --short-id-length flag and without task.sh
   assert.equal(hit.status, 0);
   assert.equal(hit.stdout.trim(), taskId);
 
-  const widthErr = spawnSync("node", [SCRIPT, "resolve", "#1"], { encoding: "utf8", cwd: tmp });
-  assert.equal(widthErr.status, 1, `stderr=${widthErr.stderr}`);
-  assert.match(widthErr.stderr, /expected #NN \(2-digit zero-padded/);
+  // Bare numeric and non-padded #N also resolve to the same task under L=2.
+  const bareHit = spawnSync("node", [SCRIPT, "resolve", "1"], { encoding: "utf8", cwd: tmp });
+  assert.equal(bareHit.status, 0, `stderr=${bareHit.stderr}`);
+  assert.equal(bareHit.stdout.trim(), taskId);
+
+  const unpaddedHit = spawnSync("node", [SCRIPT, "resolve", "#1"], { encoding: "utf8", cwd: tmp });
+  assert.equal(unpaddedHit.status, 0, `stderr=${unpaddedHit.stderr}`);
+  assert.equal(unpaddedHit.stdout.trim(), taskId);
+
+  // Over-capacity is still rejected at the script level.
+  const overWidth = spawnSync("node", [SCRIPT, "resolve", "#100"], { encoding: "utf8", cwd: tmp });
+  assert.equal(overWidth.status, 1, `stderr=${overWidth.stderr}`);
+  assert.match(overWidth.stderr, /exceeds shortIdLength=2 capacity/);
 });
 
 test("SKILL.md no longer embeds multi-line short-id bash snippet (U-2 slimming)", () => {

--- a/tests/unit/templates/output-templates-task-ref.test.ts
+++ b/tests/unit/templates/output-templates-task-ref.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RUNTIME_FILES = [
+  '.agents/skills/review-analysis/reference/output-templates.md',
+  '.agents/skills/review-plan/reference/output-templates.md',
+  '.agents/skills/review-code/reference/output-templates.md',
+  '.agents/skills/code-task/reference/output-template.md',
+  '.agents/skills/code-task/reference/fix-mode.md'
+];
+
+const TEMPLATE_FILES = [
+  'templates/.agents/skills/review-analysis/reference/output-templates.en.md',
+  'templates/.agents/skills/review-plan/reference/output-templates.en.md',
+  'templates/.agents/skills/review-code/reference/output-templates.en.md',
+  'templates/.agents/skills/code-task/reference/output-template.en.md',
+  'templates/.agents/skills/code-task/reference/fix-mode.en.md',
+  'templates/.agents/skills/review-analysis/reference/output-templates.zh-CN.md',
+  'templates/.agents/skills/review-plan/reference/output-templates.zh-CN.md',
+  'templates/.agents/skills/review-code/reference/output-templates.zh-CN.md',
+  'templates/.agents/skills/code-task/reference/output-template.zh-CN.md',
+  'templates/.agents/skills/code-task/reference/fix-mode.zh-CN.md'
+];
+
+// "Next-step" command line: a TUI prefix + invocation token + task ref.
+const NEXT_STEP_LINE = /^\s*-\s*(?:Claude Code(?:\s*\/\s*OpenCode)?|Gemini CLI|Codex CLI|OpenCode)\s*[:：]\s*[/$][A-Za-z0-9:_/{}-]+\s+\{(task-id|task-ref)\}/m;
+
+function read(p: string): string {
+  return fs.readFileSync(path.resolve(p), 'utf8');
+}
+
+for (const file of [...RUNTIME_FILES, ...TEMPLATE_FILES]) {
+  test(`${file}: next-step command lines use {task-ref}`, () => {
+    const content = read(file);
+    // No command line should still use {task-id}.
+    const stillTaskId = content
+      .split('\n')
+      .filter((line) => /^\s*-\s*(?:Claude Code(?:\s*\/\s*OpenCode)?|Gemini CLI|Codex CLI|OpenCode)\s*[:：]\s*[/$]/m.test(line))
+      .filter((line) => /\{task-id\}/.test(line));
+    assert.deepEqual(
+      stillTaskId,
+      [],
+      `next-step command lines should use {task-ref}, but found {task-id}:\n${stillTaskId.join('\n')}`
+    );
+    // At least one {task-ref} must exist (file should have next-step blocks).
+    assert.match(content, /\{task-ref\}/, `${file} should contain at least one {task-ref}`);
+  });
+
+  test(`${file}: report titles and paths preserve {task-id}`, () => {
+    const content = read(file);
+    // Report-summary line ("任务 {task-id} ..." / "Task {task-id} ...") and
+    // the active-workspace path ".agents/workspace/active/{task-id}/..." must
+    // keep the full task id placeholder.
+    const hasFullPath = /\.agents\/workspace\/active\/\{task-id\}\//.test(content);
+    const hasReportSummary = /(?:任务|Task)\s+\{task-id\}/.test(content);
+    assert.ok(
+      hasFullPath || hasReportSummary,
+      `${file} should retain {task-id} in titles or paths`
+    );
+  });
+}

--- a/tests/unit/templates/task-short-id-rule-parity.test.ts
+++ b/tests/unit/templates/task-short-id-rule-parity.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RUNTIME = path.resolve(process.cwd(), '.agents/rules/task-short-id.md');
+const TEMPLATE_ZH = path.resolve(process.cwd(), 'templates/.agents/rules/task-short-id.zh-CN.md');
+const TEMPLATE_EN = path.resolve(process.cwd(), 'templates/.agents/rules/task-short-id.en.md');
+
+function read(p: string): string {
+  return fs.readFileSync(p, 'utf8');
+}
+
+// Structural check: the SKILL parameter resolver section must contain
+// the executable bash guard literal — not just any prose mentioning it.
+const SKILL_GUARD_LITERAL = '`^[#]?[0-9]+$`';
+const SKILL_BASH_LITERAL = '[[ "{task-id}" =~ ^[#]?[0-9]+$ ]]';
+
+test('task-short-id rule doc (runtime) embeds the executable SKILL parser guard', () => {
+  const content = read(RUNTIME);
+  assert.ok(content.includes(SKILL_GUARD_LITERAL), 'rule doc should reference the parser regex literal');
+  assert.ok(content.includes(SKILL_BASH_LITERAL), 'rule doc should embed the runnable bash guard');
+});
+
+test('task-short-id rule doc (zh-CN template) embeds the executable SKILL parser guard', () => {
+  const content = read(TEMPLATE_ZH);
+  assert.ok(content.includes(SKILL_GUARD_LITERAL), 'zh-CN template should reference the parser regex literal');
+  assert.ok(content.includes(SKILL_BASH_LITERAL), 'zh-CN template should embed the runnable bash guard');
+});
+
+test('task-short-id rule doc (en template) embeds the executable SKILL parser guard', () => {
+  const content = read(TEMPLATE_EN);
+  assert.ok(content.includes(SKILL_GUARD_LITERAL), 'en template should reference the parser regex literal');
+  assert.ok(content.includes(SKILL_BASH_LITERAL), 'en template should embed the runnable bash guard');
+});
+
+// Structural check: the resolution-scope table for sandbox entrypoints must
+// reference both `ai sandbox exec` and `ai sandbox create` (canonical entry
+// points after this PR — they share `resolveTaskBranch`).
+const SANDBOX_EXEC = '`ai sandbox exec';
+const SANDBOX_CREATE = '`ai sandbox create';
+
+test('task-short-id rule doc lists both sandbox exec and sandbox create entry points', () => {
+  for (const [name, p] of [
+    ['runtime', RUNTIME],
+    ['zh-CN', TEMPLATE_ZH],
+    ['en', TEMPLATE_EN]
+  ] as const) {
+    const content = read(p);
+    assert.ok(content.includes(SANDBOX_EXEC), `${name} should list ai sandbox exec in resolution scope`);
+    assert.ok(content.includes(SANDBOX_CREATE), `${name} should list ai sandbox create in resolution scope`);
+  }
+});

--- a/tests/unit/templates/task-short-id-skill-args.test.ts
+++ b/tests/unit/templates/task-short-id-skill-args.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const LIFECYCLE_SKILLS = [
+  'analyze-task',
+  'review-analysis',
+  'plan-task',
+  'review-plan',
+  'code-task',
+  'review-code',
+  'commit',
+  'create-pr',
+  'complete-task',
+  'cancel-task',
+  'block-task',
+  'restore-task',
+  'check-task',
+  'create-task',
+  'import-issue',
+  'import-codescan',
+  'import-dependabot',
+  'close-codescan',
+  'close-dependabot'
+];
+
+const GUARD_LITERAL = '`^[#]?[0-9]+$`';
+
+function read(p: string): string {
+  return fs.readFileSync(p, 'utf8');
+}
+
+// Structural check: every lifecycle SKILL.md (runtime + en/zh-CN templates)
+// must reference the new SKILL-parameter parser regex literal. The regex
+// itself is the executable contract — if the doc shows it, the parser
+// behaves consistently. We do not assert against any prose wording.
+
+for (const name of LIFECYCLE_SKILLS) {
+  test(`runtime SKILL.md (${name}) declares the SKILL parameter guard`, () => {
+    const p = path.resolve('.agents/skills', name, 'SKILL.md');
+    assert.ok(fs.existsSync(p), `missing runtime SKILL.md for ${name}`);
+    const content = read(p);
+    assert.ok(
+      content.includes(GUARD_LITERAL),
+      `${p} should reference ${GUARD_LITERAL} in the task-id short-ref guard`
+    );
+  });
+
+  test(`zh-CN template SKILL.md (${name}) declares the SKILL parameter guard`, () => {
+    const p = path.resolve('templates/.agents/skills', name, 'SKILL.zh-CN.md');
+    assert.ok(fs.existsSync(p), `missing zh-CN template SKILL.md for ${name}`);
+    const content = read(p);
+    assert.ok(
+      content.includes(GUARD_LITERAL),
+      `${p} should reference ${GUARD_LITERAL} in the task-id short-ref guard`
+    );
+  });
+
+  test(`en template SKILL.md (${name}) declares the SKILL parameter guard`, () => {
+    const p = path.resolve('templates/.agents/skills', name, 'SKILL.en.md');
+    assert.ok(fs.existsSync(p), `missing en template SKILL.md for ${name}`);
+    const content = read(p);
+    assert.ok(
+      content.includes(GUARD_LITERAL),
+      `${p} should reference ${GUARD_LITERAL} in the task-id short-ref guard`
+    );
+  });
+}

--- a/tests/unit/templates/task-short-id-template-parity.test.ts
+++ b/tests/unit/templates/task-short-id-template-parity.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RUNTIME = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+const TEMPLATE = path.resolve(process.cwd(), 'templates/.agents/scripts/task-short-id.js');
+
+function extractParseShortIdArg(content: string): string {
+  const m = content.match(/function parseShortIdArg\(arg, shortIdLength\) \{[\s\S]+?\n\}/);
+  assert.ok(m, 'parseShortIdArg function not found');
+  return m[0]
+    .split('\n')
+    .map((line) => line.replace(/\s+$/g, ''))
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n')
+    .trim();
+}
+
+test('parseShortIdArg function body is byte-identical between runtime and template scripts', () => {
+  const runtime = extractParseShortIdArg(fs.readFileSync(RUNTIME, 'utf8'));
+  const template = extractParseShortIdArg(fs.readFileSync(TEMPLATE, 'utf8'));
+  assert.equal(
+    runtime,
+    template,
+    'parseShortIdArg drifted between .agents/scripts/task-short-id.js and templates/.agents/scripts/task-short-id.js'
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #433

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [x] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

实现 #433：新增 `ai task` CLI 子命令并把任务短号入参从加引号的 `'#N'` 改为裸数字 `N`，覆盖 `ai sandbox exec/create` 与所有生命周期 SKILL；同时消除 `ai sandbox exec '#N'` 的「任务短号 vs ls 行号」双语义冲突（breaking）。

- **新功能**：移动端 / 远程终端体验差 —— 浏览任务只能 `ls .agents/workspace/`；现在 `ai task ls` / `ai task show 11` 即可（裸数字、`#11`、`TASK-id` 三种入口等价）。
- **CLI 一致性**：`ai sandbox exec '#5'` 必须加引号躲 bash 注释符，而生命周期 SKILL 也只识别 `#NN`；现在所有入口接受裸数字 `5`、`#5`、`#05` 等价。
- **Breaking 治理**：`ai sandbox exec '#N'` 同时承载「任务短号注册表」与「ls 第 N 行」两套语义（#414），叠加裸数字后会让用户直觉与实际优先级相反；本 PR 一次性消除（C+A 组合）。

## 📋 主要变更 / Brief Changelog

- **范围 1（新功能）**：`ai task ls [--all|--blocked|--completed]` / `ai task show <N | #N | TASK-id>`；`ls` 复用 `ai sandbox ls` 的表格渲染抽出的 `lib/table.formatTable()`；`show` 支持 `archive/YYYY/MM/DD/{taskId}/` 三级日期布局，按 newest-first 有界遍历。
- **范围 2 & 3 & 5（一致性）**：把短号归一化下沉到 `lib/task/short-id.ts` 与 `.agents/scripts/task-short-id.js` 单一来源：`normalizeShortIdInput()` / `parseShortIdArg()` 接受 `^[#]?[0-9]+$`，按**数值容量**而非字符宽度校验（`#005` 在 `shortIdLength=2` 下解析为 `#05`，`#100` 报 over-capacity）；`ai sandbox exec` / `ai sandbox create` / `lib/task/commands/show.ts` 与 19 个生命周期 SKILL 的 `{task-id}` 参数全部共享。
- **范围 4（breaking）**：删除 `lib/sandbox/commands/list-running.ts` 的 `resolveByRunningIndex()`，`resolveTaskShortRef()` registry miss 直接抛错；`ai sandbox ls` 的 `#` 列从「运行容器 1-based 行号」改为「该容器分支对应的任务短号」（无对应任务显示 `-`），与 `ai task ls` 的 `#` 同语义。
- **`{task-ref}` 渲染契约**：在 `review-{analysis,plan,code}` / `code-task` 4 个 SKILL 的 `reference/output-template{,s}.md` + `fix-mode.md` 共 5 个运行时 reference 与 10 个双语镜像里，把「下一步」命令行的 `{task-id}` 占位换为 `{task-ref}`（短号存在时取裸数字，缺失回退完整 TASK-id）。
- **规则 + 模板镜像同步**：`task-short-id.md` 重写 §解析作用域 / §resolve 工作流 / §错误场景（runtime + en/zh-CN）；19 SKILL × 3 镜像（57 个 SKILL.md）的「任务入参短号别名」段统一为新正则。
- **测试**：新增 7 个测试文件（57 SKILL × 3 镜像 parity / 脚本 parity / 规则 parity / `{task-ref}` parity / `ai task ls/show/--help` 集成 / `ai sandbox ls` 短号反查 / `lib/table` 单元 / `lib/task/short-id` + `lib/task/frontmatter` 单元）；改造 4 个既有测试以反映新契约。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量回归（**965 pass / 0 fail / 1 OS-conditional skip**，4 轮 code-review 期间增量 +56 用例）。
2. 端到端正向：`node --experimental-strip-types ./bin/cli.ts task ls` 列出 12 个 active 任务，含 `#11`；`task show 11` / `task show '#11'` / `task show '#01'` / `task show TASK-20260612-162737` 四种入口等价。
3. 范围 4 行为反转回归：`tests/integration/cli/sandbox-core.test.ts` 旧 `resolveTaskShortRef` 5 用例改为「miss 即抛错」；`tests/integration/cli/sandbox-tools.test.ts` 的 `sandbox exec '#1'` 用例确认**不**再触发 `docker ps` 调用。
4. 跨日 archive 回归：`tests/integration/cli/task-show.test.ts:106` `cross-day` 用例（task id `TASK-20260612-...` 在 `archive/2026/06/13/` 下）通过。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue filed for the change (#433)
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / Comments added where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / Mocks used for cross-module dependencies
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / Documentation updated (task-short-id.md + 57 SKILL.md mirrors + 15 reference output templates)
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented (see § 破坏性变更 below)
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered（`'#NN'` 兼容写法保留；脚本端与 CLI 端双源同步由 parity 测试守住）

## 💥 破坏性变更 / Breaking Changes

1. **`ai sandbox exec '#N'` 不再回退到「ls 第 N 行运行容器」**（原 #414 行为废弃）。`#N` / 裸数字 `N` 严格走任务短号注册表；miss 直接抛错并提示用任务短号 / `TASK-id` / 分支名。
2. **`ai sandbox ls` 的 `#` 列语义**从「运行容器的 1-based 行号」改为「该容器分支对应的 active 任务短号」（无对应任务显示 `-`），与 `ai task ls` 的 `#` 完全对应。

兼容性：旧的 `'#NN'` 写法在所有入口都保留（`ai sandbox exec '#5'` / `ai task show '#11'` / `/analyze-task '#11'` 均可），但**推荐**裸数字（无需 shell 引号）。

## 📋 附加信息 / Additional Notes

- **运行时 + 模板镜像严格同步**：19 SKILL × 3 镜像（57 SKILL.md）+ `task-short-id.md` × 3 + 脚本 × 2 + 5 reference × 3 镜像 = 共 ~83 文件成对修改，由新增的 `tests/unit/templates/{task-short-id-template-parity,task-short-id-rule-parity,task-short-id-skill-args,output-templates-task-ref}.test.ts` 守住后续漂移。
- **Scope extended（Issue 评论 2026-06-13）**：用户在 plan-r4 通过后追加要求 `ai sandbox create` 同步接入；本次实现已通过 `lib/sandbox/task-resolver.ts` 的 `SHORT_ID_RE` 扩展为 `/^#?\d+$/` 隐式覆盖（`create` 已经调用 `resolveTaskBranch`）。
- 4 轮 review-code 全部 Approved，最终一轮 0 blocker / 0 major / 0 minor。

Closes #433

---

**审查者注意事项 / Reviewer Notes:**

- `lib/task/short-id.ts:1` 的 `normalizeShortIdInput()` 字面规则与 `.agents/scripts/task-short-id.js:187` 的 `parseShortIdArg()` 必须保持函数体字面一致（由 `tests/unit/templates/task-short-id-template-parity.test.ts` 守住）。
- `lib/task/commands/show.ts:69` 的 `findInArchive()` 按 `archive/{4位年}/{2位月}/{2位日}/{taskId}/task.md` 有界遍历；不依赖 `archive/manifest.md` 解析（Markdown 表格不稳定），不依赖 task id 时间戳推导路径（archive-tasks 用 `completed_at`，非 task id 创建日）。
- `lib/sandbox/commands/list-running.ts` 的 `resolveTaskShortRef()` 签名从 `(arg, { running, repoRoot })` 简化为 `(arg, { repoRoot })`，所有调用点已同步；`ai sandbox exec` 不再触发 `docker ps` 调用（性能优化副作用，但主要意图是消除歧义）。
- `{task-ref}` 占位符语义在 4 个 SKILL.md 的「告知用户」段加了显式契约一行，agent 端实际渲染需在下一次 review 类技能执行时验证。

Generated with AI assistance