### PR TITLE
feat(cli): 优化 ai task ls / ai sandbox ls 表格斑马纹可读性

### DIFF
--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -32,10 +32,11 @@ type ContainerTableRow = {
   branch: string;
 };
 
-export function formatContainerTable(rows: ContainerTableRow[]): string[] {
+export function formatContainerTable(rows: ContainerTableRow[], zebra = false): string[] {
   return formatTable(
     CONTAINER_TABLE_HEADERS,
-    rows.map((r) => [r.row, r.shortId, r.name, r.status, r.branch])
+    rows.map((r) => [r.row, r.shortId, r.name, r.status, r.branch]),
+    { zebra }
   );
 }
 
@@ -76,7 +77,7 @@ export function ls(args: string[] = []): void {
         branch: container.branch
       };
     });
-    for (const line of formatContainerTable(tableRows)) {
+    for (const line of formatContainerTable(tableRows, Boolean(process.stdout.isTTY))) {
       process.stdout.write(`  ${line}\n`);
     }
     process.stdout.write(`  Total: ${ordered.length} containers\n`);

--- a/lib/table.ts
+++ b/lib/table.ts
@@ -1,7 +1,11 @@
+import pc from 'picocolors';
+
 function formatTable(
   headers: readonly string[],
-  rows: readonly (readonly string[])[]
+  rows: readonly (readonly string[])[],
+  options: { zebra?: boolean } = {}
 ): string[] {
+  const { zebra = false } = options;
   const columnCount = headers.length;
   const widths = headers.map((header, i) => {
     const headerLen = header.length;
@@ -26,7 +30,15 @@ function formatTable(
     return parts.join('  ').trimEnd();
   };
 
-  return [renderRow(headers), ...rows.map((row) => renderRow(row))];
+  const dataLines = rows.map((row, i) => {
+    const line = renderRow(row);
+    // Zebra stripes: dim even-numbered data rows (rows 2, 4, 6... -> 0-based
+    // odd index). The header and odd rows are left untouched. When zebra is
+    // off, pc.dim is never called, so the output is byte-identical to before.
+    return zebra && i % 2 === 1 ? pc.dim(line) : line;
+  });
+
+  return [renderRow(headers), ...dataLines];
 }
 
 export { formatTable };

--- a/lib/task/commands/ls.ts
+++ b/lib/task/commands/ls.ts
@@ -129,7 +129,7 @@ function ls(args: string[] = []): void {
     r.branch,
     r.title
   ]);
-  for (const line of formatTable(TABLE_HEADERS, tableRows)) {
+  for (const line of formatTable(TABLE_HEADERS, tableRows, { zebra: Boolean(process.stdout.isTTY) })) {
     process.stdout.write(`${line}\n`);
   }
   process.stdout.write(`Total: ${rows.length} tasks\n`);

--- a/tests/integration/cli/render-table-zebra.test.ts
+++ b/tests/integration/cli/render-table-zebra.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+
+// picocolors freezes its color-support decision at module-load time, and
+// loadFreshEsm only cache-busts the target module (not the bare 'picocolors'
+// dependency). So the only reliable way to exercise the colored zebra path is a
+// fresh child process with color forced on (FORCE_COLOR=1, NO_COLOR removed).
+// This test fails if formatTable forgets to wrap even data rows in pc.dim.
+test('formatTable zebra: even data rows are dim-wrapped when color is forced on', () => {
+  const tableUrl = new URL('../../../lib/table.ts', import.meta.url).href;
+  const script = [
+    `import { formatTable } from ${JSON.stringify(tableUrl)};`,
+    `const rows = [['1', 'a'], ['2', 'b'], ['3', 'c'], ['4', 'd']];`,
+    `const out = formatTable(['#', 'NAME'], rows, { zebra: true });`,
+    `process.stdout.write(JSON.stringify(out));`
+  ].join('\n');
+
+  const env = { ...process.env, FORCE_COLOR: '1' };
+  delete env.NO_COLOR; // FORCE_COLOR only takes effect when NO_COLOR is unset
+
+  const stdout = execFileSync(
+    process.execPath,
+    ['--experimental-strip-types', '--no-warnings', '--input-type=module', '--eval', script],
+    { encoding: 'utf8', env }
+  );
+
+  const out = JSON.parse(stdout) as string[];
+  const ESC = String.fromCharCode(27);
+  const OPEN = `${ESC}[2m`;
+  const CLOSE = `${ESC}[22m`;
+
+  assert.equal(out.length, 5);
+  // Header + odd data rows (rows 1 and 3 -> indices 0, 2 after the header) carry no ANSI.
+  assert.ok(!out[0].includes(ESC), 'header must not be dimmed');
+  assert.ok(!out[1].includes(ESC), 'odd data row 1 must not be dimmed');
+  assert.ok(!out[3].includes(ESC), 'odd data row 3 must not be dimmed');
+  // Even data rows (rows 2 and 4 -> indices 2, 4) must be dim-wrapped.
+  assert.ok(out[2].startsWith(OPEN) && out[2].endsWith(CLOSE), 'even data row 2 must be dim-wrapped');
+  assert.ok(out[4].startsWith(OPEN) && out[4].endsWith(CLOSE), 'even data row 4 must be dim-wrapped');
+});

--- a/tests/unit/cli/render-table.test.ts
+++ b/tests/unit/cli/render-table.test.ts
@@ -31,3 +31,21 @@ test('formatTable column widths track widest header or row cell', () => {
   assert.equal(out[0], 'short  h');
   assert.equal(out[1], 'a      verylong');
 });
+
+test('formatTable zebra: header + odd rows unchanged vs baseline; row count preserved', () => {
+  const headers = ['#', 'NAME'];
+  const rows = [['1', 'a'], ['2', 'b'], ['3', 'c'], ['4', 'd']];
+  const plain = formatTable(headers, rows); // zebra off → baseline, never dimmed
+  const out = formatTable(headers, rows, { zebra: true });
+
+  // Structural guarantees that hold regardless of the ambient color state:
+  // the header and odd-numbered data rows are byte-identical to the baseline
+  // (which proves they carry no ANSI), and the row count is preserved. The
+  // colored even-row wrapping is verified in the forced-color integration test
+  // (tests/integration/cli/render-table-zebra.test.ts), because pc.dim is a
+  // no-op under NO_COLOR and an in-process equality check would pass vacuously.
+  assert.equal(out.length, plain.length);
+  assert.equal(out[0], plain[0]); // header never dimmed
+  assert.equal(out[1], plain[1]); // odd data row 1 unchanged
+  assert.equal(out[3], plain[3]); // odd data row 3 unchanged
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #464

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`ai task ls` 与 `ai sandbox ls` 的输出虽是对齐表格，但所有行同色纯文本，行数一多就难以横向锁定"哪一行对哪一列"。本 PR 在 **TTY 场景**给数据行加斑马纹（偶数序数数据行 ANSI `dim`，奇数行与表头保持正常），提升横向扫读体验；**非 TTY（管道 / 重定向）自动回退纯文本**，不向下游 `grep` / `awk` / `less` 注入任何转义序列。

## 📋 主要变更 / Brief Changelog

- `lib/table.ts`：`formatTable` 新增可选第 3 参数 `{ zebra?: boolean }`，仅对偶数序数数据行用 `picocolors` 的 `pc.dim()` 整行包裹；列宽在着色前计算，对齐不受 ANSI 影响；表头永不 dim。`zebra` 为假/省略时 `pc.dim` 永不调用，输出与改动前**逐字节一致**。
- `lib/task/commands/ls.ts`、`lib/sandbox/commands/ls.ts`：调用处传 `zebra: Boolean(process.stdout.isTTY)`，把"管道/重定向回退纯文本"作为硬保证（非 TTY → `zebra=false` → 零 ANSI），不依赖 picocolors 的环境判定。`Total:` 行与 `SHORT '-' = …` 提示行不纳入斑马纹。
- `tests/integration/cli/render-table-zebra.test.ts`（新增）：在强制色彩（`FORCE_COLOR=1` 且移除 `NO_COLOR`）的子进程里验证偶数行被 `dim` 包裹——遗漏 `pc.dim` 即失败，规避了 `NO_COLOR` 环境下的假阳性。
- `tests/unit/cli/render-table.test.ts`：新增结构层用例（表头/奇数行 `=== zebra-off 基线`、行数不变，环境无关）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run test:core`（单元 + 集成）→ 847 项，846 通过 / 0 失败 / 1 平台 skip。
2. 强制色彩子进程用例在**实现前**确为 RED（偶数行未包裹失败），实现后转 GREEN，证明用例能失败于"遗漏 `pc.dim`"。
3. 真实 CLI 非 TTY 管道实测 `0` 个 ESC(0x1b) 字节（`isTTY=undefined` → 纯文本），确认下游不被污染。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 向后兼容：`formatTable` / `formatContainerTable` 新参数可选且默认 `false`，所有现存调用（含两个直接调用 `formatContainerTable` 的集成测试）零改动即保持纯文本行为。
- 未新增依赖（复用既有 `picocolors@1.1.1`）、未新增 CLI flag（`NO_COLOR` 经 picocolors 已覆盖关闭着色）。
- 真实 **TTY 着色效果**未在自动化中目视验证（需真 pty），建议 reviewer 在终端跑 `ai task ls` / `ai sandbox ls` 目视确认偶数行变暗、对齐无误。

---

**审查者注意事项 / Reviewer Notes:**

重点关注 `tests/integration/cli/render-table-zebra.test.ts` 的强制色彩子进程方案是否在目标 CI 下稳定，以及 `zebra=false` 路径的逐字节兼容性。

Closes #464

Generated with AI assistance
