### PR TITLE
refactor(meta): 统一 Activity Log 步骤名为 skill 名

### DIFF
--- a/.agents/rules/create-issue.md
+++ b/.agents/rules/create-issue.md
@@ -180,7 +180,7 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 - 把 `issue_number: {n}` 写入 frontmatter（已存在则替换；不存在则在 frontmatter 末尾追加）
 - 更新 `updated_at` 为当前时间（命令：`date "+%Y-%m-%d %H:%M:%S%:z"`）
 
-> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Task Created`），由调用方 SKILL 步骤 3 写入。
+> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Create Task`），由调用方 SKILL 步骤 3 写入。
 
 ### 9. 返回结果
 

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -155,7 +155,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `priority` 字段
-  - 在 `Requirement Analysis (Round N)` 条目之前追加一条转移记录：
+  - 在 `Analyze Task (Round N)` 条目之前追加一条转移记录：
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
     ```
@@ -163,7 +163,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Requirement Analysis \\(Round \\d+\\)",
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -55,7 +55,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Block Task** by {agent} — {一行原因}
   ```
 
 在 task.md 中添加阻塞信息部分。

--- a/.agents/skills/block-task/config/verify.json
+++ b/.agents/skills/block-task/config/verify.json
@@ -18,7 +18,7 @@
       "require_blocked_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Blocked",
+      "expected_action_pattern": "(Block Task|Blocked)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -56,7 +56,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancel Task** by {agent} — {一行取消原因}
   ```
 
 ### 4. 转移任务

--- a/.agents/skills/cancel-task/config/verify.json
+++ b/.agents/skills/cancel-task/config/verify.json
@@ -19,7 +19,7 @@
       "require_cancelled_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Cancelled",
+      "expected_action_pattern": "(Cancel Task|Cancelled)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -82,7 +82,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Codescan** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 - **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -90,7 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Dependabot** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 - **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -152,8 +152,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{code-round}` 的 `{code-artifact}`
 - 追加：
-  - 初次实现：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {code-artifact}`
-  - 修复模式：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code (Round {N}, fix for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {code-artifact}`
+  - 初次实现：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Task (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {code-artifact}`
+  - 修复模式：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Task (Round {N}, fix for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {code-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`

--- a/.agents/skills/code-task/config/verify.json
+++ b/.agents/skills/code-task/config/verify.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Code \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -88,7 +88,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Complete Task** by {agent} — Task moved to completed/
   ```
 
 ### 4. 转移任务

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -18,7 +18,7 @@
       "require_completed_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Completed",
+      "expected_action_pattern": "(Complete Task|Completed)",
       "freshness_minutes": 30
     },
     "completion-checklist": {

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -96,7 +96,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -15,7 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "PR Created",
+      "expected_action_pattern": "(Create PR|PR Created)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/create-pr/reference/comment-publish.md
+++ b/.agents/skills/create-pr/reference/comment-publish.md
@@ -12,4 +12,4 @@
 
 ## 结果回传
 
-将 `.agents/rules/pr-sync.md` 中的结果回传字符串用于当前 skill 的用户输出或 `PR Created` Activity Log 复用。
+将 `.agents/rules/pr-sync.md` 中的结果回传字符串用于当前 skill 的用户输出或 `Create PR` Activity Log 复用。

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -108,12 +108,12 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Task** by {agent} — Task created from description
   ```
 
 ### 4. 按 `.agents/rules/create-issue.md` 级联创建 Issue
 
-在 task.md 落盘并记录 `Task Created` 后，先读取 `.agents/rules/create-issue.md` 并按其中描述的步骤执行 Issue 创建。
+在 task.md 落盘并记录 `Create Task` 后，先读取 `.agents/rules/create-issue.md` 并按其中描述的步骤执行 Issue 创建。
 
 规则文件由当前配置的代码平台决定其内容：
 - 支持 Issue 创建的平台：包含完整的认证检测、模板检测、label/Issue Type/milestone 推断、Issue 创建调用、`task.md` 回写流程

--- a/.agents/skills/create-task/config/verify.json
+++ b/.agents/skills/create-task/config/verify.json
@@ -18,7 +18,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Task Created",
+      "expected_action_pattern": "(Create Task|Task Created)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/import-codescan/SKILL.md
+++ b/.agents/skills/import-codescan/SKILL.md
@@ -57,7 +57,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Codescan** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/.agents/skills/import-codescan/config/verify.json
+++ b/.agents/skills/import-codescan/config/verify.json
@@ -17,7 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Import Code Scanning Alert",
+      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)",
       "freshness_minutes": 30
     },
     "platform-sync": null

