### PR TITLE
feat(meta): 为 CC 添加 API 错误自动恢复 hook

### DIFF
--- a/.agents/hooks/auto-resume.sh
+++ b/.agents/hooks/auto-resume.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# StopFailure hook: auto-resume Claude Code after a recoverable API error.
+#
+# Fires when a turn ends due to an API error. Runs four gates and, if all pass,
+# injects a "please continue" message into the current tmux pane via send-keys.
+# StopFailure output and exit code are ignored by Claude Code, so recovery is
+# delivered out-of-band through tmux; every exit path here returns 0 and the
+# only observable trace is the log file.
+#
+# Intentionally NOT using `set -e`: the network probe, tmux and state-file
+# writes may fail locally without warranting an abort of the whole script.
+
+LOG="$HOME/.claude/auto-resume.log"
+STATE_DIR="$HOME/.claude/auto-resume.state"
+WHITELIST="unknown server_error overloaded"
+WINDOW=1800
+MAX=10
+PROBE_URL="https://api.anthropic.com/"
+PROBE_DEADLINE=60
+RESUME_TEXT="Unexpected interruption. Please continue the unfinished operation."
+
+log() {
+  mkdir -p "$HOME/.claude" 2>/dev/null
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S%z')" "$1" >> "$LOG"
+  lines=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+  if [ "$lines" -gt 5000 ]; then
+    tail -n 2500 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG"
+  fi
+}
+
+# Read the StopFailure payload once, then extract session_id and error. The
+# `error` field identifies the API error type and drives the whitelist gate.
+payload=$(cat)
+session_id=$(printf '%s' "$payload" | node -e 'let c=[];process.stdin.on("data",d=>c.push(d));process.stdin.on("end",()=>{try{const p=JSON.parse(Buffer.concat(c).toString());process.stdout.write(String(p.session_id||""))}catch{process.stdout.write("")}})' 2>/dev/null)
+error=$(printf '%s' "$payload" | node -e 'let c=[];process.stdin.on("data",d=>c.push(d));process.stdin.on("end",()=>{try{const p=JSON.parse(Buffer.concat(c).toString());process.stdout.write(String(p.error||""))}catch{process.stdout.write("")}})' 2>/dev/null)
+
+# Gate 1: only act inside a tmux pane; stay silent everywhere else.
+if [ -z "$TMUX_PANE" ]; then
+  log "not in tmux, skip (error=$error)"
+  exit 0
+fi
+
+# Gate 2: only recover from the whitelisted, retriable error types.
+case " $WHITELIST " in
+  *" $error "*) : ;;
+  *) log "blocked: non-recoverable error=$error"; exit 0 ;;
+esac
+
+# Gate 3: back off after MAX fires within a WINDOW-second sliding window per session.
+mkdir -p "$STATE_DIR" 2>/dev/null
+# Treat the payload session_id as untrusted: sanitize to a safe filename so a
+# value like "../outside" cannot write the state file outside STATE_DIR.
+safe_session=$(printf '%s' "${session_id:-nosession}" | tr -c 'A-Za-z0-9._-' '_')
+f="$STATE_DIR/$safe_session.count"
+now=$(date +%s)
+if [ -f "$f" ]; then
+  awk -v n="$now" -v w="$WINDOW" '$1 > n - w' "$f" > "$f.tmp" 2>/dev/null && mv "$f.tmp" "$f"
+fi
+count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null || echo 0 )
+if [ "$count" -ge "$MAX" ]; then
+  log "backoff: $count fires in 30m, skip (error=$error)"
+  exit 0
+fi
+echo "$now" >> "$f"
+
+# Gate 4: wait until the API is reachable again, up to PROBE_DEADLINE seconds.
+# No --fail: any HTTP response (incl. 401/404) proves TLS/network connectivity.
+waited=0
+until curl -s -o /dev/null --max-time 3 "$PROBE_URL"; do
+  waited=$((waited + 3))
+  if [ "$waited" -ge "$PROBE_DEADLINE" ]; then
+    log "probe timeout after ${waited}s, skip (error=$error)"
+    exit 0
+  fi
+  sleep 3
+done
+log "probe ok after ${waited}s (error=$error)"
+
+# Inject: Escape first to leave any non-input TUI state, then the resume text.
+tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null
+tmux send-keys -t "$TMUX_PANE" "$RESUME_TEXT" Enter 2>/dev/null
+log "send-keys done (error=$error)"
+exit 0

