### PR TITLE
feat(cli): ai sandbox ls 无短号语义优化与剩余归档 skill 清理提示

### DIFF
--- a/.agents/skills/block-task/SKILL.md
+++ b/.agents/skills/block-task/SKILL.md
@@ -107,6 +107,8 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「归档路径」之后、「解除阻塞时执行」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 blocked/，从 `.agents/workspace/blocked/{task-id}/task.md` 读取）。该块独立于「下一步」语义。
+
 输出格式：
 ```
 任务 {task-id} 已标记为阻塞。
@@ -114,6 +116,11 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
 阻塞原因：{摘要}
 解除阻塞所需：{需要什么}
 归档路径：.agents/workspace/blocked/{task-id}/
+
+可选：清理本任务的沙箱
+（任务已阻塞并移到 blocked/，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 解除阻塞时执行：
   mv .agents/workspace/blocked/{task-id} .agents/workspace/active/{task-id}

--- a/.agents/skills/close-codescan/SKILL.md
+++ b/.agents/skills/close-codescan/SKILL.md
@@ -95,6 +95,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) 第 7 步按告警号定位到了关联任务、(3) 该关联任务 task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「注意：…」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取第 7 步定位到的关联任务 task.md 的 `branch` 值。该块独立于「下一步」语义。
+
 ```
 Code Scanning 告警 #{alert-number} 已关闭。
 
@@ -106,6 +108,11 @@ Code Scanning 告警 #{alert-number} 已关闭。
 查看：{html_url}
 
 注意：如有需要，可在 平台上重新打开。
+
+可选：清理本任务的沙箱
+（关联任务的沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-ref}

--- a/.agents/skills/close-dependabot/SKILL.md
+++ b/.agents/skills/close-dependabot/SKILL.md
@@ -103,6 +103,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) 第 7 步按告警号定位到了关联任务、(3) 该关联任务 task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「注意：…」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取第 7 步定位到的关联任务 task.md 的 `branch` 值。该块独立于「下一步」语义。
+
 ```
 安全告警 #{alert-number} 已关闭。
 
@@ -114,6 +116,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 查看：{alert-url}
 
 注意：如有需要，可在平台侧重新打开。
+
+可选：清理本任务的沙箱
+（关联任务的沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-ref}

--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -18,7 +18,9 @@ Lists all containers for the current project. The '#' column is a
 display-only row number; the 'SHORT' column shows the active task short
 id bound to each container's branch (via
 .agents/workspace/active/.short-ids.json), or '-' if no active task is
-bound. Pass the SHORT value to "ai sandbox exec" (e.g. 'ai sandbox exec 11').`;
+bound. Pass the SHORT value to "ai sandbox exec" (e.g. 'ai sandbox exec 11').
+A '-' means no active task is bound to that branch, so the sandbox is free
+to remove with "ai sandbox rm <branch>".`;
 
 const CONTAINER_TABLE_HEADERS = ['#', 'SHORT', 'NAMES', 'STATUS', 'BRANCH'] as const;
 
@@ -78,6 +80,11 @@ export function ls(args: string[] = []): void {
       process.stdout.write(`  ${line}\n`);
     }
     process.stdout.write(`  Total: ${ordered.length} containers\n`);
+    if (tableRows.some((r) => r.shortId === '-')) {
+      process.stdout.write(
+        `  SHORT '-' = no active task bound; that sandbox is free to remove with 'ai sandbox rm <branch>'.\n`
+      );
+    }
   }
 
   p.log.step('Worktrees');

--- a/lib/task/short-id.ts
+++ b/lib/task/short-id.ts
@@ -70,6 +70,16 @@ function loadShortIdByTaskId(repoRoot: string): Map<string, string> {
   return map;
 }
 
+/**
+ * Resolve a branch to its active-task short id (`#NN`), or `null` when no
+ * active task is bound to that branch.
+ *
+ * Two-state semantics: this only consults the active registry
+ * (`active/.short-ids.json`) plus each `active/{taskId}/task.md`. Tasks moved
+ * to completed/blocked/cancelled/archive have already released their short id,
+ * so their branches return `null` — in `ai sandbox ls` that surfaces as `-`,
+ * meaning the sandbox is free to remove.
+ */
 function lookupShortIdByBranch(
   branch: string,
   repoRoot: string,

--- a/templates/.agents/skills/block-task/SKILL.en.md
+++ b/templates/.agents/skills/block-task/SKILL.en.md
@@ -108,6 +108,8 @@ Keep the gate output in your reply as fresh evidence. Do not claim completion wi
 
 > **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name). Before rendering the "Next steps" commands, read `.agents/rules/next-step-output.md` and use its short-id snippet to render `{task-ref}` in the commands as the short id `#NN` (falling back to the full TASK-id when unallocated or released).
 
