### PR TITLE
feat(meta): 为 complete-task / cancel-task 补充可选沙箱清理提示

### DIFF
--- a/.agents/skills/cancel-task/SKILL.md
+++ b/.agents/skills/cancel-task/SKILL.md
@@ -120,6 +120,8 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「目标路径」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 completed/，从 `.agents/workspace/completed/{task-id}/task.md` 读取）。该块独立于「下一步」语义。
+
 输出格式：
 ```
 任务 {task-id} 已取消，任务目录已转移到 completed/。
@@ -127,6 +129,11 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
 取消原因：{reason}
 状态标签：{status-label 或 skipped}
 目标路径：.agents/workspace/completed/{task-id}/
+
+可选：清理本任务的沙箱
+（任务已归档，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 查看已转移任务：
   - Claude Code / OpenCode：/check-task {task-ref}

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -171,7 +171,9 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 > 仅在校验通过后执行本步骤。
 
-> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但仍统一打印该收尾行。
+> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但会在收尾行之前渲染一段**可选的沙箱清理提示**（见下方门控），且仍统一打印该收尾行。
+
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 completed/，从 `.agents/workspace/completed/{task-id}/task.md` 读取）。该块独立于「下一步」语义，不是工作流后继命令。
 
 输出格式：
 ```
@@ -184,6 +186,11 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
+
+可选：清理本任务的沙箱
+（任务已归档，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 Completed at: {completion-time}
 ```

--- a/templates/.agents/skills/cancel-task/SKILL.en.md
+++ b/templates/.agents/skills/cancel-task/SKILL.en.md
@@ -121,6 +121,8 @@ Keep the gate output in your reply as fresh evidence. Do not claim completion wi
 
 > **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name). Before rendering the "Next steps" commands, read `.agents/rules/next-step-output.md` and use its short-id snippet to render `{task-ref}` in the commands as the short id `#NN` (falling back to the full TASK-id when unallocated or released).
 
+> **Optional sandbox-cleanup hint (gated)**: Render the "Optional: clean up this task's sandbox" block — placed after "Target path" and before "Next step" in the output below — only when BOTH (1) `.agents/.airc.json` has a `sandbox` field and (2) task.md's `branch` field exists and is not `main` / `master`; otherwise omit the whole block. `{branch}` is the `branch` value from the task.md you already loaded (the task has moved to completed/, so read it from `.agents/workspace/completed/{task-id}/task.md`). This block is independent of "Next steps" semantics.
+
 Output format:
 ```
 Task {task-id} cancelled; task directory moved to completed/.
@@ -128,6 +130,11 @@ Task {task-id} cancelled; task directory moved to completed/.
 Cancellation reason: {reason}
 Status label: {status-label or skipped}
 Target path: .agents/workspace/completed/{task-id}/
+
+Optional: clean up this task's sandbox
+(The task is archived; the sandbox container and per-branch config directory are not reclaimed automatically. Run this if you no longer need them:)
+
+ai sandbox rm {branch}
 
 Next step - inspect the moved task:
   - Claude Code / OpenCode: /check-task {task-ref}

--- a/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/cancel-task/SKILL.zh-CN.md
@@ -120,6 +120,8 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「目标路径」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 completed/，从 `.agents/workspace/completed/{task-id}/task.md` 读取）。该块独立于「下一步」语义。
+
 输出格式：
 ```
 任务 {task-id} 已取消，任务目录已转移到 completed/。
@@ -127,6 +129,11 @@ node .agents/scripts/validate-artifact.js gate cancel-task .agents/workspace/com
 取消原因：{reason}
 状态标签：{status-label 或 skipped}
 目标路径：.agents/workspace/completed/{task-id}/
+
+可选：清理本任务的沙箱
+（任务已归档，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 查看已转移任务：
   - Claude Code / OpenCode：/check-task {task-ref}

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -172,7 +172,9 @@ Keep the gate output in your reply as fresh evidence. Do not claim completion wi
 
 > Execute this step only after the verification gate passes.
 
