### PR TITLE
refactor(cli): 优化 PR 流程开关：删除 init 提问，commit 后二选一

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -5,7 +5,7 @@
   "platform": {
     "type": "github"
   },
-  "requiresPullRequest": true,
+  "prFlow": "required",
   "templateVersion": "v0.7.2",
   "sandbox": {
     "engine": "orbstack",

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -61,10 +61,9 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 > **重要**：向用户展示下一步时，必须完整输出所有 TUI 命令格式，并直接使用 `reference/task-status-update.md` 中对应场景的标准模板。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
 追加 Commit 的 Activity Log，并且只能选择一个下一步分支：
-- 最终提交 -> `complete-task {task-id}`
+- 最终提交 -> 按 `.agents/.airc.json` 的 `prFlow` 渲染下一步（`disabled` → 单选 `complete-task`；`required` → 单选 `create-pr`；缺省 → 二选一 `create-pr` / `complete-task`），详见 `reference/task-status-update.md` 场景 1
 - 还有后续工作 -> 更新 task.md 后停止
 - 准备审查 -> `review-code {task-id}`
-- 准备创建 PR（仅项目启用 PR 流程，即 `requiresPullRequest !== false`）-> `create-pr`
 
 ## 6. 同步 Issue 元数据（按需）
 

--- a/.agents/skills/commit/reference/task-status-update.md
+++ b/.agents/skills/commit/reference/task-status-update.md
@@ -23,20 +23,19 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 最新的 `review-code.md` / `review-code-r{N}.md` 是否无问题通过
 - 是否仍然存在待修复项、待审查工作或待创建 PR 的步骤
 
-**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。所有依赖该字段的分支按此规则判定。
+**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR）。所有依赖该偏好的分支按此三态判定。
 
 必须且只能选择一个分支：
 
 | 判断依据 | 必选分支 |
 |---|---|
-| 所有工作流步骤都已完成 + 最新审查无问题通过 + 所有测试通过 | 场景 1：最终提交 |
+| 所有工作流步骤都已完成 + 最新审查无问题通过 + 所有测试通过 | 场景 1：最终提交（按 `prFlow` 渲染下一步） |
 | 仍有未完成步骤、待修复项或等待他人的动作 | 场景 2：还有后续工作 |
 | 这次提交是为了把任务交给代码审查 | 场景 3：准备进入审查 |
-| 代码已提交、审查已完成，且**项目启用 PR 流程**，下一步是创建 PR | 场景 4：准备创建 PR |
 
 绝对不要同时套用多个分支。先匹配唯一的下一步分支，再更新任务。
 
-**门控降级**：当 `requiresPullRequest === false` 时，场景 4 永远不被进入；原本会落入场景 4 的提交统一收敛到场景 1（最终提交 → `/complete-task`）。
+**场景 1 下一步渲染（先判 `prFlow` 强约束）**：终态「最终提交」的下一步命令按 `prFlow` 渲染——`"disabled"` → 单选「直接完成」（`/complete-task`），永不引导创建 PR；`"required"` → 单选「走 PR 流程」（`/create-pr`）；字段缺省 → 二选一（`/create-pr` 或 `/complete-task`）。创建 PR 的动作统一由场景 1 的「走 PR 流程」选项承载，不再单列独立场景。
 
 ### 场景 1：最终提交
 
@@ -44,15 +43,40 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - [ ] 所有代码都已提交
 - [ ] 所有测试通过
 - [ ] 代码审查已通过
-- [ ] 所有工作流步骤已完成（对 yaml `commit` 步骤的 `pr_tasks` 列表，仅在 `requiresPullRequest !== false` 时计入）
+- [ ] 所有工作流步骤已完成（对 yaml `commit` 步骤的 `pr_tasks` 列表，按「走 PR 路径」判定是否计入：`prFlow=required` 始终计入；`prFlow=disabled` 不计入；缺省下仅当 `pr_status=skipped` 时不计入，否则计入）
 
-必带下一步命令：
+必带下一步命令（按 `prFlow` 渲染）：
+
+`prFlow="disabled"` → 单选「直接完成」：
 
 ```text
 下一步 - 完成并归档任务：
   - Claude Code / OpenCode: /complete-task {task-ref}
   - Gemini CLI: /agent-infra:complete-task {task-ref}
   - Codex CLI: $complete-task {task-ref}
+```
+
+`prFlow="required"` → 单选「走 PR 流程」：
+
+```text
+下一步 - 创建 Pull Request：
+  - Claude Code / OpenCode: /create-pr {task-ref}
+  - Gemini CLI: /agent-infra:create-pr {task-ref}
+  - Codex CLI: $create-pr {task-ref}
+```
+
+字段缺省 → 二选一：
+
+```text
+下一步 - 二选一：
+  - 走 PR 流程：
+    - Claude Code / OpenCode: /create-pr {task-ref}
+    - Gemini CLI: /agent-infra:create-pr {task-ref}
+    - Codex CLI: $create-pr {task-ref}
+  - 直接完成（无 PR）：
+    - Claude Code / OpenCode: /complete-task {task-ref}
+    - Gemini CLI: /agent-infra:complete-task {task-ref}
+    - Codex CLI: $complete-task {task-ref}
 ```
 
 ### 场景 2：还有后续工作
@@ -80,20 +104,4 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - Codex CLI: $review-code {task-ref}
 ```
 
-### 场景 4：准备创建 PR
-
-如果下一步是创建 Pull Request：
-- 更新 `updated_at`
-- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
-- 在 `task.md` 中记录 PR 计划
-
-必带下一步命令：
-
-```text
-下一步 - 创建 Pull Request：
-  - Claude Code / OpenCode: /create-pr {task-ref}
-  - Gemini CLI: /agent-infra:create-pr {task-ref}
-  - Codex CLI: $create-pr {task-ref}
-```
-
-> 注意：四个场景之外，只要 `task.md` 中存在有效 `pr_number`，commit 技能必须先按 `reference/pr-summary-sync.md` 同步 PR 摘要，再进入完成校验。
+> 注意：上述场景之外，只要 `task.md` 中存在有效 `pr_number`，commit 技能必须先按 `reference/pr-summary-sync.md` 同步 PR 摘要，再进入完成校验。

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -43,10 +43,36 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ### 2. 验证完成前置条件（未满足则必须停止）
 
-**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。下面的工作流步骤完成判定按此规则裁剪。
+**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR），以及 `task.md` frontmatter 的 `pr_status`（`pending` / `created` / `skipped`）。
+
+**PR 维度判定（先判 `prFlow` 强约束，后看 `pr_status`）**：
+
+| `prFlow` | `pr_status` | 判定 |
+|---|---|---|
+| `disabled` | 任意 | 无 PR 路径 → PR 维度满足，继续其余前置条件 |
+| `required` | `created` | PR 维度满足，继续 |
+| `required` | `pending` / `skipped` | **停止**：强制 PR 下必须先 `/create-pr`；`--skip-pr` 不被接受（含既有/手动写入的 `skipped`） |
+| 缺省 | `created` / `skipped` | PR 维度满足，继续 |
+| 缺省 | `pending` | **默认停止**并输出下方二选一引导；除非用户提供 `--skip-pr`（写 `pr_status: skipped` 后继续）或 `--force` |
+
+- `--skip-pr` 处理：仅在 `prFlow` 非 `required` 时生效——把 `task.md` 的 `pr_status` 写为 `skipped` 后继续；`prFlow=required` 时忽略 `--skip-pr` 并按上表停止。
+- 注：`--force` 可越过下方其余前置条件，但**不解除 `prFlow=required` 的 PR 强约束**（强约束的唯一出口是创建 PR）。
+
+缺省 + `pending` 的二选一引导消息：
+```
+任务 {task-id} 尚未创建 PR（pr_status: pending）。请二选一：
+  - 走 PR 流程：/create-pr {task-ref}
+  - 显式跳过并完成：/complete-task {task-ref} --skip-pr
+```
+
+`required` + `pending`/`skipped` 的停止消息：
+```
+当前项目强制 PR 流程（prFlow: "required"），任务尚未创建 PR。
+请先运行 /create-pr {task-ref} 创建 PR 后再完成；--skip-pr 在强制 PR 下不被接受。
+```
 
 标记完成之前，验证以下所有条件：
-- [ ] 所有工作流步骤已完成（检查 task.md 中的工作流进度；**对 yaml 中 commit 步骤的 `pr_tasks` 列表，仅在 `.agents/.airc.json:requiresPullRequest !== false` 时计入未完成判定**）
+- [ ] 所有工作流步骤已完成（检查 task.md 中的工作流进度；**对 yaml 中 commit 步骤的 `pr_tasks` 列表，按「走 PR 路径」判定是否计入未完成判定：`prFlow=required` 始终计入；`prFlow=disabled` 不计入；缺省下仅当 `pr_status=skipped` 时不计入，否则计入**）
 - [ ] 代码已审查（`review-code.md` 或 `review-code-r{N}.md` 存在，且最新审查结论为 Approved；或已在外部完成审查）
 - [ ] 代码已提交（没有与此任务相关的未提交变更）
 - [ ] 测试通过

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -19,14 +19,14 @@ description: "创建 Pull Request 到目标分支"
 
 ### 前置门控：项目级 PR 流程检查
 
-**门控读取（项目级 PR 流程策略）**：在执行编号步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。
+**门控读取（项目级 PR 流程策略）**：在执行编号步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR）。
 
 按读取结果分支：
-- 缺失 / `true` → 继续到下方第 1 步
-- 显式 `false` → 输出以下消息后**立即停止**，不要执行任何后续编号步骤、不要触发任何 PR 创建命令、不要修改 `task.md` 的 `pr_number`、不要发布 PR 摘要评论：
+- 缺省 / `"required"` → 继续到下方第 1 步
+- `"disabled"` → 输出以下消息后**立即停止**，不要执行任何后续编号步骤、不要触发任何 PR 创建命令、不要修改 `task.md` 的 `pr_number` / `pr_status`、不要发布 PR 摘要评论：
 
 ```
-当前项目未启用 PR 流程（`.agents/.airc.json` 中 `requiresPullRequest: false`）。
+当前项目未启用 PR 流程（`.agents/.airc.json` 中 `prFlow: "disabled"`）。
 无需创建 Pull Request，请直接运行：
   - Claude Code / OpenCode：/complete-task {task-ref}
   - Gemini CLI：/agent-infra:complete-task {task-ref}
@@ -96,7 +96,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`pr_status`（设为 `created`）、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -23,7 +23,6 @@ const DEFAULTS = {
   "platform": {
     "type": "github"
   },
-  "requiresPullRequest": true,
   "sandbox": {
     "engine": null,
     "runtimes": [

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -13,6 +13,7 @@ start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD
 target_date:                    # Feature 可选 Issue 字段：YYYY-MM-DD
 current_step: requirement-analysis # requirement-analysis | requirement-analysis-review | technical-design | technical-design-review | code | code-review | completed
 assigned_to:                   # claude | codex | gemini | opencode | human
+pr_status: pending             # PR 状态：pending（默认）| created（已创建 PR）| skipped（显式跳过）
 ---
 
 # 任务：[标题]

--- a/.agents/workflows/bug-fix.yaml
+++ b/.agents/workflows/bug-fix.yaml
@@ -1,8 +1,9 @@
 # 缺陷修复工作流
 # 修复缺陷时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: bug-fix
 description: 诊断和修复缺陷的工作流。
@@ -176,7 +177,7 @@ steps:
       - 问题列表（如有）
 
   - name: commit
-    description: 最终确认缺陷修复并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认缺陷修复并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -192,4 +193,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/.agents/workflows/feature-development.yaml
+++ b/.agents/workflows/feature-development.yaml
@@ -1,8 +1,9 @@
 # 功能开发工作流
 # 实现新功能时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: feature-development
 description: 开发新功能的端到端工作流。
@@ -176,7 +177,7 @@ steps:
       - 待修复问题列表
 
   - name: commit
-    description: 最终确认变更并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认变更并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -192,4 +193,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/.agents/workflows/refactoring.yaml
+++ b/.agents/workflows/refactoring.yaml
@@ -1,8 +1,9 @@
 # 重构工作流
 # 代码重构任务时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: refactoring
 description: 安全且结构化的代码重构工作流。
@@ -180,7 +181,7 @@ steps:
       - 问题列表（如有）
 
   - name: commit
-    description: 最终确认重构并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认重构并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -196,4 +197,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/assets/demo-init.tape
+++ b/assets/demo-init.tape
@@ -80,26 +80,21 @@ Sleep 1s
 
 # Prompt 5: Platform type — accept default (github)
 Enter
-Wait+Screen /Pull Request flow/
-Sleep 1s
-
-# Prompt 6: Require Pull Request flow — accept default (yes)
-Enter
 Wait+Screen /Built-in TUI/
 Sleep 3s
 
-# Prompt 7: Built-in TUI command files — keep all four built-in TUIs
+# Prompt 6: Built-in TUI command files — keep all four built-in TUIs
 Type "1,2,3,4"
 Sleep 500ms
 Enter
 Wait+Screen /Template sources/
 Sleep 1s
 
-# Prompt 8: Template sources — skip (Enter)
+# Prompt 7: Template sources — skip (Enter)
 Enter
 Sleep 1s
 
-# Prompt 9: Skill sources — skip (Enter)
+# Prompt 8: Skill sources — skip (Enter)
 Enter
 Sleep 5s
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -2,7 +2,6 @@
   "platform": {
     "type": "github"
   },
-  "requiresPullRequest": true,
   "sandbox": {
     "engine": null,
     "runtimes": [

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -32,7 +32,6 @@ type Defaults = {
   sandbox: Record<string, unknown>;
   task: { shortIdLength: number };
   labels: Record<string, unknown>;
-  requiresPullRequest: boolean;
 };
 
 type AgentConfig = {
@@ -40,7 +39,6 @@ type AgentConfig = {
   org: string;
   language: string;
   platform: { type: string };
-  requiresPullRequest: boolean;
   templateVersion: string;
   sandbox: Record<string, unknown>;
   task: { shortIdLength: number };
@@ -224,13 +222,6 @@ async function cmdInit(): Promise<void> {
     );
   }
 
-  const requiresPRChoice = await select(
-    'Require Pull Request flow?',
-    ['yes', 'no'],
-    'yes'
-  );
-  const requiresPullRequest = requiresPRChoice !== 'no';
-
   let enabledTUIs: string[];
   try {
     enabledTUIs = await multiSelect(
@@ -324,7 +315,6 @@ async function cmdInit(): Promise<void> {
     org: orgName,
     language,
     platform: { type: platformType },
-    requiresPullRequest,
     templateVersion: VERSION,
     sandbox: structuredClone(defaults.sandbox),
     task: structuredClone(defaults.task),

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -17,7 +17,8 @@ type UpdateConfig = {
   org: string;
   language: string;
   platform?: { type?: string };
-  requiresPullRequest?: boolean;
+  requiresPullRequest?: boolean;       // legacy field; read-only, migrated to prFlow then removed
+  prFlow?: 'required' | 'disabled';
   sandbox?: Record<string, unknown>;
   task?: { shortIdLength: number };
   labels?: Record<string, unknown>;
@@ -27,7 +28,6 @@ type UpdateConfig = {
 
 type Defaults = {
   platform: { type: string };
-  requiresPullRequest: boolean;
   sandbox: Record<string, unknown>;
   task: { shortIdLength: number };
   labels: Record<string, unknown>;
@@ -40,6 +40,25 @@ const defaults = JSON.parse(
 
 const CONFIG_DIR = '.agents';
 const CONFIG_PATH = path.join(CONFIG_DIR, '.airc.json');
+
+// One-time migration of the legacy project-level PR switch to the three-state
+// `prFlow` preference. `true` (the old default / "PR flow on") maps to the
+// strong constraint `required`; `false` maps to `disabled`. A missing or
+// already-migrated config is left untouched (idempotent). Returns the new
+// prFlow value when a migration happened, otherwise null.
+function migratePrFlow(config: UpdateConfig): 'required' | 'disabled' | null {
+  if (config.requiresPullRequest === true) {
+    delete config.requiresPullRequest;
+    config.prFlow = 'required';
+    return 'required';
+  }
+  if (config.requiresPullRequest === false) {
+    delete config.requiresPullRequest;
+    config.prFlow = 'disabled';
+    return 'disabled';
+  }
+  return null;
+}
 
 function isPathOwnedByOtherPlatform(relativePath: string, platformType: string): boolean {
   const top = String(relativePath || '').replace(/\\/g, '/').replace(/^\.\//, '').split('/')[0] ?? '';
@@ -195,7 +214,7 @@ async function cmdUpdate(): Promise<void> {
   const sandboxAdded = !config.sandbox;
   const taskAdded = !config.task;
   const labelsAdded = !config.labels;
-  const requiresPullRequestAdded = config.requiresPullRequest === undefined;
+  const prFlowMigrated = migratePrFlow(config);
   let configChanged = changed;
 
   if (platformAdded) {
@@ -218,8 +237,7 @@ async function cmdUpdate(): Promise<void> {
     configChanged = true;
   }
 
-  if (requiresPullRequestAdded) {
-    config.requiresPullRequest = defaults.requiresPullRequest;
+  if (prFlowMigrated) {
     configChanged = true;
   }
 
@@ -233,7 +251,7 @@ async function cmdUpdate(): Promise<void> {
       for (const entry of added.merged) {
         ok(`  merged: ${entry}`);
       }
-    } else if (platformAdded || sandboxAdded || taskAdded || labelsAdded || requiresPullRequestAdded) {
+    } else if (platformAdded || sandboxAdded || taskAdded || labelsAdded || prFlowMigrated) {
       if (platformAdded) {
         info(`Default platform config added to ${CONFIG_PATH}.`);
       }
@@ -246,8 +264,8 @@ async function cmdUpdate(): Promise<void> {
       if (labelsAdded) {
         info(`Default labels.in config added to ${CONFIG_PATH}.`);
       }
-      if (requiresPullRequestAdded) {
-        info(`Default requiresPullRequest=${defaults.requiresPullRequest} added to ${CONFIG_PATH}.`);
+      if (prFlowMigrated) {
+        info(`Migrated legacy requiresPullRequest to prFlow="${prFlowMigrated}" in ${CONFIG_PATH}.`);
       }
     } else {
       info(`File registry changed in ${CONFIG_PATH}.`);
@@ -264,8 +282,8 @@ async function cmdUpdate(): Promise<void> {
     if (hasNewEntries && platformAdded) {
       info(`Default platform config added to ${CONFIG_PATH}.`);
     }
-    if (hasNewEntries && requiresPullRequestAdded) {
-      info(`Default requiresPullRequest=${defaults.requiresPullRequest} added to ${CONFIG_PATH}.`);
+    if (hasNewEntries && prFlowMigrated) {
+      info(`Migrated legacy requiresPullRequest to prFlow="${prFlowMigrated}" in ${CONFIG_PATH}.`);
     }
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n', 'utf8');
     ok(`Updated ${CONFIG_PATH}`);

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -61,10 +61,9 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 > **IMPORTANT**: When showing the next step, output every TUI command format in full and directly use the standard template from `reference/task-status-update.md`. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name). Before rendering the "Next steps" commands, read `.agents/rules/next-step-output.md` and use its short-id snippet to render `{task-ref}` in the commands as the short id `#NN` (falling back to the full TASK-id when unallocated or released).
 
 Append the Commit Activity Log entry and choose exactly one next-step case:
-- final commit -> `complete-task {task-id}`
+- final commit -> render the next step by `.agents/.airc.json`'s `prFlow` (`disabled` -> single option `complete-task`; `required` -> single option `create-pr`; absent -> two options `create-pr` / `complete-task`); see Case 1 in `reference/task-status-update.md`
 - more work remains -> update task.md and stop
 - ready for review -> `review-code {task-id}`
-- ready for PR (only when the project enables the PR flow, i.e. `requiresPullRequest !== false`) -> `create-pr`
 
 ## 6. Sync Issue Metadata When Applicable
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -61,10 +61,9 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 > **重要**：向用户展示下一步时，必须完整输出所有 TUI 命令格式，并直接使用 `reference/task-status-update.md` 中对应场景的标准模板。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
 追加 Commit 的 Activity Log，并且只能选择一个下一步分支：
-- 最终提交 -> `complete-task {task-id}`
+- 最终提交 -> 按 `.agents/.airc.json` 的 `prFlow` 渲染下一步（`disabled` → 单选 `complete-task`；`required` → 单选 `create-pr`；缺省 → 二选一 `create-pr` / `complete-task`），详见 `reference/task-status-update.md` 场景 1
 - 还有后续工作 -> 更新 task.md 后停止
 - 准备审查 -> `review-code {task-id}`
-- 准备创建 PR（仅项目启用 PR 流程，即 `requiresPullRequest !== false`）-> `create-pr`
 
 ## 6. 同步 Issue 元数据（按需）
 

--- a/templates/.agents/skills/commit/reference/task-status-update.en.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.en.md
@@ -23,20 +23,19 @@ Before selecting the next step, verify:
 - whether the latest `review-code.md` / `review-code-r{N}.md` passed without findings
 - whether there are still pending fixes, review work, or PR creation steps
 
-**Gate read (project-level PR flow policy)**: Before running this step, read `.agents/.airc.json`'s `requiresPullRequest` field. Treat missing or `true` as "PR flow enabled" (default); treat explicit `false` as "PR flow disabled". All branches that depend on this field follow the same rule.
+**Gate read (project-level PR flow policy)**: Before running this step, read `.agents/.airc.json`'s `prFlow` field (three states: field absent = recommend PR by default, skipping allowed; `"required"` = PR mandatory; `"disabled"` = no PR flow). All branches that depend on this preference follow the same three states.
 
 Choose exactly one case:
 
 | Decision Basis | Required Case |
 |---|---|
-| all workflow steps completed + latest review approved with no findings + all tests passed | Case 1: final commit |
+| all workflow steps completed + latest review approved with no findings + all tests passed | Case 1: final commit (render next step by `prFlow`) |
 | unfinished steps, pending fixes, or waiting on others still exist | Case 2: more work remains |
 | this commit prepares the task for code review | Case 3: ready for review |
-| code is committed, review is done, **and the project enables the PR flow**, with PR creation as the next step | Case 4: ready for PR |
 
 Never apply more than one case. Match the single next-step branch first, then update the task.
 
-**Gate downgrade**: When `requiresPullRequest === false`, Case 4 must never be entered; commits that would otherwise fall into Case 4 collapse into Case 1 (final commit -> `/complete-task`).
+**Case 1 next-step rendering (evaluate the `prFlow` strong constraint first)**: the terminal "final commit" next step is rendered by `prFlow` -- `"disabled"` -> single option "complete directly" (`/complete-task`), never guide PR creation; `"required"` -> single option "go through the PR flow" (`/create-pr`); field absent -> two options (`/create-pr` or `/complete-task`). PR creation is carried by Case 1's "go through the PR flow" option; it is no longer a separate case.
 
 ### Case 1: Final Commit
 
@@ -44,15 +43,40 @@ Prerequisites:
 - [ ] all code committed
 - [ ] all tests passed
 - [ ] code review approved
-- [ ] all workflow steps completed (for the `pr_tasks` list under each yaml `commit` step, count those items toward completion only when `requiresPullRequest !== false`)
+- [ ] all workflow steps completed (for the `pr_tasks` list under each yaml `commit` step, decide whether to count them by the "PR path" rule: `prFlow=required` always counts; `prFlow=disabled` never counts; when absent, exclude only if `pr_status=skipped`, otherwise count)
 
-Required next-step commands:
+Required next-step commands (rendered by `prFlow`):
+
+`prFlow="disabled"` -> single option "complete directly":
 
 ```text
 Next step - complete and archive the task:
   - Claude Code / OpenCode: /complete-task {task-ref}
   - Gemini CLI: /agent-infra:complete-task {task-ref}
   - Codex CLI: $complete-task {task-ref}
+```
+
+`prFlow="required"` -> single option "go through the PR flow":
+
+```text
+Next step - create Pull Request:
+  - Claude Code / OpenCode: /create-pr {task-ref}
+  - Gemini CLI: /agent-infra:create-pr {task-ref}
+  - Codex CLI: $create-pr {task-ref}
+```
+
+field absent -> two options:
+
+```text
+Next step - choose one:
+  - Go through the PR flow:
+    - Claude Code / OpenCode: /create-pr {task-ref}
+    - Gemini CLI: /agent-infra:create-pr {task-ref}
+    - Codex CLI: $create-pr {task-ref}
+  - Complete directly (no PR):
+    - Claude Code / OpenCode: /complete-task {task-ref}
+    - Gemini CLI: /agent-infra:complete-task {task-ref}
+    - Codex CLI: $complete-task {task-ref}
 ```
 
 ### Case 2: More Work Remains
@@ -80,20 +104,4 @@ Next step - code review:
   - Codex CLI: $review-code {task-ref}
 ```
 
-### Case 4: Ready for PR
-
-If the next step is Pull Request creation:
-- update `updated_at`
-- update `agent_infra_version` from `.agents/rules/version-stamp.md`
-- record the PR plan in `task.md`
-
-Required next-step commands:
-
-```text
-Next step - create Pull Request:
-  - Claude Code / OpenCode: /create-pr {task-ref}
-  - Gemini CLI: /agent-infra:create-pr {task-ref}
-  - Codex CLI: $create-pr {task-ref}
-```
-
-> Note: beyond the four cases, if `task.md` contains a valid `pr_number`, the commit skill must sync the PR summary via `reference/pr-summary-sync.md` before entering the verification gate.
+> Note: beyond the cases above, if `task.md` contains a valid `pr_number`, the commit skill must sync the PR summary via `reference/pr-summary-sync.md` before entering the verification gate.

--- a/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
@@ -23,20 +23,19 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 最新的 `review-code.md` / `review-code-r{N}.md` 是否无问题通过
 - 是否仍然存在待修复项、待审查工作或待创建 PR 的步骤
 
-**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。所有依赖该字段的分支按此规则判定。
+**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR）。所有依赖该偏好的分支按此三态判定。
 
 必须且只能选择一个分支：
 
 | 判断依据 | 必选分支 |
 |---|---|
-| 所有工作流步骤都已完成 + 最新审查无问题通过 + 所有测试通过 | 场景 1：最终提交 |
+| 所有工作流步骤都已完成 + 最新审查无问题通过 + 所有测试通过 | 场景 1：最终提交（按 `prFlow` 渲染下一步） |
 | 仍有未完成步骤、待修复项或等待他人的动作 | 场景 2：还有后续工作 |
 | 这次提交是为了把任务交给代码审查 | 场景 3：准备进入审查 |
-| 代码已提交、审查已完成，且**项目启用 PR 流程**，下一步是创建 PR | 场景 4：准备创建 PR |
 
 绝对不要同时套用多个分支。先匹配唯一的下一步分支，再更新任务。
 
-**门控降级**：当 `requiresPullRequest === false` 时，场景 4 永远不被进入；原本会落入场景 4 的提交统一收敛到场景 1（最终提交 → `/complete-task`）。
+**场景 1 下一步渲染（先判 `prFlow` 强约束）**：终态「最终提交」的下一步命令按 `prFlow` 渲染——`"disabled"` → 单选「直接完成」（`/complete-task`），永不引导创建 PR；`"required"` → 单选「走 PR 流程」（`/create-pr`）；字段缺省 → 二选一（`/create-pr` 或 `/complete-task`）。创建 PR 的动作统一由场景 1 的「走 PR 流程」选项承载，不再单列独立场景。
 
 ### 场景 1：最终提交
 
@@ -44,15 +43,40 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - [ ] 所有代码都已提交
 - [ ] 所有测试通过
 - [ ] 代码审查已通过
-- [ ] 所有工作流步骤已完成（对 yaml `commit` 步骤的 `pr_tasks` 列表，仅在 `requiresPullRequest !== false` 时计入）
+- [ ] 所有工作流步骤已完成（对 yaml `commit` 步骤的 `pr_tasks` 列表，按「走 PR 路径」判定是否计入：`prFlow=required` 始终计入；`prFlow=disabled` 不计入；缺省下仅当 `pr_status=skipped` 时不计入，否则计入）
 
-必带下一步命令：
+必带下一步命令（按 `prFlow` 渲染）：
+
+`prFlow="disabled"` → 单选「直接完成」：
 
 ```text
 下一步 - 完成并归档任务：
   - Claude Code / OpenCode: /complete-task {task-ref}
   - Gemini CLI: /agent-infra:complete-task {task-ref}
   - Codex CLI: $complete-task {task-ref}
+```
+
+`prFlow="required"` → 单选「走 PR 流程」：
+
+```text
+下一步 - 创建 Pull Request：
+  - Claude Code / OpenCode: /create-pr {task-ref}
+  - Gemini CLI: /agent-infra:create-pr {task-ref}
+  - Codex CLI: $create-pr {task-ref}
+```
+
+字段缺省 → 二选一：
+
+```text
+下一步 - 二选一：
+  - 走 PR 流程：
+    - Claude Code / OpenCode: /create-pr {task-ref}
+    - Gemini CLI: /agent-infra:create-pr {task-ref}
+    - Codex CLI: $create-pr {task-ref}
+  - 直接完成（无 PR）：
+    - Claude Code / OpenCode: /complete-task {task-ref}
+    - Gemini CLI: /agent-infra:complete-task {task-ref}
+    - Codex CLI: $complete-task {task-ref}
 ```
 
 ### 场景 2：还有后续工作
@@ -80,20 +104,4 @@ date "+%Y-%m-%d %H:%M:%S%:z"
   - Codex CLI: $review-code {task-ref}
 ```
 
-### 场景 4：准备创建 PR
-
-如果下一步是创建 Pull Request：
-- 更新 `updated_at`
-- 按 `.agents/rules/version-stamp.md` 更新 `agent_infra_version`
-- 在 `task.md` 中记录 PR 计划
-
-必带下一步命令：
-
-```text
-下一步 - 创建 Pull Request：
-  - Claude Code / OpenCode: /create-pr {task-ref}
-  - Gemini CLI: /agent-infra:create-pr {task-ref}
-  - Codex CLI: $create-pr {task-ref}
-```
-
-> 注意：四个场景之外，只要 `task.md` 中存在有效 `pr_number`，commit 技能必须先按 `reference/pr-summary-sync.md` 同步 PR 摘要，再进入完成校验。
+> 注意：上述场景之外，只要 `task.md` 中存在有效 `pr_number`，commit 技能必须先按 `reference/pr-summary-sync.md` 同步 PR 摘要，再进入完成校验。

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -44,10 +44,36 @@ If not found in `active/`, check `blocked/` and `completed/`:
 
 ### 2. Verify Completion Prerequisites (Failure Must Stop)
 
-**Gate read (project-level PR flow policy)**: Before running this step, read `.agents/.airc.json`'s `requiresPullRequest` field. Treat missing or `true` as "PR flow enabled" (default); treat explicit `false` as "PR flow disabled". The completion check below is pruned accordingly.
+**Gate read (project-level PR flow policy)**: Before running this step, read `.agents/.airc.json`'s `prFlow` field (three states: field absent = recommend PR by default, skipping allowed; `"required"` = PR mandatory; `"disabled"` = no PR flow), and `pr_status` from `task.md` frontmatter (`pending` / `created` / `skipped`).
+
+**PR dimension decision (evaluate the `prFlow` strong constraint FIRST, then `pr_status`)**:
+
+| `prFlow` | `pr_status` | Decision |
+|---|---|---|
+| `disabled` | any | No PR path -> PR dimension satisfied, continue with the other prerequisites |
+| `required` | `created` | PR dimension satisfied, continue |
+| `required` | `pending` / `skipped` | **Stop**: under a mandatory PR flow you must run `/create-pr` first; `--skip-pr` is NOT accepted (including a pre-existing / manually-set `skipped`) |
+| absent | `created` / `skipped` | PR dimension satisfied, continue |
+| absent | `pending` | **Stop by default** and print the two-option guidance below; unless the user passes `--skip-pr` (writes `pr_status: skipped`, then continues) or `--force` |
+
+- `--skip-pr` handling: effective only when `prFlow` is not `required` -> set `pr_status` to `skipped` in `task.md`, then continue; when `prFlow=required`, ignore `--skip-pr` and stop per the table.
+- Note: `--force` may override the other prerequisites below, but does **NOT** lift the `prFlow=required` PR constraint (the only exit from the strong constraint is creating a PR).
+
+Two-option guidance for absent + `pending`:
+```
+Task {task-id} has no PR yet (pr_status: pending). Choose one:
+  - Go through the PR flow: /create-pr {task-ref}
+  - Explicitly skip and complete: /complete-task {task-ref} --skip-pr
+```
+
+Stop message for `required` + `pending`/`skipped`:
+```
+This project enforces the PR flow (prFlow: "required") and the task has no PR yet.
+Run /create-pr {task-ref} first, then complete; --skip-pr is not accepted under a mandatory PR flow.
+```
 
 Before marking complete, verify ALL of these:
-- [ ] All workflow steps are complete (check workflow progress in task.md; **for the `pr_tasks` list under each yaml `commit` step, count those items toward the missing-work decision only when `.agents/.airc.json:requiresPullRequest !== false`**)
+- [ ] All workflow steps are complete (check workflow progress in task.md; **for the `pr_tasks` list under each yaml `commit` step, decide whether to count them by the "PR path" rule: `prFlow=required` always counts; `prFlow=disabled` never counts; when absent, exclude only if `pr_status=skipped`, otherwise count**)
 - [ ] Code has been reviewed (`review-code.md` or `review-code-r{N}.md` exists, and the latest review verdict is Approved; or review was done externally)
 - [ ] Code has been committed (no uncommitted changes related to this task)
 - [ ] Tests are passing

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -43,10 +43,36 @@ tail .agents/workspace/active/{task-id}/task.md
 
 ### 2. 验证完成前置条件（未满足则必须停止）
 
-**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。下面的工作流步骤完成判定按此规则裁剪。
+**门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR），以及 `task.md` frontmatter 的 `pr_status`（`pending` / `created` / `skipped`）。
+
+**PR 维度判定（先判 `prFlow` 强约束，后看 `pr_status`）**：
+
+| `prFlow` | `pr_status` | 判定 |
+|---|---|---|
+| `disabled` | 任意 | 无 PR 路径 → PR 维度满足，继续其余前置条件 |
+| `required` | `created` | PR 维度满足，继续 |
+| `required` | `pending` / `skipped` | **停止**：强制 PR 下必须先 `/create-pr`；`--skip-pr` 不被接受（含既有/手动写入的 `skipped`） |
+| 缺省 | `created` / `skipped` | PR 维度满足，继续 |
+| 缺省 | `pending` | **默认停止**并输出下方二选一引导；除非用户提供 `--skip-pr`（写 `pr_status: skipped` 后继续）或 `--force` |
+
+- `--skip-pr` 处理：仅在 `prFlow` 非 `required` 时生效——把 `task.md` 的 `pr_status` 写为 `skipped` 后继续；`prFlow=required` 时忽略 `--skip-pr` 并按上表停止。
+- 注：`--force` 可越过下方其余前置条件，但**不解除 `prFlow=required` 的 PR 强约束**（强约束的唯一出口是创建 PR）。
+
+缺省 + `pending` 的二选一引导消息：
+```
+任务 {task-id} 尚未创建 PR（pr_status: pending）。请二选一：
+  - 走 PR 流程：/create-pr {task-ref}
+  - 显式跳过并完成：/complete-task {task-ref} --skip-pr
+```
+
+`required` + `pending`/`skipped` 的停止消息：
+```
+当前项目强制 PR 流程（prFlow: "required"），任务尚未创建 PR。
+请先运行 /create-pr {task-ref} 创建 PR 后再完成；--skip-pr 在强制 PR 下不被接受。
+```
 
 标记完成之前，验证以下所有条件：
-- [ ] 所有工作流步骤已完成（检查 task.md 中的工作流进度；**对 yaml 中 commit 步骤的 `pr_tasks` 列表，仅在 `.agents/.airc.json:requiresPullRequest !== false` 时计入未完成判定**）
+- [ ] 所有工作流步骤已完成（检查 task.md 中的工作流进度；**对 yaml 中 commit 步骤的 `pr_tasks` 列表，按「走 PR 路径」判定是否计入未完成判定：`prFlow=required` 始终计入；`prFlow=disabled` 不计入；缺省下仅当 `pr_status=skipped` 时不计入，否则计入**）
 - [ ] 代码已审查（`review-code.md` 或 `review-code-r{N}.md` 存在，且最新审查结论为 Approved；或已在外部完成审查）
 - [ ] 代码已提交（没有与此任务相关的未提交变更）
 - [ ] 测试通过

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -19,14 +19,14 @@ Version stamp rule: when creating or updating `task.md` frontmatter, read `.agen
 
 ### Pre-gate: Project-level PR Flow Check
 
-**Gate read (project-level PR flow policy)**: Before running any numbered step, read `.agents/.airc.json`'s `requiresPullRequest` field. Treat missing or `true` as "PR flow enabled" (default); treat explicit `false` as "PR flow disabled".
+**Gate read (project-level PR flow policy)**: Before running any numbered step, read `.agents/.airc.json`'s `prFlow` field (three states: field absent = recommend PR by default, skipping allowed; `"required"` = PR mandatory; `"disabled"` = no PR flow).
 
 Branch on the result:
-- missing / `true` -> continue to Step 1 below
-- explicit `false` -> output the message below and **stop immediately**. Do not run any subsequent numbered step, do not trigger any PR-creation command, do not modify `pr_number` in `task.md`, and do not publish a PR summary comment:
+- absent / `"required"` -> continue to Step 1 below
+- `"disabled"` -> output the message below and **stop immediately**. Do not run any subsequent numbered step, do not trigger any PR-creation command, do not modify `pr_number` / `pr_status` in `task.md`, and do not publish a PR summary comment:
 
 ```
-This project does not enable the PR flow (`.agents/.airc.json` sets `requiresPullRequest: false`).
+This project does not enable the PR flow (`.agents/.airc.json` sets `prFlow: "disabled"`).
 No Pull Request is required; run instead:
   - Claude Code / OpenCode: /complete-task {task-ref}
   - Gemini CLI: /agent-infra:complete-task {task-ref}
@@ -96,7 +96,7 @@ Get the current time:
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-If `{task-id}` is available, update task.md with `pr_number`, `updated_at`, `agent_infra_version`, and append the Create PR Activity Log entry including metadata-sync and summary results.
+If `{task-id}` is available, update task.md with `pr_number`, `pr_status` (set to `created`), `updated_at`, `agent_infra_version`, and append the Create PR Activity Log entry including metadata-sync and summary results.
 
 ### 9. Verification Gate
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -19,14 +19,14 @@ description: "创建 Pull Request 到目标分支"
 
 ### 前置门控：项目级 PR 流程检查
 
-**门控读取（项目级 PR 流程策略）**：在执行编号步骤前，读取 `.agents/.airc.json` 的 `requiresPullRequest` 字段；当字段缺失或为 `true` 时视为「启用 PR 流程」（默认），仅当显式为 `false` 时视为「关闭 PR 流程」。
+**门控读取（项目级 PR 流程策略）**：在执行编号步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR）。
 
 按读取结果分支：
-- 缺失 / `true` → 继续到下方第 1 步
-- 显式 `false` → 输出以下消息后**立即停止**，不要执行任何后续编号步骤、不要触发任何 PR 创建命令、不要修改 `task.md` 的 `pr_number`、不要发布 PR 摘要评论：
+- 缺省 / `"required"` → 继续到下方第 1 步
+- `"disabled"` → 输出以下消息后**立即停止**，不要执行任何后续编号步骤、不要触发任何 PR 创建命令、不要修改 `task.md` 的 `pr_number` / `pr_status`、不要发布 PR 摘要评论：
 
 ```
-当前项目未启用 PR 流程（`.agents/.airc.json` 中 `requiresPullRequest: false`）。
+当前项目未启用 PR 流程（`.agents/.airc.json` 中 `prFlow: "disabled"`）。
 无需创建 Pull Request，请直接运行：
   - Claude Code / OpenCode：/complete-task {task-ref}
   - Gemini CLI：/agent-infra:complete-task {task-ref}
@@ -96,7 +96,7 @@ description: "创建 Pull Request 到目标分支"
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
+如果获取到了 `{task-id}`，更新 task.md 的 `pr_number`、`pr_status`（设为 `created`）、`updated_at`、`agent_infra_version`，并追加 Create PR 的 Activity Log，记录元数据同步和摘要发布结果。
 
 ### 9. 完成校验
 

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -23,7 +23,6 @@ const DEFAULTS = {
   "platform": {
     "type": "github"
   },
-  "requiresPullRequest": true,
   "sandbox": {
     "engine": null,
     "runtimes": [

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -13,6 +13,7 @@ start_date:                     # Optional Issue field for Feature: YYYY-MM-DD
 target_date:                    # Optional Issue field for Feature: YYYY-MM-DD
 current_step: requirement-analysis # requirement-analysis | requirement-analysis-review | technical-design | technical-design-review | code | code-review | completed
 assigned_to:                   # claude | codex | gemini | opencode | human
+pr_status: pending             # PR status: pending (default) | created (PR created) | skipped (explicitly skipped)
 ---
 
 # Task: [Title]

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -13,6 +13,7 @@ start_date:                     # Feature 可选 Issue 字段：YYYY-MM-DD
 target_date:                    # Feature 可选 Issue 字段：YYYY-MM-DD
 current_step: requirement-analysis # requirement-analysis | requirement-analysis-review | technical-design | technical-design-review | code | code-review | completed
 assigned_to:                   # claude | codex | gemini | opencode | human
+pr_status: pending             # PR 状态：pending（默认）| created（已创建 PR）| skipped（显式跳过）
 ---
 
 # 任务：[标题]

--- a/templates/.agents/workflows/bug-fix.en.yaml
+++ b/templates/.agents/workflows/bug-fix.en.yaml
@@ -1,8 +1,10 @@
 # Bug-fix workflow
 # Use this workflow when fixing a defect.
 #
-# Note: a step's `pr_tasks` list is counted toward workflow progress only when
-# `.agents/.airc.json:requiresPullRequest !== false` (see .agents/skills/complete-task/SKILL.md).
+# Note: whether a step's `pr_tasks` list counts toward workflow progress follows the "PR path" rule:
+# `.agents/.airc.json:prFlow="required"` always counts; `prFlow="disabled"` never counts;
+# when the field is absent, exclude only if task.md's `pr_status=skipped`, otherwise count
+# (see .agents/skills/complete-task/SKILL.md).
 
 name: bug-fix
 description: Workflow for diagnosing and fixing a defect.
@@ -176,7 +178,7 @@ steps:
       - Findings list, if any
 
   - name: commit
-    description: Finalize the defect fix and create a pull request (the PR portion runs only when the project enables the PR flow).
+    description: Finalize the defect fix and create a pull request (the PR portion runs only on the PR path).
     recommended_agents:
       - claude
       - human
@@ -192,4 +194,4 @@ steps:
       - Task workspace
     outputs:
       - Completed task workspace under .agents/workspace/completed/
-      - Pull request (only when the project enables the PR flow)
+      - Pull request (only on the PR path)

--- a/templates/.agents/workflows/bug-fix.zh-CN.yaml
+++ b/templates/.agents/workflows/bug-fix.zh-CN.yaml
@@ -1,8 +1,9 @@
 # 缺陷修复工作流
 # 修复缺陷时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: bug-fix
 description: 诊断和修复缺陷的工作流。
@@ -176,7 +177,7 @@ steps:
       - 问题列表（如有）
 
   - name: commit
-    description: 最终确认缺陷修复并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认缺陷修复并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -192,4 +193,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/templates/.agents/workflows/feature-development.en.yaml
+++ b/templates/.agents/workflows/feature-development.en.yaml
@@ -1,8 +1,10 @@
 # Feature development workflow
 # Use this workflow when implementing a new feature.
 #
-# Note: a step's `pr_tasks` list is counted toward workflow progress only when
-# `.agents/.airc.json:requiresPullRequest !== false` (see .agents/skills/complete-task/SKILL.md).
+# Note: whether a step's `pr_tasks` list counts toward workflow progress follows the "PR path" rule:
+# `.agents/.airc.json:prFlow="required"` always counts; `prFlow="disabled"` never counts;
+# when the field is absent, exclude only if task.md's `pr_status=skipped`, otherwise count
+# (see .agents/skills/complete-task/SKILL.md).
 
 name: feature-development
 description: End-to-end workflow for developing a new feature.
@@ -176,7 +178,7 @@ steps:
       - Findings to fix
 
   - name: commit
-    description: Finalize changes and create a pull request (the PR portion runs only when the project enables the PR flow).
+    description: Finalize changes and create a pull request (the PR portion runs only on the PR path).
     recommended_agents:
       - claude
       - human
@@ -192,4 +194,4 @@ steps:
       - Task workspace
     outputs:
       - Completed task workspace under .agents/workspace/completed/
-      - Pull request (only when the project enables the PR flow)
+      - Pull request (only on the PR path)

--- a/templates/.agents/workflows/feature-development.zh-CN.yaml
+++ b/templates/.agents/workflows/feature-development.zh-CN.yaml
@@ -1,8 +1,9 @@
 # 功能开发工作流
 # 实现新功能时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: feature-development
 description: 开发新功能的端到端工作流。
@@ -176,7 +177,7 @@ steps:
       - 待修复问题列表
 
   - name: commit
-    description: 最终确认变更并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认变更并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -192,4 +193,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/templates/.agents/workflows/refactoring.en.yaml
+++ b/templates/.agents/workflows/refactoring.en.yaml
@@ -1,8 +1,10 @@
 # Refactoring workflow
 # Use this workflow for code refactoring tasks.
 #
-# Note: a step's `pr_tasks` list is counted toward workflow progress only when
-# `.agents/.airc.json:requiresPullRequest !== false` (see .agents/skills/complete-task/SKILL.md).
+# Note: whether a step's `pr_tasks` list counts toward workflow progress follows the "PR path" rule:
+# `.agents/.airc.json:prFlow="required"` always counts; `prFlow="disabled"` never counts;
+# when the field is absent, exclude only if task.md's `pr_status=skipped`, otherwise count
+# (see .agents/skills/complete-task/SKILL.md).
 
 name: refactoring
 description: Safe and structured workflow for code refactoring.
@@ -180,7 +182,7 @@ steps:
       - Findings list, if any
 
   - name: commit
-    description: Finalize the refactoring and create a pull request (the PR portion runs only when the project enables the PR flow).
+    description: Finalize the refactoring and create a pull request (the PR portion runs only on the PR path).
     recommended_agents:
       - claude
       - human
@@ -196,4 +198,4 @@ steps:
       - Task workspace
     outputs:
       - Completed task workspace under .agents/workspace/completed/
-      - Pull request (only when the project enables the PR flow)
+      - Pull request (only on the PR path)

--- a/templates/.agents/workflows/refactoring.zh-CN.yaml
+++ b/templates/.agents/workflows/refactoring.zh-CN.yaml
@@ -1,8 +1,9 @@
 # 重构工作流
 # 代码重构任务时使用此工作流。
 #
-# 注：步骤中的 `pr_tasks` 列表仅在 `.agents/.airc.json:requiresPullRequest !== false` 时
-# 被计入工作流进度判定（详见 .agents/skills/complete-task/SKILL.md）。
+# 注：步骤中的 `pr_tasks` 列表按「走 PR 路径」判定是否计入工作流进度：
+# `.agents/.airc.json:prFlow="required"` 始终计入；`prFlow="disabled"` 不计入；
+# 字段缺省时仅当 task.md 的 `pr_status=skipped` 排除，否则计入（详见 .agents/skills/complete-task/SKILL.md）。
 
 name: refactoring
 description: 安全且结构化的代码重构工作流。
@@ -180,7 +181,7 @@ steps:
       - 问题列表（如有）
 
   - name: commit
-    description: 最终确认重构并创建拉取请求（PR 部分仅在项目启用 PR 流程时执行）。
+    description: 最终确认重构并创建拉取请求（PR 部分仅在走 PR 路径时执行）。
     recommended_agents:
       - claude
       - human
@@ -196,4 +197,4 @@ steps:
       - 任务文件
     outputs:
       - 已完成的任务文件（位于 .agents/workspace/completed/）
-      - 拉取请求（仅项目启用 PR 流程时）
+      - 拉取请求（仅走 PR 路径时）

--- a/tests/integration/cli/cli-requires-pr.test.ts
+++ b/tests/integration/cli/cli-requires-pr.test.ts
@@ -43,39 +43,70 @@ function readUpdatedConfig(tmpDir: string): Record<string, unknown> {
   );
 }
 
-test("agent-infra update backfills missing requiresPullRequest to true", () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-requires-pr-missing-"));
+function runUpdate(tmpDir: string): Record<string, unknown> {
+  execFileSync(process.execPath, cliArgs("update"), {
+    cwd: tmpDir,
+    stdio: "pipe",
+    encoding: "utf8"
+  });
+  return readUpdatedConfig(tmpDir);
+}
+
+test("agent-infra update migrates legacy requiresPullRequest=true to prFlow=required", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-prflow-true-"));
   try {
-    makeStubProject(tmpDir, {});
+    makeStubProject(tmpDir, { requiresPullRequest: true });
 
-    execFileSync(process.execPath, cliArgs("update"), {
-      cwd: tmpDir,
-      stdio: "pipe",
-      encoding: "utf8"
-    });
-
-    const updated = readUpdatedConfig(tmpDir);
-    assert.equal(updated.requiresPullRequest, true,
-      "missing requiresPullRequest field should be backfilled to true");
+    const updated = runUpdate(tmpDir);
+    assert.equal(updated.prFlow, "required",
+      "legacy requiresPullRequest=true should map to prFlow=required");
+    assert.ok(!("requiresPullRequest" in updated),
+      "legacy requiresPullRequest key should be removed after migration");
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
-test("agent-infra update preserves an explicit requiresPullRequest=false", () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-requires-pr-false-"));
+test("agent-infra update migrates legacy requiresPullRequest=false to prFlow=disabled", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-prflow-false-"));
   try {
     makeStubProject(tmpDir, { requiresPullRequest: false });
 
-    execFileSync(process.execPath, cliArgs("update"), {
-      cwd: tmpDir,
-      stdio: "pipe",
-      encoding: "utf8"
-    });
+    const updated = runUpdate(tmpDir);
+    assert.equal(updated.prFlow, "disabled",
+      "legacy requiresPullRequest=false should map to prFlow=disabled (no-PR preserved)");
+    assert.ok(!("requiresPullRequest" in updated),
+      "legacy requiresPullRequest key should be removed after migration");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
 
-    const updated = readUpdatedConfig(tmpDir);
-    assert.equal(updated.requiresPullRequest, false,
-      "explicit requiresPullRequest=false should be preserved as-is");
+test("agent-infra update leaves a config without the legacy field untouched (no prFlow added)", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-prflow-missing-"));
+  try {
+    makeStubProject(tmpDir, {});
+
+    const updated = runUpdate(tmpDir);
+    assert.ok(!("requiresPullRequest" in updated),
+      "no legacy field should be introduced");
+    assert.ok(!("prFlow" in updated),
+      "missing field means default (recommend PR); update must not add prFlow");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("agent-infra update is idempotent for an already-migrated prFlow config", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-prflow-idempotent-"));
+  try {
+    makeStubProject(tmpDir, { prFlow: "required" });
+
+    const updated = runUpdate(tmpDir);
+    assert.equal(updated.prFlow, "required",
+      "already-migrated prFlow should be preserved as-is");
+    assert.ok(!("requiresPullRequest" in updated),
+      "no legacy field should be reintroduced");
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -301,7 +301,7 @@ test("agent-infra init records an optional external template source for any plat
   try {
     execFileSync(process.execPath, cliArgs("init"), {
       cwd: tmpDir,
-      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n\n~/private-templates\n\n`,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n~/private-templates\n\n`,
       stdio: "pipe"
     });
 
@@ -310,7 +310,6 @@ test("agent-infra init records an optional external template source for any plat
     );
 
     assert.deepEqual(config.platform, { type: "github" });
-    assert.equal(config.requiresPullRequest, true);
     assert.deepEqual(config.templates, {
       sources: [{ type: "local", path: "~/private-templates" }]
     });
@@ -350,7 +349,7 @@ test("agent-infra init records optional external skill sources", () => {
   try {
     execFileSync(process.execPath, cliArgs("init"), {
       cwd: tmpDir,
-      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n\n\n~/private-skills, ~/team-skills\n`,
+      input: `testproj\ntestorg\n\n${ENGINE_NL}github\n\n\n~/private-skills, ~/team-skills\n`,
       stdio: "pipe"
     });
 

--- a/tests/integration/cli/init-tuis.test.ts
+++ b/tests/integration/cli/init-tuis.test.ts
@@ -20,16 +20,14 @@ const ENGINE_NL = PLATFORM_DEFAULT_ENGINES[os.platform()] ? "\n" : "";
 //   3. language
 //   4. sandbox engine (only when engineChoices.length > 0; otherwise no prompt)
 //   5. platform
-//   6. requires PR
-//   7. built-in TUI multi-select       <-- new step
-//   8. template sources
-//   9. skill sources
+//   6. built-in TUI multi-select
+//   7. template sources
+//   8. skill sources
 function makeInput(parts: {
   project?: string;
   org?: string;
   language?: string;
   platform?: string;
-  requiresPR?: string;
   tuis: string;
   templateSources?: string;
   skillSources?: string;
@@ -40,7 +38,6 @@ function makeInput(parts: {
     parts.language ?? "",          // default zh-CN
     ENGINE_NL.replace(/\n$/, ""),  // engine default (bare enter when applicable)
     parts.platform ?? "github",
-    parts.requiresPR ?? "",        // default yes
     parts.tuis,
     parts.templateSources ?? "",
     parts.skillSources ?? ""

--- a/tests/unit/core/airc.test.ts
+++ b/tests/unit/core/airc.test.ts
@@ -38,14 +38,8 @@ test(".agents/.airc.json declares github as the default platform", () => {
   assert.deepEqual(collaborator.platform, { type: "github" });
 });
 
-test(".agents/.airc.json declares requiresPullRequest=true for this project", () => {
-  assert.equal(collaborator.requiresPullRequest, true);
-});
-
-const libDefaults = JSON.parse(read("lib/defaults.json"));
-
-test("lib/defaults.json defaults requiresPullRequest to true", () => {
-  assert.equal(libDefaults.requiresPullRequest, true);
+test(".agents/.airc.json declares prFlow=required for this project", () => {
+  assert.equal(collaborator.prFlow, "required");
 });
 
 const mergedPresent = [

--- a/tests/unit/core/pr-status-contract.test.ts
+++ b/tests/unit/core/pr-status-contract.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { read } from "../../helpers.ts";
+
+// Task templates must carry the pr_status field with the `pending` default so
+// new tasks start on the soft-gated path.
+const taskTemplates = [
+  ".agents/templates/task.md",
+  "templates/.agents/templates/task.en.md",
+  "templates/.agents/templates/task.zh-CN.md"
+];
+
+for (const templatePath of taskTemplates) {
+  test(`${templatePath} declares pr_status: pending default`, () => {
+    assert.match(read(templatePath), /^pr_status: pending/m);
+  });
+}
+
+// Extract markdown table rows (lines that start with `|`) as cell arrays.
+// cells[0] is the empty leading segment; cells[1..] are the real columns.
+function tableRows(content: string): string[][] {
+  return content
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("|"))
+    .map((line) => line.split("|").map((cell) => cell.trim()));
+}
+
+// Locate the complete-task PR-dimension decision row for prFlow=required with
+// pr_status in {pending, skipped} and return its decision cell.
+function requiredSkippedDecisionCell(content: string): string | null {
+  for (const cells of tableRows(content)) {
+    if (cells.length < 4) continue;
+    const prFlow = cells[1];
+    const prStatus = cells[2];
+    if (/required/.test(prFlow) && /pending/.test(prStatus) && /skipped/.test(prStatus)) {
+      return cells[3];
+    }
+  }
+  return null;
+}
+
+// Regression guard (blocker from review-plan round 1, hardened per review-code
+// round 1): the prFlow=required strong constraint must NOT be bypassable by a
+// pre-existing / manually-set pr_status=skipped. We assert the STRUCTURE of the
+// decision row, not mere keyword co-occurrence: the required + pending/skipped
+// row must STOP, point to /create-pr, and refuse --skip-pr.
+const completeTaskDocs: Array<{ path: string; stop: RegExp; refuse: RegExp }> = [
+  { path: ".agents/skills/complete-task/SKILL.md", stop: /停止/, refuse: /不被接受/ },
+  { path: "templates/.agents/skills/complete-task/SKILL.zh-CN.md", stop: /停止/, refuse: /不被接受/ },
+  { path: "templates/.agents/skills/complete-task/SKILL.en.md", stop: /stop/i, refuse: /not accepted/i }
+];
+
+for (const { path, stop, refuse } of completeTaskDocs) {
+  test(`${path} required + pending/skipped decision stops and refuses --skip-pr`, () => {
+    const cell = requiredSkippedDecisionCell(read(path));
+    assert.ok(cell, "expected a prFlow=required + pending/skipped decision row");
+    assert.match(cell as string, stop, "required + skipped must STOP (no bypass)");
+    assert.match(cell as string, /\/create-pr/, "must direct the user to /create-pr");
+    assert.match(cell as string, /--skip-pr/, "must mention --skip-pr in the decision");
+    assert.match(cell as string, refuse, "--skip-pr must be refused under required");
+  });
+}
+
+// Regression guard (major from review-plan round 1, hardened per review-code
+// round 1): under prFlow=required the workflow pr_tasks ALWAYS counts, and the
+// pr_status=skipped exclusion is scoped to the DEFAULT (field-absent) case only
+// — i.e. the two are distinct branches, so `skipped` can never drop pr_tasks
+// under `required`. We assert that structural relationship, not co-occurrence.
+const workflowDocs = [
+  ".agents/workflows/feature-development.yaml",
+  ".agents/workflows/bug-fix.yaml",
+  ".agents/workflows/refactoring.yaml",
+  "templates/.agents/workflows/feature-development.en.yaml",
+  "templates/.agents/workflows/bug-fix.en.yaml",
+  "templates/.agents/workflows/refactoring.en.yaml",
+  "templates/.agents/workflows/feature-development.zh-CN.yaml",
+  "templates/.agents/workflows/bug-fix.zh-CN.yaml",
+  "templates/.agents/workflows/refactoring.zh-CN.yaml"
+];
+
+// The leading comment block (lines starting with `#`) carries the gate rule.
+function leadingComment(content: string): string {
+  const lines: string[] = [];
+  for (const line of content.split("\n")) {
+    if (line.startsWith("#")) lines.push(line.replace(/^#\s?/, ""));
+    else if (lines.length > 0) break;
+  }
+  return lines.join("\n");
+}
+
+for (const workflowPath of workflowDocs) {
+  test(`${workflowPath} pr_tasks rule: required always counts, skipped excludes only when default`, () => {
+    const comment = leadingComment(read(workflowPath));
+    // `required` is bound to "always counts" on the same clause.
+    assert.match(
+      comment,
+      /required[^\n]*?(始终计入|always counts)/i,
+      "prFlow=required must always count pr_tasks"
+    );
+    // The skipped exclusion is scoped to the field-absent / default case, so it
+    // cannot apply to `required`.
+    assert.match(
+      comment,
+      /(字段缺省|field is absent)[\s\S]{0,120}skipped/i,
+      "pr_status=skipped exclusion must be scoped to the field-absent case"
+    );
+  });
+}

--- a/tests/unit/core/requires-pr-gating.test.ts
+++ b/tests/unit/core/requires-pr-gating.test.ts
@@ -101,7 +101,8 @@ for (const workflowPath of workflowPaths) {
     });
   }
 
-  test(`${workflowPath} references requiresPullRequest gating`, () => {
-    assert.match(yamlText, /requiresPullRequest/);
+  test(`${workflowPath} references prFlow / pr_status gating`, () => {
+    assert.match(yamlText, /prFlow/);
+    assert.match(yamlText, /pr_status/);
   });
 }

--- a/tests/unit/core/requires-pr-skill-gating.test.ts
+++ b/tests/unit/core/requires-pr-skill-gating.test.ts
@@ -19,9 +19,9 @@ const skillsWithGating = [
 ];
 
 for (const skillPath of skillsWithGating) {
-  test(`${skillPath} references requiresPullRequest gating`, () => {
+  test(`${skillPath} references prFlow gating`, () => {
     const content = read(skillPath);
-    assert.match(content, /requiresPullRequest/);
+    assert.match(content, /prFlow/);
   });
 }
 
@@ -32,17 +32,17 @@ const createPrPaths: Array<{ path: string; stopMarker: string }> = [
 ];
 
 for (const { path, stopMarker } of createPrPaths) {
-  test(`${path} describes refusal path when requiresPullRequest is false`, () => {
+  test(`${path} describes refusal path when prFlow is disabled`, () => {
     const content = read(path);
-    const gateIndex = content.indexOf("requiresPullRequest");
-    assert.ok(gateIndex >= 0, "requiresPullRequest mention required");
+    const gateIndex = content.indexOf("prFlow");
+    assert.ok(gateIndex >= 0, "prFlow mention required");
 
-    const falseIndex = content.indexOf("false", gateIndex);
+    const disabledIndex = content.indexOf("disabled", gateIndex);
     const stopIndex = content.indexOf(stopMarker, gateIndex);
 
-    assert.ok(falseIndex >= 0 && falseIndex - gateIndex < 800,
-      "expected `false` to appear near the requiresPullRequest mention");
+    assert.ok(disabledIndex >= 0 && disabledIndex - gateIndex < 800,
+      "expected `disabled` to appear near the prFlow mention");
     assert.ok(stopIndex >= 0 && stopIndex - gateIndex < 800,
-      `expected refusal language (${stopMarker}) to appear near the requiresPullRequest mention`);
+      `expected refusal language (${stopMarker}) to appear near the prFlow mention`);
   });
 }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#436</mark> 👈👈

Closes #436

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)

## 📝 变更目的 / Purpose of the Change

把 `ai init` 时的「Require Pull Request flow?」（yes/no）这个项目级硬开关，重构为**任务级软选择 + 可选的项目级偏好**：

1. init 时强迫用户做不可预测的决策（刚 init 时无法判断后续是否要 PR），增加学习成本 —— 删除该提问。
2. 现状把「团队策略（是否走 PR）」和「单次任务执行（这次要不要 PR）」混在同一个全局开关上；常规走 PR 的项目偶尔做本地小实验时必须改 `.airc.json` 才能绕过。
3. 合理流程：commit 之后在「创建 PR」与「直接完成」之间二选一；`complete-task` 区分「显式跳过」与「忘了创建」，避免静默漏 PR。

## 📋 主要变更 / Brief Changelog

- **init**：删除 `Require Pull Request flow?` 提问；新项目 `.airc.json` 缺省不写 PR 字段（语义＝默认推荐 PR、允许跳过）。
- **项目级偏好**：用三态字符串枚举 `prFlow`（`"required"` / `"disabled"` / 缺省）替代布尔 `requiresPullRequest`；仅手动配置。
- **任务级状态**：`task.md` frontmatter 新增 `pr_status`（`pending` / `created` / `skipped`）。
- **统一门控矩阵（先判 `prFlow` 强约束，后看 `pr_status`）**：commit 最终提交按 `prFlow` 渲染单选/单选/二选一；create-pr 在 `disabled` 时拒绝、成功后写 `pr_status: created`；complete-task 在 `required` 下只有 `created` 满足、`pending`/`skipped` 停止要求 `/create-pr`，新增 `--skip-pr`，且 `required` 强约束不可被 `skipped` 或 `--force` 绕过。
- **workflow**：`pr_tasks` 从硬性未完成项降级为「走 PR 路径才计入」（`required` 始终计入；`disabled` 不计入；缺省下仅 `skipped` 排除）。
- **迁移**：`ai update` 一次性迁移存量配置 `requiresPullRequest: true → prFlow:"required"`、`false → "disabled"`，并删除旧键（幂等）。
- **双语镜像 + dogfood**：本地与 `templates/` 的 en/zh-CN 全部同步；本仓库 `.agents/.airc.json` 迁移为 `prFlow:"required"`；`assets/demo-init.tape` 移除 PR 提问录制片段。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `npm test`（全量 1031：1030 pass / 0 fail / 1 skipped）
3. `rg "requiresPullRequest|Require Pull Request" lib templates tests assets .agents -g '!**/workspace/**'` —— 仅剩 `lib/update.ts` 的迁移读旧键与迁移测试的预期引用

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

新增 `tests/unit/core/pr-status-contract.test.ts`：结构化解析 complete-task 决策表与 workflow gate 注释，护栏 `prFlow=required` 不可被 `pr_status=skipped` 绕过；`cli-requires-pr.test.ts` 重写为四态迁移用例。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（技能/工作流/模板双语镜像）/ I have updated the docs (bilingual skill/workflow/template mirrors)
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 存量兼容：`ai update` 自动迁移旧 `requiresPullRequest`，`false → disabled` 严格保留「无 PR」语义；缺省配置不被补写 `prFlow`。
- 未重新生成 `assets/demo-init.gif`（需 `vhs`，属发布前资产步骤）。

---

**审查者注意事项 / Reviewer Notes:**

- 重点：`prFlow=required` 的强约束不可被既有/手动 `pr_status=skipped` 或 `--force` 绕过（complete-task 矩阵 + workflow 计入规则 + 结构化回归测试）。
- 门控为文档驱动：12 个技能文件 + 9 个 workflow 文件的本地/en/zh-CN 三份口径需一致。

Generated with AI assistance