+> **Optional sandbox-cleanup hint (gated)**: Render the "Optional: clean up this task's sandbox" block — placed after "Archived to" and before "To unblock" in the output below — only when BOTH (1) `.agents/.airc.json` has a `sandbox` field and (2) task.md's `branch` field exists and is not `main` / `master`; otherwise omit the whole block. `{branch}` is the `branch` value from the task.md you already loaded (the task has moved to blocked/, so read it from `.agents/workspace/blocked/{task-id}/task.md`). This block is independent of "Next step" semantics.
+
 Output format:
 ```
 Task {task-id} marked as blocked.
@@ -115,6 +117,11 @@ Task {task-id} marked as blocked.
 Blocking reason: {summary}
 Required to unblock: {what's needed}
 Archived to: .agents/workspace/blocked/{task-id}/
+
+Optional: clean up this task's sandbox
+(The task is blocked and moved to blocked/; the sandbox container and per-branch config directory are not reclaimed automatically. Run this if you no longer need them:)
+
+ai sandbox rm {branch}
 
 To unblock when the issue is resolved:
   mv .agents/workspace/blocked/{task-id} .agents/workspace/active/{task-id}

--- a/templates/.agents/skills/block-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/block-task/SKILL.zh-CN.md
@@ -107,6 +107,8 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「归档路径」之后、「解除阻塞时执行」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取已读入的 task.md 的 `branch` 值（任务此时已移动到 blocked/，从 `.agents/workspace/blocked/{task-id}/task.md` 读取）。该块独立于「下一步」语义。
+
 输出格式：
 ```
 任务 {task-id} 已标记为阻塞。
@@ -114,6 +116,11 @@ node .agents/scripts/validate-artifact.js gate block-task .agents/workspace/bloc
 阻塞原因：{摘要}
 解除阻塞所需：{需要什么}
 归档路径：.agents/workspace/blocked/{task-id}/
+
+可选：清理本任务的沙箱
+（任务已阻塞并移到 blocked/，沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 解除阻塞时执行：
   mv .agents/workspace/blocked/{task-id} .agents/workspace/active/{task-id}

--- a/templates/.agents/skills/close-codescan/SKILL.en.md
+++ b/templates/.agents/skills/close-codescan/SKILL.en.md
@@ -95,6 +95,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name). Before rendering the "Next steps" commands, read `.agents/rules/next-step-output.md` and use its short-id snippet to render `{task-ref}` in the commands as the short id `#NN` (falling back to the full TASK-id when unallocated or released).
 
+> **Optional sandbox-cleanup hint (gated)**: Render the "Optional: clean up this task's sandbox" block — placed after the "Note:" line and before "Next step" in the output below — only when ALL of (1) `.agents/.airc.json` has a `sandbox` field, (2) step 7 located a related task by the alert number, and (3) that related task's task.md `branch` field exists and is not `main` / `master`; otherwise omit the whole block. `{branch}` is the `branch` value from the related task.md located in step 7. This block is independent of "Next step" semantics.
+
 ```
 Code Scanning alert #{alert-number} dismissed.
 
@@ -106,6 +108,11 @@ Explanation: {explanation}
 View: {html_url}
 
 Note: it can be reopened on the platform if necessary.
+
+Optional: clean up this task's sandbox
+(The related task's sandbox container and per-branch config directory are not reclaimed automatically. Run this if you no longer need them:)
+
+ai sandbox rm {branch}
 
 Next step - complete and archive the task if a related task exists:
   - Claude Code / OpenCode: /complete-task {task-ref}

--- a/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-codescan/SKILL.zh-CN.md
@@ -95,6 +95,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) 第 7 步按告警号定位到了关联任务、(3) 该关联任务 task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「注意：…」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取第 7 步定位到的关联任务 task.md 的 `branch` 值。该块独立于「下一步」语义。
+
 ```
 Code Scanning 告警 #{alert-number} 已关闭。
 
