### PR TITLE
feat(cli): 为 ai task 新增 status 聚合视图子命令

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,7 +18,7 @@ Usage:
   agent-infra init            Initialize a new project with update-agent-infra seed command
   agent-infra merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   agent-infra sandbox         Manage Docker-based AI sandboxes
-  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat)
+  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat / status)
   agent-infra update          Update seed files and sync file registry for an existing project
   agent-infra version         Show version
 

--- a/lib/task/commands/status.ts
+++ b/lib/task/commands/status.ts
@@ -1,0 +1,302 @@
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolveTaskRef } from '../resolve-ref.ts';
+import { enumerateArtifacts, type Artifact } from '../artifacts.ts';
+import { parseTaskFrontmatter, extractTitle, type Frontmatter } from '../frontmatter.ts';
+import { loadShortIdByTaskId } from '../short-id.ts';
+
+const USAGE = `Usage: ai task status <N | #N | TASK-id>
+
+Prints an aggregated "health check" view for a task: header, metadata, an
+artifacts summary, git branch state, and best-effort GitHub issue/PR status.
+  <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
+
+Git and Platform rows are best-effort: a failed git/gh call degrades that row to
+'-' without failing the command.
+`;
+
+const DASH = '-';
+
+// Subprocess boundary: the single place this command shells out. Injectable so
+// the collectors below can be unit-tested without spawning git/gh. Returns the
+// command's stdout; throws (like execFileSync) on a non-zero exit or spawn error.
+type Runner = (file: string, args: string[]) => string;
+
+function makeRunner(cwd: string): Runner {
+  return (file, args) =>
+    execFileSync(file, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+// Run `run` and swallow any failure into null, so a single failing git/gh call
+// degrades only its own field instead of aborting the whole view.
+function tryRun(run: Runner, file: string, args: string[]): string | null {
+  try {
+    return run(file, args);
+  } catch {
+    return null;
+  }
+}
+
+// Frontmatter keys shown in the Metadata section, in a fixed display order.
+const METADATA_KEYS = [
+  'type',
+  'status',
+  'current_step',
+  'priority',
+  'effort',
+  'branch',
+  'assigned_to',
+  'created_at',
+  'updated_at',
+  'issue_number',
+  'pr_status'
+] as const;
+
+function collectMetadata(fm: Frontmatter): [string, string][] {
+  return METADATA_KEYS.map((key) => [key, fm[key] ? fm[key]! : DASH]);
+}
+
+// Workflow stages in timeline order; artifacts are bucketed by filename prefix.
+// `review-*` prefixes are matched before their bare counterparts so that, e.g.,
+// `review-analysis.md` is never swallowed by the `analysis` bucket.
+const STAGE_ORDER = [
+  'analysis',
+  'review-analysis',
+  'plan',
+  'review-plan',
+  'code',
+  'review-code',
+  'task',
+  'other'
+] as const;
+
+function stageOf(name: string): string {
+  const stem = name.replace(/\.md$/, '');
+  if (stem === 'task') return 'task';
+  if (stem.startsWith('review-analysis')) return 'review-analysis';
+  if (stem.startsWith('review-plan')) return 'review-plan';
+  if (stem.startsWith('review-code')) return 'review-code';
+  if (stem.startsWith('analysis')) return 'analysis';
+  if (stem.startsWith('plan')) return 'plan';
+  if (stem.startsWith('code')) return 'code';
+  return 'other';
+}
+
+// Group artifacts by workflow stage, preserving the input order (mtime ascending
+// from enumerateArtifacts) within each stage and dropping empty stages.
+function groupArtifacts(artifacts: Artifact[]): { stage: string; files: string[] }[] {
+  const byStage = new Map<string, string[]>();
+  for (const artifact of artifacts) {
+    const stage = stageOf(artifact.name);
+    const bucket = byStage.get(stage);
+    if (bucket) bucket.push(artifact.name);
+    else byStage.set(stage, [artifact.name]);
+  }
+  const groups: { stage: string; files: string[] }[] = [];
+  for (const stage of STAGE_ORDER) {
+    const files = byStage.get(stage);
+    if (files && files.length > 0) groups.push({ stage, files });
+  }
+  return groups;
+}
+
+type GitInfo = {
+  current: string;
+  frontmatter: string;
+  match: string;
+  exists: string;
+  uncommitted: string;
+  aheadBehind: string;
+};
+
+// `frontmatterBranch` is the task.md `branch` field (caller passes '' when absent).
+// It is read straight from frontmatter and never depends on a subprocess, so it
+// keeps its value even when every git call fails. All other fields degrade to '-'
+// on failure of their own command.
+function collectGit(frontmatterBranch: string, run: Runner): GitInfo {
+  const frontmatter = frontmatterBranch ? frontmatterBranch : DASH;
+
+  let current = DASH;
+  const cur = tryRun(run, 'git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+  if (cur !== null && cur.trim()) current = cur.trim();
+
+  let match = DASH;
+  if (current !== DASH && frontmatter !== DASH) {
+    match = current === frontmatter ? 'yes' : 'no';
+  }
+
+  let exists = DASH;
+  if (frontmatter !== DASH) {
+    const verified = tryRun(run, 'git', ['rev-parse', '--verify', '--quiet', `refs/heads/${frontmatter}`]);
+    exists = verified === null ? 'no' : 'yes';
+  }
+
+  let uncommitted = DASH;
+  const porcelain = tryRun(run, 'git', ['status', '--porcelain']);
+  if (porcelain !== null) {
+    const changed = porcelain.split('\n').filter((line) => line.trim() !== '');
+    uncommitted = changed.length === 0 ? 'clean' : `${changed.length} file(s)`;
+  }
+
+  let aheadBehind = DASH;
+  if (frontmatter !== DASH) {
+    const counts = tryRun(run, 'git', [
+      'rev-list',
+      '--left-right',
+      '--count',
+      `${frontmatter}...${frontmatter}@{upstream}`
+    ]);
+    if (counts !== null) {
+      const parts = counts.trim().split(/\s+/);
+      if (parts.length === 2) aheadBehind = `${parts[0]} ahead / ${parts[1]} behind`;
+    }
+  }
+
+  return { current, frontmatter, match, exists, uncommitted, aheadBehind };
+}
+
+type PlatformInfo = { issue: string; pr: string };
+
+function collectPlatform(fm: Frontmatter, run: Runner): PlatformInfo {
+  let issue = DASH;
+  if (fm.issue_number && /^\d+$/.test(fm.issue_number)) {
+    const out = tryRun(run, 'gh', ['issue', 'view', fm.issue_number, '--json', 'state,labels']);
+    if (out !== null) {
+      try {
+        const data = JSON.parse(out);
+        const labels = Array.isArray(data.labels)
+          ? data.labels.map((label: { name: string }) => label.name).join(', ')
+          : '';
+        issue = labels ? `${data.state} [${labels}]` : `${data.state}`;
+      } catch {
+        issue = DASH;
+      }
+    }
+  }
+
+  let pr = DASH;
+  if (fm.pr_status === 'created' && fm.pr_number && /^\d+$/.test(fm.pr_number)) {
+    const out = tryRun(run, 'gh', ['pr', 'view', fm.pr_number, '--json', 'state,statusCheckRollup']);
+    if (out !== null) {
+      try {
+        const data = JSON.parse(out);
+        const rollup = Array.isArray(data.statusCheckRollup) ? data.statusCheckRollup : [];
+        const passed = rollup.filter(
+          (check: { conclusion?: string; state?: string }) =>
+            check.conclusion === 'SUCCESS' || check.state === 'SUCCESS'
+        ).length;
+        pr = rollup.length > 0 ? `${data.state}, checks: ${passed}/${rollup.length}` : `${data.state}`;
+      } catch {
+        pr = DASH;
+      }
+    }
+  }
+
+  return { issue, pr };
+}
+
+type StatusModel = {
+  taskId: string;
+  shortId: string;
+  title: string;
+  issueNumber: string;
+  metadata: [string, string][];
+  artifacts: { count: number; groups: { stage: string; files: string[] }[] };
+  git: GitInfo;
+  platform: PlatformInfo;
+};
+
+// Indent each label/value pair by two spaces and pad labels to a common width so
+// every section reads as an aligned "key   value" block.
+function renderPairs(rows: [string, string][]): string[] {
+  const width = rows.reduce((max, [label]) => Math.max(max, label.length), 0);
+  return rows.map(([label, value]) => `  ${label.padEnd(width)}  ${value}`.trimEnd());
+}
+
+function renderStatus(model: StatusModel): string[] {
+  const lines: string[] = [];
+
+  lines.push(`Task ${model.taskId}  (${model.shortId})`);
+  if (model.title) lines.push(model.title);
+
+  lines.push('', 'Metadata', ...renderPairs(model.metadata));
+
+  lines.push('', `Artifacts (${model.artifacts.count})`);
+  if (model.artifacts.groups.length === 0) {
+    lines.push('  (none)');
+  } else {
+    lines.push(...renderPairs(model.artifacts.groups.map((group) => [group.stage, group.files.join(', ')])));
+  }
+
+  lines.push(
+    '',
+    'Git',
+    ...renderPairs([
+      ['current', model.git.current],
+      ['frontmatter', model.git.frontmatter],
+      ['match', model.git.match],
+      ['exists', model.git.exists],
+      ['uncommitted', model.git.uncommitted],
+      ['ahead/behind', model.git.aheadBehind]
+    ])
+  );
+
+  const issueLabel = model.issueNumber ? `issue #${model.issueNumber}` : 'issue';
+  lines.push(
+    '',
+    'Platform',
+    ...renderPairs([
+      [issueLabel, model.platform.issue],
+      ['pr', model.platform.pr]
+    ])
+  );
+
+  return lines;
+}
+
+function status(args: string[] = []): void {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    if (args.length === 0) process.exitCode = 1;
+    return;
+  }
+
+  const resolved = resolveTaskRef(args[0]!);
+  if (!resolved.ok) {
+    process.stderr.write(`ai task status: ${resolved.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const content = fs.readFileSync(resolved.taskMdPath, 'utf8');
+  const fm = parseTaskFrontmatter(content);
+  const run = makeRunner(resolved.repoRoot);
+  const artifacts = enumerateArtifacts(resolved.taskDir);
+
+  const model: StatusModel = {
+    taskId: resolved.taskId,
+    shortId: loadShortIdByTaskId(resolved.repoRoot).get(resolved.taskId) ?? DASH,
+    title: extractTitle(content),
+    issueNumber: fm.issue_number && /^\d+$/.test(fm.issue_number) ? fm.issue_number : '',
+    metadata: collectMetadata(fm),
+    artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
+    git: collectGit(fm.branch ?? '', run),
+    platform: collectPlatform(fm, run)
+  };
+
+  for (const line of renderStatus(model)) {
+    process.stdout.write(`${line}\n`);
+  }
+}
+
+export {
+  status,
+  makeRunner,
+  collectMetadata,
+  groupArtifacts,
+  collectGit,
+  collectPlatform,
+  renderStatus,
+  METADATA_KEYS
+};
+export type { Runner, GitInfo, PlatformInfo, StatusModel };

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -5,6 +5,7 @@ Commands:
   show <N | #N | TASK-id>                Print a task.md
   files <ref>                            List artifacts in a task dir (numbered)
   cat <ref> <artifact | N>               Print a task artifact (by name or number)
+  status <ref>                           Aggregated status view (metadata / artifacts / git / platform)
 
 Examples:
   ai task ls
@@ -13,6 +14,7 @@ Examples:
   ai task files 11
   ai task cat 11 analysis
   ai task cat 11 3
+  ai task status 11
 
 Run 'ai task <command> --help' for details.`;
 
@@ -49,6 +51,11 @@ export async function runTask(args: string[]): Promise<void> {
     case 'cat': {
       const { cat } = await import('./commands/cat.ts');
       cat(rest);
+      break;
+    }
+    case 'status': {
+      const { status } = await import('./commands/status.ts');
+      status(rest);
       break;
     }
     default:

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -1,19 +1,19 @@
 const USAGE = `Usage: ai task <command> [options]
 
 Commands:
+  cat <ref> <artifact | N>               Print a task artifact (by name or number)
+  files <ref>                            List artifacts in a task dir (numbered)
   ls [--all | --blocked | --completed]   List tasks (default: active)
   show <N | #N | TASK-id>                Print a task.md
-  files <ref>                            List artifacts in a task dir (numbered)
-  cat <ref> <artifact | N>               Print a task artifact (by name or number)
   status <ref>                           Aggregated status view (metadata / artifacts / git / platform)
 
 Examples:
+  ai task cat 11 analysis
+  ai task cat 11 3
+  ai task files 11
   ai task ls
   ai task show 11
   ai task show TASK-20260612-162737
-  ai task files 11
-  ai task cat 11 analysis
-  ai task cat 11 3
   ai task status 11
 
 Run 'ai task <command> --help' for details.`;

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -34,6 +34,12 @@ test('ai task show --help prints subcommand USAGE', () => {
   assert.match(out.stdout, /Usage: ai task show/);
 });
 
+test('ai task status --help prints subcommand USAGE', () => {
+  const out = runCli(['task', 'status', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task status/);
+});
+
 test('ai task <unknown> reports error', () => {
   const out = runCli(['task', 'wat']);
   assert.equal(out.status, 1);

--- a/tests/integration/cli/task-status.test.ts
+++ b/tests/integration/cli/task-status.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+import { gitSafeEnv, initIsolatedGitRepo } from '../../helpers/git.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-status-'));
+  // Isolated repo so the command's git subcommands operate on the fixture, not
+  // agent-infra's own repo (see tests/helpers/git.ts).
+  initIsolatedGitRepo(repoRoot);
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  fs.mkdirSync(path.join(agentsDir, 'workspace', 'active'), { recursive: true });
+  return { repoRoot };
+}
+
+function writeTask(repoRoot: string, state: string, taskId: string): string {
+  const dir = path.join(repoRoot, '.agents', 'workspace', state, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'task.md'),
+    `---\nid: ${taskId}\nbranch: feat-${state}\nstatus: ${state}\nissue_number: 999\n---\n# 任务：${taskId}\n`
+  );
+  fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body\n');
+  fs.writeFileSync(path.join(dir, 'plan.md'), 'plan body\n');
+  return dir;
+}
+
+function runCli(args: string[], cwd: string) {
+  // gitSafeEnv() strips leaked GIT_* so the command's git calls stay scoped to cwd.
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8', env: gitSafeEnv() });
+}
+
+function assertCoreSections(stdout: string, taskId: string): void {
+  assert.match(stdout, new RegExp(`^Task ${taskId}\\b`, 'm'));
+  assert.match(stdout, /^Metadata$/m);
+  assert.match(stdout, /^Artifacts \(\d+\)$/m);
+  assert.match(stdout, /^Git$/m);
+  // Platform is best-effort; with issue 999 / no gh network it must still render
+  // a row (degraded to '-') rather than crash the command.
+  assert.match(stdout, /^Platform$/m);
+}
+
+// Acceptance: `ai task status <ref>` must work across active / blocked / completed.
+for (const state of ['active', 'blocked', 'completed'] as const) {
+  test(`ai task status <TASK-id> renders the core sections for a ${state} task`, () => {
+    const { repoRoot } = mkFixture();
+    const taskId = 'TASK-20260101-000042';
+    writeTask(repoRoot, state, taskId);
+
+    const out = runCli(['task', 'status', taskId], repoRoot);
+    assert.equal(out.status, 0, out.stderr);
+    assertCoreSections(out.stdout, taskId);
+    // Metadata reflects the task's own frontmatter.
+    assert.match(out.stdout, new RegExp(`^  status +${state}$`, 'm'));
+    // Artifacts are grouped by stage (analysis + plan written above).
+    assert.match(out.stdout, /^  analysis +analysis\.md$/m);
+    assert.match(out.stdout, /^  plan +plan\.md$/m);
+  });
+}
+
+test('ai task status resolves an active task by its short id', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  writeTask(repoRoot, 'active', taskId);
+  const alloc = spawnSync('node', [SCRIPT, 'alloc', taskId], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: gitSafeEnv()
+  });
+  assert.equal(alloc.status, 0, alloc.stderr);
+
+  const out = runCli(['task', 'status', '1'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assertCoreSections(out.stdout, taskId);
+  // Active task shows its short id in the header (blocked/completed would be '-').
+  assert.match(out.stdout, new RegExp(`^Task ${taskId}  \\(#01\\)$`, 'm'));
+});
+
+test('ai task status requires an argument', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'status'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task status/);
+});
+
+test('ai task status rejects an unknown ref', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'status', 'not-a-task'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /ai task status:/);
+});

--- a/tests/unit/cli/task-status.test.ts
+++ b/tests/unit/cli/task-status.test.ts
@@ -1,0 +1,238 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  collectMetadata,
+  groupArtifacts,
+  collectGit,
+  collectPlatform,
+  renderStatus,
+  type Runner,
+  type StatusModel
+} from '../../../lib/task/commands/status.ts';
+import type { Artifact } from '../../../lib/task/artifacts.ts';
+
+function artifact(name: string, mtimeMs: number): Artifact {
+  return { index: mtimeMs, name, path: `/tmp/${name}`, size: 1, mtimeMs };
+}
+
+// --- collectMetadata -------------------------------------------------------
+
+test('collectMetadata emits the fixed key order and degrades missing fields to -', () => {
+  const rows = collectMetadata({
+    type: 'feature',
+    status: 'active',
+    current_step: 'code',
+    priority: 'High',
+    branch: 'feat',
+    issue_number: '468'
+  });
+  assert.deepEqual(rows, [
+    ['type', 'feature'],
+    ['status', 'active'],
+    ['current_step', 'code'],
+    ['priority', 'High'],
+    ['effort', '-'],
+    ['branch', 'feat'],
+    ['assigned_to', '-'],
+    ['created_at', '-'],
+    ['updated_at', '-'],
+    ['issue_number', '468'],
+    ['pr_status', '-']
+  ]);
+});
+
+// --- groupArtifacts --------------------------------------------------------
+
+test('groupArtifacts buckets by stage in timeline order and preserves input order', () => {
+  const artifacts = [
+    'analysis.md',
+    'review-analysis.md',
+    'plan.md',
+    'plan-r2.md',
+    'review-plan.md',
+    'code.md',
+    'task.md',
+    'weird.md'
+  ].map((name, i) => artifact(name, i));
+
+  const groups = groupArtifacts(artifacts);
+  assert.deepEqual(
+    groups.map((g) => g.stage),
+    ['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'task', 'other']
+  );
+  // plan group keeps the input (mtime) order, not alphabetical.
+  assert.deepEqual(groups.find((g) => g.stage === 'plan')!.files, ['plan.md', 'plan-r2.md']);
+  // review-analysis is NOT swallowed by the analysis bucket.
+  assert.deepEqual(groups.find((g) => g.stage === 'analysis')!.files, ['analysis.md']);
+  assert.deepEqual(groups.find((g) => g.stage === 'review-analysis')!.files, ['review-analysis.md']);
+  // unrecognized names fall into 'other'.
+  assert.deepEqual(groups.find((g) => g.stage === 'other')!.files, ['weird.md']);
+});
+
+test('groupArtifacts returns no groups for an empty task dir', () => {
+  assert.deepEqual(groupArtifacts([]), []);
+});
+
+// --- collectGit ------------------------------------------------------------
+
+const throwingRun: Runner = () => {
+  throw new Error('git unavailable');
+};
+
+test('collectGit degrades every git-derived field on failure but keeps frontmatter branch', () => {
+  // Acceptance point: git调用失败降级（mock execFileSync）. frontmatter is read
+  // straight from task.md, so it survives even when every subprocess throws.
+  const git = collectGit('feat', throwingRun);
+  assert.equal(git.frontmatter, 'feat');
+  assert.equal(git.current, '-');
+  assert.equal(git.match, '-');
+  assert.equal(git.exists, 'no');
+  assert.equal(git.uncommitted, '-');
+  assert.equal(git.aheadBehind, '-');
+});
+
+test('collectGit renders frontmatter/match/exists as - when task.md has no branch', () => {
+  const run: Runner = (_file, args) => {
+    if (args.includes('--abbrev-ref')) return 'main\n';
+    if (args[0] === 'status') return '';
+    throw new Error(`unexpected git ${args.join(' ')}`);
+  };
+  const git = collectGit('', run);
+  assert.equal(git.frontmatter, '-');
+  assert.equal(git.match, '-');
+  assert.equal(git.exists, '-');
+});
+
+test('collectGit parses current/match/uncommitted/aheadBehind from stubbed output', () => {
+  const run: Runner = (_file, args) => {
+    if (args.includes('--abbrev-ref')) return 'feat\n';
+    if (args.includes('--verify')) return 'deadbeef\n';
+    if (args[0] === 'status') return ' M a.ts\n M b.ts\n';
+    if (args[0] === 'rev-list') return '2\t3\n';
+    throw new Error(`unexpected git ${args.join(' ')}`);
+  };
+  const git = collectGit('feat', run);
+  assert.equal(git.current, 'feat');
+  assert.equal(git.match, 'yes');
+  assert.equal(git.exists, 'yes');
+  assert.equal(git.uncommitted, '2 file(s)');
+  assert.equal(git.aheadBehind, '2 ahead / 3 behind');
+});
+
+test('collectGit isolates a single failing field (rev-list) without degrading the rest', () => {
+  const run: Runner = (_file, args) => {
+    if (args.includes('--abbrev-ref')) return 'feat\n';
+    if (args.includes('--verify')) return 'deadbeef\n';
+    if (args[0] === 'status') return '';
+    if (args[0] === 'rev-list') throw new Error('no upstream configured');
+    throw new Error(`unexpected git ${args.join(' ')}`);
+  };
+  const git = collectGit('feat', run);
+  assert.equal(git.aheadBehind, '-');
+  assert.equal(git.current, 'feat');
+  assert.equal(git.uncommitted, 'clean');
+  assert.equal(git.exists, 'yes');
+});
+
+// --- collectPlatform -------------------------------------------------------
+
+test('collectPlatform makes no calls when there is no issue and pr is not created', () => {
+  let calls = 0;
+  const run: Runner = () => {
+    calls += 1;
+    throw new Error('should not be called');
+  };
+  const platform = collectPlatform({}, run);
+  assert.equal(platform.issue, '-');
+  assert.equal(platform.pr, '-');
+  assert.equal(calls, 0);
+});
+
+test('collectPlatform skips the PR call when pr_status is created but pr_number is absent', () => {
+  let calls = 0;
+  const run: Runner = () => {
+    calls += 1;
+    throw new Error('should not be called');
+  };
+  const platform = collectPlatform({ pr_status: 'created' }, run);
+  assert.equal(platform.pr, '-');
+  assert.equal(calls, 0);
+});
+
+test('collectPlatform summarizes gh JSON for issue and pr', () => {
+  const run: Runner = (_file, args) => {
+    if (args[0] === 'issue') {
+      return JSON.stringify({ state: 'OPEN', labels: [{ name: 'in: cli' }, { name: 'type: feature' }] });
+    }
+    if (args[0] === 'pr') {
+      return JSON.stringify({
+        state: 'OPEN',
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }, { conclusion: 'FAILURE' }]
+      });
+    }
+    throw new Error(`unexpected gh ${args.join(' ')}`);
+  };
+  const platform = collectPlatform(
+    { issue_number: '468', pr_status: 'created', pr_number: '42' },
+    run
+  );
+  assert.equal(platform.issue, 'OPEN [in: cli, type: feature]');
+  assert.equal(platform.pr, 'OPEN, checks: 1/2');
+});
+
+test('collectPlatform degrades to - when gh fails (offline)', () => {
+  const run: Runner = () => {
+    throw new Error('gh: offline');
+  };
+  const platform = collectPlatform({ issue_number: '468' }, run);
+  assert.equal(platform.issue, '-');
+});
+
+// --- renderStatus ----------------------------------------------------------
+
+const baseModel: StatusModel = {
+  taskId: 'TASK-20260101-000001',
+  shortId: '#01',
+  title: 'demo title',
+  issueNumber: '468',
+  metadata: [
+    ['type', 'feature'],
+    ['status', 'active']
+  ],
+  artifacts: {
+    count: 2,
+    groups: [
+      { stage: 'analysis', files: ['analysis.md'] },
+      { stage: 'plan', files: ['plan.md', 'plan-r2.md'] }
+    ]
+  },
+  git: {
+    current: 'feat',
+    frontmatter: 'feat',
+    match: 'yes',
+    exists: 'yes',
+    uncommitted: 'clean',
+    aheadBehind: '-'
+  },
+  platform: { issue: 'OPEN', pr: '-' }
+};
+
+test('renderStatus emits all five sections with aligned rows', () => {
+  const out = renderStatus(baseModel).join('\n');
+  assert.match(out, /^Task TASK-20260101-000001  \(#01\)$/m);
+  assert.match(out, /^demo title$/m);
+  assert.match(out, /^Metadata$/m);
+  assert.match(out, /^Artifacts \(2\)$/m);
+  assert.match(out, /^Git$/m);
+  assert.match(out, /^Platform$/m);
+  // Stage group renders its files joined, in order.
+  assert.match(out, /^  plan +plan\.md, plan-r2\.md$/m);
+  // Platform issue row is labeled with the issue number.
+  assert.match(out, /^  issue #468 +OPEN$/m);
+});
+
+test('renderStatus shows (none) when a task has no artifacts', () => {
+  const out = renderStatus({ ...baseModel, artifacts: { count: 0, groups: [] } }).join('\n');
+  assert.match(out, /^Artifacts \(0\)\n {2}\(none\)$/m);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #468 👈👈

Closes #468

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

「ai task 详情命令」系列的第 2 个：在任务 1（#467，`files`/`cat`/`enumerateArtifacts` 原语）合并后，新增 `ai task status <ref>` 只读子命令，提供任务的「体检报告」式聚合视图——把 Header、Metadata、Artifacts 概览、Git 分支状态、Platform（Issue/PR）状态汇总到一次输出里，避免用户在 `show` / `files` / `gh pr view` 之间反复跳转。

命令纯只读、复用既有纯读函数、不引入新依赖、对 `ls`/`show`/`files`/`cat` 零回归。

## 📋 主要变更 / Brief Changelog

- 新增 `lib/task/commands/status.ts`：渲染 Header / Metadata / Artifacts / Git / Platform 五段。子进程收敛到一个可注入的 `Runner`（默认包 `execFileSync`），`collectGit` / `collectPlatform` 接收 `run` 参数，单字段失败就地降级为 `-`，resolve 成功后命令恒 `exit 0`。
- Git 段语义：`frontmatter` 字段直读 `task.md` 的 `branch`，不经子进程——git 整体失败时仍保留分支名；`current`/`match`/`exists`/`uncommitted`/`ahead-behind` 各自 best-effort 降级。
- Platform 段：`issue_number` 命中时 `gh issue view` 摘要状态/标签；仅当 `pr_status: created` 且 `pr_number` 为纯数字时 `gh pr view` 摘要状态/检查（与 `create-pr`/`watch-pr`/`commit` 的 `pr_number` 单一事实源一致）；无网/无 `gh` 优雅降级为 `-`。
- Artifacts 段：复用 `enumerateArtifacts`，按工作流阶段前缀分组（`review-*` 先于裸前缀判定，组内保持 mtime 升序）。
- 接线：`lib/task/index.ts` 新增 `case 'status'` 路由与 USAGE 两行；`bin/cli.ts` 顶层 USAGE 文案补 `status`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（`tsc` 编译通过）
2. `npm run typecheck`（erasable-only TS，无 enum）
3. `npm test`（完整测试套件）
4. 手动：`ai task status <ref>` 对 active / blocked / completed 任务各跑一次，确认五段输出；离线时 Platform 段降级为 `-`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

新增 22 个用例：单元（注入 `Runner`，不起子进程）覆盖 `collectMetadata` 顺序与缺失回退、`groupArtifacts` 阶段分组与 `review-analysis` 不被 `analysis` 误吞、`collectGit` 全失败降级且 `frontmatter` 保留、单点（rev-list）降级隔离、`collectPlatform` 的 PR `pr_number` 门禁与离线降级、`renderStatus` 结构；集成（真实子进程 + `initIsolatedGitRepo` + `gitSafeEnv`）表驱动覆盖 active/blocked/completed 三状态 + 短号输入 + 参数缺失/未知 ref 边界。完整套件 1092 个用例通过、0 失败。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- Platform `pr` 行的检查摘要仅给 `STATE, checks: P/T` 计数，不列失败 check 名（保守默认，避免输出膨胀）。
- 暂不提供 `--json` 机器可读输出模式（YAGNI，留待后续按需）。

---

Generated with AI assistance