--- a/.agents/hooks/auto-resume.sh
+++ b/.agents/hooks/auto-resume.sh
@@ -22,7 +22,8 @@ RESUME_TEXT="Unexpected interruption. Please continue the unfinished operation."
 log() {
   mkdir -p "$HOME/.claude" 2>/dev/null
   printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S%z')" "$1" >> "$LOG"
-  lines=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+  lines=$(wc -l < "$LOG" 2>/dev/null | tr -cd '0-9')
+  [ -z "$lines" ] && lines=0
   if [ "$lines" -gt 5000 ]; then
     tail -n 2500 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG"
   fi
@@ -56,7 +57,10 @@ now=$(date +%s)
 if [ -f "$f" ]; then
   awk -v n="$now" -v w="$WINDOW" '$1 > n - w' "$f" > "$f.tmp" 2>/dev/null && mv "$f.tmp" "$f"
 fi
-count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null || echo 0 )
+# BSD `wc -l` (macOS) pads the count with leading spaces; strip to bare digits
+# so the integer compare and the log line stay portable across GNU/BSD.
+count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null | tr -cd '0-9' || echo 0 )
+[ -z "$count" ] && count=0
 if [ "$count" -ge "$MAX" ]; then
   log "backoff: $count fires in 30m, skip (error=$error)"
   exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,17 @@
           }
         ]
       }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.agents/hooks/auto-resume.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/.agents/hooks/auto-resume.sh