@@ -106,6 +108,11 @@ Code Scanning 告警 #{alert-number} 已关闭。
 查看：{html_url}
 
 注意：如有需要，可在 平台上重新打开。
+
+可选：清理本任务的沙箱
+（关联任务的沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-ref}

--- a/templates/.agents/skills/close-dependabot/SKILL.en.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.en.md
@@ -103,6 +103,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **IMPORTANT**: All TUI command formats listed below must be output in full. Do not show only the format for the current AI agent. If `.agents/.airc.json` configures custom TUIs (via `customTUIs`), read each tool's `name` and `invoke`, then add the matching command line in the same format (`${skillName}` becomes the skill name and `${projectName}` becomes the project name). Before rendering the "Next steps" commands, read `.agents/rules/next-step-output.md` and use its short-id snippet to render `{task-ref}` in the commands as the short id `#NN` (falling back to the full TASK-id when unallocated or released).
 
+> **Optional sandbox-cleanup hint (gated)**: Render the "Optional: clean up this task's sandbox" block — placed after the "Note:" line and before "Next step" in the output below — only when ALL of (1) `.agents/.airc.json` has a `sandbox` field, (2) step 7 located a related task by the alert number, and (3) that related task's task.md `branch` field exists and is not `main` / `master`; otherwise omit the whole block. `{branch}` is the `branch` value from the related task.md located in step 7. This block is independent of "Next step" semantics.
+
 ```
 Security alert #{alert-number} dismissed.
 
@@ -114,6 +116,11 @@ Explanation: {explanation}
 View: {alert-url}
 
 Note: it can be reopened on the platform if necessary.
+
+Optional: clean up this task's sandbox
+(The related task's sandbox container and per-branch config directory are not reclaimed automatically. Run this if you no longer need them:)
+
+ai sandbox rm {branch}
 
 Next step - complete and archive the task if a related task exists:
   - Claude Code / OpenCode: /complete-task {task-ref}

--- a/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
+++ b/templates/.agents/skills/close-dependabot/SKILL.zh-CN.md
@@ -103,6 +103,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 > **重要**：以下「下一步」中列出的所有 TUI 命令格式必须完整输出，不要只展示当前 AI 代理对应的格式。如果 `.agents/.airc.json` 中配置了自定义 TUI（`customTUIs`），读取每个工具的 `name` 和 `invoke`，按同样格式补充对应命令行（`${skillName}` 替换为技能名，`${projectName}` 替换为项目名）。 渲染「下一步」命令前，先读取 `.agents/rules/next-step-output.md`，按其取短号片段把命令中的 `{task-ref}` 渲染为短号 `#NN`（未分配/已释放时回退完整 TASK-id）。
 
