### PR TITLE
feat(cli): 继承 Codex 模型 catalog 到沙箱

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -840,7 +840,34 @@ export function ensureClaudeSettings(toolDir: string, hostHomeDir?: string): voi
   }
 }
 
-export function ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void {
+function resolveHostCatalogPath(value: unknown, hostHomeDir: string): string | null {
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+  let resolved: string;
+  if (value === '~' || value.startsWith('~/') || value.startsWith('~\\')) {
+    resolved = path.join(hostHomeDir, value.slice(1).replace(/^[/\\]+/, ''));
+  } else if (path.isAbsolute(value)) {
+    resolved = value;
+  } else {
+    resolved = path.join(hostHomeDir, '.codex', value);
+  }
+  try {
+    if (!fs.statSync(resolved).isFile()) {
+      return null;
+    }
+    fs.accessSync(resolved, fs.constants.R_OK);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+export function ensureCodexModelInheritance(
+  toolDir: string,
+  hostHomeDir?: string,
+  containerCodexDir: string = '/home/devuser/.codex'
+): void {
   if (!hostHomeDir) {
     return;
   }
@@ -888,6 +915,22 @@ export function ensureCodexModelInheritance(toolDir: string, hostHomeDir?: strin
     }
     sandboxParsed[key] = value;
     changed = true;
+  }
+
+  if (!Object.hasOwn(sandboxParsed, 'model_catalog_json')) {
+    const hostCatalogPath = resolveHostCatalogPath(hostParsed['model_catalog_json'], hostHomeDir);
+    if (hostCatalogPath) {
+      try {
+        const basename = path.basename(hostCatalogPath);
+        const destDir = path.join(toolDir, 'model-catalogs');
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.copyFileSync(hostCatalogPath, path.join(destDir, basename));
+        sandboxParsed['model_catalog_json'] = path.posix.join(containerCodexDir, 'model-catalogs', basename);
+        changed = true;
+      } catch {
+        // Copy failed (e.g. permissions): skip catalog, keep scalar inheritance intact.
+      }
+    }
   }
 
   if (changed) {
@@ -1342,7 +1385,7 @@ export async function create(args: string[]): Promise<void> {
             }
             const codexEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'codex');
             if (codexEntry) {
-              ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home);
+              ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home, codexEntry.tool.containerMount);
               ensureCodexWorkspaceTrust(codexEntry.dir);
             }
             const geminiEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'gemini-cli');