+++ b/templates/.agents/hooks/auto-resume.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# StopFailure hook: auto-resume Claude Code after a recoverable API error.
+#
+# Fires when a turn ends due to an API error. Runs four gates and, if all pass,
+# injects a "please continue" message into the current tmux pane via send-keys.
+# StopFailure output and exit code are ignored by Claude Code, so recovery is
+# delivered out-of-band through tmux; every exit path here returns 0 and the
+# only observable trace is the log file.
+#
+# Intentionally NOT using `set -e`: the network probe, tmux and state-file
+# writes may fail locally without warranting an abort of the whole script.
+
+LOG="$HOME/.claude/auto-resume.log"
+STATE_DIR="$HOME/.claude/auto-resume.state"
+WHITELIST="unknown server_error overloaded"
+WINDOW=1800
+MAX=10
+PROBE_URL="https://api.anthropic.com/"
+PROBE_DEADLINE=60
+RESUME_TEXT="Unexpected interruption. Please continue the unfinished operation."
+
+log() {
+  mkdir -p "$HOME/.claude" 2>/dev/null
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S%z')" "$1" >> "$LOG"
+  lines=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+  if [ "$lines" -gt 5000 ]; then
+    tail -n 2500 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG"
+  fi
+}
+
+# Read the StopFailure payload once, then extract session_id and error. The
+# `error` field identifies the API error type and drives the whitelist gate.
+payload=$(cat)
+session_id=$(printf '%s' "$payload" | node -e 'let c=[];process.stdin.on("data",d=>c.push(d));process.stdin.on("end",()=>{try{const p=JSON.parse(Buffer.concat(c).toString());process.stdout.write(String(p.session_id||""))}catch{process.stdout.write("")}})' 2>/dev/null)
+error=$(printf '%s' "$payload" | node -e 'let c=[];process.stdin.on("data",d=>c.push(d));process.stdin.on("end",()=>{try{const p=JSON.parse(Buffer.concat(c).toString());process.stdout.write(String(p.error||""))}catch{process.stdout.write("")}})' 2>/dev/null)
+
+# Gate 1: only act inside a tmux pane; stay silent everywhere else.
+if [ -z "$TMUX_PANE" ]; then
+  log "not in tmux, skip (error=$error)"
+  exit 0
+fi
+
+# Gate 2: only recover from the whitelisted, retriable error types.
+case " $WHITELIST " in
+  *" $error "*) : ;;
+  *) log "blocked: non-recoverable error=$error"; exit 0 ;;
+esac
+
+# Gate 3: back off after MAX fires within a WINDOW-second sliding window per session.
+mkdir -p "$STATE_DIR" 2>/dev/null
+# Treat the payload session_id as untrusted: sanitize to a safe filename so a
+# value like "../outside" cannot write the state file outside STATE_DIR.
+safe_session=$(printf '%s' "${session_id:-nosession}" | tr -c 'A-Za-z0-9._-' '_')
+f="$STATE_DIR/$safe_session.count"
+now=$(date +%s)
+if [ -f "$f" ]; then
+  awk -v n="$now" -v w="$WINDOW" '$1 > n - w' "$f" > "$f.tmp" 2>/dev/null && mv "$f.tmp" "$f"
+fi
+count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null || echo 0 )
+if [ "$count" -ge "$MAX" ]; then
+  log "backoff: $count fires in 30m, skip (error=$error)"
+  exit 0
+fi
+echo "$now" >> "$f"
+
+# Gate 4: wait until the API is reachable again, up to PROBE_DEADLINE seconds.
+# No --fail: any HTTP response (incl. 401/404) proves TLS/network connectivity.
+waited=0
+until curl -s -o /dev/null --max-time 3 "$PROBE_URL"; do
+  waited=$((waited + 3))
+  if [ "$waited" -ge "$PROBE_DEADLINE" ]; then
+    log "probe timeout after ${waited}s, skip (error=$error)"
+    exit 0
+  fi
+  sleep 3
+done
+log "probe ok after ${waited}s (error=$error)"
+
+# Inject: Escape first to leave any non-input TUI state, then the resume text.
+tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null
+tmux send-keys -t "$TMUX_PANE" "$RESUME_TEXT" Enter 2>/dev/null
+log "send-keys done (error=$error)"
+exit 0

--- a/templates/.agents/hooks/auto-resume.sh
+++ b/templates/.agents/hooks/auto-resume.sh
@@ -22,7 +22,8 @@ RESUME_TEXT="Unexpected interruption. Please continue the unfinished operation."
 log() {
   mkdir -p "$HOME/.claude" 2>/dev/null
   printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S%z')" "$1" >> "$LOG"
-  lines=$(wc -l < "$LOG" 2>/dev/null || echo 0)
+  lines=$(wc -l < "$LOG" 2>/dev/null | tr -cd '0-9')
+  [ -z "$lines" ] && lines=0
   if [ "$lines" -gt 5000 ]; then
     tail -n 2500 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG"
   fi
@@ -56,7 +57,10 @@ now=$(date +%s)
 if [ -f "$f" ]; then
   awk -v n="$now" -v w="$WINDOW" '$1 > n - w' "$f" > "$f.tmp" 2>/dev/null && mv "$f.tmp" "$f"
 fi
-count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null || echo 0 )
+# BSD `wc -l` (macOS) pads the count with leading spaces; strip to bare digits
+# so the integer compare and the log line stay portable across GNU/BSD.
+count=$( [ -f "$f" ] && wc -l < "$f" 2>/dev/null | tr -cd '0-9' || echo 0 )
+[ -z "$count" ] && count=0
 if [ "$count" -ge "$MAX" ]; then
   log "backoff: $count fires in 30m, skip (error=$error)"
   exit 0

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -29,6 +29,17 @@
           }
         ]
       }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.agents/hooks/auto-resume.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/unit/hooks/auto-resume.test.ts
