### PR TITLE
feat(meta): 生命周期技能输出末尾打印本地完成时间戳

### DIFF
--- a/.agents/rules/next-step-output.md
+++ b/.agents/rules/next-step-output.md
@@ -45,3 +45,15 @@ process.stdout.write(hit?("#"+hit[0]):full);
 ## `#` 前缀与 shell 引用
 
 短号统一渲染为带 `#` 前缀的 `#NN`，与 task.md frontmatter 的 `short_id` 渲染一致。`#` 在 bash 中是注释起始符，示例命令若直接粘贴需视 TUI 而定（裸数字 `NN` 与 `#NN` 都被 `task-short-id.js resolve` 接受）。
+
+## 完成时间收尾行（Completed at）
+
+所有读取本规则、并向用户渲染「下一步 / 告知用户」输出的 skill，在面向用户输出的**绝对最后一行**统一追加一行完成时间，便于用户在 tmux 多窗口扫视时一眼判断各 Agent 的完成先后：
+
+```text
+Completed at: YYYY-MM-DD HH:mm:ss
+```
+
+- 取值命令（本地时区、不带偏移）：`date "+%Y-%m-%d %H:%M:%S"`
+- 位置：必须是整段面向用户输出的最后一行，排在所有「下一步」命令之后。若某场景在命令之后还有条件性提醒行（如 env-blocked 提醒），收尾行排在该提醒行之后。
+- 该行只用于终端扫视，不写入任何产物文件或 Issue/PR 评论；完成时刻的单一事实源仍是 task.md 的 Activity Log。

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -145,6 +145,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 > 仅在校验通过后执行本步骤。
 
+> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但仍统一打印该收尾行。
+
 输出格式：
 ```
 任务 {task-id} 已完成，任务目录已转移到 completed/。
@@ -156,6 +158,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
+
+Completed at: {completion-time}
 ```
 
 

--- a/templates/.agents/rules/next-step-output.en.md
+++ b/templates/.agents/rules/next-step-output.en.md
@@ -45,3 +45,15 @@ process.stdout.write(hit?("#"+hit[0]):full);
 ## `#` prefix and shell quoting
 
 Short ids are always rendered with a `#` prefix as `#NN`, matching how task.md frontmatter renders `short_id`. `#` starts a comment in bash, so pasting example commands depends on the TUI (both the bare numeric `NN` and `#NN` are accepted by `task-short-id.js resolve`).
+
+## Completion timestamp line (Completed at)
+
+Every skill that reads this rule and renders "Next steps / Inform user" output appends a single completion-time line as the **very last line** of its user-facing output, so users scanning across tmux windows can tell at a glance which agent finished most recently:
+
+```text
+Completed at: YYYY-MM-DD HH:mm:ss
+```
+
+- Value command (local timezone, no offset): `date "+%Y-%m-%d %H:%M:%S"`
+- Position: it must be the last line of the entire user-facing output, after all "Next steps" commands. If a scenario has a conditional reminder line after the commands (e.g. the env-blocked reminder), the completion line goes after that reminder.
+- This line is for terminal scanning only; it is never written to any artifact file or Issue/PR comment. The single source of truth for completion time remains the Activity Log in task.md.

--- a/templates/.agents/rules/next-step-output.zh-CN.md
+++ b/templates/.agents/rules/next-step-output.zh-CN.md
@@ -45,3 +45,15 @@ process.stdout.write(hit?("#"+hit[0]):full);
 ## `#` 前缀与 shell 引用
 
 短号统一渲染为带 `#` 前缀的 `#NN`，与 task.md frontmatter 的 `short_id` 渲染一致。`#` 在 bash 中是注释起始符，示例命令若直接粘贴需视 TUI 而定（裸数字 `NN` 与 `#NN` 都被 `task-short-id.js resolve` 接受）。
+
+## 完成时间收尾行（Completed at）
+
+所有读取本规则、并向用户渲染「下一步 / 告知用户」输出的 skill，在面向用户输出的**绝对最后一行**统一追加一行完成时间，便于用户在 tmux 多窗口扫视时一眼判断各 Agent 的完成先后：
+
+```text
+Completed at: YYYY-MM-DD HH:mm:ss
+```
+
+- 取值命令（本地时区、不带偏移）：`date "+%Y-%m-%d %H:%M:%S"`
+- 位置：必须是整段面向用户输出的最后一行，排在所有「下一步」命令之后。若某场景在命令之后还有条件性提醒行（如 env-blocked 提醒），收尾行排在该提醒行之后。
+- 该行只用于终端扫视，不写入任何产物文件或 Issue/PR 评论；完成时刻的单一事实源仍是 task.md 的 Activity Log。

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -146,6 +146,8 @@ Keep the gate output in your reply as fresh evidence. Do not claim completion wi
 
 > Execute this step only after the verification gate passes.
 