--- a/tests/integration/cli/sandbox-inheritance.test.ts
+++ b/tests/integration/cli/sandbox-inheritance.test.ts
@@ -7,7 +7,9 @@ import * as toml from "smol-toml";
 
 import {
   filePath,
-  loadFreshEsm
+  loadFreshEsm,
+  onPlatforms,
+  supportsPosixModeBits
 } from "../../helpers.ts";
 
 type CommandOptions = Record<string, unknown> & {
@@ -41,7 +43,7 @@ type SandboxCreateModule = {
   assertBranchAvailable(repoRoot: string, branch: string, options?: { allowedWorktrees?: string[]; runFn?: RunSafeFn }): void;
   ensureClaudeOnboarding(toolDir: string, hostHomeDir?: string): void;
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
-  ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
+  ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string, containerCodexDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
   ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureGeminiWorkspaceTrust(toolDir: string): void;
@@ -650,6 +652,300 @@ test("ensureCodexModelInheritance leaves malformed sandbox config alone", async 
     assert.doesNotThrow(() => sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome));
     assert.equal(fs.readFileSync(configPath, "utf8"), "=");
   } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance copies a relative host catalog and rewrites to the container path", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-rel-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-rel-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".codex", "catalogs", "gpt.json"), '{"models":[]}', "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model = "gpt-5.5"\nmodel_catalog_json = "catalogs/gpt.json"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model?: string;
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model, "gpt-5.5");
+    assert.equal(data.model_catalog_json, "/home/devuser/.codex/model-catalogs/gpt.json");
+    assert.equal(
+      fs.readFileSync(path.join(tmpDir, "model-catalogs", "gpt.json"), "utf8"),
+      '{"models":[]}'
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance copies an absolute host catalog", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-abs-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-abs-"));
+  const catalogFile = path.join(hostHome, "elsewhere", "custom.json");
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.mkdirSync(path.dirname(catalogFile), { recursive: true });
+    fs.writeFileSync(catalogFile, '{"k":1}', "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      `model_catalog_json = ${JSON.stringify(catalogFile)}\n`,
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model_catalog_json, "/home/devuser/.codex/model-catalogs/custom.json");
+    assert.equal(fs.readFileSync(path.join(tmpDir, "model-catalogs", "custom.json"), "utf8"), '{"k":1}');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance expands a tilde host catalog path", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-tilde-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-tilde-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".codex", "catalogs", "gpt.json"), "{}", "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = "~/.codex/catalogs/gpt.json"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model_catalog_json, "/home/devuser/.codex/model-catalogs/gpt.json");
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs", "gpt.json")), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance preserves an existing sandbox model_catalog_json", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-keep-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-keep-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".codex", "catalogs", "gpt.json"), "{}", "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = "catalogs/gpt.json"\n',
+      "utf8"
+    );
+    fs.writeFileSync(path.join(tmpDir, "config.toml"), 'model_catalog_json = "/custom/path.json"\n', "utf8");
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model_catalog_json, "/custom/path.json");
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance skips a missing host catalog file", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-missing-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-missing-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model = "gpt-5.5"\nmodel_catalog_json = "/nonexistent/x.json"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model?: string;
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model, "gpt-5.5");
+    assert.equal(data.model_catalog_json, undefined);
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance skips a host catalog path that is a directory", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-dir-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-dir-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = "catalogs"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    assert.equal(fs.existsSync(path.join(tmpDir, "config.toml")), false);
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance keeps catalog and model before the workspace trust section", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-order-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-order-"));
+  const configPath = path.join(tmpDir, "config.toml");
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".codex", "catalogs", "gpt.json"), "{}", "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model = "gpt-5.5"\nmodel_catalog_json = "catalogs/gpt.json"\n',
+      "utf8"
+    );
+    fs.writeFileSync(configPath, '[projects."/workspace"]\ntrust_level = "trusted"\n', "utf8");
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const content = fs.readFileSync(configPath, "utf8");
+    const lines = content.split(/\r?\n/);
+    const catalogLine = lines.findIndex((line) => line.startsWith("model_catalog_json = "));
+    const sectionLine = lines.findIndex((line) => line.startsWith("[projects."));
+    assert.ok(catalogLine >= 0);
+    assert.ok(sectionLine > catalogLine);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance honors a non-default container codex dir", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-customdir-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-customdir-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex", "catalogs"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".codex", "catalogs", "gpt.json"), "{}", "utf8");
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = "catalogs/gpt.json"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome, "/custom/codex");
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model_catalog_json?: string;
+    };
+    assert.equal(data.model_catalog_json, "/custom/codex/model-catalogs/gpt.json");
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs", "gpt.json")), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance skips a non-string model_catalog_json", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-nonstring-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-nonstring-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model = "gpt-5.5"\nmodel_catalog_json = ["a", "b"]\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    const data = toml.parse(fs.readFileSync(path.join(tmpDir, "config.toml"), "utf8")) as {
+      model?: string;
+      model_catalog_json?: unknown;
+    };
+    assert.equal(data.model, "gpt-5.5");
+    assert.equal(data.model_catalog_json, undefined);
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance skips an empty model_catalog_json", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-empty-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-empty-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = ""\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    assert.equal(fs.existsSync(path.join(tmpDir, "config.toml")), false);
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance skips an unreadable host catalog file", onPlatforms("linux", "darwin"), async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-catalog-unreadable-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-catalog-unreadable-"));
+  const catalogFile = path.join(hostHome, ".codex", "catalogs", "gpt.json");
+
+  try {
+    if (!supportsPosixModeBits()) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(catalogFile), { recursive: true });
+    fs.writeFileSync(catalogFile, "{}", "utf8");
+    fs.chmodSync(catalogFile, 0o000);
+    // Running as root bypasses the read bit; the unreadable scenario cannot be reproduced there.
+    try {
+      fs.accessSync(catalogFile, fs.constants.R_OK);
+      return;
+    } catch {
+      // Genuinely unreadable: proceed to assert safe-skip.
+    }
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      'model_catalog_json = "catalogs/gpt.json"\n',
+      "utf8"
+    );
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+    assert.equal(fs.existsSync(path.join(tmpDir, "config.toml")), false);
+    assert.equal(fs.existsSync(path.join(tmpDir, "model-catalogs")), false);
+  } finally {
+    try {
+      fs.chmodSync(catalogFile, 0o600);
+    } catch {
+      // best-effort restore so cleanup can remove the file
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(hostHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #479 👈👈

Closes #479

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

当前 sandbox 创建只继承宿主机 Codex 的 `model`、`model_reasoning_effort`、`model_auto_compact_token_limit`，不继承 `model_catalog_json`。对于本地用自定义 model catalog 启用更大上下文窗口的用户，新沙箱会出现「继承了高 compact 阈值却仍用默认 catalog」的不匹配。

本 PR 让沙箱创建时继承宿主机 `~/.codex/config.toml` 的 `model_catalog_json`：把它指向的 catalog 文件复制进沙箱 Codex 工具目录，并把沙箱 `config.toml` 的该字段改写为容器内路径——复用宿主机本地偏好，同时不把宿主机绝对路径写进容器，也不把个人模型偏好提交到项目配置。

## 📋 主要变更 / Brief Changelog

- 新增纯函数 `resolveHostCatalogPath`：解析宿主机 `model_catalog_json`（tilde / 绝对 / 相对路径，相对路径锚定 `~/.codex`），并用 `isFile()` + `accessSync(R_OK)` 校验可读性，任何非法/不可读形态返回 `null` 安全跳过。
- `ensureCodexModelInheritance` 在标量继承之后、写回之前新增 catalog 处理：复制文件到 `<toolDir>/model-catalogs/<basename>`，把字段改写为 `path.posix.join(containerCodexDir, 'model-catalogs', basename)`，复用既有 `changed` 写回事务；沿用 `Object.hasOwn` 短路，沙箱已显式配置则不覆盖。
- 容器路径来源透传：函数新增可选第 3 参 `containerCodexDir`，唯一调用点传入 `codexEntry.tool.containerMount`，避免硬编码 `/home/devuser/.codex` 漂移。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（`tsc` 编译通过）
2. `npm test`（完整测试套件）
3. 可选手动：宿主机 `~/.codex/config.toml` 配置 `model_catalog_json` 指向真实 catalog，`ai sandbox create <branch>` 后进容器确认 `/home/devuser/.codex/config.toml` 的该字段为容器路径、`/home/devuser/.codex/model-catalogs/<file>` 存在。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

新增 11 个 catalog 行为用例：相对/绝对/tilde 路径继承、沙箱已有值保留、文件不存在/目录/非字符串/空串/不可读（`onPlatforms("linux","darwin")` 守卫）安全跳过、与 workspace-trust 段的 root-key 顺序、非默认 `containerCodexDir` 透传。完整套件 1072 个用例通过、0 失败。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 对未配置 `model_catalog_json` 的用户零行为变化；catalog 分支仅在宿主机配置该字段时触发。
- 与既有标量字段一致：沙箱目录已存在该字段后不自动刷新宿主机 catalog 变化（如需强制刷新可重置沙箱工具目录）。
- 文档：双语 `docs/{en,zh-CN}/sandbox.md` 当前未记录任何 Codex 继承行为，仅补 `model_catalog_json` 会造成不一致，故本 PR 不改文档，留作独立的「补齐完整 Codex 继承段」跟进项。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注容器路径透传（用例「honors a non-default container codex dir」锁定 `/custom/codex/model-catalogs/gpt.json`）。
- 不可读文件用例在以 root 运行时通过 `accessSync(R_OK)` early-return 跳过以避免 flaky。

---

Generated with AI assistance