-> The completion timestamp line (the last line of the whole output) uses `date "+%Y-%m-%d %H:%M:%S"` (local timezone, no offset) and always sits at the very end of the output for at-a-glance scanning across windows. This skill renders no "Next steps" commands but still prints the line.
+> The completion timestamp line (the last line of the whole output) uses `date "+%Y-%m-%d %H:%M:%S"` (local timezone, no offset) and always sits at the very end of the output for at-a-glance scanning across windows. This skill renders no "Next steps" commands, but it does render an **optional sandbox-cleanup hint** before the timestamp line (see the gate below), and still prints the line.
+
+> **Optional sandbox-cleanup hint (gated)**: Render the "Optional: clean up this task's sandbox" block in the output below only when BOTH (1) `.agents/.airc.json` has a `sandbox` field and (2) task.md's `branch` field exists and is not `main` / `master`; otherwise omit the whole block. `{branch}` is the `branch` value from the task.md you already loaded (the task has moved to completed/, so read it from `.agents/workspace/completed/{task-id}/task.md`). This block is independent of "Next steps" semantics — it is not a workflow successor command.
 
 Output format:
 ```
@@ -185,6 +187,11 @@ Task info:
 
 Deliverables:
 - {List of key outputs: files modified, tests added, etc.}
+
+Optional: clean up this task's sandbox
+(The task is archived; the sandbox container and per-branch config directory are not reclaimed automatically. Run this if you no longer need them:)
+
+ai sandbox rm {branch}
 
 Completed at: {completion-time}
 ```

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -171,7 +171,9 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 > 仅在校验通过后执行本步骤。
 
-> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但仍统一打印该收尾行。
+> 完成时间收尾行（整段输出的最后一行）取值 `date "+%Y-%m-%d %H:%M:%S"`（本地时区、不带偏移），固定放在输出的绝对末尾，便于多窗口扫视。本 skill 不渲染「下一步」命令，但会在收尾行之前渲染一段**可选的沙箱清理提示**（见下方门控），且仍统一打印该收尾行。
+
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 completed/，从 `.agents/workspace/completed/{task-id}/task.md` 读取）。该块独立于「下一步」语义，不是工作流后继命令。
 
 输出格式：
 ```
@@ -184,6 +186,11 @@ node .agents/scripts/validate-artifact.js gate complete-task .agents/workspace/c
 
 交付物：
 - {关键产出列表：修改的文件、添加的测试等}
+
+可选：清理本任务的沙箱
+（任务已归档，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 Completed at: {completion-time}
 ```


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #457

Closes #457

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

`complete-task` / `cancel-task` 归档任务后，对启用了沙箱的项目（`.agents/.airc.json` 含 `sandbox`）不会自动回收沙箱容器与 per-branch 配置目录，但「告知用户」输出里没有任何清理提示，用户体感「断头」。本变更在两个 skill 的第 8 步「告知用户」输出中，新增一段**门控渲染、独立于「下一步」语义**的「可选：清理本任务的沙箱」提示（`ai sandbox rm {branch}`）。

## 📋 主要变更 / Brief Changelog

- 为 `complete-task` / `cancel-task` 第 8 步新增门控渲染的「可选清理沙箱」提示：仅当 `.airc.json` 存在 `sandbox` 字段且任务 `branch` 非默认分支（`main`/`master`）时渲染，否则整段省略。
- complete-task 锚点为「交付物」之后、`Completed at:` 之前并改写其元注释；cancel-task 锚点为「目标路径」之后、「下一步」之前，二者均与「下一步」语义分离。
- 同步源 `SKILL.md` 与双语模板镜像（`SKILL.en.md` / `SKILL.zh-CN.md`），共 6 个文件；不抽公共规则文件、不引入「分支是否已合并」门控、不在提示里写 `git branch -D`（`ai sandbox rm` 已有交互式询问）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1037 用例，1036 通过 / 0 失败 / 1 平台守卫跳过（含 `tests/unit/templates/skills.test.ts` 对两棵 skill 树的步骤连续编号、frontmatter、双语变体断言）。
2. `grep -cF 'ai sandbox rm {branch}'` 6 个目标文件各为 1。
3. `diff` 校验：complete-task 源 `SKILL.md` 与模板 `SKILL.zh-CN.md` 第 8 步逐字节一致；cancel-task 二者仅差既有 Gemini `/{{project}}:` 行。

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

> 纯文档/指令文本改动，遵循项目测试纪律（`.agents/rules/testing-discipline.md`）不为 hint 文案新增脆弱的关键词断言，以既有结构性测试 + 全量回归为准。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / There is a Github issue for the change
- [x] 你的 Pull Request 只解决一个 Issue / The PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body
- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经更新了相应的文档 / I have made corresponding documentation changes
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（提示按门控渲染，不影响未启用沙箱的项目）

---

Generated with AI assistance
