### PR TITLE
docs(contributing): CONTRIBUTING 双语化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,188 +1,190 @@
-# 开发者指导手册
+# Developer Guide
 
-## 简介
+> English | [简体中文](./CONTRIBUTING.zh-CN.md)
 
-本指导手册旨在为项目的开发者提供一份详细的开发指导，包括分支管理、标签管理、提交规则、代码审查等内容。遵循这些指导有助于项目的高效开发和良好协作。
+## Introduction
 
-## 开发模式
+This guide provides developers with detailed development guidance, covering branch management, tag management, commit rules, code review, and more. Following these guidelines helps the project develop efficiently and collaborate smoothly.
 
-我们使用 [Git](https://git-scm.com/) 作为版本控制工具，项目开发模式遵从多版本的 `Git-Flow` 模式：
+## Development Model
 
-- `main` 分支为主干开发分支，所有特性都从该分支检出并合入
-- `agent-infra-feature-*` 分支为特性开发分支
-- `agent-infra-{$majorVersion}.{$minorVersion}.x` 为指定版本分支
-- `agent-infra-bugfix-*` 分支为问题修复分支
-- 所有问题修复或者功能增强，均需要找到合适的最低版本分支进行处理，然后逐级分支往上合入，最终合入 `main` 分支
+We use [Git](https://git-scm.com/) for version control, and the project follows a multi-version `Git-Flow` development model:
 
-## 环境配置
+- The `main` branch is the trunk development branch; all features are checked out from and merged back into it
+- `agent-infra-feature-*` branches are feature development branches
+- `agent-infra-{$majorVersion}.{$minorVersion}.x` branches are version-specific branches
+- `agent-infra-bugfix-*` branches are bug-fix branches
+- Every bug fix or enhancement must be handled on the appropriate lowest version branch, then merged upward branch by branch until it reaches the `main` branch
 
-### 前置条件
+## Environment Setup
+
+### Prerequisites
 
 - Git
-- Node.js >= 22（用于内置测试运行器 `node:test`）
-- Shell（sh/bash/zsh）
+- Node.js >= 22 (for the built-in test runner `node:test`)
+- A shell (sh/bash/zsh)
 
-### 快速开始
+### Quick Start
 
 ```bash
-# 克隆项目
+# Clone the project
 git clone git@github.com:fitlab-ai/agent-infra.git
 
-# 安装依赖：开发检出后必须先安装真实 npm 依赖
+# Install dependencies: real npm dependencies must be installed after a development checkout
 npm install
 
-# 启用 Git hooks（仅首次 clone 后执行一次）
+# Enable Git hooks (run once after the first clone)
 git config core.hooksPath .git-hooks
 
-# 构建（修改 src/ 或 lib/ 后需要运行）
+# Build (required after modifying src/ or lib/)
 npm run build
 
-# 运行测试
+# Run tests
 npm test
 
-# 代码检查：暂未配置 lint 工具
+# Linting: no lint tool configured yet
 ```
 
-请参考项目的 `README.md` 文件以获取更多关于如何配置开发环境的指导。
+Refer to the project's `README.md` for more guidance on how to set up the development environment.
 
-## 分支管理
+## Branch Management
 
-- 为每个功能或问题修复创建一个新的分支，避免在主分支（如 `main`）上直接开发。
-- 分支命名应简洁明了，描述分支的主要目的。
-  - 分支以 `agent-infra-` 开头。
-  - 特性分支以 `agent-infra-feature-` 开头，功能增强分支以 `agent-infra-enhancement-` 开头，任务型分支以 `agent-infra-task-` 开头，问题修复分支以 `agent-infra-bugfix-` 开头。
-  - 使用短划线 `-` 来分隔单词。
-  - 版本分支最后跟两个版本号和一个 `x` 字母，例如：`agent-infra-1.0.x`。
-  - 发布分支后面跟三个版本号，例如：`agent-infra-1.0.0`。
+- Create a new branch for every feature or bug fix; avoid developing directly on the main branch (e.g. `main`).
+- Branch names should be concise and clearly describe the branch's main purpose.
+  - Branches start with `agent-infra-`.
+  - Feature branches start with `agent-infra-feature-`, enhancement branches with `agent-infra-enhancement-`, task branches with `agent-infra-task-`, and bug-fix branches with `agent-infra-bugfix-`.
+  - Use hyphens `-` to separate words.
+  - Version branches end with two version numbers and the letter `x`, e.g. `agent-infra-1.0.x`.
+  - Release branches end with three version numbers, e.g. `agent-infra-1.0.0`.
 
-### 版本分支合并规则
+### Version Branch Merge Rules
 
-- 版本分支合并必须遵循低版本向高版本合并的原则，且不可跨越某一个版本。
-- 当任意 `feature`、`enhancement` 或 `bugfix` 合入指定版本分支之后，需要依次向上合并直到 `main` 分支为止。
+- Version branch merges must follow the principle of merging from lower versions to higher versions, and must not skip any version.
+- After any `feature`, `enhancement`, or `bugfix` is merged into a version-specific branch, it must be merged upward in order until it reaches the `main` branch.
 
-## 标签管理
+## Tag Management
 
-- 每个标签的名字和发布分支的名字需要保持一致，例如：`agent-infra-1.0.0`。
-- 纯数字版本的分支需要以 `v` 开头，例如：`v0.1.0`。
-- 候选版本以特殊词组结尾，例如：`agent-infra-1.0.0-alpha1`。
-- 当标签被打出后，对应的发布分支应当删除。
-- 所有的 Issue 和 PR 都需要至少包含两种标签：`in: {$module}` 和 `type: {$type}`。
+- Each tag name must match the name of its release branch, e.g. `agent-infra-1.0.0`.
+- Branches with purely numeric versions must start with `v`, e.g. `v0.1.0`.
+- Release candidates end with a special suffix, e.g. `agent-infra-1.0.0-alpha1`.
+- Once a tag is created, the corresponding release branch should be deleted.
+- Every Issue and PR must include at least two kinds of labels: `in: {$module}` and `type: {$type}`.
 
-## 开发规范
+## Development Standards
 
-### 代码风格
+### Code Style
 
-- `install.sh` 保持 POSIX sh 兼容，使用 `set -e` 进行错误处理
-- 模板文件使用 `{{project}}` 和 `{{org}}` 作为渲染占位符
-- 面向用户的 Markdown 文件提供双语版本（英文为主 + 中文翻译），如 README、SECURITY
+- `install.sh` stays POSIX sh compatible and uses `set -e` for error handling
+- Template files use `{{project}}` and `{{org}}` as rendering placeholders
+- User-facing Markdown files provide bilingual versions (English-first + Chinese translation), such as README and SECURITY
 
-### 平台无关层与平台层
+### Platform-Agnostic Layer vs Platform Layer
 
-本仓库的模板需要区分平台无关 baseline 与平台特定实现。平台特定内容只能放在以下位置：
+The templates in this repository must distinguish between the platform-agnostic baseline and platform-specific implementations. Platform-specific content may only live in the following locations:
 
 - `.agents/rules/*.{platform}.md`
 - `.agents/scripts/platform-adapters/platform-sync.{platform}.js`
-- 明确属于平台集成的脚本或工作流目录
+- Scripts or workflow directories that explicitly belong to platform integration
 
-除上述位置外，`SKILL.md`、`reference/*.md`、命令面板、QUICKSTART、README 等 baseline 文件必须保持平台无关。baseline 文件应引用 `.agents/rules/*.md` 或 `.agents/scripts/` 中的抽象入口，不直接写入平台命令、路径或 schema。
+Apart from the locations above, baseline files such as `SKILL.md`, `reference/*.md`, command palettes, QUICKSTART, and README must remain platform-agnostic. Baseline files should reference the abstract entry points in `.agents/rules/*.md` or `.agents/scripts/` rather than embedding platform commands, paths, or schemas directly.
 
-判断平台耦合时，先检查这些硬指标：
+When judging platform coupling, first check these hard indicators:
 
-- 平台名，如 `GitHub`
-- 平台路径，如 `.github/`
-- 平台 CLI，如 `gh CLI` 或以 `gh ` 开头的命令
+- Platform names, such as `GitHub`
+- Platform paths, such as `.github/`
+- Platform CLIs, such as `gh CLI` or commands starting with `gh `
 
-还要人工检查这些软指标：
+Also manually check these soft indicators:
 
-- 平台特定 schema 字段名，如 GitHub Issue Forms 的 `textarea`、`input`、`dropdown`、`checkboxes`、`attributes.label`
-- 平台文件命名约定，如 `.yml` Issue Form 文件名、`PULL_REQUEST_TEMPLATE.md`
-- 已在 rules/scripts 中定义过的命令或 marker 字符串副本
+- Platform-specific schema field names, such as the GitHub Issue Forms `textarea`, `input`, `dropdown`, `checkboxes`, `attributes.label`
+- Platform file naming conventions, such as `.yml` Issue Form file names and `PULL_REQUEST_TEMPLATE.md`
+- Copies of commands or marker strings already defined in rules/scripts
 
-`tests/unit/templates/platform-coupling.test.js` 提供结构性护栏：baseline 文案不得含平台硬指标，skill reference 目录不得新增 `.github.*` 这类平台变体。测试不能覆盖所有软指标，PR 作者和 reviewer 仍需人工检查 schema 字段、命令重复和措辞包装。
+`tests/unit/templates/platform-coupling.test.js` provides a structural guardrail: baseline content must not contain platform hard indicators, and skill reference directories must not add platform variants like `.github.*`. The test cannot cover all soft indicators, so PR authors and reviewers must still manually check schema fields, duplicated commands, and wording wrappers.
 
-### 路径级平台门控（init/sync 实施层）
+### Path-Level Platform Gating (init/sync implementation layer)
 
-`templates/` 下顶层段为 `.{platform}/` 的路径（如 `.github/`、未来的 `.gitlab/`）由 `src/sync-templates.js` 按 `cfg.platform.type` 自动门控分发：
+Paths under `templates/` whose top-level segment is `.{platform}/` (such as `.github/`, or a future `.gitlab/`) are automatically gated for distribution by `src/sync-templates.js` based on `cfg.platform.type`:
 
-- 当 `cfg.platform.type` 等于该 platform：正常分发与同步
-- 当 `cfg.platform.type` 是其他 `KNOWN_PLATFORMS` 值或自定义平台：跳过分发，并清理项目中残留的同名目录条目
+- When `cfg.platform.type` equals that platform: distribute and sync normally
+- When `cfg.platform.type` is another `KNOWN_PLATFORMS` value or a custom platform: skip distribution and clean up any residual directory entries of the same name left in the project
 
-项目级（非平台特定）的 git hooks、配置等不应放在 `.{platform}/` 下；放在平台中性路径（如 `.git-hooks/`）才能跨平台分发。
+Project-level (non-platform-specific) git hooks, configs, and so on should not be placed under `.{platform}/`; placing them in platform-neutral paths (such as `.git-hooks/`) is what makes them distributable across platforms.
 
-示例：
+Examples:
 
-- 反例：在 `templates/.agents/skills/create-pr/reference/pr-body-template.en.md` 中直接写 `gh pr list --limit 3 --state merged`
-- 正例：baseline reference 写“按 `.agents/rules/issue-pr-commands.md` 的最近 PR 查询命令执行”，GitHub 具体命令只放在 `issue-pr-commands.github.en.md`
+- Anti-pattern: writing `gh pr list --limit 3 --state merged` directly in `templates/.agents/skills/create-pr/reference/pr-body-template.en.md`
+- Correct pattern: have the baseline reference say "run the recent-PR query command per `.agents/rules/issue-pr-commands.md`", and keep the GitHub-specific command only in `issue-pr-commands.github.en.md`
 
-已采纳的架构决策：
+Adopted architectural decisions:
 
-- `verify.json` 应优先通过 `expected_*_key` 引用平台 adapter 的默认值，而不是复制 marker 或 status label 字符串。
-- `platform-sync.{platform}.js#getDefaults()` 是平台默认 marker 和 status label 的单一信息源。
-- 这个 key-based 抽象是为多平台扩展保留的设计：把 N 个 skill × M 个平台的配置成本收敛为 N 个 key 引用 + M 个 adapter 默认值。
+- `verify.json` should prefer referencing the platform adapter's default values via `expected_*_key` rather than copying marker or status label strings.
+- `platform-sync.{platform}.js#getDefaults()` is the single source of truth for platform default markers and status labels.
+- This key-based abstraction is a design reserved for multi-platform expansion: it collapses the configuration cost of N skills × M platforms into N key references + M adapter defaults.
 
-### 构建架构
+### Build Architecture
 
-- `src/sync-templates.js` 是开发源码，保留可读的源码结构和对 `lib/` 数据文件的标准读取方式。
-- `templates/.agents/skills/update-agent-infra/scripts/sync-templates.js` 是构建产物，发布时会把默认配置和版本号内联为常量。
-- 之所以需要这层构建，是因为 `sync-templates.js` 会被复制到用户项目中运行，届时不能再依赖 installer 仓库里的 `lib/` 目录。
-- 修改 `src/`、`lib/defaults.json` 或相关版本信息后，应执行 `npm run build` 重新生成产物，不要直接手工编辑 `templates/` 下的生成文件。
+- `src/sync-templates.js` is the development source code; it keeps a readable source structure and the standard way of reading `lib/` data files.
+- `templates/.agents/skills/update-agent-infra/scripts/sync-templates.js` is the build artifact; at release time it inlines the default config and version number as constants.
+- This build layer is needed because `sync-templates.js` is copied into user projects to run, where it can no longer depend on the `lib/` directory inside the installer repository.
+- After modifying `src/`, `lib/defaults.json`, or related version information, run `npm run build` to regenerate the artifact; do not manually edit the generated files under `templates/`.
 
-### 注释信息
+### Comments
 
-- 每一个模块文件都建议包含注释，说明其职责和用途。
-- 所有被 `export` 的类、函数、接口等都需要添加文档注释。
+- Every module file is recommended to include comments explaining its responsibility and purpose.
+- All `export`ed classes, functions, interfaces, and so on must have documentation comments.
 
-## 提交规则
+## Commit Rules
 
-### 提交信息格式
+### Commit Message Format
 
-我们采用 [Conventional Commits](https://www.conventionalcommits.org/) 规范：
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
 `<type>(<scope>): <subject>`
 
-- **type（类型）**：`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
-- **scope（范围/模块）**：对应项目模块名。如果涉及多个模块或全局变动，可以使用 `*` 或留空。
-- **subject（描述）**：简短描述主要内容，使用英文祈使语气，不超过 50 字符，结尾不需要句号。
+- **type**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+- **scope (module)**: corresponds to the project module name. If multiple modules or a global change are involved, use `*` or leave it empty.
+- **subject**: a short description of the main content, in the English imperative mood, no longer than 50 characters, with no trailing period.
 
-**样例：**
+**Examples:**
 - `feat(ai): add multi-agent collaboration workflow`
 - `fix(github): fix PR title validation regex`
 - `docs(ai): update collaboration quick start guide`
 
-## 代码审查
+## Code Review
 
-- 开发完成后，通过创建合并请求将变更合并到主分支。在合并请求中描述所做的更改，并邀请其他项目成员进行代码审查。
-- 保持主分支始终可部署，确保合并的代码经过充分测试。
+- After development, merge your changes into the main branch by creating a merge request. Describe the changes you made in the merge request and invite other project members to review the code.
+- Keep the main branch always deployable, and ensure merged code is thoroughly tested.
 
-## 测试
+## Testing
 
-- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 22）
-- 构建命令：`npm run build`（修改 `src/`、`lib/defaults.json` 或版本信息后需要运行）
-- 运行命令：`npm test`
-- 等价于：`node scripts/build-inline.js --check && node --test tests/*.test.js`
-- 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
-- 提交前务必确保所有测试通过
+- Test framework: Node.js built-in test runner (`node:test`, requires Node.js >= 22)
+- Build command: `npm run build` (required after modifying `src/`, `lib/defaults.json`, or version information)
+- Run command: `npm test`
+- Equivalent to: `node scripts/build-inline.js --check && node --test tests/*.test.js`
+- Test coverage: template file integrity, CLI initialization flow, placeholder rendering validation
+- Always make sure all tests pass before committing
 
-## 发布流程
+## Release Process
 
-遵循项目的发布计划和流程。在发布新版本时，请按照标签管理的规定创建一个新的 `tag`。
+Follow the project's release plan and process. When releasing a new version, create a new `tag` per the tag management rules.
 
-维护者请参阅 [RELEASING.md](./RELEASING.md) 了解 npm 发布流程与 Trusted Publisher 一次性配置。
+Maintainers, see [RELEASING.md](./RELEASING.md) for the npm release process and the one-time Trusted Publisher configuration.
 
-## 问题和需求跟踪
+## Issue and Requirement Tracking
 
-使用项目的 `Issue` 跟踪器来报告和跟踪问题、需求和功能建议。在创建新 `Issue` 时，请尽量提供详细的信息。
+Use the project's `Issue` tracker to report and track issues, requirements, and feature suggestions. When creating a new `Issue`, please provide as much detail as possible.
 
-## 贡献指南
+## Contribution Guidelines
 
-对于希望参与项目的贡献者，请遵循以下步骤：
+Contributors who wish to participate in the project should follow these steps:
 
-1. Fork 当前项目。
-2. 克隆 Fork 后的仓库到本地。
-3. 在本地仓库中创建一个新的分支，进行开发。
-4. 遵循本文档中的提交规范，将更改提交到新分支。
-5. 通过页面创建一个 PR，请求将更改合并到该项目的对应分支，PR 中仅能包含一次提交。
-6. 参与代码审查和讨论，根据反馈进行必要的修改。
-7. 一旦更改被接受并合并，您的贡献将成为项目的一部分。
+1. Fork this project.
+2. Clone the forked repository locally.
+3. Create a new branch in your local repository and develop on it.
+4. Follow the commit conventions in this document and commit your changes to the new branch.
+5. Create a PR through the web interface, requesting to merge your changes into the corresponding branch of the project; a PR may contain only a single commit.
+6. Participate in code review and discussion, and make the necessary changes based on feedback.
+7. Once your changes are accepted and merged, your contribution becomes part of the project.
 
-> - 项目维护者可能会提出修改建议，请保持开放态度并积极沟通。
-> - 如果您发现了一个问题但并不准备自己修复，可以仅提交一个 Issue。如果对方案存在疑问，可以在"讨论"模块中提问。
+> - Project maintainers may suggest changes; please stay open and communicate actively.
+> - If you find a problem but are not ready to fix it yourself, you may submit just an Issue. If you have questions about the approach, you can ask in the "Discussions" section.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,190 @@
+# 开发者指导手册
+
+> [English](./CONTRIBUTING.md) | 简体中文
+
+## 简介
+
+本指导手册旨在为项目的开发者提供一份详细的开发指导，包括分支管理、标签管理、提交规则、代码审查等内容。遵循这些指导有助于项目的高效开发和良好协作。
+
+## 开发模式
+
+我们使用 [Git](https://git-scm.com/) 作为版本控制工具，项目开发模式遵从多版本的 `Git-Flow` 模式：
+
+- `main` 分支为主干开发分支，所有特性都从该分支检出并合入
+- `agent-infra-feature-*` 分支为特性开发分支
+- `agent-infra-{$majorVersion}.{$minorVersion}.x` 为指定版本分支
+- `agent-infra-bugfix-*` 分支为问题修复分支
+- 所有问题修复或者功能增强，均需要找到合适的最低版本分支进行处理，然后逐级分支往上合入，最终合入 `main` 分支
+
+## 环境配置
+
+### 前置条件
+
+- Git
+- Node.js >= 22（用于内置测试运行器 `node:test`）
+- Shell（sh/bash/zsh）
+
+### 快速开始
+
+```bash
+# 克隆项目
+git clone git@github.com:fitlab-ai/agent-infra.git
+
+# 安装依赖：开发检出后必须先安装真实 npm 依赖
+npm install
+
+# 启用 Git hooks（仅首次 clone 后执行一次）
+git config core.hooksPath .git-hooks
+
+# 构建（修改 src/ 或 lib/ 后需要运行）
+npm run build
+
+# 运行测试
+npm test
+
+# 代码检查：暂未配置 lint 工具
+```
+
+请参考项目的 `README.md` 文件以获取更多关于如何配置开发环境的指导。
+
+## 分支管理
+
+- 为每个功能或问题修复创建一个新的分支，避免在主分支（如 `main`）上直接开发。
+- 分支命名应简洁明了，描述分支的主要目的。
+  - 分支以 `agent-infra-` 开头。
+  - 特性分支以 `agent-infra-feature-` 开头，功能增强分支以 `agent-infra-enhancement-` 开头，任务型分支以 `agent-infra-task-` 开头，问题修复分支以 `agent-infra-bugfix-` 开头。
+  - 使用短划线 `-` 来分隔单词。
+  - 版本分支最后跟两个版本号和一个 `x` 字母，例如：`agent-infra-1.0.x`。
+  - 发布分支后面跟三个版本号，例如：`agent-infra-1.0.0`。
+
+### 版本分支合并规则
+
+- 版本分支合并必须遵循低版本向高版本合并的原则，且不可跨越某一个版本。
+- 当任意 `feature`、`enhancement` 或 `bugfix` 合入指定版本分支之后，需要依次向上合并直到 `main` 分支为止。
+
+## 标签管理
+
+- 每个标签的名字和发布分支的名字需要保持一致，例如：`agent-infra-1.0.0`。
+- 纯数字版本的分支需要以 `v` 开头，例如：`v0.1.0`。
+- 候选版本以特殊词组结尾，例如：`agent-infra-1.0.0-alpha1`。
+- 当标签被打出后，对应的发布分支应当删除。
+- 所有的 Issue 和 PR 都需要至少包含两种标签：`in: {$module}` 和 `type: {$type}`。
+
+## 开发规范
+
+### 代码风格
+
+- `install.sh` 保持 POSIX sh 兼容，使用 `set -e` 进行错误处理
+- 模板文件使用 `{{project}}` 和 `{{org}}` 作为渲染占位符
+- 面向用户的 Markdown 文件提供双语版本（英文为主 + 中文翻译），如 README、SECURITY
+
+### 平台无关层与平台层
+
+本仓库的模板需要区分平台无关 baseline 与平台特定实现。平台特定内容只能放在以下位置：
+
+- `.agents/rules/*.{platform}.md`
+- `.agents/scripts/platform-adapters/platform-sync.{platform}.js`
+- 明确属于平台集成的脚本或工作流目录
+
+除上述位置外，`SKILL.md`、`reference/*.md`、命令面板、QUICKSTART、README 等 baseline 文件必须保持平台无关。baseline 文件应引用 `.agents/rules/*.md` 或 `.agents/scripts/` 中的抽象入口，不直接写入平台命令、路径或 schema。
+
+判断平台耦合时，先检查这些硬指标：
+
+- 平台名，如 `GitHub`
+- 平台路径，如 `.github/`
+- 平台 CLI，如 `gh CLI` 或以 `gh ` 开头的命令
+
+还要人工检查这些软指标：
+
+- 平台特定 schema 字段名，如 GitHub Issue Forms 的 `textarea`、`input`、`dropdown`、`checkboxes`、`attributes.label`
+- 平台文件命名约定，如 `.yml` Issue Form 文件名、`PULL_REQUEST_TEMPLATE.md`
+- 已在 rules/scripts 中定义过的命令或 marker 字符串副本
+
+`tests/unit/templates/platform-coupling.test.js` 提供结构性护栏：baseline 文案不得含平台硬指标，skill reference 目录不得新增 `.github.*` 这类平台变体。测试不能覆盖所有软指标，PR 作者和 reviewer 仍需人工检查 schema 字段、命令重复和措辞包装。
+
+### 路径级平台门控（init/sync 实施层）
+
+`templates/` 下顶层段为 `.{platform}/` 的路径（如 `.github/`、未来的 `.gitlab/`）由 `src/sync-templates.js` 按 `cfg.platform.type` 自动门控分发：
+
+- 当 `cfg.platform.type` 等于该 platform：正常分发与同步
+- 当 `cfg.platform.type` 是其他 `KNOWN_PLATFORMS` 值或自定义平台：跳过分发，并清理项目中残留的同名目录条目
+
+项目级（非平台特定）的 git hooks、配置等不应放在 `.{platform}/` 下；放在平台中性路径（如 `.git-hooks/`）才能跨平台分发。
+
+示例：
+
+- 反例：在 `templates/.agents/skills/create-pr/reference/pr-body-template.en.md` 中直接写 `gh pr list --limit 3 --state merged`
+- 正例：baseline reference 写“按 `.agents/rules/issue-pr-commands.md` 的最近 PR 查询命令执行”，GitHub 具体命令只放在 `issue-pr-commands.github.en.md`
+
+已采纳的架构决策：
+
+- `verify.json` 应优先通过 `expected_*_key` 引用平台 adapter 的默认值，而不是复制 marker 或 status label 字符串。
+- `platform-sync.{platform}.js#getDefaults()` 是平台默认 marker 和 status label 的单一信息源。
+- 这个 key-based 抽象是为多平台扩展保留的设计：把 N 个 skill × M 个平台的配置成本收敛为 N 个 key 引用 + M 个 adapter 默认值。
+
+### 构建架构
+
+- `src/sync-templates.js` 是开发源码，保留可读的源码结构和对 `lib/` 数据文件的标准读取方式。
+- `templates/.agents/skills/update-agent-infra/scripts/sync-templates.js` 是构建产物，发布时会把默认配置和版本号内联为常量。
+- 之所以需要这层构建，是因为 `sync-templates.js` 会被复制到用户项目中运行，届时不能再依赖 installer 仓库里的 `lib/` 目录。
+- 修改 `src/`、`lib/defaults.json` 或相关版本信息后，应执行 `npm run build` 重新生成产物，不要直接手工编辑 `templates/` 下的生成文件。
+
+### 注释信息
+
+- 每一个模块文件都建议包含注释，说明其职责和用途。
+- 所有被 `export` 的类、函数、接口等都需要添加文档注释。
+
+## 提交规则
+
+### 提交信息格式
+
+我们采用 [Conventional Commits](https://www.conventionalcommits.org/) 规范：
+`<type>(<scope>): <subject>`
+
+- **type（类型）**：`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+- **scope（范围/模块）**：对应项目模块名。如果涉及多个模块或全局变动，可以使用 `*` 或留空。
+- **subject（描述）**：简短描述主要内容，使用英文祈使语气，不超过 50 字符，结尾不需要句号。
+
+**样例：**
+- `feat(ai): add multi-agent collaboration workflow`
+- `fix(github): fix PR title validation regex`
+- `docs(ai): update collaboration quick start guide`
+
+## 代码审查
+
+- 开发完成后，通过创建合并请求将变更合并到主分支。在合并请求中描述所做的更改，并邀请其他项目成员进行代码审查。
+- 保持主分支始终可部署，确保合并的代码经过充分测试。
+
+## 测试
+
+- 测试框架：Node.js 内置测试运行器（`node:test`，需 Node.js >= 22）
+- 构建命令：`npm run build`（修改 `src/`、`lib/defaults.json` 或版本信息后需要运行）
+- 运行命令：`npm test`
+- 等价于：`node scripts/build-inline.js --check && node --test tests/*.test.js`
+- 测试覆盖：模板文件完整性、CLI 初始化流程、占位符渲染验证
+- 提交前务必确保所有测试通过
+
+## 发布流程
+
+遵循项目的发布计划和流程。在发布新版本时，请按照标签管理的规定创建一个新的 `tag`。
+
+维护者请参阅 [RELEASING.md](./RELEASING.md) 了解 npm 发布流程与 Trusted Publisher 一次性配置。
+
+## 问题和需求跟踪
+
+使用项目的 `Issue` 跟踪器来报告和跟踪问题、需求和功能建议。在创建新 `Issue` 时，请尽量提供详细的信息。
+
+## 贡献指南
+
+对于希望参与项目的贡献者，请遵循以下步骤：
+
+1. Fork 当前项目。
+2. 克隆 Fork 后的仓库到本地。
+3. 在本地仓库中创建一个新的分支，进行开发。
+4. 遵循本文档中的提交规范，将更改提交到新分支。
+5. 通过页面创建一个 PR，请求将更改合并到该项目的对应分支，PR 中仅能包含一次提交。
+6. 参与代码审查和讨论，根据反馈进行必要的修改。
+7. 一旦更改被接受并合并，您的贡献将成为项目的一部分。
+
+> - 项目维护者可能会提出修改建议，请保持开放态度并积极沟通。
+> - 如果您发现了一个问题但并不准备自己修复，可以仅提交一个 Issue。如果对方案存在疑问，可以在"讨论"模块中提问。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-brightgreen?logo=node.js" alt="Node.js >= 22"></a>
   <a href="https://github.com/fitlab-ai/agent-infra/releases"><img src="https://img.shields.io/github/v/release/fitlab-ai/agent-infra" alt="GitHub release"></a>
   <a href="https://codecov.io/gh/fitlab-ai/agent-infra"><img src="https://codecov.io/gh/fitlab-ai/agent-infra/graph/badge.svg" alt="codecov"></a>
-  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
+  <a href="CONTRIBUTING.zh-CN.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
 
 <p align="center">
@@ -929,7 +929,7 @@ agent-infra 通过 Git tag 和 GitHub release 使用语义化版本号。当前�
 
 ## 参与贡献
 
-开发规范请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+开发规范请参阅 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)。
 
 <a id="license"></a>
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #474 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 📚 文档更新 / Documentation update

## 📝 变更目的 / Purpose of the Change

此前根级 `CONTRIBUTING.md` 是纯中文 188 行，与 `README.md`（英文主）/ `README.zh-CN.md`（中文副）、`SECURITY.md` / `SECURITY.zh-CN.md` 的双语策略不一致，外部不熟悉中文的贡献者无法阅读，抬高了 OSS 贡献门槛。本 PR 把 `CONTRIBUTING` 补齐双语，命名遵循 README 模式：英文为根级主文件，中文为 `.zh-CN.md` 副本。

## 📋 主要变更 / Brief Changelog

- 把原中文 `CONTRIBUTING.md` 用 `git mv` 重命名为 `CONTRIBUTING.zh-CN.md`（保留 git 历史），仅在顶部新增一行语言互链，正文一字未改
- 新写**英文** `CONTRIBUTING.md`（`# Developer Guide`）作为根级主文件，按章节逐段忠实翻译，命令 / URL / 分支模式 / Conventional Commits type / 文件路径等标识符原样保留
- 两份文件顶部各加 blockquote 语言互链（`> English | [简体中文](...)` / `> [English](...) | 简体中文`）
- 把 `README.zh-CN.md` 中指向 CONTRIBUTING 的两处链接（PRs-welcome 徽章 + 正文）改指中文版，使「中文读者落中文文档」；英文侧链接（`README.md`、`.github/PULL_REQUEST_TEMPLATE.md`）保持指向英文 `CONTRIBUTING.md` 不变

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1040 pass / 0 fail / 1 skipped（平台守卫跳过）
2. `grep -rn "CONTRIBUTING" README.md README.zh-CN.md .github/PULL_REQUEST_TEMPLATE.md` —— 英文侧引用指向 `CONTRIBUTING.md`，中文 README 引用指向 `CONTRIBUTING.zh-CN.md`，两个目标文件均存在
3. 章节标题对齐：`grep -cE '^## '`/`'^### '` 两版均为 12 个 `##` + 9 个 `###`

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests（纯文档改动，无测试绑定 CONTRIBUTING，按项目测试纪律未新增）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（链接可达性 + 章节对齐 grep 校验）

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述
- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 所有现有测试都通过 / Unit tests pass
- [x] 我已经更新了相应的文档（本变更即文档本身）
- [x] 我已经考虑了向后兼容性（`CONTRIBUTING.md` 路径保留，英文侧既有链接零破坏）

## 📋 附加信息 / Additional Notes

- 英文 H1 采用 `# Developer Guide`（镜像中文 `# 开发者指导手册`）。
- 中文 README 链接改指中文 CONTRIBUTING 的裁定依据：仓库内既有双语链接先例是两份 README 各自链向语言同侧兄弟文件（`README.md` ↔ `README.zh-CN.md`）。
- `.github/PULL_REQUEST_TEMPLATE.md:15` 的 `Contributing Guide(CONTRIBUTING.md)` 为既有非标准 markdown 链接写法（缺方括号），属非目标，本 PR 未改动。
- 非目标：未改动 `RELEASING.md` / `AGENTS.md`（仍中文单语）与 `SECURITY*`（已双语）。

Closes #474

---

Generated with AI assistance