+> **可选沙箱清理提示（门控渲染）**：仅当同时满足 (1) `.agents/.airc.json` 存在 `sandbox` 字段、(2) 第 7 步按告警号定位到了关联任务、(3) 该关联任务 task.md 的 `branch` 字段存在且不是 `main` / `master` 时，才渲染下方输出中「注意：…」之后、「下一步」之前的「可选：清理本任务的沙箱」块；任一不满足则整段省略。`{branch}` 取第 7 步定位到的关联任务 task.md 的 `branch` 值。该块独立于「下一步」语义。
+
 ```
 安全告警 #{alert-number} 已关闭。
 
@@ -114,6 +116,11 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 查看：{alert-url}
 
 注意：如有需要，可在平台侧重新打开。
+
+可选：清理本任务的沙箱
+（关联任务的沙箱容器和 per-branch 配置目录不会自动回收。如果不再需要可执行：）
+
+ai sandbox rm {branch}
 
 下一步 - 完成并归档任务（如有关联任务）：
   - Claude Code / OpenCode：/complete-task {task-ref}


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** <mark>#442</mark> 👈👈

Closes #442

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`ai sandbox ls` 用二态语义把容器分支映射到短号（`有短号 = active 任务绑定`；`没短号 = 沙箱可删除`），但此前 `-` 标记没有把「可删除」这层下游含义表达给用户；同时 #10（PR #459）只给 `complete-task` / `cancel-task` 补了沙箱清理提示，剩余三个归档 skill（`block-task` / `close-codescan` / `close-dependabot`）仍缺同形态提示，用户结束任务后找不到清理沙箱的入口。

本 PR 收敛为两个互不耦合的子目标：让 `ls` 的「无短号 = 可删除」语义对用户可见，并把 #10 形态的门控沙箱清理提示补齐到剩余三个归档 skill。

## 📋 主要变更 / Brief Changelog

- **子目标 A（ls 二态语义）**：扩写 `ai sandbox ls` 的 USAGE 与表尾 legend、补 `lookupShortIdByBranch` 的 TSDoc，明确「无短号 = 该沙箱可用 `ai sandbox rm <branch>` 删除」；保留 `-` 标记字面、不改列宽、不动既有 ls 测试。
- **子目标 B（归档 skill 清理提示）**：把 #10（PR #459）的门控沙箱清理提示移植到 `block-task` / `close-codescan` / `close-dependabot`，覆盖源 `SKILL.md` 与 en / zh-CN 模板共 9 个文件。
- **按 skill 适配门控**：`block-task` 用两条件门控（`blocked/` 路径、文案改「已阻塞」）；`close-codescan` / `close-dependabot` 用三条件门控（额外要求「第 7 步定位到关联任务」），`{branch}` 取该关联任务、路径无关，规避其第 7/8 步既有的归档时机表述歧义。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（tsc 类型检查通过）
2. `npm test`（全量：1037 pass / 0 fail / 1 skipped）
3. `node --experimental-strip-types ./bin/cli.ts sandbox ls --help` 查看 USAGE 新增的可删除语义说明
4. 一致性核查：9 个 SKILL 文件各含 1 处 `ai sandbox rm {branch}`；源 `SKILL.md` 与对应 `SKILL.zh-CN.md` 第 8 步区段 `diff` 逐字节一致

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

> 本次为「展示文本 + 文档指令」改动，按 `.agents/rules/testing-discipline.md`（禁止关键词语义断言）未对 legend / hint / USAGE 文案新增脆弱断言；以既有结构性测试（`skills.test.ts` 步骤连续编号、模板 zh-CN 变体、源↔模板一致、`sandbox-ls-short-id-column.test.ts` 的 `-` 断言）保持绿 + 全量回归为验证依据。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性（沿用既有结构性测试）/ I have necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass（项目暂未配置 lint）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（SKILL.md 源 + en/zh-CN 模板同步）/ I have made corresponding documentation changes
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（无破坏性变更）/ Breaking changes documented (none)
- [x] 我已经考虑了向后兼容性（纯增量，保留 `-` 标记，向后兼容）/ I have considered backward compatibility

## 📋 附加信息 / Additional Notes

已知问题：`close-codescan` / `close-dependabot` 第 7 步「归档任务」与第 8 步「/complete-task（如有关联任务）」对归档时机的表述本就不一致——属既有问题，本 PR 按外科手术原则未顺手重构，仅以路径无关措辞规避，可作为独立后续项。

---

**审查者注意事项 / Reviewer Notes:**

- `close-*` 三条件门控（尤其「第 7 步定位到关联任务」与 `{branch}` 路径无关取值），以及在「无关联任务 / 无 branch / 默认分支」下整段省略的语义。
- `block-task` hint 文案「已阻塞并移到 blocked/」与 #10「已归档」措辞的有意区分。
- `ls.ts` legend 的条件渲染（仅存在 `-` 行时打印），未对全量 `ls` 输出引入快照脆弱性。
- 源 `SKILL.md` 与模板 `SKILL.zh-CN.md` 的逐字节一致性。

Generated with AI assistance