### PR TITLE
fix(meta): 修复 auto-resume hook tmux 注入序列的两个 race

### DIFF
--- a/.agents/hooks/auto-resume.sh
+++ b/.agents/hooks/auto-resume.sh
@@ -80,8 +80,25 @@ until curl -s -o /dev/null --max-time 3 "$PROBE_URL"; do
 done
 log "probe ok after ${waited}s (error=$error)"
 
-# Inject: Escape first to leave any non-input TUI state, then the resume text.
-tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null
-tmux send-keys -t "$TMUX_PANE" "$RESUME_TEXT" Enter 2>/dev/null
-log "send-keys done (error=$error)"
+# Inject the resume message with a deliberately timing-insensitive sequence:
+#   1. Escape leaves any non-input TUI state.
+#   2. A 1s settle covers every known TUI escape timeout (vim 1000ms,
+#      xterm/readline 50ms) so the next bytes are delivered as fresh input
+#      instead of being folded into the escape sequence (the dropped-`U` race).
+#   3. The text travels through a NAMED paste buffer pasted with bracketed
+#      paste (-p): the TUI ingests it as a single paste rather than per-character
+#      keypresses, so no leading char is eaten and the body is not read as a
+#      submit. The named buffer (-b) guarantees we paste exactly this text, and
+#      -d deletes it afterward so the user's anonymous paste stack is untouched.
+#   4. Enter is a separate send-keys after the paste, so the submit signal is
+#      never merged into the pasted content (the must-press-Enter race).
+# Every step stays non-blocking (2>/dev/null, exit 0 below) and logs a WARN on
+# failure so the log can localize which tmux step broke.
+log "tmux inject start (error=$error)"
+tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null || log "WARN: tmux Escape failed (error=$error)"
+sleep 1
+tmux set-buffer -b auto-resume -- "$RESUME_TEXT" 2>/dev/null || log "WARN: tmux set-buffer failed (error=$error)"
+tmux paste-buffer -t "$TMUX_PANE" -b auto-resume -p -d 2>/dev/null || log "WARN: tmux paste-buffer failed (error=$error)"
+tmux send-keys -t "$TMUX_PANE" Enter 2>/dev/null || log "WARN: tmux Enter failed (error=$error)"
+log "tmux inject done (error=$error)"
 exit 0

--- a/templates/.agents/hooks/auto-resume.sh
+++ b/templates/.agents/hooks/auto-resume.sh
@@ -80,8 +80,25 @@ until curl -s -o /dev/null --max-time 3 "$PROBE_URL"; do
 done
 log "probe ok after ${waited}s (error=$error)"
 
-# Inject: Escape first to leave any non-input TUI state, then the resume text.
-tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null
-tmux send-keys -t "$TMUX_PANE" "$RESUME_TEXT" Enter 2>/dev/null
-log "send-keys done (error=$error)"
+# Inject the resume message with a deliberately timing-insensitive sequence:
+#   1. Escape leaves any non-input TUI state.
+#   2. A 1s settle covers every known TUI escape timeout (vim 1000ms,
+#      xterm/readline 50ms) so the next bytes are delivered as fresh input
+#      instead of being folded into the escape sequence (the dropped-`U` race).
+#   3. The text travels through a NAMED paste buffer pasted with bracketed
+#      paste (-p): the TUI ingests it as a single paste rather than per-character
+#      keypresses, so no leading char is eaten and the body is not read as a
+#      submit. The named buffer (-b) guarantees we paste exactly this text, and
+#      -d deletes it afterward so the user's anonymous paste stack is untouched.
+#   4. Enter is a separate send-keys after the paste, so the submit signal is
+#      never merged into the pasted content (the must-press-Enter race).
+# Every step stays non-blocking (2>/dev/null, exit 0 below) and logs a WARN on
+# failure so the log can localize which tmux step broke.
+log "tmux inject start (error=$error)"
+tmux send-keys -t "$TMUX_PANE" Escape 2>/dev/null || log "WARN: tmux Escape failed (error=$error)"
+sleep 1
+tmux set-buffer -b auto-resume -- "$RESUME_TEXT" 2>/dev/null || log "WARN: tmux set-buffer failed (error=$error)"
+tmux paste-buffer -t "$TMUX_PANE" -b auto-resume -p -d 2>/dev/null || log "WARN: tmux paste-buffer failed (error=$error)"
+tmux send-keys -t "$TMUX_PANE" Enter 2>/dev/null || log "WARN: tmux Enter failed (error=$error)"
+log "tmux inject done (error=$error)"
 exit 0

