### PR TITLE
refactor(meta): 短号脱离 task.md，改为纯本地状态

### DIFF
--- a/.agents/rules/task-short-id.md
+++ b/.agents/rules/task-short-id.md
@@ -16,12 +16,12 @@
 
 ## 生命周期
 
-| 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
+| 动作      | 触发时机                                                                                     | 注册表效应                                                       |
 |-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入 task.md 的 `short_id` 字段。              |
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入注册表。                                  |
 | resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#NN` → 完整 task id 查询，不分配。                              |
-| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
-| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
+| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除。                                                   |
+| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表。                         |
 
 短号仅在任务处于 `.agents/workspace/active/` 期间有效；任务移动到
 `completed/` / `blocked/` / `archive/` 后短号立即释放，可被新任务复用。
@@ -48,8 +48,7 @@
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
 | `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | 解析为完整 task id 后查 task.md 取 `branch` | **严格报错** —— 不再回退到 ls 行号或字面分支名；提示用任务短号 / `TASK-id` / 分支名 |
 
-`list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
-三者差异，但不修改任何状态。
+`list --verify` 严格只读：报告 active 目录 / 注册表 两者差异，但不修改任何状态。
 
 ## SKILL 入参解析
 
@@ -73,31 +72,15 @@ fi
 
 ## 存储位置
 
-短号系统跨两处持久化状态，二者在稳态时一一对应：
-
-| 位置 | 写入时机 | 读取时机 | 删除时机 |
-|---|---|---|---|
-| `.agents/workspace/active/.short-ids.json`（注册表） | `alloc` / 冷启动迁移 | `resolve` 唯一权威源 / `list` / `list --verify` | `release` / 冷启动 stale 清理 |
-| 各 task.md frontmatter 的 `short_id` 字段 | `alloc` / 冷启动迁移 | `list --verify`（比对一致性） | **永不删除**（归档后保留为历史值） |
-
-**注册表**：
+短号是纯本地状态，唯一持久化在注册表 `.agents/workspace/active/.short-ids.json`，task.md 不持有短号：
 
 - 路径：`<repo-root>/.agents/workspace/active/.short-ids.json`
 - Schema：`{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
 - key 是零填充到 `task.shortIdLength` 位的字符串，value 是完整 `TASK-…` task id
 - 自动 git ignore（active 工作区整体 ignore；无需新增 ignore 条目）
-- 首次 `alloc` / `resolve` 时按需自动创建；不存在时按空注册表处理
-
-**task.md `short_id` 字段**：
-
-- 在 frontmatter 中、紧跟 `id` 字段之后；格式 `short_id: #01`
-- 与注册表 key 字面一致（含 `#` 前缀）
-- 归档（complete-task / cancel-task / block-task / close-*）后：注册表 entry 立即
-  删除（短号可被新任务复用），但 task.md `short_id` 字段保留作为历史值。解析器
-  只信任注册表
-- 冷启动迁移：升级 agent-infra 后首次 alloc / resolve 路径会扫描所有 active
-  目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
-  `updated_at` / `agent_infra_version`、不追加 Activity Log）
+- 首次 `alloc` 时按需自动创建；不存在时按空注册表处理
+- 短号只由显式 `alloc`（`create-task` / `import-*` / `restore-task`）分配；`resolve` / `list` / `release` 不分配，仅在执行时自动清理指向非 active 任务的 stale entry
+- 归档（complete-task / cancel-task / block-task / close-*）后注册表 entry 立即删除，短号可被新任务复用；归档后引用任务一律用完整 `TASK-…` id
 
 `resolve(<N|'#N'>)` 工作流：① 校验入参匹配 `^[#]?[0-9]+$` → ② 去前导零取
 数值 `n`，按 `n` 是否 `== 0`（保留）/ `> 10^shortIdLength - 1`（超容量）/