+> The completion timestamp line (the last line of the whole output) uses `date "+%Y-%m-%d %H:%M:%S"` (local timezone, no offset) and always sits at the very end of the output for at-a-glance scanning across windows. This skill renders no "Next steps" commands but still prints the line.
+
 Output format:
 ```
 Task {task-id} completed; task directory moved to completed/.
@@ -157,6 +159,8 @@ Task info:
 
 Deliverables:
 - {List of key outputs: files modified, tests added, etc.}
+
+Completed at: {completion-time}
 ```
 
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -145,6 +145,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 > 仅在校验通过后执行本步骤。
 
+> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但仍统一打印该收尾行。
+
 输出格式：
 ```
 任务 {task-id} 已完成，任务目录已转移到 completed/。
@@ -156,6 +158,8 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
+
+Completed at: {completion-time}
 ```
 
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#449</mark> 👈👈

Closes #449

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

用户在 tmux 多窗口并行运行 Claude Code / Codex 时，切回某个窗口往往两边都已显示「SKILL 执行完成」，但无法一眼识别**哪个 Agent 最后完成**，目前必须切到 `task.md` 翻 Activity Log 才能确认完成顺序。

本变更在生命周期 SKILL 的面向用户输出**绝对最后一行**统一打印一行 `Completed at: YYYY-MM-DD HH:mm:ss`（本地时区、不带偏移），让用户在多窗口扫视时一眼定位最近完成的 Agent，无需切换到日志文件。该行仅用于终端扫视，不写入任何产物或评论，完成时刻的单一事实源仍是 Activity Log。

## 📋 主要变更 / Brief Changelog

- 在 `next-step-output` 规则（en + zh）新增「完成时间收尾行」节，作为收尾行格式 / 取值命令 / 位置 / 适用范围的**唯一权威定义**；所有在渲染输出前已读取该规则的生命周期 SKILL 一次定义、处处生效（方案 A，避免逐 SKILL 逐场景重复编辑）
- `complete-task` 不读取该规则，单独在其「告知用户」步骤输出末尾追加 `Completed at: {completion-time}` 收尾行，并保留既有结构化完成时间字段
- 改双语模板后通过脚本化 sync（传工作树 `templates/` override）重新生成 2 个 `.agents/` 部署副本，未手工编辑 managed 文件

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1005 pass / 0 fail / 1 platform-skip
2. 单独复跑 `tests/unit/templates/skills.test.ts` 与 `tests/unit/templates/output-templates-task-ref.test.ts` —— 80/80（frontmatter / 连续步骤编号 / 引用完整 / 双语变体 / `{task-ref}` 约束不回退）
3. 抽查在范围内 SKILL（analyze-task / review-code / code-task）均引用 `next-step-output.md`，确保收尾行指令在输出前进入上下文

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

> 说明：本变更为纯文档 / 输出约定，无可执行代码面。按项目「测试编写规约 #1」（禁止对 SKILL 文案做关键词语义断言）未新增针对 `Completed at` 字样的断言测试；回归以既有结构性测试套件为准。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [ ] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests（纯文档约定，见上「测试覆盖」说明）
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist（N/A）
- [x] 代码检查通过 / Lint checks pass（项目暂未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（规则与 SKILL 文档即本变更主体）
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（纯新增收尾行，向后兼容）

## 📋 附加信息 / Additional Notes

- 覆盖范围（OQ2）：集中规则对所有读取它的 SKILL 统一生效（含 import-* / cancel / block / create-pr / check-task 等），这是 Issue「统一」诉求的有意效果。
- emission 可靠性（OQ1）：各 SKILL 输出模板本身不内联字面收尾行，依赖「输出前已 Read 规则 + 规则强约束末行」；如需更强可靠性可后续在单块模板补字面行。
- sync 顺带刷新的 3 个无关漂移文件与 `.airc.json` 版本号已回退，留待独立 `update-agent-infra` 处理，保持本 PR 改动面仅 6 个文件。

---

Generated with AI assistance