--- a/tests/unit/hooks/auto-resume.test.ts
+++ b/tests/unit/hooks/auto-resume.test.ts
@@ -26,15 +26,21 @@ interface Harness {
 
 // Build an isolated HOME plus a bin dir holding tmux/curl stubs. tmux records
 // every invocation so tests can assert injection happened (or did not). curl's
-// exit code simulates network reachability for the probe gate.
-function setup(curlExit: number): Harness {
+// exit code simulates network reachability for the probe gate. When
+// failTmuxSubcommand is set, the tmux stub exits non-zero for that subcommand
+// (e.g. "paste-buffer") so the WARN-on-failure path can be exercised; the
+// default empty value never matches a real subcommand, preserving prior behaviour.
+function setup(curlExit: number, failTmuxSubcommand = ""): Harness {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "auto-resume-"));
   const home = path.join(root, "home");
   const bin = path.join(root, "bin");
   fs.mkdirSync(home, { recursive: true });
   fs.mkdirSync(bin, { recursive: true });
   const tmuxCalls = path.join(root, "tmux-calls.txt");
-  writeStub(path.join(bin, "tmux"), `#!/bin/sh\nprintf '%s\\n' "$*" >> "${tmuxCalls}"\n`);
+  writeStub(
+    path.join(bin, "tmux"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${tmuxCalls}"\n[ "$1" = "${failTmuxSubcommand}" ] && exit 1\nexit 0\n`
+  );
   writeStub(path.join(bin, "curl"), `#!/bin/sh\nexit ${curlExit}\n`);
   return { home, bin, tmuxCalls, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
 }
@@ -137,11 +143,35 @@ test("happy path: whitelisted error with reachable network injects the resume te
     const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
     const result = run(h, env, { session_id: "s1", error: "unknown" });
     assert.equal(result.status, 0);
-    assert.match(readLog(h.home), /send-keys done \(error=unknown\)/, "should log a completed injection");
-    assert.equal(tmuxWasCalled(h), true, "should drive tmux send-keys");
+    const log = readLog(h.home);
+    assert.match(log, /tmux inject start \(error=unknown\)/, "should log the start of injection");
+    assert.match(log, /tmux inject done \(error=unknown\)/, "should log a completed injection");
+    assert.equal(tmuxWasCalled(h), true, "should drive tmux");
     const calls = fs.readFileSync(h.tmuxCalls, "utf8");
     assert.match(calls, /send-keys -t %9 Escape/, "should send Escape to the target pane first");
-    assert.match(calls, /Unexpected interruption\. Please continue the unfinished operation\./, "should inject the resume text");
+    assert.match(
+      calls,
+      /set-buffer -b auto-resume -- .*Unexpected interruption\. Please continue the unfinished operation\./,
+      "should stage the resume text in the named paste buffer"
+    );
+    assert.match(calls, /paste-buffer -t %9 -b auto-resume -p -d/, "should paste via bracketed paste from the named buffer");
+    assert.match(calls, /send-keys -t %9 Enter/, "should submit with a separate Enter after the paste");
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("a failing tmux step is logged as WARN and never blocks", POSIX, () => {
+  const h = setup(0, "paste-buffer"); // reachable network, but the paste step fails
+  try {
+    const env = { ...baseEnv(h.home), TMUX_PANE: "%9" };
+    const result = run(h, env, { session_id: "s1", error: "unknown" });
+    assert.equal(result.status, 0, "a failing tmux step must not break the non-blocking exit 0");
+    assert.match(
+      readLog(h.home),
+      /WARN: tmux paste-buffer failed \(error=unknown\)/,
+      "should log the failing tmux step as a WARN line"
+    );
   } finally {
     h.cleanup();
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #455 👈👈

Closes #455

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`auto-resume.sh`（StopFailure hook，PR #451 引入）通过 `tmux send-keys` 注入 resume 文本时存在两个同源 race：

1. **首字符被吞**：UI 显示 `nexpected interruption...`（缺首字母 `U`）。Escape 与文本两次 `send-keys` 零间隔，终端收到 `0x1B`(ESC) 后进入 ANSI escape 状态机，紧跟的 `U` 与 ESC 合成 `Meta-U` 被 TUI 当独立按键消费掉。
2. **Enter 不提交**：同一时序问题，Escape 后状态未稳定，文本尾部的 `Enter` 被当作「多行输入换行」而非「提交」，用户须手动回车。

本 PR 把注入序列重写为对时序不敏感的形态，从根本上断开这个耦合。

## 📋 主要变更 / Brief Changelog

- 注入段重写为五步时序不敏感序列：`Escape → sleep 1（兜底 escape timeout）→ set-buffer(-b auto-resume) → paste-buffer(-b auto-resume -p -d，bracketed paste) → 独立 Enter`；文本作为「粘贴块」整体注入、不再逐字符经 key-name 解析，Enter 在 paste 完成后单独发送。
- 具名 buffer `auto-resume` + `-d`：保证粘贴的就是本脚本写入的文本且用后即删，不污染用户匿名粘贴栈；新增 `tmux inject start` / `tmux inject done` 日志与 4 条 tmux 操作的 `WARN` 兜底，保持「失败不阻断、每路径 `exit 0`」语义。
- 模板镜像 `templates/.agents/hooks/auto-resume.sh` 逐字节同步（parity 测试强制）；更新 hook 单测：文本断言绑定到 `set-buffer` 行、新增 `paste-buffer -p -d` 与独立 `Enter` 断言，并通过给 `setup()` 增加可选 `failTmuxSubcommand` 参数新增 1 个 WARN 路径用例。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（全量回归）。
2. `node --experimental-strip-types --no-warnings --test tests/unit/hooks/auto-resume.test.ts`（hook 单测 6/6）。
3. `diff .agents/hooks/auto-resume.sh templates/.agents/hooks/auto-resume.sh`（parity，输出为空）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

> 说明：终端层的真实 race（首字符吞 / Enter 不提交）依赖具体 TUI + tmux 运行时，单测以「tmux 调用序列 + 日志」结构性断言代理覆盖，实机 TUI 验证属交付后人工确认（与 Issue「此 hook 不便用单测覆盖所有终端行为」一致）。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass (项目暂未配置 lint 工具)
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation (本变更无需文档更新)
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them (无破坏性变更)
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

注入成功路径每次新增约 1s（`sleep 1`），相对一次对话动辄 10min 量级可忽略，且仅在 recoverable API 错误的自动恢复路径触发。本机 tmux 3.6b 已验证 `set-buffer -b` / `paste-buffer -b -p -d` 选项可用。

---

Generated with AI assistance