### PR TITLE
docs(meta): 新增 .agents/rules/README.md 索引

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -34,6 +34,7 @@
     bug-fix.yaml                # 缺陷修复工作流
     code-review.yaml            # 代码审查工作流
     refactoring.yaml            # 重构工作流
+  rules/                        # 协作规则索引（见 rules/README.md）
   workspace/                    # 运行时工作区（已被 git ignore）
     active/                     # 当前活跃任务
     blocked/                    # 被阻塞的任务

--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -1,0 +1,39 @@
+# 规则索引
+
+`.agents/rules/` 收录本项目所有协作规则。各 SKILL 执行时按需加载其中若干篇；
+本索引按业务域列出全部规则及其用途，便于快速定位「该读哪几篇」，无需逐文件翻阅。
+
+> 维护提醒：新增或删除 `.agents/rules/*.md` 时，请同步更新本索引。
+
+## 通用准则
+
+- [`no-mid-flow-questions.md`](no-mid-flow-questions.md) — SKILL 执行期禁言：默认不向用户提问，及两类例外。
+- [`next-step-output.md`](next-step-output.md) — 「下一步」输出规则：任务短号渲染与 `Completed at` 收尾行。
+- [`version-stamp.md`](version-stamp.md) — `agent_infra_version` 版本戳的取值命令与写入时机。
+
+## Issue / PR
+
+- [`issue-pr-commands.md`](issue-pr-commands.md) — 验证平台认证、读写 Issue / PR 的 GitHub 命令集。
+- [`pr-checks-commands.md`](pr-checks-commands.md) — 监控 PR required checks、拉取失败日志的命令集（`watch-pr`）。
+- [`create-issue.md`](create-issue.md) — `create-task` 落盘后级联创建 Issue 的规则。
+- [`issue-sync.md`](issue-sync.md) — task 产物与 Issue 评论 / 标签 / 字段的同步标记与流程。
+- [`issue-fields.md`](issue-fields.md) — Issue Type pinned 字段（Priority/Effort/日期）的读写流程。
+- [`pr-sync.md`](pr-sync.md) — 面向 reviewer 的唯一 PR 摘要评论的同步规则。
+
+## 任务工作流
+
+- [`task-management.md`](task-management.md) — 任务语义识别与工作流命令映射。
+- [`task-short-id.md`](task-short-id.md) — 任务短号 `#NN` / 裸数字的解析、分配与生命周期。
+- [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。
+- [`label-milestone-setup.md`](label-milestone-setup.md) — 初始化 label / milestone 的平台命令集。
+- [`security-alerts.md`](security-alerts.md) — 导入 / 关闭 Dependabot 与 Code Scanning 告警的命令集。
+
+## 提交与发布
+
+- [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits 提交信息与 PR 规范。
+- [`release-commands.md`](release-commands.md) — 读取历史 release、查询已合并 PR、发布 Release notes。
+
+## 测试与跨平台
+
+- [`testing-discipline.md`](testing-discipline.md) — 测试编写纪律：结构性断言优先，禁止脆弱的措辞匹配。
+- [`cross-platform-tests.md`](cross-platform-tests.md) — 跨平台测试守卫：用 `onPlatforms()` 表达平台跳过。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,3 +192,4 @@ npm test
 
 **提交代码或创建 PR 时**，必须先读取 `.agents/rules/commit-and-pr.md`。
 **执行任务工作流命令时**，必须先读取 `.agents/rules/task-management.md`。
+**不确定该加载哪篇规则时**，先查阅 `.agents/rules/README.md` 规则索引（按业务域列出全部规则及其用途）。

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -34,6 +34,7 @@ This dual-config approach ensures every AI tool receives appropriate project con
     bug-fix.yaml                # Bug fix workflow
     code-review.yaml            # Code review workflow
     refactoring.yaml            # Refactoring workflow
+  rules/                        # Collaboration rule index (see rules/README.md)
   workspace/                    # Runtime workspace (git-ignored)
     active/                     # Currently active tasks
     blocked/                    # Blocked tasks

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -34,6 +34,7 @@
     bug-fix.yaml                # 缺陷修复工作流
     code-review.yaml            # 代码审查工作流
     refactoring.yaml            # 重构工作流
+  rules/                        # 协作规则索引（见 rules/README.md）
   workspace/                    # 运行时工作区（已被 git ignore）
     active/                     # 当前活跃任务
     blocked/                    # 被阻塞的任务

--- a/templates/.agents/rules/README.en.md
+++ b/templates/.agents/rules/README.en.md
@@ -1,0 +1,40 @@
+# Rules Index
+
+`.agents/rules/` holds every collaboration rule in this project. Each SKILL loads the
+relevant few on demand; this index groups all rules by domain with a one-line purpose,
+so you can quickly find "which ones to read" without opening each file.
+
+> Maintenance note: when adding or removing `.agents/rules/*.md`, update this index too.
+
+## General Principles
+
+- [`no-mid-flow-questions.md`](no-mid-flow-questions.md) — Silence during SKILL runs: no user questions by default, plus two exceptions.
+- [`next-step-output.md`](next-step-output.md) — "Next step" output rules: task short-id rendering and the `Completed at` trailer.
+- [`version-stamp.md`](version-stamp.md) — How and when to stamp `agent_infra_version`.
+
+## Issue / PR
+
+- [`issue-pr-commands.md`](issue-pr-commands.md) — GitHub commands to verify auth and read/write Issues / PRs.
+- [`pr-checks-commands.md`](pr-checks-commands.md) — Commands to watch PR required checks and pull failure logs (`watch-pr`).
+- [`create-issue.md`](create-issue.md) — Cascading Issue creation after `create-task` writes `task.md`.
+- [`issue-sync.md`](issue-sync.md) — Sync markers and flow for task artifacts ↔ Issue comments / labels / fields.
+- [`issue-fields.md`](issue-fields.md) — Read/write flow for Issue Type pinned fields (Priority/Effort/dates).
+- [`pr-sync.md`](pr-sync.md) — Sync rule for the single reviewer-facing PR summary comment.
+
+## Task Workflow
+
+- [`task-management.md`](task-management.md) — Task intent detection and workflow-command mapping.
+- [`task-short-id.md`](task-short-id.md) — Resolution, allocation and lifecycle of `#NN` / bare-number short ids.
+- [`milestone-inference.md`](milestone-inference.md) — Milestone inference for create-task / code-task / create-pr.
+- [`label-milestone-setup.md`](label-milestone-setup.md) — Platform commands to initialize labels / milestones.
+- [`security-alerts.md`](security-alerts.md) — Commands to import / close Dependabot and Code Scanning alerts.
+
+## Commit & Release
+
+- [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits message and PR conventions.
+- [`release-commands.md`](release-commands.md) — Read past releases, query merged PRs, publish release notes.
+
+## Testing & Cross-platform
+
+- [`testing-discipline.md`](testing-discipline.md) — Test-writing discipline: prefer structural asserts, no brittle wording matches.
+- [`cross-platform-tests.md`](cross-platform-tests.md) — Cross-platform test guards: express platform skips via `onPlatforms()`.

--- a/templates/.agents/rules/README.zh-CN.md
+++ b/templates/.agents/rules/README.zh-CN.md
@@ -1,0 +1,39 @@
+# 规则索引
+
+`.agents/rules/` 收录本项目所有协作规则。各 SKILL 执行时按需加载其中若干篇；
+本索引按业务域列出全部规则及其用途，便于快速定位「该读哪几篇」，无需逐文件翻阅。
+
+> 维护提醒：新增或删除 `.agents/rules/*.md` 时，请同步更新本索引。
+
+## 通用准则
+
+- [`no-mid-flow-questions.md`](no-mid-flow-questions.md) — SKILL 执行期禁言：默认不向用户提问，及两类例外。
+- [`next-step-output.md`](next-step-output.md) — 「下一步」输出规则：任务短号渲染与 `Completed at` 收尾行。
+- [`version-stamp.md`](version-stamp.md) — `agent_infra_version` 版本戳的取值命令与写入时机。
+
+## Issue / PR
+
+- [`issue-pr-commands.md`](issue-pr-commands.md) — 验证平台认证、读写 Issue / PR 的 GitHub 命令集。
+- [`pr-checks-commands.md`](pr-checks-commands.md) — 监控 PR required checks、拉取失败日志的命令集（`watch-pr`）。
+- [`create-issue.md`](create-issue.md) — `create-task` 落盘后级联创建 Issue 的规则。
+- [`issue-sync.md`](issue-sync.md) — task 产物与 Issue 评论 / 标签 / 字段的同步标记与流程。
+- [`issue-fields.md`](issue-fields.md) — Issue Type pinned 字段（Priority/Effort/日期）的读写流程。
+- [`pr-sync.md`](pr-sync.md) — 面向 reviewer 的唯一 PR 摘要评论的同步规则。
+
+## 任务工作流
+
+- [`task-management.md`](task-management.md) — 任务语义识别与工作流命令映射。
+- [`task-short-id.md`](task-short-id.md) — 任务短号 `#NN` / 裸数字的解析、分配与生命周期。
+- [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。
+- [`label-milestone-setup.md`](label-milestone-setup.md) — 初始化 label / milestone 的平台命令集。
+- [`security-alerts.md`](security-alerts.md) — 导入 / 关闭 Dependabot 与 Code Scanning 告警的命令集。
+
+## 提交与发布
+
+- [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits 提交信息与 PR 规范。
+- [`release-commands.md`](release-commands.md) — 读取历史 release、查询已合并 PR、发布 Release notes。
+
+## 测试与跨平台
+
+- [`testing-discipline.md`](testing-discipline.md) — 测试编写纪律：结构性断言优先，禁止脆弱的措辞匹配。
+- [`cross-platform-tests.md`](cross-platform-tests.md) — 跨平台测试守卫：用 `onPlatforms()` 表达平台跳过。

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -168,6 +168,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
   const syncFiles: Array<[string, string]> = [
     [".agents/QUICKSTART.md", "templates/.agents/QUICKSTART.en.md"],
     [".agents/README.md", "templates/.agents/README.en.md"],
+    [".agents/rules/README.md", "templates/.agents/rules/README.en.md"],
     [".agents/templates/task.md", "templates/.agents/templates/task.en.md"],
     [".agents/skills/archive-tasks/SKILL.md", "templates/.agents/skills/archive-tasks/SKILL.en.md"],
     [".agents/skills/archive-tasks/scripts/archive-tasks.sh", "templates/.agents/skills/archive-tasks/scripts/archive-tasks.sh"],
@@ -457,5 +458,18 @@ test("template JavaScript files do not contain shebang lines", () => {
       "Homebrew rewrites shebangs to machine-specific absolute paths during installation, " +
       "which pollutes project files when synced. Use 'node <path>' to invoke these scripts."
     );
+  });
+});
+
+test("rules README index lists every rule file", () => {
+  const dir = ".agents/rules";
+  const ruleNames = fs.readdirSync(dir)
+    .filter((fileName) => fileName.endsWith(".md") && fileName !== "README.md")
+    .map((fileName) => fileName.replace(/\.md$/, ""))
+    .sort();
+  const index = read(`${dir}/README.md`);
+
+  ruleNames.forEach((name) => {
+    assert.ok(index.includes(name), `rules/README.md should reference ${name}`);
   });
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #473

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 📚 文档更新 / Documentation update

## 📝 变更目的 / Purpose of the Change

`.agents/rules/` 目录有 18 个 rule 文件却没有索引，几乎每个 SKILL 都会引用其中若干个，但「哪一篇管什么」需要逐文件读才知道。本 PR 新增一个轻量、平台无关的规则索引，按业务域分组列出全部 18 条 rule，每行一句话说明用途，让 AI 和新成员无需翻阅每个文件即可快速定位「该读哪几篇」。

## 📋 主要变更 / Brief Changelog

- 新增索引「三件套」：`.agents/rules/README.md`（运行态，39 行）+ `templates/.agents/rules/README.zh-CN.md` / `README.en.md`（双语模板变体）。索引不含 `{{project}}` 占位符，故运行态与 zh-CN 模板逐字节相同；`.agents/rules/` 已是 managed 目录，模板由目录扫描自动纳管，**无需改 `lib/defaults.json`**。
- 分组沿用 Issue 建议的 5 组（通用准则 / Issue · PR / 任务工作流 / 提交与发布 / 测试与跨平台），3+6+5+2+2 = 18，全覆盖。
- 加指针：`AGENTS.md` 末尾「规则加载指令簇」追加一行索引指针；`.agents/README.md` 目录树补 `rules/` 行（此前遗漏），并同步两个 `templates/.agents/README.*` 变体以满足 parity 测试。
- 防漂移守卫（`tests/unit/templates/templates.test.ts`，2 处）：① 把运行态 ↔ 模板的 parity 检查登记进既有 `syncFiles`；② 新增结构性完整性测试，断言每个 rule 文件名都出现在索引中（不绑定任何自然语言措辞，遵守 `testing-discipline`）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1043 pass / 0 fail / 1 skipped（既有平台守卫）；新增「rules README index lists every rule file」与 parity 用例均通过。
2. `diff .agents/rules/README.md templates/.agents/rules/README.zh-CN.md` —— 无差异（运行态与 zh-CN 模板逐字节一致）。
3. `wc -l` 三个索引文件 —— 39 / 39 / 40 行，均 ≤ 80。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档（本变更即文档本身）/ I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 非目标（严格遵守）：未合并 / 重命名 / 删除任何现有 rule；未改任何 SKILL.md 的 rule 引用路径；未引入 `.github.` / `.platform.` 变体（索引平台无关）。
- 关键耦合：`.agents/README.md` 受 parity 测试约束（`templates.test.ts`），故目录树改动同步到两个模板变体；新增的 parity 登记会长期守护运行态与 zh-CN 模板不漂移。
- 与「README 瘦身」「CONTRIBUTING 双语化」两个文档治理任务相互独立。

---

**审查者注意事项 / Reviewer Notes:**

- 索引内容准确性：18 条 rule 的单行描述是否与各 rule 实际职责一致。
- 完整性测试的取舍：是否同意以「rule basename 出现在索引中」作为防漂移的结构性断言（刻意不校验措辞质量，避免脆弱断言）。

Closes #473

Generated with AI assistance