+++ b/tests/unit/hooks/auto-resume.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { envWithPrependedPath, onPlatforms } from "../../helpers.ts";
+
+// auto-resume.sh is a POSIX sh StopFailure hook; the behavioural gates only run
+// on platforms with /bin/sh. Windows is skipped at the whole-test level.
+const POSIX = onPlatforms("linux", "darwin");
+const SCRIPT = path.resolve(".agents/hooks/auto-resume.sh");
+
+function writeStub(filePathname: string, body: string): void {
+  fs.writeFileSync(filePathname, body);
+  fs.chmodSync(filePathname, 0o755);
+}
+
+interface Harness {
+  home: string;
+  bin: string;
+  tmuxCalls: string;
+  cleanup: () => void;
+}
+
+// Build an isolated HOME plus a bin dir holding tmux/curl stubs. tmux records
+// every invocation so tests can assert injection happened (or did not). curl's
+// exit code simulates network reachability for the probe gate.
+function setup(curlExit: number): Harness {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "auto-resume-"));
+  const home = path.join(root, "home");
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(bin, { recursive: true });
+  const tmuxCalls = path.join(root, "tmux-calls.txt");
+  writeStub(path.join(bin, "tmux"), `#!/bin/sh\nprintf '%s\\n' "$*" >> "${tmuxCalls}"\n`);
+  writeStub(path.join(bin, "curl"), `#!/bin/sh\nexit ${curlExit}\n`);
+  return { home, bin, tmuxCalls, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+}
+
+// process.env may already carry TMUX_PANE (the dev session can run inside tmux);
+// strip it so each test controls the tmux gate explicitly.
+function baseEnv(home: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+  delete env.TMUX_PANE;
+  delete env.TMUX;
+  return env;
+}
+
+function run(h: Harness, env: NodeJS.ProcessEnv, payload: object) {
+  return spawnSync("sh", [SCRIPT], {
+    encoding: "utf8",
+    input: JSON.stringify(payload),
+    env: envWithPrependedPath(env, h.bin)
+  });
+}
+
+function readLog(home: string): string {
+  const logPath = path.join(home, ".claude", "auto-resume.log");
+  return fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+}
+
+function tmuxWasCalled(h: Harness): boolean {
+  return fs.existsSync(h.tmuxCalls) && fs.readFileSync(h.tmuxCalls, "utf8").trim() !== "";
+}
+
+test("gate 1: outside tmux it logs a skip and never injects", POSIX, () => {
+  const h = setup(0);
+  try {
+    const result = run(h, baseEnv(h.home), { session_id: "s1", error: "unknown" });
+    assert.equal(result.status, 0, "hook always exits 0 (StopFailure ignores exit code)");
+    assert.match(readLog(h.home), /not in tmux, skip/, "should record the non-tmux skip reason");
+    assert.equal(tmuxWasCalled(h), false, "must not touch tmux outside a pane");
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("gate 2: a non-recoverable error is blocked with a logged reason and no injection", POSIX, () => {
+  const h = setup(0);
+  try {
+    const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
+    const result = run(h, env, { session_id: "s1", error: "authentication_failed" });
+    assert.equal(result.status, 0);
+    assert.match(readLog(h.home), /blocked: non-recoverable error=authentication_failed/, "should log the interception reason");
+    assert.equal(tmuxWasCalled(h), false, "must not inject for non-whitelisted errors");
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("gate 3: backs off after 10 fires within the window and does not inject", POSIX, () => {
+  const h = setup(0);
+  try {
+    const stateDir = path.join(h.home, ".claude", "auto-resume.state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    const now = Math.floor(Date.now() / 1000);
+    // Seed 10 recent (in-window) fires so this 11th attempt must back off.
+    fs.writeFileSync(path.join(stateDir, "s1.count"), Array.from({ length: 10 }, () => String(now)).join("\n") + "\n");
+    const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
+    const result = run(h, env, { session_id: "s1", error: "unknown" });
+    assert.equal(result.status, 0);
+    assert.match(readLog(h.home), /backoff: 10 fires in 30m, skip/, "should log the backoff");
+    assert.equal(tmuxWasCalled(h), false, "must not inject once backed off");
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("a traversal session_id cannot write the state file outside the state dir", POSIX, () => {
+  const h = setup(0);
+  try {
+    const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
+    const result = run(h, env, { session_id: "../outside", error: "unknown" });
+    assert.equal(result.status, 0);
+    // The pre-sanitization bug wrote ~/.claude/outside.count, escaping the state dir.
+    assert.equal(
+      fs.existsSync(path.join(h.home, ".claude", "outside.count")),
+      false,
+      "must not create a count file outside the state directory"
+    );
+    const stateDir = path.join(h.home, ".claude", "auto-resume.state");
+    const stateFiles = fs.existsSync(stateDir) ? fs.readdirSync(stateDir) : [];
+    assert.ok(
+      stateFiles.some((name) => name.endsWith(".count")),
+      "the sanitized count file should live inside the state directory"
+    );
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("happy path: whitelisted error with reachable network injects the resume text", POSIX, () => {
+  const h = setup(0); // curl exit 0 => reachable, probe passes immediately
+  try {
+    const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
+    const result = run(h, env, { session_id: "s1", error: "unknown" });
+    assert.equal(result.status, 0);
+    assert.match(readLog(h.home), /send-keys done \(error=unknown\)/, "should log a completed injection");
+    assert.equal(tmuxWasCalled(h), true, "should drive tmux send-keys");
+    const calls = fs.readFileSync(h.tmuxCalls, "utf8");
+    assert.match(calls, /send-keys -t %9 Escape/, "should send Escape to the target pane first");
+    assert.match(calls, /Unexpected interruption\. Please continue the unfinished operation\./, "should inject the resume text");
+  } finally {
+    h.cleanup();
+  }
+});

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -84,6 +84,7 @@ test("required template files were migrated into templates/", () => {
     "templates/.git-hooks/check-version-format.sh",
     "templates/.git-hooks/pre-commit",
     "templates/.agents/hooks/check-version-format.sh",
+    "templates/.agents/hooks/auto-resume.sh",
     "templates/.codex/hooks.json",
     "templates/.claude/settings.json",
     "templates/.claude/commands/archive-tasks.en.md",
@@ -194,6 +195,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/workflows/refactoring.yaml", "templates/.agents/workflows/refactoring.en.yaml"],
     [".git-hooks/check-version-format.sh", "templates/.git-hooks/check-version-format.sh"],
     [".agents/hooks/check-version-format.sh", "templates/.agents/hooks/check-version-format.sh"],
+    [".agents/hooks/auto-resume.sh", "templates/.agents/hooks/auto-resume.sh"],
     [".codex/hooks.json", "templates/.codex/hooks.json"],
     ...buildCommandSyncFiles(project),
     ...referenceSyncFiles
@@ -328,7 +330,7 @@ test("version format validation hooks are wired into templates and local config"
   ([
     [".claude/settings.json", rootClaudeSettings],
     ["templates/.claude/settings.json", templateClaudeSettings]
-  ] as Array<[string, { hooks?: { PreToolUse?: unknown; PostToolUse?: unknown } }]>).forEach(([relativePath, settings]) => {
+  ] as Array<[string, { hooks?: { PreToolUse?: unknown; PostToolUse?: unknown; StopFailure?: unknown } }]>).forEach(([relativePath, settings]) => {
     assert.deepEqual(
       settings.hooks?.PreToolUse,
       [
@@ -344,6 +346,21 @@ test("version format validation hooks are wired into templates and local config"
         }
       ],
       `${relativePath} should configure the PreToolUse version format validation hook`
+    );
+    assert.deepEqual(
+      settings.hooks?.StopFailure,
+      [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: "sh \"$(git rev-parse --show-toplevel)/.agents/hooks/auto-resume.sh\""
+            }
+          ]
+        }
+      ],
+      `${relativePath} should configure the StopFailure auto-resume hook`
     );
     assert.equal(settings.hooks?.PostToolUse, undefined, `${relativePath} should not configure a PostToolUse reminder hook`);
   });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #438

Closes #438

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

CC 长任务偶发可恢复 API 错误（典型 `API Error: ... (ECONNRESET)`）会让 turn 异常终止、TUI 停在 input-wait 态，必须人工敲「请继续」才能恢复，沙箱内长任务成本更高。本 PR 新增一个 `StopFailure` hook，在可恢复错误且网络恢复后自动经 tmux 注入续跑指令，免人工干预；对不可恢复错误与非 tmux 环境零打扰、只留日志。

## 📋 主要变更 / Brief Changelog

- 新增 `.agents/hooks/auto-resume.sh`（POSIX sh）：4 道闸（非 tmux 跳过 → 官方 `error` 字段白名单 `unknown/server_error/overloaded` → 同 session 30 分钟滑动窗口退避 ≤10 → `curl` 网络探针 ≤60s）+ `tmux send-keys` 注入；全程 `exit 0`（StopFailure 输出/退出码被官方忽略），可观测性落 `~/.claude/auto-resume.log`（超 5000 行自截断）。
- 两份 `.claude/settings.json` 追加 `StopFailure` 配置（`matcher: ""`，白名单交脚本，因验收要求对不可恢复错误也记录拦截日志）。
- 同步 `templates/` 镜像（脚本 + settings），供下游 init 落地。
- 测试：`templates.test.ts` 新增镜像 parity + `StopFailure` 配置断言；新增 `tests/unit/hooks/auto-resume.test.ts`（PATH-stub 行为测试，覆盖各闸 + 注入 + 路径穿越防护）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量单元/集成/E2E 测试通过（含新增 hook 行为测试与模板 parity）。
2. 行为测试以 PATH-stub 的 `tmux`/`curl` 驱动，断言：非 tmux 跳过、不可恢复错误拦截、退避命中、`session_id` 路径穿越被收敛、happy path 注入续跑文字。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing（见下「附加信息」的待人工验证清单）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock（PATH-stub `tmux`/`curl`）
- [x] 代码检查通过
- [x] 单元测试通过

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（hook 脚本内注释 + 模板镜像）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更，纯增量）
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

**待人工验证（env-blocked，CI 无法覆盖）：**
- [ ] 本地 tmux 内跑 CC，断网造 `ECONNRESET` → 日志 fired → 网络恢复 → 自动注入续跑文字（验收 #1）
- [ ] 沙箱（`agent-infra` 进容器）内复现 #1（验收 #3）
- [ ] `authentication_failed` 等不可恢复错误 → 日志 `blocked`、不注入（验收 #4）
- [ ] 连续 10+ 次 `ECONNRESET` → 第 11 次日志 `backoff`、不注入（验收 #5）

**下游同步说明**：`.claude/settings.json` 属 `merged` 文件，`update-agent-infra` 不自动合并，仅入 `merged.pending` 交 AI/人工**语义合并**；下游升级时需把 `StopFailure` 段幂等并入既有 `hooks`，不重复、不覆盖既有事件。

---

**审查者注意事项 / Reviewer Notes:**

- **闸 2 走「路径 B」（脚本内白名单读官方 `error` 字段）而非 matcher 预过滤**：因验收 #4 要求对不可恢复错误「记录拦截原因」，matcher 预过滤会让 hook 对这些错误根本不触发、无从记日志。`error` 字段名已据 Claude Code 官方 Hooks 文档确认（非 `error_type`）。
- 注入文字为通用英文：`Unexpected interruption. Please continue the unfinished operation.`

Generated with AI assistance