--- a/.agents/skills/import-dependabot/SKILL.md
+++ b/.agents/skills/import-dependabot/SKILL.md
@@ -58,7 +58,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/.agents/skills/import-dependabot/config/verify.json
+++ b/.agents/skills/import-dependabot/config/verify.json
@@ -17,7 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Import Dependabot Alert",
+      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)",
       "freshness_minutes": 30
     },
     "platform-sync": null

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -116,7 +116,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `effort` 字段
-  - 在 `Technical Design (Round N)` 条目之前追加一条转移记录：
+  - 在 `Plan Task (Round N)` 条目之前追加一条转移记录：
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
     ```
@@ -124,7 +124,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -33,7 +33,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Technical Design \\(Round \\d+\\)",
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -76,7 +76,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Analysis (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并发布 `{review-artifact}` 评论。
 

--- a/.agents/skills/review-analysis/config/verify.json
+++ b/.agents/skills/review-analysis/config/verify.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Analysis Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -84,7 +84,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
 
 env-blocked = 0 时省略括号部分；env-blocked > 0 时附加 ` (+ {n} env-blocked)`。
 

--- a/.agents/skills/review-code/config/verify.json
+++ b/.agents/skills/review-code/config/verify.json
@@ -34,7 +34,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Code Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -76,7 +76,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Plan (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并发布 `{review-artifact}` 评论。
 

--- a/.agents/skills/review-plan/config/verify.json
+++ b/.agents/skills/review-plan/config/verify.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Plan Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/.agents/workflows/bug-fix.yaml
+++ b/.agents/workflows/bug-fix.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/.agents/workflows/feature-development.yaml
+++ b/.agents/workflows/feature-development.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/.agents/workflows/refactoring.yaml
+++ b/.agents/workflows/refactoring.yaml
@@ -141,7 +141,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/rules/create-issue.github.en.md
+++ b/templates/.agents/rules/create-issue.github.en.md
@@ -180,7 +180,7 @@ Update task.md:
 - Write `issue_number: {n}` into the frontmatter (replace if it exists; append at the end of the frontmatter otherwise)
 - Update `updated_at` to the current time (command: `date "+%Y-%m-%d %H:%M:%S%:z"`)
 
-> Do NOT append an Activity Log entry here. The Issue creation event is already captured by the GitHub Issue itself and by the frontmatter `issue_number` field; the Activity Log only records the single `create-task` skill execution anchor (`Task Created`), written by the caller SKILL step 3.
+> Do NOT append an Activity Log entry here. The Issue creation event is already captured by the GitHub Issue itself and by the frontmatter `issue_number` field; the Activity Log only records the single `create-task` skill execution anchor (`Create Task`), written by the caller SKILL step 3.
 
 ### 9. Return the Result
 

--- a/templates/.agents/rules/create-issue.github.zh-CN.md
+++ b/templates/.agents/rules/create-issue.github.zh-CN.md
@@ -180,7 +180,7 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 - 把 `issue_number: {n}` 写入 frontmatter（已存在则替换；不存在则在 frontmatter 末尾追加）
 - 更新 `updated_at` 为当前时间（命令：`date "+%Y-%m-%d %H:%M:%S%:z"`）
 
-> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Task Created`），由调用方 SKILL 步骤 3 写入。
+> 不要在此追加 Activity Log 条目。Issue 创建事件已由 GitHub Issue 自身和 frontmatter `issue_number` 承载；Activity Log 仅记录 `create-task` skill 一次执行的整体锚点（`Create Task`），由调用方 SKILL 步骤 3 写入。
 
 ### 9. 返回结果
 

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -156,7 +156,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark requirement-analysis as complete in workflow progress and include the actual round when the task template supports it
 - Before appending the workflow Activity Log entry, re-estimate `priority` based on the analysis findings (business impact, risks, dependencies, blockers). If the re-estimated value differs from the current value in `task.md`:
   - Overwrite the `priority` field in frontmatter with the new value