@@ -120,13 +103,3 @@ fi
 `#N` / `#NN` 写法也接受；但 bash 中 `#` 是注释起始符，必须单引号：
 `ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
 在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
-
-## 冷启动迁移
-
-升级 agent-infra 后，首次 `alloc` / `resolve` 调用会触发冷启动迁移：
-
-- 所有 active task.md 缺 `short_id` 字段时自动补发并回写（仅修改 `short_id`
-  一行，不刷新 `updated_at` / `agent_infra_version`，不追加 Activity Log）。
-- 若 active 任务总数超过 `shortIdLength` 容量，**在任何写入之前**报错退出 2。
-- 若 task.md 写入中途失败，`tx.commit()` 按缓存的原内容回滚所有已写文件（含
-  `mtime` / `atime` 恢复）。

--- a/.agents/scripts/task-short-id.js
+++ b/.agents/scripts/task-short-id.js
@@ -32,11 +32,11 @@ function usage() {
     "Usage: task-short-id.js <subcommand> [args]",
     "",
     "Subcommands:",
-    "  alloc <task-id>      Allocate short id for a task; writes registry + short_id to task.md",
+    "  alloc <task-id>      Allocate short id for a task in the registry",
     "  release <task-id>    Release short id (idempotent; exit 0 if not present)",
     "  resolve <#N>         Resolve short id to full task id",
     "  list                 Print registry JSON",
-    "  list --verify        Read-only check; exit 1 if active dir / registry / task.md disagree",
+    "  list --verify        Read-only check; exit 1 if active dir / registry disagree",
     "",
     "Options:",
     "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
@@ -161,17 +161,6 @@ function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
   }
 }
 
-function writeTaskMdShortId(taskMdPath, shortId) {
-  const content = fs.readFileSync(taskMdPath, "utf8");
-  let updated;
-  if (/^short_id:.*$/m.test(content)) {
-    updated = content.replace(/^short_id:.*$/m, `short_id: ${shortId}`);
-  } else {
-    updated = content.replace(/^(id:.*)$/m, `$1\nshort_id: ${shortId}`);
-  }
-  fs.writeFileSync(taskMdPath, updated);
-}
-
 function padShortId(n, shortIdLength) {
   return String(n).padStart(shortIdLength, "0");
 }
@@ -226,7 +215,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
       .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
   );
 
-  // A2: stale entries
+  // A2: stale entries (registry points at a task no longer active)
   const pendingRegistryDeletes = [];
   for (const [key, taskId] of Object.entries(registry.ids)) {
     if (!activeTaskIds.has(taskId)) pendingRegistryDeletes.push(key);
@@ -248,106 +237,17 @@ function planTransaction(registry, activeDir, shortIdLength) {
     taskIdToKey.set(taskId, key);
   }
 
-  // A4: classify each active task
+  // The registry is the sole source of truth: short ids are allocated only by
+  // explicit `alloc` (planAlloc), never inferred from task.md or auto-allocated
+  // for active tasks. Read paths (resolve/list) only run stale cleanup (A2).
   const plannedRegistryWrites = [];
-  const plannedTaskMdWrites = [];
-  const pendingAlloc = [];
 
-  for (const taskId of activeTaskIds) {
-    const taskMdPath = path.join(activeDir, taskId, "task.md");
-    const originalStat = fs.statSync(taskMdPath);
-    const originalContent = fs.readFileSync(taskMdPath, "utf8");
-    const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-
-    if (existing) {
-      const declared = existing[1];
-      const n = declared.slice(1);
-      if (projectedIds[n] === taskId) continue; // 4a
-      if (taskIdToKey.has(taskId)) {
-        const registryKey = taskIdToKey.get(taskId);
-        writeStderr(
-          `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
-        );
-        process.exit(2);
-      }
-      if (projectedIds[n] && projectedIds[n] !== taskId) {
-        writeStderr(
-          `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
-        );
-        process.exit(2);
-      }
-      // 4d
-      plannedRegistryWrites.push({ key: n, taskId });
-      projectedIds[n] = taskId;
-      taskIdToKey.set(taskId, n);
-      continue;
-    }
-
-    if (taskIdToKey.has(taskId)) {
-      // 4e
-      const registryKey = taskIdToKey.get(taskId);
-      plannedTaskMdWrites.push({
-        taskMdPath,
-        originalContent,
-        originalAtime: originalStat.atime,
-        originalMtime: originalStat.mtime,
-        shortId: `#${registryKey}`,
-        kind: "4e"
-      });
-      continue;
-    }
-
-    // 4f: deferred
-    pendingAlloc.push({
-      taskId,
-      taskMdPath,
-      originalContent,
-      originalAtime: originalStat.atime,
-      originalMtime: originalStat.mtime
-    });
-  }
-
-  // A5: capacity pre-check
-  const availableSlots = maxN - Object.keys(projectedIds).length;
-  if (pendingAlloc.length > availableSlots) {
-    writeStderr(
-      `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
-        `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
-        `Archive some active tasks (complete-task / cancel-task / block-task) ` +
-        `or raise task.shortIdLength in .agents/.airc.json.\n`
-    );
-    process.exit(2);
-  }
-
-  pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
-
-  for (const item of pendingAlloc) {
-    const n = allocateMinFreeInt({ ids: projectedIds }, shortIdLength);
-    if (n === null) {
-      throw new Error("Internal invariant: pendingAlloc capacity check failed");
-    }
-    const key = padShortId(n, shortIdLength);
-    projectedIds[key] = item.taskId;
-    taskIdToKey.set(item.taskId, key);
-    plannedRegistryWrites.push({ key, taskId: item.taskId });
-    plannedTaskMdWrites.push({
-      taskMdPath: item.taskMdPath,
-      originalContent: item.originalContent,
-      originalAtime: item.originalAtime,
-      originalMtime: item.originalMtime,
-      shortId: `#${key}`,
-      kind: "4f"
-    });
-  }
-
-  // Build transaction object
   const tx = {
     _registry: registry,
     _activeDir: activeDir,
     _registrySnapshot: { ...registry.ids },
     _pendingRegistryDeletes: pendingRegistryDeletes,
     _plannedRegistryWrites: plannedRegistryWrites,
-    _plannedTaskMdWrites: plannedTaskMdWrites,
     _projectedIds: projectedIds,
     _taskIdToKey: taskIdToKey,
     _shortIdLength: shortIdLength,
@@ -373,20 +273,6 @@ function planTransaction(registry, activeDir, shortIdLength) {
       this._projectedIds[key] = taskId;
       this._taskIdToKey.set(taskId, key);
       this._plannedRegistryWrites.push({ key, taskId });
-      const originalStat = fs.statSync(taskMdPath);
-      const originalContent = fs.readFileSync(taskMdPath, "utf8");
-      // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
-      const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-      if (!existing || existing[1] !== `#${key}`) {
-        this._plannedTaskMdWrites.push({
-          taskMdPath,
-          originalContent,
-          originalAtime: originalStat.atime,
-          originalMtime: originalStat.mtime,
-          shortId: `#${key}`,
-          kind: "caller-alloc"
-        });
-      }
       return key;  // zero-padded; matches registry key
     },
 
@@ -396,54 +282,22 @@ function planTransaction(registry, activeDir, shortIdLength) {
       this._plannedRegistryWrites = this._plannedRegistryWrites.filter(
         (w) => w.taskId !== taskId
       );
-      this._plannedTaskMdWrites = this._plannedTaskMdWrites.filter(
-        (w) => path.basename(path.dirname(w.taskMdPath)) !== taskId
-      );
       this._pendingRegistryDeletes.push(key);
       delete this._projectedIds[key];
       this._taskIdToKey.delete(taskId);
     },
 
     commit(registryPath) {
-      // B1: apply registry mutation in memory
+      // Apply registry mutation in memory, then persist atomically.
       for (const key of this._pendingRegistryDeletes) delete this._registry.ids[key];
       for (const { key, taskId } of this._plannedRegistryWrites) {
         this._registry.ids[key] = taskId;
       }
-
-      const completedWrites = [];
-      const rollback = (reason) => {
-        for (const done of completedWrites.reverse()) {
-          try {
-            fs.writeFileSync(done.taskMdPath, done.originalContent);
-            fs.utimesSync(done.taskMdPath, done.originalAtime, done.originalMtime);
-          } catch {
-            /* best-effort */
-          }
-        }
-        this._registry.ids = this._registrySnapshot;
-        const tail =
-          completedWrites.length > 0
-            ? `; rolled back ${completedWrites.length} prior task.md write(s)`
-            : "";
-        throw new Error(`${reason}${tail}`);
-      };
-
-      // B2: write task.md per plan
-      for (const write of this._plannedTaskMdWrites) {
-        try {
-          writeTaskMdShortId(write.taskMdPath, write.shortId);
-          completedWrites.push(write);
-        } catch (e) {
-          rollback(`Failed to write short_id to ${write.taskMdPath}: ${e.message}`);
-        }
-      }
-
-      // B3: atomic registry persistence
       try {
         writeRegistryAtomic(this._registry, registryPath);
       } catch (e) {
-        rollback(`Failed to persist registry to ${registryPath}: ${e.message}`);
+        this._registry.ids = this._registrySnapshot;
+        throw new Error(`Failed to persist registry to ${registryPath}: ${e.message}`);
       }
     }
   };
@@ -459,27 +313,10 @@ function verifyRegistry(registry, activeDir) {
       .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
   );
   const registryTaskIds = new Set(Object.values(registry.ids));
