### PR TITLE
feat(cli): 为 ai task 新增 files / cat 子命令及 artifact 枚举原语

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,7 +18,7 @@ Usage:
   agent-infra init            Initialize a new project with update-agent-infra seed command
   agent-infra merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   agent-infra sandbox         Manage Docker-based AI sandboxes
-  agent-infra task            Read-only views over .agents/workspace tasks (ls / show)
+  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat)
   agent-infra update          Update seed files and sync file registry for an existing project
   agent-infra version         Show version
 

--- a/lib/task/artifacts.ts
+++ b/lib/task/artifacts.ts
@@ -9,55 +9,32 @@ type Artifact = {
   mtimeMs: number;
 };
 
-// Lifecycle group ranking. Lower rank sorts first; within a rank, entries sort
-// by filename ascending. `task.md` always leads, then the lifecycle order
-// analysis → review-analysis → plan → review-plan → fallback. The more specific
-// `review-*` matchers are listed before their base prefixes so the match order
-// is unambiguous, but each keeps the rank that places it AFTER its base group.
-const GROUP_MATCHERS: ReadonlyArray<{ rank: number; test: (name: string) => boolean }> = [
-  { rank: 0, test: (n) => n === 'task.md' },
-  { rank: 2, test: (n) => /^review-analysis/.test(n) },
-  { rank: 1, test: (n) => /^analysis/.test(n) },
-  { rank: 4, test: (n) => /^review-plan/.test(n) },
-  { rank: 3, test: (n) => /^plan/.test(n) }
-];
-// Anything not matched above (reports, code*, review-code*, verify-pr-*, etc.).
-const FALLBACK_RANK = 5;
-
-function groupRank(name: string): number {
-  for (const matcher of GROUP_MATCHERS) {
-    if (matcher.test(name)) return matcher.rank;
-  }
-  return FALLBACK_RANK;
-}
-
 /**
- * Enumerate a task directory's artifacts in a deterministic order: `task.md`
- * first, then by lifecycle group (analysis → review-analysis → plan →
- * review-plan → fallback), and filename-ascending within each group.
+ * Enumerate a task directory's artifacts ordered by modification time, oldest
+ * first, so the listing reads like the task's timeline. Filename ascending is a
+ * deterministic tiebreak when two files share the same mtime (e.g. written in
+ * the same millisecond).
  *
  * Only top-level regular files are included; subdirectories and dotfiles are
- * skipped so the numbered index contract stays stable and every entry is
- * something `cat` can print. The returned 1-based `index` is the single source
- * of truth shared by `files` and `cat`.
+ * skipped so every entry is something `cat` can print. The returned 1-based
+ * `index` is the source of truth shared by `files` and `cat`.
  */
 function enumerateArtifacts(taskDir: string): Artifact[] {
   const entries = fs
     .readdirSync(taskDir, { withFileTypes: true })
     .filter((dirent) => dirent.isFile() && !dirent.name.startsWith('.'))
-    .map((dirent) => dirent.name);
+    .map((dirent) => {
+      const abs = path.join(taskDir, dirent.name);
+      const stat = fs.statSync(abs);
+      return { name: dirent.name, path: abs, size: stat.size, mtimeMs: stat.mtimeMs };
+    });
 
   entries.sort((a, b) => {
-    const rankDiff = groupRank(a) - groupRank(b);
-    if (rankDiff !== 0) return rankDiff;
-    return a < b ? -1 : a > b ? 1 : 0;
+    if (a.mtimeMs !== b.mtimeMs) return a.mtimeMs - b.mtimeMs;
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
   });
 
-  return entries.map((name, i) => {
-    const abs = path.join(taskDir, name);
-    const stat = fs.statSync(abs);
-    return { index: i + 1, name, path: abs, size: stat.size, mtimeMs: stat.mtimeMs };
-  });
+  return entries.map((entry, i) => ({ index: i + 1, ...entry }));
 }
 
 /**

--- a/lib/task/artifacts.ts
+++ b/lib/task/artifacts.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type Artifact = {
+  index: number;
+  name: string;
+  path: string;
+  size: number;
+  mtimeMs: number;
+};
+
+// Lifecycle group ranking. Lower rank sorts first; within a rank, entries sort
+// by filename ascending. `task.md` always leads, then the lifecycle order
+// analysis → review-analysis → plan → review-plan → fallback. The more specific
+// `review-*` matchers are listed before their base prefixes so the match order
+// is unambiguous, but each keeps the rank that places it AFTER its base group.
+const GROUP_MATCHERS: ReadonlyArray<{ rank: number; test: (name: string) => boolean }> = [
+  { rank: 0, test: (n) => n === 'task.md' },
+  { rank: 2, test: (n) => /^review-analysis/.test(n) },
+  { rank: 1, test: (n) => /^analysis/.test(n) },
+  { rank: 4, test: (n) => /^review-plan/.test(n) },
+  { rank: 3, test: (n) => /^plan/.test(n) }
+];
+// Anything not matched above (reports, code*, review-code*, verify-pr-*, etc.).
+const FALLBACK_RANK = 5;
+
+function groupRank(name: string): number {
+  for (const matcher of GROUP_MATCHERS) {
+    if (matcher.test(name)) return matcher.rank;
+  }
+  return FALLBACK_RANK;
+}
+
+/**
+ * Enumerate a task directory's artifacts in a deterministic order: `task.md`
+ * first, then by lifecycle group (analysis → review-analysis → plan →
+ * review-plan → fallback), and filename-ascending within each group.
+ *
+ * Only top-level regular files are included; subdirectories and dotfiles are
+ * skipped so the numbered index contract stays stable and every entry is
+ * something `cat` can print. The returned 1-based `index` is the single source
+ * of truth shared by `files` and `cat`.
+ */
+function enumerateArtifacts(taskDir: string): Artifact[] {
+  const entries = fs
+    .readdirSync(taskDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isFile() && !dirent.name.startsWith('.'))
+    .map((dirent) => dirent.name);
+
+  entries.sort((a, b) => {
+    const rankDiff = groupRank(a) - groupRank(b);
+    if (rankDiff !== 0) return rankDiff;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+
+  return entries.map((name, i) => {
+    const abs = path.join(taskDir, name);
+    const stat = fs.statSync(abs);
+    return { index: i + 1, name, path: abs, size: stat.size, mtimeMs: stat.mtimeMs };
+  });
+}
+
+/**
+ * Resolve an artifact selector to an absolute path within `taskDir`. The
+ * selector is either a 1-based index `N` (as listed by `files`) or a filename
+ * (with or without the `.md` suffix). Throws with a clear message on failure.
+ */
+function resolveArtifact(taskDir: string, artifactOrN: string): string {
+  if (path.basename(artifactOrN) !== artifactOrN) {
+    throw new Error('artifact name must not contain path separators');
+  }
+
+  if (/^\d+$/.test(artifactOrN)) {
+    const n = Number(artifactOrN);
+    const match = enumerateArtifacts(taskDir).find((a) => a.index === n);
+    if (!match) {
+      throw new Error(`invalid artifact index ${n} (run 'ai task files <ref>' to list)`);
+    }
+    return match.path;
+  }
+
+  const candidates = artifactOrN.endsWith('.md')
+    ? [artifactOrN]
+    : [artifactOrN, `${artifactOrN}.md`];
+  for (const candidate of candidates) {
+    const abs = path.join(taskDir, candidate);
+    if (fs.existsSync(abs) && fs.statSync(abs).isFile()) {
+      return abs;
+    }
+  }
+  throw new Error(`artifact '${artifactOrN}' not found in task directory`);
+}
+
+export { enumerateArtifacts, resolveArtifact };
+export type { Artifact };

--- a/lib/task/commands/cat.ts
+++ b/lib/task/commands/cat.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import { resolveTaskRef } from '../resolve-ref.ts';
+import { resolveArtifact } from '../artifacts.ts';
+
+const USAGE = `Usage: ai task cat <N | #N | TASK-id> <artifact | N>
+
+Prints a task artifact's raw content to stdout.
+  <ref>            Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
+  <artifact | N>   Artifact filename (with or without '.md'), or the number from 'ai task files'.
+`;
+
+function cat(args: string[] = []): void {
+  if (args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    return;
+  }
+  if (args.length < 2) {
+    process.stdout.write(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+  const resolved = resolveTaskRef(args[0]!);
+  if (!resolved.ok) {
+    process.stderr.write(`ai task cat: ${resolved.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  let artifactPath: string;
+  try {
+    artifactPath = resolveArtifact(resolved.taskDir, args[1]!);
+  } catch (e) {
+    process.stderr.write(`ai task cat: ${(e as Error).message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(fs.readFileSync(artifactPath, 'utf8'));
+}
+
+export { cat };

--- a/lib/task/commands/files.ts
+++ b/lib/task/commands/files.ts
@@ -37,9 +37,11 @@ function files(args: string[] = []): void {
     return;
   }
   const artifacts = enumerateArtifacts(resolved.taskDir);
+  // Show the name without the `.md` suffix so the NAME column is exactly what
+  // `ai task cat <ref> <name>` accepts (the resolver re-adds `.md`).
   const rows = artifacts.map((a) => [
     String(a.index),
-    a.name,
+    a.name.replace(/\.md$/, ''),
     String(a.size),
     formatMtime(a.mtimeMs)
   ]);

--- a/lib/task/commands/files.ts
+++ b/lib/task/commands/files.ts
@@ -1,0 +1,51 @@
+import { formatTable } from '../../table.ts';
+import { resolveTaskRef } from '../resolve-ref.ts';
+import { enumerateArtifacts } from '../artifacts.ts';
+
+const USAGE = `Usage: ai task files <N | #N | TASK-id>
+
+Lists the artifacts in a task directory with stable numbers.
+  <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
+
+Columns: # (artifact number, usable with 'ai task cat') / NAME / SIZE (bytes) / MTIME
+`;
+
+const TABLE_HEADERS = ['#', 'NAME', 'SIZE', 'MTIME'] as const;
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function formatMtime(mtimeMs: number): string {
+  const d = new Date(mtimeMs);
+  return (
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ` +
+    `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`
+  );
+}
+
+function files(args: string[] = []): void {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    if (args.length === 0) process.exitCode = 1;
+    return;
+  }
+  const resolved = resolveTaskRef(args[0]!);
+  if (!resolved.ok) {
+    process.stderr.write(`ai task files: ${resolved.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const artifacts = enumerateArtifacts(resolved.taskDir);
+  const rows = artifacts.map((a) => [
+    String(a.index),
+    a.name,
+    String(a.size),
+    formatMtime(a.mtimeMs)
+  ]);
+  for (const line of formatTable(TABLE_HEADERS, rows, { zebra: Boolean(process.stdout.isTTY) })) {
+    process.stdout.write(`${line}\n`);
+  }
+}
+
+export { files };

--- a/lib/task/commands/show.ts
+++ b/lib/task/commands/show.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
-import path from 'node:path';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { normalizeShortIdInput } from '../short-id.ts';
+import { resolveTaskRef } from '../resolve-ref.ts';
 
 const USAGE = `Usage: ai task show <N | #N | TASK-id>
 
@@ -11,129 +9,19 @@ Prints the task.md content for the matching task.
   TASK-YYYYMMDD-HHMMSS  Locates a task in active / blocked / completed / archive.
 `;
 
-const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
-// Flat-structured workspace dirs that hold tasks under `{dir}/{taskId}/task.md`.
-// Note: `archive` uses a three-level YYYY/MM/DD layout and is handled separately.
-const FLAT_WORKSPACE_DIRS = ['active', 'blocked', 'completed'] as const;
-
-function detectRepoRoot(): string {
-  try {
-    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-  } catch {
-    throw new Error('ai task: current directory is not inside a git repository');
-  }
-}
-
-function readShortIdLength(repoRoot: string): number {
-  try {
-    const cfg = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8'));
-    const v = cfg?.task?.shortIdLength;
-    if (typeof v === 'number' && Number.isFinite(v) && v >= 1) return v;
-  } catch {
-    // fall through to default
-  }
-  return 2;
-}
-
-function resolveShortIdToTaskId(arg: string, repoRoot: string): string {
-  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
-  if (!fs.existsSync(scriptPath)) {
-    throw new Error(`task-short-id.js not found at ${scriptPath}`);
-  }
-  const result = spawnSync('node', [scriptPath, 'resolve', arg], {
-    encoding: 'utf8',
-    cwd: repoRoot
-  });
-  if (result.status !== 0) {
-    throw new Error((result.stderr || '').trim() || `failed to resolve '${arg}'`);
-  }
-  return result.stdout.trim();
-}
-
-function listSortedNumeric(dir: string, width: number): string[] {
-  if (!fs.existsSync(dir)) return [];
-  const pattern = new RegExp(`^\\d{${width}}$`);
-  return fs
-    .readdirSync(dir)
-    .filter((entry) => pattern.test(entry))
-    .sort()
-    .reverse();
-}
-
-function findInArchive(repoRoot: string, taskId: string): string | null {
-  // archive-tasks SKILL writes to .agents/workspace/archive/YYYY/MM/DD/{taskId}/task.md
-  // where YYYY/MM/DD comes from completed_at (or updated_at fallback) — NOT from
-  // the task id's creation date. So we cannot derive the path from taskId alone;
-  // walk the bounded YYYY/MM/DD tree instead. Newest-first to favor recent archives.
-  const archiveDir = path.join(repoRoot, '.agents', 'workspace', 'archive');
-  for (const year of listSortedNumeric(archiveDir, 4)) {
-    const yearDir = path.join(archiveDir, year);
-    for (const month of listSortedNumeric(yearDir, 2)) {
-      const monthDir = path.join(yearDir, month);
-      for (const day of listSortedNumeric(monthDir, 2)) {
-        const candidate = path.join(monthDir, day, taskId, 'task.md');
-        if (fs.existsSync(candidate)) return candidate;
-      }
-    }
-  }
-  return null;
-}
-
-function findTaskMd(repoRoot: string, taskId: string): string | null {
-  for (const sub of FLAT_WORKSPACE_DIRS) {
-    const candidate = path.join(repoRoot, '.agents', 'workspace', sub, taskId, 'task.md');
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return findInArchive(repoRoot, taskId);
-}
-
 function show(args: string[] = []): void {
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(USAGE);
     if (args.length === 0) process.exitCode = 1;
     return;
   }
-  const repoRoot = detectRepoRoot();
-  const arg = args[0]!;
-  let taskId: string;
-  if (TASK_ID_RE.test(arg)) {
-    taskId = arg;
-  } else {
-    const shortIdLength = readShortIdLength(repoRoot);
-    const normalized = normalizeShortIdInput(arg, { shortIdLength });
-    if (normalized.kind === 'error') {
-      process.stderr.write(`ai task show: ${normalized.message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-    if (normalized.kind === 'pass') {
-      process.stderr.write(
-        `ai task show: '${arg}' is not a valid short id or TASK-id; ` +
-          `expected bare digits, '#N', or 'TASK-YYYYMMDD-HHMMSS'\n`
-      );
-      process.exitCode = 1;
-      return;
-    }
-    try {
-      taskId = resolveShortIdToTaskId(normalized.value, repoRoot);
-    } catch (e) {
-      process.stderr.write(`ai task show: ${(e as Error).message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  }
-  const taskMdPath = findTaskMd(repoRoot, taskId);
-  if (!taskMdPath) {
-    process.stderr.write(
-      `ai task show: task ${taskId} not found in active / blocked / completed / archive\n`
-    );
+  const resolved = resolveTaskRef(args[0]!);
+  if (!resolved.ok) {
+    process.stderr.write(`ai task show: ${resolved.message}\n`);
     process.exitCode = 1;
     return;
   }
-  process.stdout.write(fs.readFileSync(taskMdPath, 'utf8'));
+  process.stdout.write(fs.readFileSync(resolved.taskMdPath, 'utf8'));
 }
 
 export { show };

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -3,11 +3,16 @@ const USAGE = `Usage: ai task <command> [options]
 Commands:
   ls [--all | --blocked | --completed]   List tasks (default: active)
   show <N | #N | TASK-id>                Print a task.md
+  files <ref>                            List artifacts in a task dir (numbered)
+  cat <ref> <artifact | N>               Print a task artifact (by name or number)
 
 Examples:
   ai task ls
   ai task show 11
   ai task show TASK-20260612-162737
+  ai task files 11
+  ai task cat 11 analysis
+  ai task cat 11 3
 
 Run 'ai task <command> --help' for details.`;
 
@@ -34,6 +39,16 @@ export async function runTask(args: string[]): Promise<void> {
     case 'show': {
       const { show } = await import('./commands/show.ts');
       show(rest);
+      break;
+    }
+    case 'files': {
+      const { files } = await import('./commands/files.ts');
+      files(rest);
+      break;
+    }
+    case 'cat': {
+      const { cat } = await import('./commands/cat.ts');
+      cat(rest);
       break;
     }
     default:

--- a/lib/task/resolve-ref.ts
+++ b/lib/task/resolve-ref.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { normalizeShortIdInput } from './short-id.ts';
+
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+// Flat-structured workspace dirs that hold tasks under `{dir}/{taskId}/task.md`.
+// Note: `archive` uses a three-level YYYY/MM/DD layout and is handled separately.
+const FLAT_WORKSPACE_DIRS = ['active', 'blocked', 'completed'] as const;
+
+type ResolveRefResult =
+  | {
+      ok: true;
+      repoRoot: string;
+      taskId: string;
+      taskDir: string;
+      taskMdPath: string;
+    }
+  | { ok: false; message: string };
+
+function detectRepoRoot(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    throw new Error('ai task: current directory is not inside a git repository');
+  }
+}
+
+function readShortIdLength(repoRoot: string): number {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8'));
+    const v = cfg?.task?.shortIdLength;
+    if (typeof v === 'number' && Number.isFinite(v) && v >= 1) return v;
+  } catch {
+    // fall through to default
+  }
+  return 2;
+}
+
+function resolveShortIdToTaskId(arg: string, repoRoot: string): string {
+  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
+  if (!fs.existsSync(scriptPath)) {
+    throw new Error(`task-short-id.js not found at ${scriptPath}`);
+  }
+  const result = spawnSync('node', [scriptPath, 'resolve', arg], {
+    encoding: 'utf8',
+    cwd: repoRoot
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `failed to resolve '${arg}'`);
+  }
+  return result.stdout.trim();
+}
+
+function listSortedNumeric(dir: string, width: number): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const pattern = new RegExp(`^\\d{${width}}$`);
+  return fs
+    .readdirSync(dir)
+    .filter((entry) => pattern.test(entry))
+    .sort()
+    .reverse();
+}
+
+function findInArchive(repoRoot: string, taskId: string): string | null {
+  // archive-tasks SKILL writes to .agents/workspace/archive/YYYY/MM/DD/{taskId}/task.md
+  // where YYYY/MM/DD comes from completed_at (or updated_at fallback) — NOT from
+  // the task id's creation date. So we cannot derive the path from taskId alone;
+  // walk the bounded YYYY/MM/DD tree instead. Newest-first to favor recent archives.
+  const archiveDir = path.join(repoRoot, '.agents', 'workspace', 'archive');
+  for (const year of listSortedNumeric(archiveDir, 4)) {
+    const yearDir = path.join(archiveDir, year);
+    for (const month of listSortedNumeric(yearDir, 2)) {
+      const monthDir = path.join(yearDir, month);
+      for (const day of listSortedNumeric(monthDir, 2)) {
+        const candidate = path.join(monthDir, day, taskId, 'task.md');
+        if (fs.existsSync(candidate)) return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function findTaskMd(repoRoot: string, taskId: string): string | null {
+  for (const sub of FLAT_WORKSPACE_DIRS) {
+    const candidate = path.join(repoRoot, '.agents', 'workspace', sub, taskId, 'task.md');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return findInArchive(repoRoot, taskId);
+}
+
+/**
+ * Resolve a task ref (bare short id, `#N`, or `TASK-YYYYMMDD-HHMMSS`) to its
+ * task directory across active / blocked / completed / archive.
+ *
+ * The returned `message` on failure is command-agnostic (no `ai task <cmd>:`
+ * prefix); callers prepend their own prefix so each command keeps its existing
+ * stderr wording byte-for-byte.
+ */
+function resolveTaskRef(arg: string): ResolveRefResult {
+  const repoRoot = detectRepoRoot();
+  let taskId: string;
+  if (TASK_ID_RE.test(arg)) {
+    taskId = arg;
+  } else {
+    const shortIdLength = readShortIdLength(repoRoot);
+    const normalized = normalizeShortIdInput(arg, { shortIdLength });
+    if (normalized.kind === 'error') {
+      return { ok: false, message: normalized.message };
+    }
+    if (normalized.kind === 'pass') {
+      return {
+        ok: false,
+        message:
+          `'${arg}' is not a valid short id or TASK-id; ` +
+          `expected bare digits, '#N', or 'TASK-YYYYMMDD-HHMMSS'`
+      };
+    }
+    try {
+      taskId = resolveShortIdToTaskId(normalized.value, repoRoot);
+    } catch (e) {
+      return { ok: false, message: (e as Error).message };
+    }
+  }
+  const taskMdPath = findTaskMd(repoRoot, taskId);
+  if (!taskMdPath) {
+    return {
+      ok: false,
+      message: `task ${taskId} not found in active / blocked / completed / archive`
+    };
+  }
+  return { ok: true, repoRoot, taskId, taskDir: path.dirname(taskMdPath), taskMdPath };
+}
+
+export { resolveTaskRef, TASK_ID_RE };
+export type { ResolveRefResult };

--- a/tests/integration/cli/task-cat.test.ts
+++ b/tests/integration/cli/task-cat.test.ts
@@ -29,6 +29,9 @@ function writeTaskWithArtifacts(activeDir: string, taskId: string): void {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\nbody\n`);
   fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body line\n');
+  // Oldest-first order: task.md (#1) then analysis.md (#2).
+  fs.utimesSync(path.join(dir, 'task.md'), 1000, 1000);
+  fs.utimesSync(path.join(dir, 'analysis.md'), 2000, 2000);
 }
 
 function runCli(args: string[], cwd: string) {

--- a/tests/integration/cli/task-cat.test.ts
+++ b/tests/integration/cli/task-cat.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-cat-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  const activeDir = path.join(agentsDir, 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTaskWithArtifacts(activeDir: string, taskId: string): void {
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\nbody\n`);
+  fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body line\n');
+}
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('ai task cat <ref> <name> and <ref> <N> produce identical output', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTaskWithArtifacts(activeDir, taskId);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const byName = runCli(['task', 'cat', '1', 'analysis'], repoRoot);
+  // analysis.md is artifact #2 (task.md is #1).
+  const byIndex = runCli(['task', 'cat', '1', '2'], repoRoot);
+  assert.equal(byName.status, 0, byName.stderr);
+  assert.equal(byIndex.status, 0, byIndex.stderr);
+  assert.equal(byName.stdout, 'analysis body line\n');
+  assert.equal(byName.stdout, byIndex.stdout);
+});
+
+test('ai task cat <ref> task is byte-identical to ai task show <ref>', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTaskWithArtifacts(activeDir, taskId);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const cat = runCli(['task', 'cat', '1', 'task'], repoRoot);
+  const show = runCli(['task', 'show', '1'], repoRoot);
+  assert.equal(cat.status, 0, cat.stderr);
+  assert.equal(show.status, 0, show.stderr);
+  assert.equal(cat.stdout, show.stdout);
+});
+
+test('ai task cat rejects a non-existent artifact name', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTaskWithArtifacts(activeDir, taskId);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const out = runCli(['task', 'cat', '1', 'nope'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /ai task cat: artifact 'nope' not found/);
+});
+
+test('ai task cat requires both ref and artifact arguments', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTaskWithArtifacts(activeDir, taskId);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const out = runCli(['task', 'cat', '1'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task cat/);
+});

--- a/tests/integration/cli/task-files.test.ts
+++ b/tests/integration/cli/task-files.test.ts
@@ -30,6 +30,10 @@ function writeTaskWithArtifacts(activeDir: string, taskId: string): void {
   fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\n`);
   fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body\n');
   fs.writeFileSync(path.join(dir, 'review-analysis.md'), 'review body\n');
+  // Deterministic mtimes (oldest first): analysis -> review-analysis -> task.
+  fs.utimesSync(path.join(dir, 'analysis.md'), 1000, 1000);
+  fs.utimesSync(path.join(dir, 'review-analysis.md'), 2000, 2000);
+  fs.utimesSync(path.join(dir, 'task.md'), 3000, 3000);
   // A subdirectory must not appear in the numbered listing.
   fs.mkdirSync(path.join(dir, 'sandbox-verify'), { recursive: true });
 }
@@ -48,10 +52,12 @@ test('ai task files <ref> prints a numbered artifact table', () => {
   assert.equal(out.status, 0, out.stderr);
   // Header columns.
   assert.match(out.stdout, /#\s+NAME\s+SIZE\s+MTIME/);
-  // task.md is artifact #1; analysis sorts before review-analysis (lifecycle order).
-  assert.match(out.stdout, /^1\s+task\.md\s+\d+\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/m);
-  assert.match(out.stdout, /^2\s+analysis\.md/m);
-  assert.match(out.stdout, /^3\s+review-analysis\.md/m);
+  // Ordered oldest-first by mtime; NAME shown without the `.md` suffix.
+  assert.match(out.stdout, /^1\s+analysis\s+\d+\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/m);
+  assert.match(out.stdout, /^2\s+review-analysis\s/m);
+  assert.match(out.stdout, /^3\s+task\s/m);
+  // Names are stripped of `.md`.
+  assert.doesNotMatch(out.stdout, /\.md/);
   // The subdirectory must not be listed.
   assert.doesNotMatch(out.stdout, /sandbox-verify/);
 });

--- a/tests/integration/cli/task-files.test.ts
+++ b/tests/integration/cli/task-files.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-files-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  const activeDir = path.join(agentsDir, 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+function writeTaskWithArtifacts(activeDir: string, taskId: string): void {
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\n`);
+  fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body\n');
+  fs.writeFileSync(path.join(dir, 'review-analysis.md'), 'review body\n');
+  // A subdirectory must not appear in the numbered listing.
+  fs.mkdirSync(path.join(dir, 'sandbox-verify'), { recursive: true });
+}
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('ai task files <ref> prints a numbered artifact table', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTaskWithArtifacts(activeDir, taskId);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const out = runCli(['task', 'files', '1'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // Header columns.
+  assert.match(out.stdout, /#\s+NAME\s+SIZE\s+MTIME/);
+  // task.md is artifact #1; analysis sorts before review-analysis (lifecycle order).
+  assert.match(out.stdout, /^1\s+task\.md\s+\d+\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/m);
+  assert.match(out.stdout, /^2\s+analysis\.md/m);
+  assert.match(out.stdout, /^3\s+review-analysis\.md/m);
+  // The subdirectory must not be listed.
+  assert.doesNotMatch(out.stdout, /sandbox-verify/);
+});
+
+test('ai task files rejects an unknown ref', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'files', 'not-a-task'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /ai task files:/);
+});
+
+test('ai task files requires an argument', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'files'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task files/);
+});

--- a/tests/unit/cli/task-artifacts.test.ts
+++ b/tests/unit/cli/task-artifacts.test.ts
@@ -17,49 +17,55 @@ function mkTaskDir(files: string[], subdirs: string[] = []): string {
   return dir;
 }
 
-test('enumerateArtifacts orders by lifecycle group (base before review-) then filename', () => {
-  // Intentionally shuffled on disk; the contract is the returned order.
-  const dir = mkTaskDir([
-    'review-plan.md',
-    'analysis-r2.md',
-    'verify-pr-1.md',
-    'plan.md',
-    'analysis.md',
-    'task.md',
-    'review-analysis.md',
-    'code.md'
-  ]);
+// Set a deterministic mtime (epoch seconds) so ordering tests don't depend on
+// the millisecond at which the fixture files happened to be written.
+function setMtime(dir: string, name: string, epochSeconds: number): void {
+  fs.utimesSync(path.join(dir, name), epochSeconds, epochSeconds);
+}
+
+test('enumerateArtifacts orders by mtime ascending (oldest first)', () => {
+  const dir = mkTaskDir(['task.md', 'analysis.md', 'plan.md', 'code.md']);
+  // Deliberately non-alphabetical timestamps; task.md is newest (as in real
+  // tasks, since it is rewritten every workflow step) so it lands last.
+  setMtime(dir, 'analysis.md', 1000);
+  setMtime(dir, 'plan.md', 2000);
+  setMtime(dir, 'code.md', 3000);
+  setMtime(dir, 'task.md', 4000);
   const names = enumerateArtifacts(dir).map((a) => a.name);
-  assert.deepEqual(names, [
-    'task.md', // rank 0
-    // rank 1 analysis, filename asc — 'analysis-r2.md' precedes 'analysis.md' because '-' (0x2D) < '.' (0x2E)
-    'analysis-r2.md',
-    'analysis.md',
-    'review-analysis.md', // rank 2
-    'plan.md', // rank 3
-    'review-plan.md', // rank 4
-    'code.md', // fallback rank 5, filename asc
-    'verify-pr-1.md'
-  ]);
+  assert.deepEqual(names, ['analysis.md', 'plan.md', 'code.md', 'task.md']);
 });
 
-test('enumerateArtifacts assigns stable 1-based indices', () => {
+test('enumerateArtifacts falls back to filename ascending when mtimes are equal', () => {
+  const dir = mkTaskDir(['plan.md', 'analysis.md', 'review-plan.md']);
+  setMtime(dir, 'plan.md', 5000);
+  setMtime(dir, 'analysis.md', 5000);
+  setMtime(dir, 'review-plan.md', 5000);
+  const names = enumerateArtifacts(dir).map((a) => a.name);
+  assert.deepEqual(names, ['analysis.md', 'plan.md', 'review-plan.md']);
+});
+
+test('enumerateArtifacts assigns 1-based indices in mtime order', () => {
   const dir = mkTaskDir(['task.md', 'analysis.md', 'plan.md']);
+  setMtime(dir, 'analysis.md', 100);
+  setMtime(dir, 'plan.md', 200);
+  setMtime(dir, 'task.md', 300);
   const artifacts = enumerateArtifacts(dir);
   assert.deepEqual(
     artifacts.map((a) => [a.index, a.name]),
     [
-      [1, 'task.md'],
-      [2, 'analysis.md'],
-      [3, 'plan.md']
+      [1, 'analysis.md'],
+      [2, 'plan.md'],
+      [3, 'task.md']
     ]
   );
 });
 
 test('enumerateArtifacts skips subdirectories and dotfiles', () => {
   const dir = mkTaskDir(['task.md', 'analysis.md', '.hidden'], ['sandbox-verify']);
-  const names = enumerateArtifacts(dir).map((a) => a.name);
-  assert.deepEqual(names, ['task.md', 'analysis.md']);
+  const names = enumerateArtifacts(dir)
+    .map((a) => a.name)
+    .sort();
+  assert.deepEqual(names, ['analysis.md', 'task.md']);
 });
 
 test('enumerateArtifacts returns absolute path, size and mtime per entry', () => {
@@ -82,6 +88,9 @@ test('resolveArtifact resolves a filename with or without the .md suffix', () =>
 
 test('resolveArtifact resolves a numeric index to the same path as enumeration', () => {
   const dir = mkTaskDir(['task.md', 'analysis.md', 'plan.md']);
+  setMtime(dir, 'task.md', 100);
+  setMtime(dir, 'analysis.md', 200);
+  setMtime(dir, 'plan.md', 300);
   assert.equal(resolveArtifact(dir, '1'), path.join(dir, 'task.md'));
   assert.equal(resolveArtifact(dir, '3'), path.join(dir, 'plan.md'));
 });

--- a/tests/unit/cli/task-artifacts.test.ts
+++ b/tests/unit/cli/task-artifacts.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { enumerateArtifacts, resolveArtifact } from '../../../lib/task/artifacts.ts';
+
+function mkTaskDir(files: string[], subdirs: string[] = []): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-artifacts-'));
+  for (const name of files) {
+    fs.writeFileSync(path.join(dir, name), `content of ${name}\n`);
+  }
+  for (const sub of subdirs) {
+    fs.mkdirSync(path.join(dir, sub), { recursive: true });
+  }
+  return dir;
+}
+
+test('enumerateArtifacts orders by lifecycle group (base before review-) then filename', () => {
+  // Intentionally shuffled on disk; the contract is the returned order.
+  const dir = mkTaskDir([
+    'review-plan.md',
+    'analysis-r2.md',
+    'verify-pr-1.md',
+    'plan.md',
+    'analysis.md',
+    'task.md',
+    'review-analysis.md',
+    'code.md'
+  ]);
+  const names = enumerateArtifacts(dir).map((a) => a.name);
+  assert.deepEqual(names, [
+    'task.md', // rank 0
+    // rank 1 analysis, filename asc — 'analysis-r2.md' precedes 'analysis.md' because '-' (0x2D) < '.' (0x2E)
+    'analysis-r2.md',
+    'analysis.md',
+    'review-analysis.md', // rank 2
+    'plan.md', // rank 3
+    'review-plan.md', // rank 4
+    'code.md', // fallback rank 5, filename asc
+    'verify-pr-1.md'
+  ]);
+});
+
+test('enumerateArtifacts assigns stable 1-based indices', () => {
+  const dir = mkTaskDir(['task.md', 'analysis.md', 'plan.md']);
+  const artifacts = enumerateArtifacts(dir);
+  assert.deepEqual(
+    artifacts.map((a) => [a.index, a.name]),
+    [
+      [1, 'task.md'],
+      [2, 'analysis.md'],
+      [3, 'plan.md']
+    ]
+  );
+});
+
+test('enumerateArtifacts skips subdirectories and dotfiles', () => {
+  const dir = mkTaskDir(['task.md', 'analysis.md', '.hidden'], ['sandbox-verify']);
+  const names = enumerateArtifacts(dir).map((a) => a.name);
+  assert.deepEqual(names, ['task.md', 'analysis.md']);
+});
+
+test('enumerateArtifacts returns absolute path, size and mtime per entry', () => {
+  const dir = mkTaskDir(['task.md']);
+  const [entry] = enumerateArtifacts(dir);
+  assert.ok(entry);
+  assert.equal(entry.path, path.join(dir, 'task.md'));
+  assert.ok(path.isAbsolute(entry.path));
+  assert.equal(entry.size, fs.statSync(entry.path).size);
+  assert.ok(entry.size > 0);
+  assert.equal(typeof entry.mtimeMs, 'number');
+});
+
+test('resolveArtifact resolves a filename with or without the .md suffix', () => {
+  const dir = mkTaskDir(['task.md', 'analysis.md']);
+  const expected = path.join(dir, 'analysis.md');
+  assert.equal(resolveArtifact(dir, 'analysis'), expected);
+  assert.equal(resolveArtifact(dir, 'analysis.md'), expected);
+});
+
+test('resolveArtifact resolves a numeric index to the same path as enumeration', () => {
+  const dir = mkTaskDir(['task.md', 'analysis.md', 'plan.md']);
+  assert.equal(resolveArtifact(dir, '1'), path.join(dir, 'task.md'));
+  assert.equal(resolveArtifact(dir, '3'), path.join(dir, 'plan.md'));
+});
+
+test('resolveArtifact throws on a non-existent artifact name', () => {
+  const dir = mkTaskDir(['task.md']);
+  assert.throws(() => resolveArtifact(dir, 'nope'), /not found in task directory/);
+});
+
+test('resolveArtifact throws on an out-of-range index', () => {
+  const dir = mkTaskDir(['task.md']);
+  assert.throws(() => resolveArtifact(dir, '999'), /invalid artifact index 999/);
+});
+
+test('resolveArtifact rejects names containing path separators', () => {
+  const dir = mkTaskDir(['task.md']);
+  assert.throws(() => resolveArtifact(dir, '../task'), /must not contain path separators/);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #467 👈👈

Closes #467

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

`ai task` 此前只有 `ls` / `show`，`show` 仅能打印 `task.md`，无法查看任务目录下的其它生命周期产物（`analysis*.md` / `plan*.md` / `review-*.md` / 报告等）。本 PR 作为「任务详情可观察」4 任务系列的**第 1 个**，建立后续命令共享的基础原语（artifact 枚举 + ref/序号 → 路径解析），并捆绑落地两个共用同一枚举/解析逻辑、强耦合的命令 `files` 与 `cat`。

## 📋 主要变更 / Brief Changelog

- 新增 `lib/task/artifacts.ts`：`enumerateArtifacts(taskDir)` 返回按 **mtime 升序**（最早在上、相同 mtime 以文件名兜底）的产物清单，仅枚举常规文件、排除子目录/dotfile；序号随 mtime 变化（非稳定）。`resolveArtifact(taskDir, name|N)` 把文件名（`.md` 可省）或序号解析为绝对路径，含路径穿越防护。
- 抽取共享解析器 `lib/task/resolve-ref.ts`（ref → 任务目录），`show.ts` 改为复用、**零行为变更**；`files` / `cat` 共用同一解析器。
- 新增 `ai task files <ref>`（带序号表格 `#`/`NAME`/`SIZE`/`MTIME`，`NAME` 去 `.md` 显示）与 `ai task cat <ref> <artifact|N>`（打印产物原文，`cat <ref> task` 与 `show <ref>` 字节一致）。
- 更新 `lib/task/index.ts` 与 `bin/cli.ts` 顶层 USAGE；不修改 `ls` / `show` 行为，不引入新依赖（复用 `lib/table.ts`）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1059 tests，1058 pass / 0 fail / 1 skipped（既有平台守卫）；新增原语单测 9 + `files` 集成 3 + `cat` 集成 4 共 16 例全绿。
2. `ai task files <ref>` —— 输出按 mtime 升序排列、`NAME` 去 `.md` 的带序号产物表格，子目录不入列。
3. `ai task cat <ref> task` 与 `ai task show <ref>` 输出 `diff` 为空；`cat <ref> <name>` 与 `cat <ref> <N>` 互通；非法 `N` / 不存在产物名返回非零并给出明确错误。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（USAGE 文案）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（`ls` / `show` 行为不变，`show` 为零行为搬运）

## 📋 附加信息 / Additional Notes

本任务是 4 任务系列的第 1 个，必须最先合并；后续 `status` / `grep` 依赖本 PR 建立的 `enumerateArtifacts` / `resolveArtifact` 原语（序号按 mtime、非稳定，跨命令优先用文件名）。已知遗留（非本 PR 范围）：`ls.ts` 中重复的 `detectRepoRoot` 未收敛。

---

Generated with AI assistance.
