### PR TITLE
refactor(meta): 把 plan-task / analyze-task 的重估记录从 Activity Log 挪到本轮产物

### DIFF
--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -155,12 +155,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `priority` 字段
-  - 在 `Analyze Task (Round N)` 条目之前追加一条转移记录：
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
-    ```
-  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
-  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
+  - 在本轮分析产物 `{analysis-artifact}` 中追加 `## 优先级重估` 段，记录一条：`priority {old} → {new} (rationale: {基于本轮分析的简短依据})`
+  若重估值与当前值一致，跳过：不写入 `## 优先级重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -116,12 +116,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `effort` 字段
-  - 在 `Plan Task (Round N)` 条目之前追加一条转移记录：
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
-    ```
-  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
-  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
+  - 在本轮方案产物 `{plan-artifact}` 中追加 `## 工作量重估` 段，记录一条：`effort {old} → {new} (rationale: {基于本轮方案的简短依据})`
+  若重估值与当前值一致，跳过：不写入 `## 工作量重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -156,12 +156,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark requirement-analysis as complete in workflow progress and include the actual round when the task template supports it
 - Before appending the workflow Activity Log entry, re-estimate `priority` based on the analysis findings (business impact, risks, dependencies, blockers). If the re-estimated value differs from the current value in `task.md`:
   - Overwrite the `priority` field in frontmatter with the new value
-  - Prepend an Activity Log entry recording the transition (placed before the `Analyze Task (Round N)` entry):
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {short basis grounded in this analysis})
-    ```
-  Both entries may share the same timestamp; ordering is conveyed by list position only.
-  If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
+  - Append a `## Priority Re-estimate` section to this round's analysis artifact `{analysis-artifact}`, recording: `priority {old} → {new} (rationale: {short basis grounded in this analysis})`
+  If the re-estimated value matches the current value, skip it: do not write the `## Priority Re-estimate` section. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -155,12 +155,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 requirement-analysis 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于分析结果（业务影响、风险、依赖、阻塞条件）重估 `priority`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `priority` 字段
-  - 在 `Analyze Task (Round N)` 条目之前追加一条转移记录：
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analysis Re-estimate** by {agent} — priority {old} → {new} (rationale: {基于本轮分析的简短依据})
-    ```
-  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
-  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
+  - 在本轮分析产物 `{analysis-artifact}` 中追加 `## 优先级重估` 段，记录一条：`priority {old} → {new} (rationale: {基于本轮分析的简短依据})`
+  若重估值与当前值一致，跳过：不写入 `## 优先级重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -117,12 +117,8 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - Mark technical-design as complete in workflow progress and include the actual round when the task template supports it
 - Before appending the workflow Activity Log entry, re-estimate `effort` based on the technical plan (number of implementation steps, files touched, test matrix scope, integration surface). If the re-estimated value differs from the current value in `task.md`:
   - Overwrite the `effort` field in frontmatter with the new value
-  - Prepend an Activity Log entry recording the transition (placed before the `Plan Task (Round N)` entry):
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {short basis grounded in this plan})
-    ```
-  Both entries may share the same timestamp; ordering is conveyed by list position only.
-  If the re-estimated value matches the current value, skip the Re-estimate entry. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
+  - Append a `## Effort Re-estimate` section to this round's plan artifact `{plan-artifact}`, recording: `effort {old} → {new} (rationale: {short basis grounded in this plan})`
+  If the re-estimated value matches the current value, skip it: do not write the `## Effort Re-estimate` section. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
 - **Append** to `## Activity Log` (do NOT overwrite previous entries):
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -116,12 +116,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 在工作流进度中标记 technical-design 为已完成，并注明实际轮次（如果任务模板支持）
 - 在追加工作流 Activity Log 条目之前，基于技术方案（实施步骤数、涉及文件、测试矩阵范围、集成面）重估 `effort`。若重估值与 `task.md` 当前值不一致：
   - 用新值覆盖 frontmatter 的 `effort` 字段
