### PR TITLE
refactor(cli): 统一 ai task ls / ai sandbox ls 的 # 列为行号

### DIFF
--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -14,16 +14,17 @@ export { containerListFormat, parseLabels } from './list-running.ts';
 
 const USAGE = `Usage: ai sandbox ls
 
-Lists all containers for the current project. The leftmost '#' column
-shows the active task short id bound to each container's branch (via
-.agents/workspace/active/.short-ids.json); '-' means no active task is
-bound to the branch. Use it as "ai sandbox exec N" or "ai sandbox exec
-'#N'" to enter the sandbox of that task.`;
+Lists all containers for the current project. The '#' column is a
+display-only row number; the 'SHORT' column shows the active task short
+id bound to each container's branch (via
+.agents/workspace/active/.short-ids.json), or '-' if no active task is
+bound. Pass the SHORT value to "ai sandbox exec" (e.g. 'ai sandbox exec 11').`;
 
-const CONTAINER_TABLE_HEADERS = ['#', 'NAMES', 'STATUS', 'BRANCH'] as const;
+const CONTAINER_TABLE_HEADERS = ['#', 'SHORT', 'NAMES', 'STATUS', 'BRANCH'] as const;
 
 type ContainerTableRow = {
-  index: string;
+  row: string;
+  shortId: string;
   name: string;
   status: string;
   branch: string;
@@ -32,7 +33,7 @@ type ContainerTableRow = {
 export function formatContainerTable(rows: ContainerTableRow[]): string[] {
   return formatTable(
     CONTAINER_TABLE_HEADERS,
-    rows.map((row) => [row.index, row.name, row.status, row.branch])
+    rows.map((r) => [r.row, r.shortId, r.name, r.status, r.branch])
   );
 }
 
@@ -63,18 +64,20 @@ export function ls(args: string[] = []): void {
   if (ordered.length === 0) {
     p.log.warn('  No sandbox containers');
   } else {
-    const tableRows: ContainerTableRow[] = ordered.map((row) => {
-      const shortId = row.branch ? lookupShortIdByBranch(row.branch, config.repoRoot) : null;
+    const tableRows: ContainerTableRow[] = ordered.map((container, i) => {
+      const shortId = container.branch ? lookupShortIdByBranch(container.branch, config.repoRoot) : null;
       return {
-        index: shortId ?? '-',
-        name: row.name,
-        status: row.status,
-        branch: row.branch
+        row: String(i + 1),
+        shortId: shortId ?? '-',
+        name: container.name,
+        status: container.status,
+        branch: container.branch
       };
     });
     for (const line of formatContainerTable(tableRows)) {
       process.stdout.write(`  ${line}\n`);
     }
+    process.stdout.write(`  Total: ${ordered.length} containers\n`);
   }
 
   p.log.step('Worktrees');

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -7,8 +7,8 @@ Commands:
                                recommended form for task short ids (e.g.
                                'ai sandbox exec 11'); '#N' is also accepted.
   ls                           List sandboxes for the current project (the '#'
-                               column shows the active task short id; '-' if no
-                               active task is bound to the container's branch)
+                               column is a display-only row number; the 'SHORT'
+                               column shows the active task short id, '-' if none)
   prune [--dry-run]            Remove orphaned per-branch state dirs
   rebuild [--quiet] [--refresh]
                                Rebuild the sandbox image (--refresh pulls base + tools)

--- a/lib/task/commands/ls.ts
+++ b/lib/task/commands/ls.ts
@@ -12,7 +12,7 @@ Lists tasks under .agents/workspace/. Defaults to active tasks only.
   --blocked     Only blocked tasks
   --completed   Only completed tasks
 
-Columns: # / short_id / type / status / current_step / branch / title
+Columns: # (display-only row number) / SHORT (task short id, usable as an argument) / type / status / current_step / branch / title
 `;
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
@@ -64,7 +64,6 @@ function parseSelection(args: string[]): ParseResult {
 }
 
 type TaskRow = {
-  shortIdNumeric: string;
   shortId: string;
   type: string;
   status: string;
@@ -88,9 +87,7 @@ function collectTasks(repoRoot: string, state: 'active' | 'blocked' | 'completed
     const fm = parseTaskFrontmatter(content);
     const title = extractTitle(content);
     const shortId = shortIdByTaskId.get(entry) ?? '-';
-    const shortIdNumeric = shortId.startsWith('#') ? String(Number(shortId.slice(1)) || 0) : '';
     rows.push({
-      shortIdNumeric,
       shortId,
       type: fm.type ?? '-',
       status: fm.status ?? state,
@@ -123,8 +120,8 @@ function ls(args: string[] = []): void {
     process.stdout.write(`No tasks under .agents/workspace/${selection.join('|')}\n`);
     return;
   }
-  const tableRows = rows.map((r) => [
-    r.shortIdNumeric,
+  const tableRows = rows.map((r, i) => [
+    String(i + 1),
     r.shortId,
     r.type,
     r.status,
@@ -135,6 +132,7 @@ function ls(args: string[] = []): void {
   for (const line of formatTable(TABLE_HEADERS, tableRows)) {
     process.stdout.write(`${line}\n`);
   }
+  process.stdout.write(`Total: ${rows.length} tasks\n`);
 }
 
 export { ls };

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -726,29 +726,32 @@ test("sandbox ls formatContainerTable aligns header and rows by column width", a
   const { formatContainerTable } = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/ls.ts")>("lib/sandbox/commands/ls.js");
 
   const rows = [
-    { index: "#01", name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
-    { index: "-", name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
-    { index: "-", name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
+    { row: "1", shortId: "#01", name: "demo-dev-feature-x", status: "Up 2 hours", branch: "feature/short" },
+    { row: "2", shortId: "-", name: "worker", status: "Exited (0) 20 minutes ago", branch: "bugfix/align-table" },
+    { row: "3", shortId: "-", name: "agent-infra-sandbox-long", status: "Created", branch: "main" }
   ];
   const lines = formatContainerTable(rows);
   const hashColumn = lines[0]!.indexOf("#");
+  const shortColumn = lines[0]!.indexOf("SHORT");
   const namesColumn = lines[0]!.indexOf("NAMES");
   const statusColumn = lines[0]!.indexOf("STATUS");
   const branchColumn = lines[0]!.indexOf("BRANCH");
 
   assert.equal(lines.length, rows.length + 1);
   assert.equal(hashColumn, 0);
-  assert.ok(namesColumn > hashColumn);
+  assert.ok(shortColumn > hashColumn);
+  assert.ok(namesColumn > shortColumn);
   assert.ok(statusColumn > namesColumn);
   assert.ok(branchColumn > statusColumn);
   for (let i = 0; i < rows.length; i += 1) {
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.name), namesColumn);
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.status), statusColumn);
     assert.equal(lines[i + 1]!.indexOf(rows[i]!.branch), branchColumn);
+    // '#' column holds the 1-based row number
+    assert.equal(lines[i + 1]!.slice(0, shortColumn).trim(), rows[i]!.row);
+    // 'SHORT' column holds the task short id (or '-')
+    assert.equal(lines[i + 1]!.slice(shortColumn, namesColumn).trim(), rows[i]!.shortId);
   }
-  assert.equal(lines[1]!.slice(0, namesColumn).trim(), "#01");
-  assert.equal(lines[2]!.slice(0, namesColumn).trim(), "-");
-  assert.equal(lines[3]!.slice(0, namesColumn).trim(), "-");
   for (const line of lines) {
     assert.equal(line.includes("\t"), false);
     assert.doesNotMatch(line, /\s+$/);

--- a/tests/integration/cli/sandbox-ls-short-id-column.test.ts
+++ b/tests/integration/cli/sandbox-ls-short-id-column.test.ts
@@ -48,11 +48,13 @@ test('formatContainerTable now uses short id / "-" instead of running-index', as
     'lib/sandbox/commands/ls.js'
   );
   const rows = [
-    { index: '#11', name: 'sb-feature-eleven', status: 'Up 1 min', branch: 'feature-eleven' },
-    { index: '-', name: 'sb-feature-orphan', status: 'Up 2 hours', branch: 'orphan-branch' }
+    { row: '1', shortId: '#11', name: 'sb-feature-eleven', status: 'Up 1 min', branch: 'feature-eleven' },
+    { row: '2', shortId: '-', name: 'sb-feature-orphan', status: 'Up 2 hours', branch: 'orphan-branch' }
   ];
   const lines = formatContainerTable(rows);
+  const shortColumn = lines[0]!.indexOf('SHORT');
   const namesColumn = lines[0]!.indexOf('NAMES');
-  assert.equal(lines[1]!.slice(0, namesColumn).trim(), '#11');
-  assert.equal(lines[2]!.slice(0, namesColumn).trim(), '-');
+  // short id now lives in the 'SHORT' column (between '#' row number and 'NAMES')
+  assert.equal(lines[1]!.slice(shortColumn, namesColumn).trim(), '#11');
+  assert.equal(lines[2]!.slice(shortColumn, namesColumn).trim(), '-');
 });

--- a/tests/integration/cli/task-ls.test.ts
+++ b/tests/integration/cli/task-ls.test.ts
@@ -162,3 +162,21 @@ test('ai task ls prints empty-state message when no tasks present', () => {
   assert.equal(out.status, 0, out.stderr);
   assert.match(out.stdout, /No tasks under/);
 });
+
+test('ai task ls numbers rows in the # column and prints a Total tail line', () => {
+  const { repoRoot, activeDir } = mkFixtureRepo();
+  writeTask(activeDir, 'TASK-20260101-000001', { branch: 'feature-one' });
+  writeTask(activeDir, 'TASK-20260101-000002', { branch: 'feature-two' });
+  writeRegistry(activeDir, { '01': 'TASK-20260101-000001', '02': 'TASK-20260101-000002' });
+  const out = runCli(['task', 'ls'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+
+  // The '#' column is a 1-based row number: each data row starts with its index.
+  const dataLines = out.stdout.split('\n').filter((l) => /feature-(one|two)/.test(l));
+  assert.equal(dataLines.length, 2);
+  assert.match(dataLines[0]!, /^1\b/);
+  assert.match(dataLines[1]!, /^2\b/);
+
+  // The table is followed by a Total tail line reflecting the row count.
+  assert.match(out.stdout, /^Total: 2 tasks$/m);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#446</mark> 👈👈

Closes #446

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

`ai task ls` 的第一列 `#`（短号裸数字 `1`）与第二列 `SHORT`（规范化 `#01`）同源、信息冗余；而在 `--all` / `--blocked` / `--completed` 模式下短号已释放显示 `-`（#440），整张表反而缺一个「行号 / 总数」展示位。#437 也声明 `ai sandbox ls` 的 `#` 列语义与 `ai task ls` 的 `#` 完全对应，两个命令应同步改造。

本 PR 把两个 ls 命令的列结构统一为 `# | SHORT | ...`：`#` 列改为 1-based 行号（纯展示，不可作为入参），`SHORT` 列承载短号 `#NN`（可作为入参），并在表末加 `Total: N ...` 尾行。**不改动任何入参解析逻辑**（`#NN` / 裸数字仍由 `task-short-id.js` / sandbox 入口解析），仅调整展示列与帮助文案。

## 📋 主要变更 / Brief Changelog

- `ai task ls`：`#` 列由「短号数字形式」改为 1-based 行号；删除冗余的 `shortIdNumeric` 字段；表末新增 `Total: N tasks` 尾行；`--help` 的 `Columns:` 说明明示 `#` 为纯展示行号、`SHORT` 可作为入参
- `ai sandbox ls`：列结构由 `# | NAMES | STATUS | BRANCH` 改为 `# | SHORT | NAMES | STATUS | BRANCH`，最左 `#` 为行号、`SHORT` 承载分支反查的任务短号；表末新增 `  Total: N containers` 尾行；USAGE 重写
- `lib/sandbox/index.ts` 子命令汇总文案同步更新；空表仍走原有空态消息，不打印 `Total: 0`

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run test:core`（810 pass / 0 fail / 1 skipped）
2. `node bin/cli.ts task ls` / `--completed`：确认首列为连续行号、`SHORT` 列短号或 `-`、末行 `Total: N tasks`
3. `node bin/cli.ts task ls --help` / `sandbox ls --help` / `sandbox --help`：确认列语义文案已更新

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

- 纯展示层改动，无运行时行为 / 解析 / 持久化结构变更；`#` 行号不可作为任何命令入参，传参仍用 `SHORT` 列短号，向后兼容。
- 文档区（含 `AGENTS.md` / `.agents/rules/` / README）经排查无「ls `#` 列是短号」类陈述，无需改动。

---

**审查者注意事项 / Reviewer Notes:**

- `formatContainerTable` 的列对齐测试以字符位置断言，重点确认新增 `SHORT` 列的切片范围（`#` 与 `NAMES` 之间）。
- `Total:` 尾行缩进：`task ls` 无前缀、`sandbox ls` 带两空格，与各自表格行一致；空态分支不输出 `Total`。

---

Generated with AI assistance