-  const taskmdShortIds = new Map();
-  for (const taskId of activeTaskIds) {
-    const taskMdPath = path.join(activeDir, taskId, "task.md");
-    const content = fs.readFileSync(taskMdPath, "utf8");
-    const m = content.match(/^short_id:\s*(#\d+)\s*$/m);
-    taskmdShortIds.set(taskId, m ? m[1] : null);
-  }
   const missing_in_registry = [];
   for (const taskId of activeTaskIds) {
     if (!registryTaskIds.has(taskId)) {
-      missing_in_registry.push({ taskId, declared: taskmdShortIds.get(taskId) });
-    }
-  }
-  const missing_in_taskmd = [];
-  for (const [key, taskId] of Object.entries(registry.ids)) {
-    if (!activeTaskIds.has(taskId)) continue;
-    const declared = taskmdShortIds.get(taskId);
-    if (declared === null) {
-      missing_in_taskmd.push({ taskId, expected: `#${key}` });
-    } else if (declared !== `#${key}`) {
-      missing_in_taskmd.push({ taskId, expected: `#${key}`, declared });
+      missing_in_registry.push({ taskId });
     }
   }
   const orphans_in_registry = [];
@@ -501,7 +338,6 @@ function verifyRegistry(registry, activeDir) {
   }
   return {
     missing_in_registry,
-    missing_in_taskmd,
     orphans_in_registry,
     duplicate_registry_keys
   };
@@ -568,8 +404,7 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
     if (!taskId) {
       const hasPendingMutations =
         tx._plannedRegistryWrites.length > 0 ||
-        tx._pendingRegistryDeletes.length > 0 ||
-        tx._plannedTaskMdWrites.length > 0;
+        tx._pendingRegistryDeletes.length > 0;
       if (hasPendingMutations) {
         try {
           tx.commit(registryPath);
@@ -614,7 +449,6 @@ function cmdList(activeDir, registryPath, verify) {
   const diff = verifyRegistry(registry, activeDir);
   const hasIssues =
     diff.missing_in_registry.length > 0 ||
-    diff.missing_in_taskmd.length > 0 ||
     diff.orphans_in_registry.length > 0 ||
     diff.duplicate_registry_keys.length > 0;
   if (hasIssues) {
@@ -709,7 +543,6 @@ export {
   readRegistry,
   writeRegistryAtomic,
   withRegistryLock,
-  writeTaskMdShortId,
   padShortId,
   parseShortIdArg,
   allocateMinFreeInt,

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -180,7 +180,7 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -180,7 +180,7 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -129,7 +129,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 5. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -62,7 +62,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -63,7 +63,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -123,7 +123,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 7. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -124,7 +124,7 @@ env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显�
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -124,7 +124,7 @@ env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显�
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -7,7 +7,6 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
-short_id:                       # 由 create-task / import-* 在 active 期内写入；归档后保留历史值
 priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
 effort:                         # 可选 Issue 字段：High | Medium | Low
 start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD

--- a/lib/task/commands/ls.ts
+++ b/lib/task/commands/ls.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { formatTable } from '../../table.ts';
 import { parseTaskFrontmatter, extractTitle } from '../frontmatter.ts';
+import { loadShortIdByTaskId } from '../short-id.ts';
 
 const USAGE = `Usage: ai task ls [--all | --blocked | --completed]
 
@@ -75,6 +76,9 @@ type TaskRow = {
 function collectTasks(repoRoot: string, state: 'active' | 'blocked' | 'completed'): TaskRow[] {
   const dir = path.join(repoRoot, '.agents', 'workspace', state);
   if (!fs.existsSync(dir)) return [];
+  // Short ids live only in the registry and only for active tasks; archived
+  // (blocked/completed) tasks have released their short id and render '-'.
+  const shortIdByTaskId = state === 'active' ? loadShortIdByTaskId(repoRoot) : new Map<string, string>();
   const rows: TaskRow[] = [];
   for (const entry of fs.readdirSync(dir).sort()) {
     if (!TASK_ID_RE.test(entry)) continue;
@@ -83,7 +87,7 @@ function collectTasks(repoRoot: string, state: 'active' | 'blocked' | 'completed
     const content = fs.readFileSync(taskMdPath, 'utf8');
     const fm = parseTaskFrontmatter(content);
     const title = extractTitle(content);
-    const shortId = (fm.short_id ?? '').trim() || '-';
+    const shortId = shortIdByTaskId.get(entry) ?? '-';
     const shortIdNumeric = shortId.startsWith('#') ? String(Number(shortId.slice(1)) || 0) : '';
     rows.push({
       shortIdNumeric,

--- a/lib/task/short-id.ts
+++ b/lib/task/short-id.ts
@@ -60,6 +60,16 @@ function readBranchFromTaskMd(repoRoot: string, taskId: string): string | null {
   return m[1].trim().replace(/^(["'])(.*)\1$/, '$2');
 }
 
+function loadShortIdByTaskId(repoRoot: string): Map<string, string> {
+  const registry = readRegistry(repoRoot);
+  const map = new Map<string, string>();
+  if (!registry) return map;
+  for (const [key, taskId] of Object.entries(registry.ids)) {
+    map.set(taskId, `#${key}`);
+  }
+  return map;
+}
+
 function lookupShortIdByBranch(
   branch: string,
   repoRoot: string,
@@ -83,5 +93,5 @@ function lookupShortIdByBranch(
   return matches[0]!;
 }
 
-export { normalizeShortIdInput, lookupShortIdByBranch };
+export { normalizeShortIdInput, lookupShortIdByBranch, loadShortIdByTaskId };
 export type { NormalizeResult, NormalizeOpts };

--- a/templates/.agents/rules/task-short-id.en.md
+++ b/templates/.agents/rules/task-short-id.en.md
@@ -22,12 +22,12 @@ task is active.
 
 ## Lifecycle
 
-| Action     | When                                                                 | Effect on registry & task.md                                  |
+| Action     | When                                                                 | Effect on registry                                            |
 |------------|-----------------------------------------------------------------------|---------------------------------------------------------------|
-| alloc      | `create-task`, `import-issue`, `import-codescan`, `import-dependabot` | Assigns lowest free `#NN`; writes `short_id` into task.md.    |
+| alloc      | `create-task`, `import-issue`, `import-codescan`, `import-dependabot` | Assigns lowest free `#NN` in the registry.                    |
 | resolve    | Lifecycle SKILLs (`analyze-task`, `plan-task`, `code-task`, …)        | Looks up `#NN` → full task id. Does not allocate.             |
-| release    | `complete-task`, `cancel-task`, `block-task`, `close-codescan`, `close-dependabot` | Removes the registry entry; leaves task.md `short_id` as a historical value. |
-| re-alloc   | `restore-task`                                                        | Re-allocates a (possibly new) `#NN` and writes it to task.md. |
+| release    | `complete-task`, `cancel-task`, `block-task`, `close-codescan`, `close-dependabot` | Removes the registry entry. |
+| re-alloc   | `restore-task`                                                        | Re-allocates a (possibly new) `#NN` in the registry. |
 
 Short ids are valid only while a task lives in `.agents/workspace/active/`.
 Once it is moved to `completed/`, `blocked/`, or `archive/`, the `#NN` slot is
@@ -56,8 +56,8 @@ archiving all active tasks first (the registry key width depends on it).
 | SKILL parameter resolver (lifecycle SKILLs)                  | resolve to full id   | **strict error** — short id not found / invalid     |
 | `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | resolve to full id, then read `branch` from task.md | **strict error** — no ls-index fallback, no literal-branch fallback; hint the user to pass a short id / `TASK-id` / branch name |
 
-`list --verify` is strictly read-only: it reports discrepancies between active
-dir, registry, and `short_id` declared in each `task.md`, but never writes.
+`list --verify` is strictly read-only: it reports discrepancies between the
+active dir and the registry, but never writes.
 
 ## SKILL parameter resolver
 
@@ -84,14 +84,8 @@ fi
 
 ## Storage
 
-The short id system persists state in two places that stay in sync at rest:
-
-| Location | Written by | Read by | Removed by |
-|---|---|---|---|
-| `.agents/workspace/active/.short-ids.json` (registry) | `alloc` / cold-start migration | `resolve` (authoritative) / `list` / `list --verify` | `release` / cold-start stale cleanup |
-| `short_id` frontmatter field in each task.md | `alloc` / cold-start migration | `list --verify` (consistency check) | **never** (kept as historical value after archive) |
-
-**Registry**:
+Short ids are pure local state, persisted only in the registry
+`.agents/workspace/active/.short-ids.json`; task.md does not hold the short id:
 
 - Path: `<repo-root>/.agents/workspace/active/.short-ids.json`
 - Schema: `{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
@@ -99,21 +93,14 @@ The short id system persists state in two places that stay in sync at rest:
   full `TASK-…` task ids.
 - Automatically git-ignored (the whole active workspace is ignored; no new
   ignore entry needed).
-- Created on demand by the first `alloc` / `resolve`; an absent file is treated
-  as an empty registry.
-
-**`short_id` field in task.md**:
-
-- Lives in frontmatter, immediately after `id`; formatted `short_id: #01`.
-- Matches the registry key byte-for-byte (including the `#` prefix).
+- Created on demand by the first `alloc`; an absent file is treated as an empty
+  registry.
+- Short ids are assigned only by an explicit `alloc` (`create-task` /
+  `import-*` / `restore-task`); `resolve` / `list` / `release` never allocate —
+  they only clean up stale entries pointing at non-active tasks.
 - After archive (complete-task / cancel-task / block-task / close-*) the
-  registry entry is deleted immediately (the short id can be reused), but the
-  `short_id` field in task.md is kept as a historical value. The resolver
-  trusts the registry only.
-- Cold-start migration: the first `alloc` / `resolve` after an upgrade scans
-  the active directory and fills in the missing field for legacy tasks; the
-  field write is constrained (does NOT refresh `updated_at` /
-  `agent_infra_version` and does NOT append Activity Log).
+  registry entry is deleted immediately and the short id may be reused; archived
+  tasks are referenced by their full `TASK-…` id.
 
 `resolve(<N|'#N'>)` workflow: ① validate arg matches `^[#]?[0-9]+$` →
 ② strip leading zeros and take the numeric value `n`; classify as reserved
@@ -144,16 +131,3 @@ The `#N` / `#NN` form is also accepted; but bash treats `#` as a comment
 marker, so it must be single-quoted: `ai sandbox exec '#03' 'npm test'`.
 Claude Code / Codex / Gemini CLI / OpenCode all forward `#NN` to SKILL
 `ARGUMENTS` literally when quoted.
-
-## Cold-start migration
-
-When a project upgrades to a version with this feature, the first call to
-`alloc` / `resolve` runs the cold-start path:
-
-- Active tasks whose `task.md` lacks `short_id` get one allocated and written
-  back (the only frontmatter mutation; `updated_at` / `agent_infra_version`
-  are **not** refreshed and Activity Log is **not** appended).
-- If active task count exceeds `shortIdLength` capacity, the migration aborts
-  **before any write** with a capacity error.
-- If a partial write fails midway, `tx.commit()` rolls all task.md files back to
-  their original content (including `mtime` / `atime`).

--- a/templates/.agents/rules/task-short-id.zh-CN.md
+++ b/templates/.agents/rules/task-short-id.zh-CN.md
@@ -16,12 +16,12 @@
 
 ## 生命周期
 
-| 动作      | 触发时机                                                                                     | 注册表 / task.md 效应                                            |
+| 动作      | 触发时机                                                                                     | 注册表效应                                                       |
 |-----------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入 task.md 的 `short_id` 字段。              |
+| alloc     | `create-task`、`import-issue`、`import-codescan`、`import-dependabot`                       | 分配最小可用 `#NN`，写入注册表。                                  |
 | resolve   | 生命周期 SKILL（`analyze-task` / `plan-task` / `code-task` / `review-*` / `commit` / …）    | `#NN` → 完整 task id 查询，不分配。                              |
-| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除；task.md 的 `short_id` 字段保留作为历史值。          |
-| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表与 task.md。               |
+| release   | `complete-task`、`cancel-task`、`block-task`、`close-codescan`、`close-dependabot`          | 从注册表移除。                                                   |
+| re-alloc  | `restore-task`                                                                              | 重新分配（可能与历史不同），写入注册表。                         |
 
 短号仅在任务处于 `.agents/workspace/active/` 期间有效；任务移动到
 `completed/` / `blocked/` / `archive/` 后短号立即释放，可被新任务复用。
@@ -48,8 +48,7 @@
 | SKILL 入参解析器（生命周期 SKILL）                          | 解析为完整 task id    | **严格报错** —— 短号不存在 / 格式错误                  |
 | `ai sandbox exec <N \| '#N'>` / `ai sandbox create <N \| '#N'>`           | 解析为完整 task id 后查 task.md 取 `branch` | **严格报错** —— 不再回退到 ls 行号或字面分支名；提示用任务短号 / `TASK-id` / 分支名 |
 
-`list --verify` 严格只读：报告 active 目录 / 注册表 / 各 task.md 的 `short_id`
-三者差异，但不修改任何状态。
+`list --verify` 严格只读：报告 active 目录 / 注册表 两者差异，但不修改任何状态。
 
 ## SKILL 入参解析
 
@@ -73,31 +72,15 @@ fi
 
 ## 存储位置
 
-短号系统跨两处持久化状态，二者在稳态时一一对应：
-
-| 位置 | 写入时机 | 读取时机 | 删除时机 |
-|---|---|---|---|
-| `.agents/workspace/active/.short-ids.json`（注册表） | `alloc` / 冷启动迁移 | `resolve` 唯一权威源 / `list` / `list --verify` | `release` / 冷启动 stale 清理 |
-| 各 task.md frontmatter 的 `short_id` 字段 | `alloc` / 冷启动迁移 | `list --verify`（比对一致性） | **永不删除**（归档后保留为历史值） |
-
-**注册表**：
+短号是纯本地状态，唯一持久化在注册表 `.agents/workspace/active/.short-ids.json`，task.md 不持有短号：
 
 - 路径：`<repo-root>/.agents/workspace/active/.short-ids.json`
 - Schema：`{ "version": 1, "ids": { "01": "TASK-20260609-192644", "02": "TASK-…" } }`
 - key 是零填充到 `task.shortIdLength` 位的字符串，value 是完整 `TASK-…` task id
 - 自动 git ignore（active 工作区整体 ignore；无需新增 ignore 条目）
-- 首次 `alloc` / `resolve` 时按需自动创建；不存在时按空注册表处理
-
-**task.md `short_id` 字段**：
-
-- 在 frontmatter 中、紧跟 `id` 字段之后；格式 `short_id: #01`
-- 与注册表 key 字面一致（含 `#` 前缀）
-- 归档（complete-task / cancel-task / block-task / close-*）后：注册表 entry 立即
-  删除（短号可被新任务复用），但 task.md `short_id` 字段保留作为历史值。解析器
-  只信任注册表
-- 冷启动迁移：升级 agent-infra 后首次 alloc / resolve 路径会扫描所有 active
-  目录并为缺字段的 task.md 补发短号；补发受字段保护约束（不刷新
-  `updated_at` / `agent_infra_version`、不追加 Activity Log）
+- 首次 `alloc` 时按需自动创建；不存在时按空注册表处理
+- 短号只由显式 `alloc`（`create-task` / `import-*` / `restore-task`）分配；`resolve` / `list` / `release` 不分配，仅在执行时自动清理指向非 active 任务的 stale entry
+- 归档（complete-task / cancel-task / block-task / close-*）后注册表 entry 立即删除，短号可被新任务复用；归档后引用任务一律用完整 `TASK-…` id
 
 `resolve(<N|'#N'>)` 工作流：① 校验入参匹配 `^[#]?[0-9]+$` → ② 去前导零取
 数值 `n`，按 `n` 是否 `== 0`（保留）/ `> 10^shortIdLength - 1`（超容量）/
@@ -120,13 +103,3 @@ fi
 `#N` / `#NN` 写法也接受；但 bash 中 `#` 是注释起始符，必须单引号：
 `ai sandbox exec '#03' 'npm test'`。Claude Code / Codex / Gemini CLI / OpenCode
 在加引号时都能把 `#NN` 字面传递到 SKILL 的 `ARGUMENTS`。
-
-## 冷启动迁移
-
-升级 agent-infra 后，首次 `alloc` / `resolve` 调用会触发冷启动迁移：
-
-- 所有 active task.md 缺 `short_id` 字段时自动补发并回写（仅修改 `short_id`
-  一行，不刷新 `updated_at` / `agent_infra_version`，不追加 Activity Log）。
-- 若 active 任务总数超过 `shortIdLength` 容量，**在任何写入之前**报错退出 2。
-- 若 task.md 写入中途失败，`tx.commit()` 按缓存的原内容回滚所有已写文件（含
-  `mtime` / `atime` 恢复）。

--- a/templates/.agents/scripts/task-short-id.js
+++ b/templates/.agents/scripts/task-short-id.js
@@ -32,11 +32,11 @@ function usage() {
     "Usage: task-short-id.js <subcommand> [args]",
     "",
     "Subcommands:",
-    "  alloc <task-id>      Allocate short id for a task; writes registry + short_id to task.md",
+    "  alloc <task-id>      Allocate short id for a task in the registry",
     "  release <task-id>    Release short id (idempotent; exit 0 if not present)",
     "  resolve <#N>         Resolve short id to full task id",
     "  list                 Print registry JSON",
-    "  list --verify        Read-only check; exit 1 if active dir / registry / task.md disagree",
+    "  list --verify        Read-only check; exit 1 if active dir / registry disagree",
     "",
     "Options:",
     "  --active-dir <path>  Override active dir (default: <repo>/.agents/workspace/active)",
@@ -161,17 +161,6 @@ function withRegistryLock(activeDir, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
   }
 }
 
-function writeTaskMdShortId(taskMdPath, shortId) {
-  const content = fs.readFileSync(taskMdPath, "utf8");
-  let updated;
-  if (/^short_id:.*$/m.test(content)) {
-    updated = content.replace(/^short_id:.*$/m, `short_id: ${shortId}`);
-  } else {
-    updated = content.replace(/^(id:.*)$/m, `$1\nshort_id: ${shortId}`);
-  }
-  fs.writeFileSync(taskMdPath, updated);
-}
-
 function padShortId(n, shortIdLength) {
   return String(n).padStart(shortIdLength, "0");
 }
@@ -226,7 +215,7 @@ function planTransaction(registry, activeDir, shortIdLength) {
       .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
   );
 
-  // A2: stale entries
+  // A2: stale entries (registry points at a task no longer active)
   const pendingRegistryDeletes = [];
   for (const [key, taskId] of Object.entries(registry.ids)) {
     if (!activeTaskIds.has(taskId)) pendingRegistryDeletes.push(key);
@@ -248,106 +237,17 @@ function planTransaction(registry, activeDir, shortIdLength) {
     taskIdToKey.set(taskId, key);
   }
 
-  // A4: classify each active task
+  // The registry is the sole source of truth: short ids are allocated only by
+  // explicit `alloc` (planAlloc), never inferred from task.md or auto-allocated
+  // for active tasks. Read paths (resolve/list) only run stale cleanup (A2).
   const plannedRegistryWrites = [];
-  const plannedTaskMdWrites = [];
-  const pendingAlloc = [];
 
-  for (const taskId of activeTaskIds) {
-    const taskMdPath = path.join(activeDir, taskId, "task.md");
-    const originalStat = fs.statSync(taskMdPath);
-    const originalContent = fs.readFileSync(taskMdPath, "utf8");
-    const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-
-    if (existing) {
-      const declared = existing[1];
-      const n = declared.slice(1);
-      if (projectedIds[n] === taskId) continue; // 4a
-      if (taskIdToKey.has(taskId)) {
-        const registryKey = taskIdToKey.get(taskId);
-        writeStderr(
-          `Inconsistent: task ${taskId} declares ${declared} but registry holds it at #${registryKey}\n`
-        );
-        process.exit(2);
-      }
-      if (projectedIds[n] && projectedIds[n] !== taskId) {
-        writeStderr(
-          `Inconsistent: task ${taskId} declares ${declared} but registry maps ${declared} to ${projectedIds[n]}\n`
-        );
-        process.exit(2);
-      }
-      // 4d
-      plannedRegistryWrites.push({ key: n, taskId });
-      projectedIds[n] = taskId;
-      taskIdToKey.set(taskId, n);
-      continue;
-    }
-
-    if (taskIdToKey.has(taskId)) {
-      // 4e
-      const registryKey = taskIdToKey.get(taskId);
-      plannedTaskMdWrites.push({
-        taskMdPath,
-        originalContent,
-        originalAtime: originalStat.atime,
-        originalMtime: originalStat.mtime,
-        shortId: `#${registryKey}`,
-        kind: "4e"
-      });
-      continue;
-    }
-
-    // 4f: deferred
-    pendingAlloc.push({
-      taskId,
-      taskMdPath,
-      originalContent,
-      originalAtime: originalStat.atime,
-      originalMtime: originalStat.mtime
-    });
-  }
-
-  // A5: capacity pre-check
-  const availableSlots = maxN - Object.keys(projectedIds).length;
-  if (pendingAlloc.length > availableSlots) {
-    writeStderr(
-      `Error: cold-start migration needs ${pendingAlloc.length} short id(s) but only ${availableSlots} ` +
-        `slot(s) available (capacity=${maxN}, in-use after stale-cleanup=${Object.keys(projectedIds).length}). ` +
-        `Archive some active tasks (complete-task / cancel-task / block-task) ` +
-        `or raise task.shortIdLength in .agents/.airc.json.\n`
-    );
-    process.exit(2);
-  }
-
-  pendingAlloc.sort((a, b) => a.taskId.localeCompare(b.taskId));
-
-  for (const item of pendingAlloc) {
-    const n = allocateMinFreeInt({ ids: projectedIds }, shortIdLength);
-    if (n === null) {
-      throw new Error("Internal invariant: pendingAlloc capacity check failed");
-    }
-    const key = padShortId(n, shortIdLength);
-    projectedIds[key] = item.taskId;
-    taskIdToKey.set(item.taskId, key);
-    plannedRegistryWrites.push({ key, taskId: item.taskId });
-    plannedTaskMdWrites.push({
-      taskMdPath: item.taskMdPath,
-      originalContent: item.originalContent,
-      originalAtime: item.originalAtime,
-      originalMtime: item.originalMtime,
-      shortId: `#${key}`,
-      kind: "4f"
-    });
-  }
-
-  // Build transaction object
   const tx = {
     _registry: registry,
     _activeDir: activeDir,
     _registrySnapshot: { ...registry.ids },
     _pendingRegistryDeletes: pendingRegistryDeletes,
     _plannedRegistryWrites: plannedRegistryWrites,
-    _plannedTaskMdWrites: plannedTaskMdWrites,
     _projectedIds: projectedIds,
     _taskIdToKey: taskIdToKey,
     _shortIdLength: shortIdLength,
@@ -373,20 +273,6 @@ function planTransaction(registry, activeDir, shortIdLength) {
       this._projectedIds[key] = taskId;
       this._taskIdToKey.set(taskId, key);
       this._plannedRegistryWrites.push({ key, taskId });
-      const originalStat = fs.statSync(taskMdPath);
-      const originalContent = fs.readFileSync(taskMdPath, "utf8");
-      // If task.md already declares the same short id (e.g. R-alloc replay), skip writing.
-      const existing = originalContent.match(/^short_id:\s*(#\d+)\s*$/m);
-      if (!existing || existing[1] !== `#${key}`) {
-        this._plannedTaskMdWrites.push({
-          taskMdPath,
-          originalContent,
-          originalAtime: originalStat.atime,
-          originalMtime: originalStat.mtime,
-          shortId: `#${key}`,
-          kind: "caller-alloc"
-        });
-      }
       return key;  // zero-padded; matches registry key
     },
 
@@ -396,54 +282,22 @@ function planTransaction(registry, activeDir, shortIdLength) {
       this._plannedRegistryWrites = this._plannedRegistryWrites.filter(
         (w) => w.taskId !== taskId
       );
-      this._plannedTaskMdWrites = this._plannedTaskMdWrites.filter(
-        (w) => path.basename(path.dirname(w.taskMdPath)) !== taskId
-      );
       this._pendingRegistryDeletes.push(key);
       delete this._projectedIds[key];
       this._taskIdToKey.delete(taskId);
     },
 
     commit(registryPath) {
-      // B1: apply registry mutation in memory
+      // Apply registry mutation in memory, then persist atomically.
       for (const key of this._pendingRegistryDeletes) delete this._registry.ids[key];
       for (const { key, taskId } of this._plannedRegistryWrites) {
         this._registry.ids[key] = taskId;
       }
-
-      const completedWrites = [];
-      const rollback = (reason) => {
-        for (const done of completedWrites.reverse()) {
-          try {
-            fs.writeFileSync(done.taskMdPath, done.originalContent);
-            fs.utimesSync(done.taskMdPath, done.originalAtime, done.originalMtime);
-          } catch {
-            /* best-effort */
-          }
-        }
-        this._registry.ids = this._registrySnapshot;
-        const tail =
-          completedWrites.length > 0
-            ? `; rolled back ${completedWrites.length} prior task.md write(s)`
-            : "";
-        throw new Error(`${reason}${tail}`);
-      };
-
-      // B2: write task.md per plan
-      for (const write of this._plannedTaskMdWrites) {
-        try {
-          writeTaskMdShortId(write.taskMdPath, write.shortId);
-          completedWrites.push(write);
-        } catch (e) {
-          rollback(`Failed to write short_id to ${write.taskMdPath}: ${e.message}`);
-        }
-      }
-
-      // B3: atomic registry persistence
       try {
         writeRegistryAtomic(this._registry, registryPath);
       } catch (e) {
-        rollback(`Failed to persist registry to ${registryPath}: ${e.message}`);
+        this._registry.ids = this._registrySnapshot;
+        throw new Error(`Failed to persist registry to ${registryPath}: ${e.message}`);
       }
     }
   };
@@ -459,27 +313,10 @@ function verifyRegistry(registry, activeDir) {
       .filter((d) => fs.existsSync(path.join(activeDir, d, "task.md")))
   );
   const registryTaskIds = new Set(Object.values(registry.ids));
-  const taskmdShortIds = new Map();
-  for (const taskId of activeTaskIds) {
-    const taskMdPath = path.join(activeDir, taskId, "task.md");
-    const content = fs.readFileSync(taskMdPath, "utf8");
-    const m = content.match(/^short_id:\s*(#\d+)\s*$/m);
-    taskmdShortIds.set(taskId, m ? m[1] : null);
-  }
   const missing_in_registry = [];
   for (const taskId of activeTaskIds) {
     if (!registryTaskIds.has(taskId)) {
-      missing_in_registry.push({ taskId, declared: taskmdShortIds.get(taskId) });
-    }
-  }
-  const missing_in_taskmd = [];
-  for (const [key, taskId] of Object.entries(registry.ids)) {
-    if (!activeTaskIds.has(taskId)) continue;
-    const declared = taskmdShortIds.get(taskId);
-    if (declared === null) {
-      missing_in_taskmd.push({ taskId, expected: `#${key}` });
-    } else if (declared !== `#${key}`) {
-      missing_in_taskmd.push({ taskId, expected: `#${key}`, declared });
+      missing_in_registry.push({ taskId });
     }
   }
   const orphans_in_registry = [];
@@ -501,7 +338,6 @@ function verifyRegistry(registry, activeDir) {
   }
   return {
     missing_in_registry,
-    missing_in_taskmd,
     orphans_in_registry,
     duplicate_registry_keys
   };
@@ -568,8 +404,7 @@ function cmdResolve(shortIdArg, activeDir, registryPath, shortIdLength) {
     if (!taskId) {
       const hasPendingMutations =
         tx._plannedRegistryWrites.length > 0 ||
-        tx._pendingRegistryDeletes.length > 0 ||
-        tx._plannedTaskMdWrites.length > 0;
+        tx._pendingRegistryDeletes.length > 0;
       if (hasPendingMutations) {
         try {
           tx.commit(registryPath);
@@ -614,7 +449,6 @@ function cmdList(activeDir, registryPath, verify) {
   const diff = verifyRegistry(registry, activeDir);
   const hasIssues =
     diff.missing_in_registry.length > 0 ||
-    diff.missing_in_taskmd.length > 0 ||
     diff.orphans_in_registry.length > 0 ||
     diff.duplicate_registry_keys.length > 0;
   if (hasIssues) {
@@ -709,7 +543,6 @@ export {
   readRegistry,
   writeRegistryAtomic,
   withRegistryLock,
-  writeTaskMdShortId,
   padShortId,
   parseShortIdArg,
   allocateMinFreeInt,

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -122,4 +122,4 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 Use `reference/output-template.md` (or `reference/fix-mode.md` in fix mode) and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`). Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -122,4 +122,4 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 Use `reference/output-template.md` (or `reference/fix-mode.md` in fix mode) and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -180,7 +180,7 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -180,7 +180,7 @@ node .agents/scripts/validate-artifact.js gate code-task .agents/workspace/activ
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。输出格式见 `reference/output-template.md`；修复模式输出见 `reference/fix-mode.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -130,7 +130,7 @@ Handle the result:
 
 ### 5. Verification Gate
 
-**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+**Allocate short id first** (ensures the registry entry is allocated; the validation gate will read it):
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -129,7 +129,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 5. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -62,7 +62,7 @@ Update task.md: `current_step` -> `requirement-analysis`.
 
 ### 4. Verification Gate
 
-**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+**Allocate short id first** (ensures the registry entry is allocated; the validation gate will read it):
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -62,7 +62,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -63,7 +63,7 @@ Update task.md: `current_step` -> `requirement-analysis`.
 
 ### 4. Verification Gate
 
-**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+**Allocate short id first** (ensures the registry entry is allocated; the validation gate will read it):
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -63,7 +63,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 4. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -123,7 +123,7 @@ If task.md contains a valid `issue_number`, perform these sync actions (skip and
 
 ### 7. Verification Gate
 
-**Allocate short id first** (writes `short_id` back to task.md and the registry entry; the validation gate will read it):
+**Allocate short id first** (ensures the registry entry is allocated; the validation gate will read it):
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -123,7 +123,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 ### 7. 完成校验
 
-**先调用短号分配**（保证 `short_id` 写回 task.md + 注册表 entry 已在；完成校验阶段会读取）：
+**先调用短号分配**（保证注册表 entry 已分配；完成校验阶段会读取）：
 
 ```bash
 node .agents/scripts/task-short-id.js alloc "$task_id"

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -79,4 +79,4 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`). Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -79,4 +79,4 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-analysis .agents/workspace
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -121,7 +121,7 @@ env-blocked counts do not influence branch selection; they are appended to the s
 
 > The full four-branch output templates, selection rules, and prohibition clauses live in `reference/output-templates.md`. Read `reference/output-templates.md` before reporting the review result.
 
-> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
 
 Include all TUI command formats in the next-step output. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name).
 

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -121,7 +121,7 @@ env-blocked counts do not influence branch selection; they are appended to the s
 
 > The full four-branch output templates, selection rules, and prohibition clauses live in `reference/output-templates.md`. Read `reference/output-templates.md` before reporting the review result.
 
-> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`). Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
 
 Include all TUI command formats in the next-step output. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name).
 

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -124,7 +124,7 @@ env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显�
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -124,7 +124,7 @@ env-blocked 的数量不参与分支选择，仅在数字摘要末尾附带显�
 
 > 完整的 4 分支输出模板、判断规则和禁止条款见 `reference/output-templates.md`。向用户汇报审查结论前先读取 `reference/output-templates.md`。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 向用户展示下一步时，必须包含所有 TUI 命令格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。
 

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -79,4 +79,4 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` follows this contract: read `short_id` from task.md frontmatter; if present (form `#NN`), render the corresponding **bare numeric** (e.g. `#11` → `11`); fall back to the full `TASK-id` otherwise. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -79,4 +79,4 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 Use the conclusion branch in `reference/output-templates.md` and show all TUI command formats.
 
-> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`); it does not read task.md frontmatter. Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.
+> When rendering "Next steps" commands, `{task-ref}` uses the verbatim `{task-id}` argument from this invocation (bare numeric / `#NN` / full `TASK-id`). Other `{task-id}` placeholders (report titles, paths) keep the full TASK-id form.

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -92,7 +92,7 @@ node .agents/scripts/validate-artifact.js gate review-plan .agents/workspace/act
 
 按 `reference/output-templates.md` 的结论分支输出，并展示所有 TUI 的下一步命令。
 
-> 渲染「下一步」命令时，`{task-ref}` 按以下契约解析：读取 task.md frontmatter 的 `short_id`，若存在（形如 `#NN`）渲染为对应的**裸数字**（如 `#11` → `11`）；缺失时回退完整 `TASK-id`。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
+> 渲染「下一步」命令时，`{task-ref}` 使用本次调用的 `{task-id}` 入参原值（裸数字 / `#NN` / 完整 `TASK-id`）原样渲染，不读取 task.md frontmatter。其他 `{task-id}` 占位（报告标题、路径）保持完整 TASK-id 形式。
 
 ## 完成检查清单
 

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -7,7 +7,6 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # Current agent-infra version; refreshed by workflow commands
-short_id:                       # Allocated by create-task / import-* in active window; kept as historical value after archival
 priority:                       # Optional Issue field: Urgent | High | Medium | Low
 effort:                         # Optional Issue field: High | Medium | Low
 start_date:                     # Optional Issue field for Feature: YYYY-MM-DD

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -7,7 +7,6 @@ status: open                   # open | in-progress | review | blocked | complet
 created_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 updated_at: YYYY-MM-DDTHH:mm:ss±HH:MM
 agent_infra_version: v0.0.0    # 当前 agent-infra 版本；由工作流命令刷新
-short_id:                       # 由 create-task / import-* 在 active 期内写入；归档后保留历史值
 priority:                       # 可选 Issue 字段：Urgent | High | Medium | Low
 effort:                         # 可选 Issue 字段：High | Medium | Low
 start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD

--- a/tests/integration/cli/task-ls.test.ts
+++ b/tests/integration/cli/task-ls.test.ts
@@ -42,6 +42,13 @@ function writeTask(
   );
 }
 
+function writeRegistry(activeDir: string, ids: Record<string, string>): void {
+  fs.writeFileSync(
+    path.join(activeDir, '.short-ids.json'),
+    JSON.stringify({ version: 1, ids })
+  );
+}
+
 function runCli(args: string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
   const result = spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
@@ -109,6 +116,44 @@ test('ai task ls rejects unknown flags', () => {
   const out = runCli(['task', 'ls', '--bogus'], repoRoot);
   assert.notEqual(out.status, 0);
   assert.match(out.stderr, /unknown flag/i);
+});
+
+test('ai task ls sources the active short id from the registry, ignoring task.md frontmatter', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  // task.md carries a stale frontmatter short_id that must be ignored…
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#77', branch: 'feature-reg' });
+  // …the registry is the real source of truth.
+  writeRegistry(activeDir, { '01': 'TASK-20260101-000001' });
+  const out = runCli(['task', 'ls'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // SHORT column reflects the registry (#01), not the frontmatter residue (#77).
+  assert.match(out.stdout, /#01/);
+  assert.doesNotMatch(out.stdout, /#77/);
+});
+
+test('ai task ls renders "-" for an active task absent from the registry', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  // Frontmatter short_id present but no registry entry → no short id.
+  writeTask(activeDir, 'TASK-20260101-000001', { short_id: '#42', branch: 'feature-noreg' });
+  const out = runCli(['task', 'ls'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /feature-noreg/);
+  assert.doesNotMatch(out.stdout, /#42/);
+});
+
+test('ai task ls renders "-" short id for archived (completed) tasks', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(
+    path.join(repoRoot, '.agents', 'workspace', 'completed'),
+    'TASK-20260101-000003',
+    { short_id: '#03', branch: 'feature-done' }
+  );
+  // A registry under active/ must not leak short ids into archived listings.
+  writeRegistry(activeDir, { '03': 'TASK-20260101-000003' });
+  const out = runCli(['task', 'ls', '--completed'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /feature-done/);
+  assert.doesNotMatch(out.stdout, /#03/);
 });
 
 test('ai task ls prints empty-state message when no tasks present', () => {

--- a/tests/unit/scripts/task-short-id.test.ts
+++ b/tests/unit/scripts/task-short-id.test.ts
@@ -55,14 +55,13 @@ function mkTmp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "tsid-"));
 }
 
-function mkTask(activeDir: string, taskId: string, withShortId?: string): string {
+function mkTask(activeDir: string, taskId: string): string {
   const dir = path.join(activeDir, taskId);
   fs.mkdirSync(dir, { recursive: true });
   const taskMd = path.join(dir, "task.md");
-  const short = withShortId ? `\nshort_id: ${withShortId}` : "";
   fs.writeFileSync(
     taskMd,
-    `---\nid: ${taskId}${short}\nbranch: x\n---\n# body\n`
+    `---\nid: ${taskId}\nbranch: x\n---\n# body\n`
   );
   return taskMd;
 }
@@ -114,8 +113,9 @@ test("alloc and release with default shortIdLength=2 emit zero-padded short ids"
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
-  mkTask(active, "TASK-20260101-000001");
+  const md1Path = mkTask(active, "TASK-20260101-000001");
   mkTask(active, "TASK-20260101-000002");
+  const md1Before = fs.readFileSync(md1Path, "utf8");
 
   const r1 = runW2(["alloc", "TASK-20260101-000001", "--active-dir", active]);
   assert.equal(r1.status, 0);
@@ -125,14 +125,14 @@ test("alloc and release with default shortIdLength=2 emit zero-padded short ids"
   assert.equal(r2.status, 0);
   assert.equal(r2.stdout.trim(), "#02");
 
-  // task.md and registry must both store the zero-padded form.
-  const md1 = fs.readFileSync(path.join(active, "TASK-20260101-000001", "task.md"), "utf8");
-  assert.match(md1, /^short_id: #01$/m);
+  // The registry is the sole store of short ids; task.md never carries one.
   const registry = JSON.parse(fs.readFileSync(path.join(active, ".short-ids.json"), "utf8"));
   assert.deepEqual(registry.ids, {
     "01": "TASK-20260101-000001",
     "02": "TASK-20260101-000002"
   });
+  // alloc must not touch task.md at all (AC-1): content is byte-identical.
+  assert.equal(fs.readFileSync(md1Path, "utf8"), md1Before);
 
   // resolve accepts both zero-padded and non-padded forms (numeric-value contract).
   const hit = runW2(["resolve", "#01", "--active-dir", active]);
@@ -215,65 +215,26 @@ test("resolve rejects reserved key, over capacity, malformed input", () => {
   assert.doesNotMatch(okFormat.stderr, /invalid short id format/);
 });
 
-test("width exhaustion (case D): cold start aborts before any write", () => {
+test("explicit alloc rejects when width is exhausted (shortIdLength=1)", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
-  const paths: string[] = [];
-  for (let i = 1; i <= 10; i += 1) {
-    paths.push(
-      mkTask(active, `TASK-20250102-${String(i).padStart(6, "0")}`)
-    );
-  }
-  const beforeMtimes = paths.map((p) => fs.statSync(p).mtimeMs);
-  const beforeContents = paths.map((p) => fs.readFileSync(p, "utf8"));
-
-  // shortIdLength=1 → capacity = 9; need 10 → fail
-  const r = run([
-    "resolve",
-    "#1",
-    "--active-dir",
-    active,
-    "--short-id-length",
-    "1"
-  ]);
-  assert.equal(r.status, 2, `unexpected exit; stderr=${r.stderr}`);
-  assert.match(r.stderr, /needs 10 short id\(s\) but only 9/);
-
-  // No fs writes: all task.md mtimes + contents preserved.
-  for (let i = 0; i < paths.length; i += 1) {
-    assert.equal(fs.statSync(paths[i]!).mtimeMs, beforeMtimes[i]);
-    assert.equal(fs.readFileSync(paths[i]!, "utf8"), beforeContents[i]);
-  }
-  // Registry must not exist.
-  assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
-});
-
-test("width tight boundary (case D'): 9 tasks fit exactly", () => {
-  const tmp = mkTmp();
-  const active = path.join(tmp, "active");
-  fs.mkdirSync(active, { recursive: true });
-  for (let i = 1; i <= 9; i += 1) {
-    mkTask(active, `TASK-20250103-${String(i).padStart(6, "0")}`);
-  }
-  const r = run([
-    "resolve",
-    "#1",
-    "--active-dir",
-    active,
-    "--short-id-length",
-    "1"
-  ]);
-  assert.equal(r.status, 0, `stderr=${r.stderr}`);
-  // Every task.md must now carry a short_id field.
+  // Fill all 9 slots (#1..#9) via explicit alloc.
   for (let i = 1; i <= 9; i += 1) {
     const taskId = `TASK-20250103-${String(i).padStart(6, "0")}`;
-    const content = fs.readFileSync(path.join(active, taskId, "task.md"), "utf8");
-    assert.match(content, /^short_id: #\d+$/m, `task ${taskId} missing short_id`);
+    mkTask(active, taskId);
+    const r = runW1(["alloc", taskId, "--active-dir", active]);
+    assert.equal(r.status, 0, `alloc ${i} failed: ${r.stderr}`);
   }
-  // list --verify must agree.
-  const verify = run(["list", "--verify", "--active-dir", active]);
-  assert.equal(verify.status, 0, `verify stderr=${verify.stderr}; stdout=${verify.stdout}`);
+  // A 10th explicit alloc must fail on capacity, not silently extend.
+  const overflowId = "TASK-20250103-000010";
+  mkTask(active, overflowId);
+  const r = runW1(["alloc", overflowId, "--active-dir", active]);
+  assert.equal(r.status, 2, `expected capacity failure; stderr=${r.stderr}`);
+  assert.match(r.stderr, /width exhausted/);
+  // The registry still holds exactly the 9 originally allocated entries.
+  const registry = JSON.parse(fs.readFileSync(path.join(active, ".short-ids.json"), "utf8"));
+  assert.equal(Object.keys(registry.ids).length, 9);
 });
 
 test("list --verify is strictly read-only (R3 B-1)", () => {
@@ -293,23 +254,63 @@ test("list --verify is strictly read-only (R3 B-1)", () => {
   assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
 });
 
-test("cold-start case B: registry has entry, task.md missing short_id → writes back", () => {
+test("list --verify exits 0 with empty stdout when active dir and registry agree", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
-  const taskId = "TASK-20250105-000001";
+  // task.md carries NO short_id — the registry alone is authoritative.
+  const taskId = "TASK-20250110-000001";
   mkTask(active, taskId);
   fs.writeFileSync(
     path.join(active, ".short-ids.json"),
     JSON.stringify({ version: 1, ids: { "1": taskId } })
   );
 
+  const r = run(["list", "--verify", "--active-dir", active, "--short-id-length", "1"]);
+  assert.equal(r.status, 0, `expected pass; stderr=${r.stderr}; stdout=${r.stdout}`);
+  assert.equal(r.stdout, "", "consistent verify must emit empty stdout");
+});
+
+test("list --verify reports missing_in_registry and orphans_in_registry diffs", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  // One active task absent from the registry → missing_in_registry.
+  const present = "TASK-20250111-000001";
+  mkTask(active, present);
+  // One registry entry whose task dir does not exist → orphans_in_registry.
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "2": "TASK-99999999-999999" } })
+  );
+
+  const r = run(["list", "--verify", "--active-dir", active, "--short-id-length", "1"]);
+  assert.equal(r.status, 1, `expected fail; stderr=${r.stderr}`);
+  // Pin the full diff shape: registry-only dimensions, no task.md dimension.
+  assert.deepEqual(JSON.parse(r.stdout), {
+    missing_in_registry: [{ taskId: present }],
+    orphans_in_registry: [{ key: "#2", taskId: "TASK-99999999-999999" }],
+    duplicate_registry_keys: []
+  });
+});
+
+test("resolve returns the task id for a registry hit without touching task.md", () => {
+  const tmp = mkTmp();
+  const active = path.join(tmp, "active");
+  fs.mkdirSync(active, { recursive: true });
+  const taskId = "TASK-20250105-000001";
+  const taskMd = mkTask(active, taskId);
+  fs.writeFileSync(
+    path.join(active, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids: { "1": taskId } })
+  );
+  const before = fs.readFileSync(taskMd, "utf8");
+
   const r = runW1(["resolve", "#1", "--active-dir", active]);
   assert.equal(r.status, 0, `stderr=${r.stderr}`);
   assert.equal(r.stdout.trim(), taskId);
-
-  const taskMd = fs.readFileSync(path.join(active, taskId, "task.md"), "utf8");
-  assert.match(taskMd, /^short_id: #1$/m);
+  // resolve never writes the short id back into task.md (registry is the source).
+  assert.equal(fs.readFileSync(taskMd, "utf8"), before);
 });
 
 test("cold-start case C (duplicate registry keys) → exit 2", () => {
@@ -351,44 +352,23 @@ test("stale entries are cleaned automatically (B4)", () => {
   assert.deepEqual(list.ids, { "1": "TASK-20250107-000001" });
 });
 
-test("alloc rejects task id not in active (R5 B-1) without touching state", () => {
+test("alloc rejects a task id not in active without touching state (R5 B-1)", () => {
   const tmp = mkTmp();
   const active = path.join(tmp, "active");
   fs.mkdirSync(active, { recursive: true });
-  // Pre-existing tasks without short_id (would trigger cold-start migration).
-  mkTask(active, "TASK-20250108-000001");
-  mkTask(active, "TASK-20250108-000002");
+  const md1 = mkTask(active, "TASK-20250108-000001");
+  const md2 = mkTask(active, "TASK-20250108-000002");
+  const before1 = fs.readFileSync(md1, "utf8");
+  const before2 = fs.readFileSync(md2, "utf8");
 
   const r = runW1(["alloc", "TASK-99999999-000000", "--active-dir", active]);
   assert.equal(r.status, 1, `stderr=${r.stderr}`);
   assert.match(r.stderr, /not found in/);
 
-  // The two existing tasks must remain untouched.
-  for (const id of ["TASK-20250108-000001", "TASK-20250108-000002"]) {
-    const md = fs.readFileSync(path.join(active, id, "task.md"), "utf8");
-    assert.doesNotMatch(md, /short_id:/, `${id} mutated`);
-  }
+  // No state mutated: existing task.md files unchanged, registry not created.
+  assert.equal(fs.readFileSync(md1, "utf8"), before1);
+  assert.equal(fs.readFileSync(md2, "utf8"), before2);
   assert.equal(fs.existsSync(path.join(active, ".short-ids.json")), false);
-});
-
-test("alloc skips re-write when task.md already declares the same short_id", () => {
-  const tmp = mkTmp();
-  const active = path.join(tmp, "active");
-  fs.mkdirSync(active, { recursive: true });
-  const taskId = "TASK-20250109-000001";
-  mkTask(active, taskId, "#1");
-  fs.writeFileSync(
-    path.join(active, ".short-ids.json"),
-    JSON.stringify({ version: 1, ids: { "1": taskId } })
-  );
-  const taskMd = path.join(active, taskId, "task.md");
-  const beforeMtime = fs.statSync(taskMd).mtimeMs;
-
-  const r = runW1(["alloc", taskId, "--active-dir", active]);
-  assert.equal(r.status, 0);
-  assert.equal(r.stdout.trim(), "#1");
-  // mtime unchanged because nothing to write.
-  assert.equal(fs.statSync(taskMd).mtimeMs, beforeMtime);
 });
 
 // --- U-2 structural assertions: SKILL.md inline bash is gone ---


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #439

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

实现 #439：让短号注册表成为唯一来源，task.md 不再持有 `short_id` 字段，短号收敛为纯本地、显式分配的临时别名。

此前短号在两处持久化（注册表 `.short-ids.json` + 各 task.md frontmatter 的 `short_id` 字段），双写带来大量对齐复杂度：`writeTaskMdShortId`、`planTransaction` 的 task.md 写入分支与 commit/rollback、cold-start 批量回写、`verifyRegistry` 的三方对齐；同时 task.md 里的 `short_id` 把「任务定义」与「个人本地别名」混为一谈，跨机器/跨人导入同一任务会冲突。本 PR 去掉这层 denormalized 缓存。

## 📋 主要变更 / Brief Changelog

- **核心脚本（注册表单源）**：`task-short-id.js`（运行时 + `templates/` 镜像，逐字一致）删除 `writeTaskMdShortId` 与 `planTransaction` 的 task.md 写入链路；**彻底移除 cold-start 自动分配**，短号只由显式 `alloc`（create-task / import-* / restore-task）分配，`resolve`/`list`/`release` 仅做 stale 清理；`verifyRegistry` 移除 `missing_in_taskmd` 维度（保留 `missing_in_registry` / `orphans_in_registry` / `duplicate_registry_keys`）。
- **CLI**：`lib/task/short-id.ts` 新增 `loadShortIdByTaskId`；`ai task ls` 的短号列改为查注册表反查（active 态），归档（blocked/completed）态显示 `-`，与 task.md 是否含残留 `short_id` 无关。
- **模板 / 规则 / SKILL**：3 份 task.md 模板删 `short_id` 字段；`task-short-id.md`（runtime + en/zh-CN）收敛「存储位置」、删除「冷启动迁移」段与「task.md short_id 字段」小节；Category A 的 4 个生命周期 SKILL（create-task / import-issue / import-codescan / import-dependabot）alloc 文案不再声称写回 task.md；Category B 的 4 个 SKILL（code-task / review-{analysis,plan,code}）的「下一步」`{task-ref}` 改为回显本次调用入参原值，不依赖 frontmatter。
- **用户可见输入契约保持不变**：`#NN`/裸数字语法、`task.shortIdLength`、解析作用域、跨 TUI 引号约定全部不动；`parseShortIdArg` 未改。
- **测试**：改写 `tests/unit/scripts/task-short-id.test.ts`（删除 cold-start 回写 / 双写 / 容量 cold-start 用例，新增显式 alloc 容量、`list --verify` 成功路径与 diff 维度用例，并以「task.md 字节不变」正向断言替代反向断言）；`tests/integration/cli/task-ls.test.ts` 新增注册表来源 / 归档显示 `-` 用例。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build` —— 编译通过，无类型错误。
2. `npm test` —— 全量回归 **972 pass / 0 fail / 1 OS-conditional skip**（含改写后的短号 / `ai task ls` / parity 测试）。
3. 端到端：在临时 active 目录 `alloc` 后 task.md 内容字节不变、`.short-ids.json` 正确写入；`resolve`（裸数字 / `#NN`）命中；`release` 触发 stale 清理；`list --verify` 一致时退出 0、空输出，注册表/active 不一致时退出 1 并输出两方 diff。
4. 镜像一致性：`.agents/scripts/task-short-id.js` 与 `templates/` 副本逐字相同；规则文档三份镜像一致（parity 测试守护）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Issue filed (#439)
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have updated the documentation (规则文档 + SKILL 文案 + task.md 模板)
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented (无破坏性变更：输入契约不变)
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- **有意的行为变化**（非破坏性，输入契约不变）：① `ai task ls` 对归档（blocked/completed）任务的短号列由「历史值」改为 `-`；② 注册表为空 / 跨机器场景下 `resolve` 不再自动重建短号——符合「短号是纯本地临时别名」的设计。
- **历史清理为独立后续动作**：对已 commit / 已归档 task.md 一次性剥离遗留 `short_id` 字段不在本 PR 范围（active 工作区已 gitignore，残留字段被忽略读取即可）。
- 升级路径无回归：现有 active 任务的注册表 entry 早由 create-task 分配并持久化，升级后 `resolve` 仍命中。

Closes #439

---

Generated with AI assistance