-  - Prepend an Activity Log entry recording the transition (placed before the `Requirement Analysis (Round N)` entry):
+  - Prepend an Activity Log entry recording the transition (placed before the `Analyze Task (Round N)` entry):
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {short basis grounded in this analysis})
     ```
@@ -164,7 +164,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -155,7 +155,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `priority` 字段
-  - 在 `Requirement Analysis (Round N)` 条目之前追加一条转移记录：
+  - 在 `Analyze Task (Round N)` 条目之前追加一条转移记录：
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
     ```
@@ -163,7 +163,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Requirement Analysis (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/analyze-task/config/verify.en.json
+++ b/templates/.agents/skills/analyze-task/config/verify.en.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Requirement Analysis \\(Round \\d+\\)",
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/analyze-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/analyze-task/config/verify.zh-CN.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Requirement Analysis \\(Round \\d+\\)",
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -56,7 +56,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {one-line reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Block Task** by {agent} — {one-line reason}
   ```
 
 Add a blocking information section to task.md.

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -55,7 +55,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Blocked** by {agent} — {一行原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Block Task** by {agent} — {一行原因}
   ```
 
 在 task.md 中添加阻塞信息部分。

--- a/templates/.agents/skills/block-task/config/verify.json
+++ b/templates/.agents/skills/block-task/config/verify.json
@@ -18,7 +18,7 @@
       "require_blocked_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Blocked",
+      "expected_action_pattern": "(Block Task|Blocked)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -57,7 +57,7 @@ Update `task.md` in the task directory:
 - `agent_infra_version`: value from `.agents/rules/version-stamp.md`
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {one-line cancellation reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancel Task** by {agent} — {one-line cancellation reason}
   ```
 
 ### 4. Move the Task

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -56,7 +56,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - **追加**到 `## Activity Log`（不要覆盖之前记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancelled** by {agent} — {一行取消原因}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Cancel Task** by {agent} — {一行取消原因}
   ```
 
 ### 4. 转移任务

--- a/templates/.agents/skills/cancel-task/config/verify.json
+++ b/templates/.agents/skills/cancel-task/config/verify.json
@@ -19,7 +19,7 @@
       "require_cancelled_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Cancelled",
+      "expected_action_pattern": "(Cancel Task|Cancelled)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -82,7 +82,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - Add the dismissal record to task.md
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Codescan** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
 - **Release short id** (after the archive `mv` succeeded; the script is idempotent):

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -82,7 +82,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Codescan** by {agent} — Code Scanning alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 - **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -90,7 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - Add the dismissal record to task.md
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Dependabot** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - Archive the task
 - **Release short id** (after the archive `mv` succeeded; the script is idempotent):

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -90,7 +90,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 添加关闭记录到 task.md
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Alert Closed** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Close Dependabot** by {agent} — Dependabot alert #{alert-number} dismissed: {reason}
   ```
 - 归档任务
 - **释放短号**（归档目录已 mv 成功，再 release；脚本幂等）：

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -104,8 +104,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 Set `current_step` to `code`, refresh task metadata, and append one Activity Log entry:
 
-- initial implementation: `Code (Round {N})`
-- fix mode: `Code (Round {N}, fix for {review-artifact})`
+- initial implementation: `Code Task (Round {N})`
+- fix mode: `Code Task (Round {N}, fix for {review-artifact})`
 
 If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, then:
 - Set `status: in-progress` according to issue-sync.md

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -152,8 +152,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 记录 Round `{code-round}` 的 `{code-artifact}`
 - 追加：
-  - 初次实现：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {code-artifact}`
-  - 修复模式：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code (Round {N}, fix for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {code-artifact}`
+  - 初次实现：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Task (Round {N})** by {agent} — Code implemented, {n} files modified, {n} tests passed → {code-artifact}`
+  - 修复模式：`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Task (Round {N}, fix for {review-artifact})** by {agent} — Fixed {n} blockers, {n} major, {n} minor issues[, skipped {n} env-blocked] → {code-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续；执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测）：
 - 按 issue-sync.md 设置 `status: in-progress`

--- a/templates/.agents/skills/code-task/config/verify.en.json
+++ b/templates/.agents/skills/code-task/config/verify.en.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Code \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/code-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/code-task/config/verify.zh-CN.json
@@ -32,7 +32,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Code \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:, fix for review-code(?:-r\\d+)?\\.md)?\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -89,7 +89,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Verify and check off all items in `## Completion Checklist` (change `- [ ]` to `- [x]`)
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Complete Task** by {agent} — Task moved to completed/
   ```
 
 ### 4. Move Task

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -88,7 +88,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 逐项验证并勾选 `## 完成检查清单` 中的所有条目（将 `- [ ]` 改为 `- [x]`）
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Completed** by {agent} — Task moved to completed/
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Complete Task** by {agent} — Task moved to completed/
   ```
 
 ### 4. 转移任务

--- a/templates/.agents/skills/complete-task/config/verify.en.json
+++ b/templates/.agents/skills/complete-task/config/verify.en.json
@@ -18,7 +18,7 @@
       "require_completed_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Completed",
+      "expected_action_pattern": "(Complete Task|Completed)",
       "freshness_minutes": 30
     },
     "completion-checklist": {

--- a/templates/.agents/skills/complete-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/complete-task/config/verify.zh-CN.json
@@ -18,7 +18,7 @@
       "require_completed_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "Completed",
+      "expected_action_pattern": "(Complete Task|Completed)",
       "freshness_minutes": 30
     },
     "completion-checklist": {

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -96,7 +96,7 @@ Get the current time:
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, `agent_infra_version`, and append the PR Created Activity Log entry including metadata-sync and summary results.
+If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, `agent_infra_version`, and append the Create PR Activity Log entry including metadata-sync and summary results.
 
 ### 9. Verification Gate
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -96,7 +96,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 PR Created 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -15,7 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "PR Created",
+      "expected_action_pattern": "(Create PR|PR Created)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/create-pr/reference/comment-publish.en.md
+++ b/templates/.agents/skills/create-pr/reference/comment-publish.en.md
@@ -12,4 +12,4 @@ Read this file before creating or updating the single reviewer-facing PR summary
 
 ## Result Reporting
 
-Reuse the normalized result string from `.agents/rules/pr-sync.md` in this skill's user output or `PR Created` Activity Log.
+Reuse the normalized result string from `.agents/rules/pr-sync.md` in this skill's user output or `Create PR` Activity Log.

--- a/templates/.agents/skills/create-pr/reference/comment-publish.zh-CN.md
+++ b/templates/.agents/skills/create-pr/reference/comment-publish.zh-CN.md
@@ -12,4 +12,4 @@
 
 ## 结果回传
 
-将 `.agents/rules/pr-sync.md` 中的结果回传字符串用于当前 skill 的用户输出或 `PR Created` Activity Log 复用。
+将 `.agents/rules/pr-sync.md` 中的结果回传字符串用于当前 skill 的用户输出或 `Create PR` Activity Log 复用。

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -109,12 +109,12 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - `## Context` -> `- **Branch**:`: update it to the generated branch name
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Task** by {agent} — Task created from description
   ```
 
 ### 4. Cascade Issue Creation via `.agents/rules/create-issue.md`
 
-After task.md is written and `Task Created` is recorded, read `.agents/rules/create-issue.md` first and follow the steps it describes to create an Issue.
+After task.md is written and `Create Task` is recorded, read `.agents/rules/create-issue.md` first and follow the steps it describes to create an Issue.
 
 The rule's content is determined by the configured code platform:
 - A platform that supports Issue creation: contains the full flow for auth detection, template detection, label/type/milestone inference, the create-Issue call, and writing back to `task.md`

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -108,12 +108,12 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `## 上下文` 中的 `- **分支**：`：更新为生成的分支名
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Task Created** by {agent} — Task created from description
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Create Task** by {agent} — Task created from description
   ```
 
 ### 4. 按 `.agents/rules/create-issue.md` 级联创建 Issue
 
-在 task.md 落盘并记录 `Task Created` 后，先读取 `.agents/rules/create-issue.md` 并按其中描述的步骤执行 Issue 创建。
+在 task.md 落盘并记录 `Create Task` 后，先读取 `.agents/rules/create-issue.md` 并按其中描述的步骤执行 Issue 创建。
 
 规则文件由当前配置的代码平台决定其内容：
 - 支持 Issue 创建的平台：包含完整的认证检测、模板检测、label/Issue Type/milestone 推断、Issue 创建调用、`task.md` 回写流程

--- a/templates/.agents/skills/create-task/config/verify.json
+++ b/templates/.agents/skills/create-task/config/verify.json
@@ -18,7 +18,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Task Created",
+      "expected_action_pattern": "(Create Task|Task Created)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/import-codescan/SKILL.en.md
+++ b/templates/.agents/skills/import-codescan/SKILL.en.md
@@ -57,7 +57,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 Update task.md: `current_step` -> `requirement-analysis`.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Codescan** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. Verification Gate

--- a/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-codescan/SKILL.zh-CN.md
@@ -57,7 +57,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Code Scanning Alert** by {agent} — Code Scanning alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Codescan** by {agent} — Code Scanning alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/templates/.agents/skills/import-codescan/config/verify.json
+++ b/templates/.agents/skills/import-codescan/config/verify.json
@@ -17,7 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Import Code Scanning Alert",
+      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)",
       "freshness_minutes": 30
     },
     "platform-sync": null

--- a/templates/.agents/skills/import-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.en.md
@@ -58,7 +58,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 Update task.md: `current_step` -> `requirement-analysis`.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. Verification Gate

--- a/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-dependabot/SKILL.zh-CN.md
@@ -58,7 +58,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 更新 task.md：`current_step` -> `requirement-analysis`。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot Alert** by {agent} — Dependabot alert #{alert-number} imported
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Import Dependabot** by {agent} — Dependabot alert #{alert-number} imported
   ```
 
 ### 4. 完成校验

--- a/templates/.agents/skills/import-dependabot/config/verify.json
+++ b/templates/.agents/skills/import-dependabot/config/verify.json
@@ -17,7 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "Import Dependabot Alert",
+      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)",
       "freshness_minutes": 30
     },
     "platform-sync": null

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -117,7 +117,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark technical-design as complete in workflow progress and include the actual round when the task template supports it
 - Before appending the workflow Activity Log entry, re-estimate `effort` based on the technical plan (number of implementation steps, files touched, test matrix scope, integration surface). If the re-estimated value differs from the current value in `task.md`:
   - Overwrite the `effort` field in frontmatter with the new value
-  - Prepend an Activity Log entry recording the transition (placed before the `Technical Design (Round N)` entry):
+  - Prepend an Activity Log entry recording the transition (placed before the `Plan Task (Round N)` entry):
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {short basis grounded in this plan})
     ```
@@ -125,7 +125,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 If task.md contains a valid `issue_number`, perform these sync actions (skip and continue on any failure):

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -116,7 +116,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `effort` 字段
-  - 在 `Technical Design (Round N)` 条目之前追加一条转移记录：
+  - 在 `Plan Task (Round N)` 条目之前追加一条转移记录：
     ```
     - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
     ```
@@ -124,7 +124,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Technical Design (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/plan-task/config/verify.en.json
+++ b/templates/.agents/skills/plan-task/config/verify.en.json
@@ -33,7 +33,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Technical Design \\(Round \\d+\\)",
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/plan-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/plan-task/config/verify.zh-CN.json
@@ -33,7 +33,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Technical Design \\(Round \\d+\\)",
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -65,7 +65,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Set `current_step` to `requirement-analysis-review`, refresh task metadata, and append:
-`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Analysis (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, sync the task comment, and publish the `{review-artifact}` comment.
 

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -76,7 +76,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Analysis (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并发布 `{review-artifact}` 评论。
 

--- a/templates/.agents/skills/review-analysis/config/verify.en.json
+++ b/templates/.agents/skills/review-analysis/config/verify.en.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Analysis Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-analysis/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-analysis/config/verify.zh-CN.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Analysis Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -81,7 +81,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Update task.md and append:
-`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
 
 Omit the bracketed segment when env-blocked = 0; append ` (+ {n} env-blocked)` when env-blocked > 0.
 

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -84,7 +84,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Code Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {artifact-filename}`
 
 env-blocked = 0 时省略括号部分；env-blocked > 0 时附加 ` (+ {n} env-blocked)`。
 

--- a/templates/.agents/skills/review-code/config/verify.en.json
+++ b/templates/.agents/skills/review-code/config/verify.en.json
@@ -34,7 +34,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Code Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-code/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-code/config/verify.zh-CN.json
@@ -34,7 +34,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Code Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -65,7 +65,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
 Set `current_step` to `technical-design-review`, refresh task metadata, and append:
-`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+`- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Plan (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, sync the task comment, and publish the `{review-artifact}` comment.
 

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -76,7 +76,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
 - 追加：
-  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Review (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
+  `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Plan (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}[ (+ {n} env-blocked)] → {review-artifact}`
 
 如果 task.md 中存在有效的 `issue_number`，执行前先读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并发布 `{review-artifact}` 评论。
 

--- a/templates/.agents/skills/review-plan/config/verify.en.json
+++ b/templates/.agents/skills/review-plan/config/verify.en.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Plan Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/skills/review-plan/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-plan/config/verify.zh-CN.json
@@ -33,7 +33,7 @@
       "freshness_minutes": 30
     },
     "activity-log": {
-      "expected_action_pattern": "Plan Review \\(Round \\d+\\)",
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
       "freshness_minutes": 30
     },
     "platform-sync": {

--- a/templates/.agents/workflows/bug-fix.en.yaml
+++ b/templates/.agents/workflows/bug-fix.en.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "Read the highest-round plan review artifact and confirm feedback is approved or handled"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Code Review entry in task.md Activity Log"
+          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Review Code entry in task.md Activity Log"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/workflows/bug-fix.zh-CN.yaml
+++ b/templates/.agents/workflows/bug-fix.zh-CN.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/workflows/feature-development.en.yaml
+++ b/templates/.agents/workflows/feature-development.en.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "Read the highest-round plan review artifact and confirm feedback is approved or handled"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Code Review entry in task.md Activity Log"
+          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Review Code entry in task.md Activity Log"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/workflows/feature-development.zh-CN.yaml
+++ b/templates/.agents/workflows/feature-development.zh-CN.yaml
@@ -139,7 +139,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/workflows/refactoring.en.yaml
+++ b/templates/.agents/workflows/refactoring.en.yaml
@@ -141,7 +141,7 @@ steps:
           rule: "Read the highest-round plan review artifact and confirm feedback is approved or handled"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Code Review entry in task.md Activity Log"
+          rule: "In fix mode, read the highest-round code review artifact and verify it matches the latest Review Code entry in task.md Activity Log"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/templates/.agents/workflows/refactoring.zh-CN.yaml
+++ b/templates/.agents/workflows/refactoring.zh-CN.yaml
@@ -141,7 +141,7 @@ steps:
           rule: "读取最高轮次的方案审查产物，确认方案已获通过或已处理反馈"
         - name: review-code
           pattern: "review-code.md | review-code-r{N}.md"
-          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Code Review 记录一致"
+          rule: "修复模式读取最高轮次的代码审查产物，并校验其与 task.md Activity Log 中最近一条 Review Code 记录一致"
       outputs:
         - name: code
           pattern: "code.md | code-r{N}.md"

--- a/tests/e2e/core/validate-artifact-review-code-verdict.test.ts
+++ b/tests/e2e/core/validate-artifact-review-code-verdict.test.ts
@@ -70,8 +70,8 @@ function buildReviewTask(overrides: Record<string, string | number> = {}) {
       NOW: formatTimestamp(new Date())
     }
   ).replace(
-    "**Code (Round 1)** by codex — Code implemented, 2 files modified, 42 tests passed → code.md",
-    "**Code Review (Round 1)** by codex — Verdict: Approved, blockers: 0, major: 0, minor: 0 → review-code.md"
+    "**Code Task (Round 1)** by codex — Code implemented, 2 files modified, 42 tests passed → code.md",
+    "**Review Code (Round 1)** by codex — Verdict: Approved, blockers: 0, major: 0, minor: 0 → review-code.md"
   );
 }
 

--- a/tests/e2e/core/validate-artifact.test.ts
+++ b/tests/e2e/core/validate-artifact.test.ts
@@ -269,6 +269,16 @@ const activityLogCases: ActivityLogCase[] = [
     name: "validate-artifact activity-log passes for create-task happy path with Issue created",
     issueNumber: 296,
     activityLines(now) {
+      return [`- ${now} — **Create Task** by codex — Task created from description`];
+    },
+    assertResult(result) {
+      assert.equal(result.status, 0, result.stderr);
+    }
+  },
+  {
+    name: "validate-artifact activity-log accepts legacy create-task step name during transition",
+    issueNumber: 296,
+    activityLines(now) {
       return [`- ${now} — **Task Created** by codex — Task created from description`];
     },
     assertResult(result) {

--- a/tests/fixtures/validate-artifact/valid-task.md
+++ b/tests/fixtures/validate-artifact/valid-task.md
@@ -8,4 +8,4 @@
 
 ## 活动日志
 
-- {{NOW}} — **Code (Round 1)** by codex — Code implemented, 2 files modified, 42 tests passed → code.md
+- {{NOW}} — **Code Task (Round 1)** by codex — Code implemented, 2 files modified, 42 tests passed → code.md


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #441

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

当前 task.md 的 Activity Log 中各步骤名与 skill 名不一致，用户查看 `ai task show NN` 时需要在「业务步骤名」和「skill 名」之间心算映射。本 PR 把所有写入 Activity Log 的**主步骤名**统一为「skill 目录名 Title-Case + 空格分词」（保留 `(Round N)` / `(Round N, fix for …)` 后缀），让阅读 task.md 与对照 skill 调用一目了然。纯文案/标识符重命名，无业务逻辑变更。

## ⚠️ 兼容性说明（请审查重点关注） / Compatibility

- `config/verify*.json` 的 `expected_action_pattern` **过渡期改为 `(新名|旧名)` 子串交替**，同时兼容新旧两种写法；**历史 task.md 不回填**。下游升级 skill 后，进行中的旧任务可能短暂出现 Activity Log 新旧步骤名混排，属预期行为。
- `code-task` 的 `, fix for review-code(?:-r\d+)?\.md` 修复模式分支**完整保留**。
- 收窄为「仅新名」、以及 check-task / workflow phase 显示名 / 文档标题对齐 skill 名，均为**后续任务**，不在本 PR。

## 📋 主要变更 / Brief Changelog

- **15 个 skill 的主步骤名重命名**（源 + en/zh 模板）：`Task Created→Create Task`、`Requirement Analysis→Analyze Task`、`Technical Design→Plan Task`、`Code→Code Task`、`Code Review→Review Code`、`Plan Review→Review Plan`、`Analysis Review→Review Analysis`、`PR Created→Create PR`、`Completed→Complete Task`、`Blocked→Block Task`、`Cancelled→Cancel Task`、`Import Dependabot Alert→Import Dependabot`、`Import Code Scanning Alert→Import Codescan`、`Alert Closed→Close Codescan/Close Dependabot`；`commit`/`import-issue`/`restore-task` 已一致，未改
- **13 源 + 20 模板 `verify.json`**：`expected_action_pattern` 改为 `(新|旧)` 交替（close-* 无 verify 配置，仅改 SKILL.md）
- **散文引用同步**：`create-issue` 规则、`create-pr/reference/comment-publish`、`workflows/{feature-development,bug-fix,refactoring}`（Activity Log 引用文案）
- **测试**：fixture 更新为新名（Code Task / Review Code / Create Task）+ 保留旧名兼容用例；新增 create-task legacy-name 过渡兼容用例
- 合计 96 文件，纯文案替换；明确未触碰文档/SKILL 标题、check-task 阶段名、issue-sync 评论标题、报告/准则标题

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（Node 内置测试运行器；含模板完整性与 validate-artifact e2e）
2. 轨 A（文档/写入点旧名零残留）：旧名 grep 排除 `/config/verify`、标题行、`/check-task/`、`issue-sync`、`report-template|review-criteria`、`Code Review Workflow` 后无真实残留
3. 轨 B（verify 结构）：13 源 + 20 模板均为 `(新|旧)` 交替，`code-task` 保留 fix 分支，`commit`/`import-issue`/`restore-task` 未改

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests（新名通过 + 旧名兼容 + 负向用例）
- [x] 所有现有测试都通过 / All existing tests pass（`npm test`：974 pass / 0 fail / 1 skipped）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Github issue filed
- [x] 你的 Pull Request 只解决一个 Issue / One PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Meaningful commit messages

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / Follows coding standards
- [x] 我已经进行了自我代码审查 / Self-reviewed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / Unit tests written
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经考虑了向后兼容性 / Considered backward compatibility（verify `(新|旧)` 交替）

## 📋 附加信息 / Additional Notes

来自本地任务 `TASK-20260613-222414`，经 3 轮需求分析审查 + 4 轮方案审查 + 1 轮代码审查（均 Approved）收敛。本 PR 自身的 Activity Log 已用新步骤名写入并通过 gate（端到端 dogfooding 验证）。

---

Generated with AI assistance