-  - 在 `Plan Task (Round N)` 条目之前追加一条转移记录：
-    ```
-    - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Re-estimate** by {agent} — effort {old} → {new} (rationale: {基于本轮方案的简短依据})
-    ```
-  两条条目可共用同一时间戳，顺序仅通过列表位置表达。
-  若重估值与当前值一致，跳过 Re-estimate 条目。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
+  - 在本轮方案产物 `{plan-artifact}` 中追加 `## 工作量重估` 段，记录一条：`effort {old} → {new} (rationale: {基于本轮方案的简短依据})`
+  若重估值与当前值一致，跳过：不写入 `## 工作量重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
 - **追加**到 `## Activity Log`（不要覆盖之前的记录）：
   ```
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -531,21 +531,21 @@ test("import-issue checklists include the task comment sync step", () => {
 
 test("analyze-task and plan-task docs require field re-estimation in update step", () => {
   const targets: Array<[string, string]> = [
-    [".agents/skills/analyze-task/SKILL.md", "重估"],
-    [".agents/skills/plan-task/SKILL.md", "重估"],
-    ["templates/.agents/skills/analyze-task/SKILL.en.md", "re-estimate"],
-    ["templates/.agents/skills/plan-task/SKILL.en.md", "re-estimate"],
-    ["templates/.agents/skills/analyze-task/SKILL.zh-CN.md", "重估"],
-    ["templates/.agents/skills/plan-task/SKILL.zh-CN.md", "重估"]
+    [".agents/skills/analyze-task/SKILL.md", "优先级重估"],
+    [".agents/skills/plan-task/SKILL.md", "工作量重估"],
+    ["templates/.agents/skills/analyze-task/SKILL.en.md", "Priority Re-estimate"],
+    ["templates/.agents/skills/plan-task/SKILL.en.md", "Effort Re-estimate"],
+    ["templates/.agents/skills/analyze-task/SKILL.zh-CN.md", "优先级重估"],
+    ["templates/.agents/skills/plan-task/SKILL.zh-CN.md", "工作量重估"]
   ];
 
-  targets.forEach(([relativePath, reEstimateToken]) => {
+  targets.forEach(([relativePath, reEstimateSectionHeading]) => {
     const content = read(relativePath);
 
     assert.match(
       content,
-      new RegExp(escapeRegExp(reEstimateToken), "i"),
-      `${relativePath} should reference the re-estimation vocabulary token`
+      new RegExp(escapeRegExp(reEstimateSectionHeading), "i"),
+      `${relativePath} should name its re-estimate artifact section heading`
     );
   });
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#445</mark> 👈👈

Closes #445

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

`analyze-task` / `plan-task` 在「重估值与当前值不一致」分支会把 `priority` / `effort` 的 `{old} → {new} + rationale` 追加到 `task.md` 的 `## Activity Log`。这会稀释 Activity Log「只记录生命周期技能执行节点」的语义、在多轮任务里反复刷屏，且让 rationale 与产生它的产物分离。

本 PR 仅迁移「那一条记录的落点」：把它从 Activity Log 改写到本轮产物（`analysis-r{N}.md` / `plan-r{N}.md`）的固定段落。重估机制本身——frontmatter 字段覆盖、触发时机与依据、Flow A 同步到 Issue 字段——完全不变。

## 📋 主要变更 / Brief Changelog

- `analyze-task` / `plan-task` 的重估 bullet：记录从 `**Analysis/Plan Re-estimate**` Activity Log 行改为写入产物 `## 优先级重估` / `## 工作量重估` 段（en：`## Priority/Effort Re-estimate`）；值未变化则省略该段
- 保留 frontmatter 覆盖、未变化跳过、Flow A Issue 字段同步三处不变；权威中文版与 zh-CN/en 双语模板同步保持 parity
- 收紧 `skills.test.ts` 的重估断言为每文件的 section 标题锚点（正向锚点，未新增反向删除断言）；未改动任何 `config/verify*.json`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（全量套件，1005 pass / 0 fail / 1 skipped）
2. `grep -rn "Re-estimate\|重估" .agents/skills templates/.agents/skills` 确认重估记录只出现在产物固定段落语境，不再出现于 Activity Log 追加语境

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

- 「重估值变化/未变化两种情况」的写入/省略属 LLM 运行时遵循文档指令的行为，无确定性代码面；为遵守仓库测试规约（禁止 SKILL 文档关键词语义断言、禁止反向删除断言），该条不以单测覆盖，改由文档语义 + 代码审查保证。
- 不回填历史已完成任务中残留的 Re-estimate Activity Log 行（历史快照，超出范围）。

---

Generated with AI assistance