### PR TITLE
feat(cli)!: ai sandbox rm --all 批量清理无短号沙箱，新增 --purge 全量拆除

### DIFF
--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -34,8 +34,13 @@ the host and the sandbox without polluting the git worktree:
 
 These paths are intentionally hardcoded; there is no `.airc.json` knob. Both
 host directories are created automatically on first `create`. When you
-`ai sandbox rm <branch>` or `ai sandbox rm --all`, you will be prompted (default
-yes) to clean up the corresponding share dirs alongside the worktrees.
+`ai sandbox rm <branch>`, you will be prompted (default yes) to clean up the
+corresponding share dirs alongside the worktrees. `ai sandbox rm --all` batch
+removes every sandbox **not bound to an active task** (i.e. the `-` rows in
+`ai sandbox ls`); add `--dry-run` to preview or `--yes` to skip the confirmation
+(required in non-interactive shells). `ai sandbox rm --purge` tears down **all**
+project sandboxes (containers, worktrees, image, VM). **Breaking change:** prior
+to this, `--all` meant the full teardown that `--purge` now performs.
 Use `ai sandbox prune --dry-run` to inspect orphaned per-branch state dirs left
 behind by older versions or interrupted cleanup, then `ai sandbox prune` to
 remove only dirs without an active sandbox container.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -28,7 +28,7 @@
 - `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/`：分支独占。
 - `/clipboard` <- `~/.agent-infra/clipboard/`：macOS 图片粘贴桥接使用的只读存储。
 
-这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；`ai sandbox rm <branch>` 与 `ai sandbox rm --all` 删除时会附带询问是否清理（默认 yes）。
+这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；执行 `ai sandbox rm <branch>` 删除时会附带询问是否清理（默认 yes）。`ai sandbox rm --all` 批量删除所有**未绑定 active 任务**的沙箱（即 `ai sandbox ls` 中短号为 `-` 的行）；可加 `--dry-run` 预览，或 `--yes` 跳过确认（非交互 shell 中必须显式传 `--yes`）。`ai sandbox rm --purge` 则拆除项目的**全部**沙箱（容器、worktree、镜像、VM）。**破坏性变更**：此前 `--all` 的语义即现在 `--purge` 的全量拆除。
 可先用 `ai sandbox prune --dry-run` 查看旧版本或异常中断遗留的孤儿 per-branch 状态目录，再用 `ai sandbox prune` 只删除没有活跃 sandbox 容器对应的目录。
 已有沙箱需要执行 `ai sandbox rm <branch>` 后再执行 `ai sandbox create <branch>`，才能加载新的挂载点。
 

--- a/lib/sandbox/commands/rm.ts
+++ b/lib/sandbox/commands/rm.ts
@@ -21,15 +21,27 @@ import { runOk, runSafe, runSafeEngine } from '../shell.ts';
 import { resolveTaskBranch } from '../task-resolver.ts';
 import { resolveTools, toolConfigDirCandidates, toolProjectDirCandidates } from '../tools.ts';
 import type { SandboxTool } from '../tools.ts';
+import { fetchSandboxRows } from './list-running.ts';
+import { lookupShortIdByBranch } from '../../task/short-id.ts';
 
-const USAGE = `Usage: ai sandbox rm <branch> [--all]`;
+const USAGE = `Usage:
+  ai sandbox rm <branch>                    Remove one sandbox (branch | TASK-id | short id)
+  ai sandbox rm --all [--dry-run] [--yes]   Remove every sandbox not bound to an active task
+  ai sandbox rm --purge                     Tear down ALL sandboxes for the project (containers, worktrees, image, VM)`;
 export { assertManagedPath } from '../managed-fs.ts';
 
 function projectToolDirs(config: SandboxConfig, tools: SandboxTool[]): string[] {
   return tools.flatMap((tool) => toolProjectDirCandidates(tool, config.project));
 }
 
-async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string): Promise<void> {
+type RmOneOptions = { assumeYes?: boolean; quiet?: boolean };
+
+async function rmOne(
+  config: SandboxConfig,
+  tools: SandboxTool[],
+  branch: string,
+  options: RmOneOptions = {}
+): Promise<void> {
   assertValidBranchName(branch);
   const engine = detectEngine(config);
   let effectiveBranch = branch;
@@ -39,7 +51,9 @@ async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string
     candidates: toolConfigDirCandidates(tool, config.project, branch)
   }));
 
-  p.intro(pc.cyan(`Removing sandbox for ${branch}`));
+  if (!options.quiet) {
+    p.intro(pc.cyan(`Removing sandbox for ${branch}`));
+  }
 
   const existing = runSafeEngine(engine, 'docker', ['ps', '-a', '--format', '{{.Names}}']).split('\n').filter(Boolean);
   const matchedContainers = containerNameCandidates(config, branch)
@@ -74,10 +88,12 @@ async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string
 
   const existingWorktrees = worktreeCandidates.filter((candidate) => fs.existsSync(candidate));
   if (existingWorktrees.length > 0) {
-    const shouldRemoveWorktree = await p.confirm({
-      message: `Remove worktree(s): ${existingWorktrees.join(', ')}?`,
-      initialValue: true
-    });
+    const shouldRemoveWorktree = options.assumeYes
+      ? true
+      : await p.confirm({
+          message: `Remove worktree(s): ${existingWorktrees.join(', ')}?`,
+          initialValue: true
+        });
 
     if (p.isCancel(shouldRemoveWorktree)) {
       p.outro('Cancelled');
@@ -89,10 +105,12 @@ async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string
         removeWorktreeDir(config.repoRoot, config.worktreeBase, worktree);
       }
 
-      const shouldDeleteBranch = await p.confirm({
-        message: `Also delete local branch '${effectiveBranch}'?`,
-        initialValue: true
-      });
+      const shouldDeleteBranch = options.assumeYes
+        ? true
+        : await p.confirm({
+            message: `Also delete local branch '${effectiveBranch}'?`,
+            initialValue: true
+          });
 
       if (!p.isCancel(shouldDeleteBranch) && shouldDeleteBranch) {
         if (!runOk('git', ['-C', config.repoRoot, 'branch', '-D', effectiveBranch])) {
@@ -116,20 +134,24 @@ async function rmOne(config: SandboxConfig, tools: SandboxTool[], branch: string
 
   const shareBranch = shareBranchDir(config, effectiveBranch);
   if (fs.existsSync(shareBranch)) {
-    const shouldRemoveShare = await p.confirm({
-      message: `Remove share dir for branch '${effectiveBranch}' (${shareBranch})?`,
-      initialValue: true
-    });
+    const shouldRemoveShare = options.assumeYes
+      ? true
+      : await p.confirm({
+          message: `Remove share dir for branch '${effectiveBranch}' (${shareBranch})?`,
+          initialValue: true
+        });
     if (!p.isCancel(shouldRemoveShare) && shouldRemoveShare) {
       removeManagedDir(config.shareBase, shareBranch);
       p.log.success(`Share dir removed: ${shareBranch}`);
     }
   }
 
-  p.outro(pc.green('Sandbox removed'));
+  if (!options.quiet) {
+    p.outro(pc.green('Sandbox removed'));
+  }
 }
 
-async function rmAll(config: SandboxConfig, tools: SandboxTool[]): Promise<void> {
+async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<void> {
   const engine = detectEngine(config);
   p.intro(pc.cyan(`Removing all sandboxes for ${config.project}`));
 
@@ -231,6 +253,70 @@ async function rmAll(config: SandboxConfig, tools: SandboxTool[]): Promise<void>
   p.outro(pc.green('All project sandboxes removed'));
 }
 
+async function rmUnbound(
+  config: SandboxConfig,
+  tools: SandboxTool[],
+  options: { dryRun: boolean; assumeYes: boolean }
+): Promise<void> {
+  const engine = detectEngine(config);
+  const { running, nonRunning } = fetchSandboxRows(engine, sandboxLabel(config), sandboxBranchLabel(config));
+  const removable = [...running, ...nonRunning].filter(
+    (row) => row.branch && lookupShortIdByBranch(row.branch, config.repoRoot) === null
+  );
+
+  p.intro(pc.cyan(`Removing sandboxes not bound to an active task for ${config.project}`));
+
+  if (removable.length === 0) {
+    p.outro('No removable sandboxes: every container is bound to an active task (or none exist)');
+    return;
+  }
+
+  for (const row of removable) {
+    p.log.message(`${row.name}  ${row.branch}`);
+  }
+
+  if (options.dryRun) {
+    p.outro(`Dry run: ${removable.length} sandbox(es) would be removed, nothing deleted`);
+    return;
+  }
+
+  if (!options.assumeYes) {
+    if (!process.stdin.isTTY) {
+      throw new Error(
+        'Refusing to remove sandboxes without confirmation in a non-interactive shell; pass --yes to proceed.'
+      );
+    }
+    const confirmed = await p.confirm({
+      message: `Remove these ${removable.length} sandbox(es)?`,
+      initialValue: false
+    });
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.outro('Cancelled');
+      return;
+    }
+  }
+
+  const failures: { branch: string; message: string }[] = [];
+  for (const row of removable) {
+    try {
+      await rmOne(config, tools, row.branch, { assumeYes: true, quiet: true });
+    } catch (error) {
+      failures.push({ branch: row.branch, message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      p.log.error(`Failed to remove '${failure.branch}': ${failure.message}`);
+    }
+    throw new Error(
+      `Removed ${removable.length - failures.length}/${removable.length} sandbox(es); ${failures.length} failed`
+    );
+  }
+
+  p.outro(pc.green(`Removed ${removable.length} sandbox(es)`));
+}
+
 export async function rm(args: string[]): Promise<void> {
   const { values, positionals } = parseArgs({
     args,
@@ -238,6 +324,9 @@ export async function rm(args: string[]): Promise<void> {
     strict: true,
     options: {
       all: { type: 'boolean' },
+      purge: { type: 'boolean' },
+      'dry-run': { type: 'boolean' },
+      yes: { type: 'boolean', short: 'y' },
       help: { type: 'boolean', short: 'h' }
     }
   });
@@ -247,15 +336,35 @@ export async function rm(args: string[]): Promise<void> {
     return;
   }
 
-  if (!values.all && positionals.length !== 1) {
+  if (values.all && values.purge) {
+    throw new Error('--all and --purge are mutually exclusive');
+  }
+
+  if ((values['dry-run'] || values.yes) && !values.all) {
+    throw new Error('--dry-run and --yes only apply to --all');
+  }
+
+  if ((values.all || values.purge) && positionals.length > 0) {
+    throw new Error(`${values.all ? '--all' : '--purge'} does not take a branch argument`);
+  }
+
+  if (!values.all && !values.purge && positionals.length !== 1) {
     throw new Error(USAGE);
   }
 
   const config = loadConfig();
   const tools = resolveTools(config);
 
+  if (values.purge) {
+    await rmPurge(config, tools);
+    return;
+  }
+
   if (values.all) {
-    await rmAll(config, tools);
+    await rmUnbound(config, tools, {
+      dryRun: Boolean(values['dry-run']),
+      assumeYes: Boolean(values.yes)
+    });
     return;
   }
 

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -16,7 +16,9 @@ Commands:
   rebuild [--quiet] [--refresh]
                                Rebuild the sandbox image (--refresh pulls base + tools)
   refresh                      Sync host Claude Code credentials to all sandbox copies
-  rm <branch> [--all]          Remove a sandbox or all sandboxes
+  rm <branch> | --all | --purge
+                               Remove one sandbox, all sandboxes not bound to an
+                               active task (--all), or tear down everything (--purge)
   vm status|start|stop         Manage the sandbox VM (macOS) or check the backend (Windows)
 
 Run 'ai sandbox <command> --help' for details.`;

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -156,9 +156,11 @@ test("sandbox create rejects invalid selinux disable environment before loading 
 test("sandbox rm defaults local branch deletion confirmation to yes", () => {
   const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
 
+  // The interactive confirm is gated by options.assumeYes (batch --all passes
+  // assumeYes:true); when prompting it still defaults to yes.
   assert.match(
     commandSource,
-    /const shouldDeleteBranch = await p\.confirm\(\{[\s\S]*?message: `Also delete local branch '\$\{effectiveBranch\}'\?`,[\s\S]*?initialValue: true[\s\S]*?\}\);/
+    /const shouldDeleteBranch = options\.assumeYes[\s\S]*?await p\.confirm\(\{[\s\S]*?message: `Also delete local branch '\$\{effectiveBranch\}'\?`,[\s\S]*?initialValue: true[\s\S]*?\}\);/
   );
 });
 
@@ -188,7 +190,7 @@ test("sandbox rm cleans per-branch shell config dir", () => {
   }
 });
 
-test("sandbox rm --all cleans shell config dirs through a single confirm", () => {
+test("sandbox rm --purge cleans shell config dirs through a single confirm", () => {
   const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
 
   assert.match(
@@ -197,25 +199,25 @@ test("sandbox rm --all cleans shell config dirs through a single confirm", () =>
   );
 });
 
-test("sandbox rm --all prunes project-scoped dangling images before managed-engine branch", () => {
+test("sandbox rm --purge prunes project-scoped dangling images before managed-engine branch", () => {
   const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
 
-  const rmAllMatch = commandSource.match(
-    /async function rmAll\b[\s\S]*?(?=\n(?:async function|export async function|export function)\b|$)/
+  const rmPurgeMatch = commandSource.match(
+    /async function rmPurge\b[\s\S]*?(?=\n(?:async function|export async function|export function)\b|$)/
   );
-  assert.ok(rmAllMatch, "expected to locate rmAll function body in rm.js");
-  const rmAllBody = rmAllMatch[0];
+  assert.ok(rmPurgeMatch, "expected to locate rmPurge function body in rm.js");
+  const rmPurgeBody = rmPurgeMatch[0];
 
-  const pruneIndex = rmAllBody.search(/pruneSandboxDanglingImages\(config,\s*engine\)/);
+  const pruneIndex = rmPurgeBody.search(/pruneSandboxDanglingImages\(config,\s*engine\)/);
   assert.ok(
     pruneIndex >= 0,
-    "expected rmAll to call pruneSandboxDanglingImages(config, engine)"
+    "expected rmPurge to call pruneSandboxDanglingImages(config, engine)"
   );
 
-  const managedIndex = rmAllBody.search(/if\s*\(\s*isManagedEngine\(\s*engine\s*\)/);
+  const managedIndex = rmPurgeBody.search(/if\s*\(\s*isManagedEngine\(\s*engine\s*\)/);
   assert.ok(
     managedIndex >= 0,
-    "expected rmAll to contain the isManagedEngine branch"
+    "expected rmPurge to contain the isManagedEngine branch"
   );
 
   assert.ok(
@@ -223,15 +225,196 @@ test("sandbox rm --all prunes project-scoped dangling images before managed-engi
     "expected pruneSandboxDanglingImages to run before the isManagedEngine branch (covers WSL2 early return)"
   );
 
-  const removeImageConfirmIndex = rmAllBody.search(/Remove image \$\{config\.imageName\}\?/);
+  const removeImageConfirmIndex = rmPurgeBody.search(/Remove image \$\{config\.imageName\}\?/);
   assert.ok(
     removeImageConfirmIndex >= 0,
-    "expected rmAll to keep the 'Remove image?' confirm prompt"
+    "expected rmPurge to keep the 'Remove image?' confirm prompt"
   );
   assert.ok(
     pruneIndex > removeImageConfirmIndex,
     "expected pruneSandboxDanglingImages to run after the 'Remove image?' confirm"
   );
+});
+
+function writeShortIdRegistry(repoDir: string, ids: Record<string, string>): void {
+  const activeDir = path.join(repoDir, ".agents", "workspace", "active");
+  fs.mkdirSync(activeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(activeDir, ".short-ids.json"),
+    JSON.stringify({ version: 1, ids }, null, 2)
+  );
+}
+
+function writeActiveTaskBranch(repoDir: string, taskId: string, branch: string): void {
+  const taskDir = path.join(repoDir, ".agents", "workspace", "active", taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, "task.md"), `---\nid: ${taskId}\nbranch: ${branch}\n---\n# body\n`);
+}
+
+function sandboxRow(name: string, branch: string, project = "demo"): string {
+  return `${name}\tUp 1 minute\t${project}.sandbox.branch=${branch},${project}.sandbox=true`;
+}
+
+function hasDockerVerb(calls: string[][], verb: string): boolean {
+  return calls.some((call) => call[0] === verb);
+}
+
+test("sandbox rm --all --dry-run lists unbound sandboxes and removes nothing", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-dry-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      dockerStdoutForPs: sandboxRow("sb-orphan", "orphan-branch")
+    });
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--dry-run"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /orphan-branch/);
+    const calls = fixture.readDockerCalls();
+    assert.equal(hasDockerVerb(calls, "stop"), false, "dry-run must not stop containers");
+    assert.equal(hasDockerVerb(calls, "rm"), false, "dry-run must not rm containers");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all skips containers bound to an active task", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-skip-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      dockerStdoutForPs: [
+        sandboxRow("sb-bound", "bound-branch"),
+        sandboxRow("sb-free", "free-branch")
+      ].join("\n")
+    });
+    writeShortIdRegistry(fixture.repoDir, { "07": "TASK-20260101-000001" });
+    writeActiveTaskBranch(fixture.repoDir, "TASK-20260101-000001", "bound-branch");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--dry-run"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /free-branch/);
+    assert.doesNotMatch(result.stdout, /bound-branch/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all exits 0 with a notice when nothing is removable", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-empty-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      dockerStdoutForPs: sandboxRow("sb-bound", "bound-branch")
+    });
+    writeShortIdRegistry(fixture.repoDir, { "07": "TASK-20260101-000001" });
+    writeActiveTaskBranch(fixture.repoDir, "TASK-20260101-000001", "bound-branch");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /No removable sandboxes/);
+    const calls = fixture.readDockerCalls();
+    assert.equal(hasDockerVerb(calls, "stop"), false);
+    assert.equal(hasDockerVerb(calls, "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all rejects a positional branch argument", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-mutex-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "feature/x"]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--all does not take a branch argument/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all without --yes fails safe in a non-interactive shell", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-tty-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      dockerStdoutForPs: sandboxRow("sb-orphan", "orphan-branch")
+    });
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all"]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--yes/);
+    const calls = fixture.readDockerCalls();
+    assert.equal(hasDockerVerb(calls, "stop"), false);
+    assert.equal(hasDockerVerb(calls, "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --dry-run without --all is rejected", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-dry-misuse-"));
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--dry-run"]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /only apply to --all/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all --yes routes each unbound branch through rmOne cleanup", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-yes-"));
+  const project = "demo";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project,
+      dockerStdoutForPs: sandboxRow("sb-cleanup", "feature/all-cleanup")
+    });
+    const shellConfigBase = path.join(tmpDir, ".agent-infra", "config", project);
+    const removedBranchDir = path.join(shellConfigBase, "feature..all-cleanup");
+    const keptBranchDir = path.join(shellConfigBase, "feature..keep");
+    fs.mkdirSync(removedBranchDir, { recursive: true });
+    fs.mkdirSync(keptBranchDir, { recursive: true });
+    fs.writeFileSync(path.join(removedBranchDir, ".bash_aliases"), "alias demo=true\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--yes"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    // The unbound branch was passed into rmOne, whose unconditional per-branch
+    // shell-config cleanup ran (observable filesystem side effect).
+    assert.equal(fs.existsSync(removedBranchDir), false);
+    // A different branch's dir is untouched (batch only targeted the unbound one).
+    assert.equal(fs.existsSync(keptBranchDir), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --all delegates to rmOne with assumeYes/quiet and aggregates failures", () => {
+  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
+
+  const rmUnboundMatch = commandSource.match(
+    /async function rmUnbound\b[\s\S]*?(?=\n(?:async function|export async function|export function)\b|$)/
+  );
+  assert.ok(rmUnboundMatch, "expected to locate rmUnbound function body in rm.js");
+  const rmUnboundBody = rmUnboundMatch[0];
+
+  // T7b: batch path forwards the removable branch into the single-container path,
+  // suppressing per-item confirms and framing.
+  assert.match(rmUnboundBody, /rmOne\([\s\S]*?assumeYes:\s*true[\s\S]*?quiet:\s*true[\s\S]*?\)/);
+  // T8: partial-failure contract — keep going, collect failures, then throw a summary.
+  assert.match(rmUnboundBody, /try\s*\{[\s\S]*?rmOne\([\s\S]*?\}\s*catch[\s\S]*?failures\.push/);
+  assert.match(rmUnboundBody, /failures\.length[\s\S]*?throw new Error\(/);
 });
 
 test("managed sandbox fs helpers remove only paths under the managed root", async () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #482 👈👈

Closes #482

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [x] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

#442（0.7.3）确立了沙箱二态语义：「有短号 = active 任务绑定」「无短号 = 沙箱可删除」。`ai sandbox ls` 已把无短号沙箱标为 `-` 提示「可清理」，但实际清理仍需用户逐个复制完整分支名，体验割裂。

本 PR 为 `ai sandbox rm` 增加 `--all`，一次性批量清理所有**未绑定 active 任务**的沙箱（复用既有单容器删除路径，含关联 worktree / 分支 / 状态目录清理）。

**💥 破坏性变更**：原 `ai sandbox rm --all`（删除项目全部沙箱、镜像、VM 的全量拆除）语义被重定义；该全量拆除能力**完整保留**到新 flag `ai sandbox rm --purge`，无能力损失。详见 Issue #482 与 task 工作区中 `analysis-r2.md` 的决策记录（D1/D2）。

## 📋 主要变更 / Brief Changelog

- `ai sandbox rm --all`：枚举所有无短号容器（`fetchSandboxRows` + `lookupShortIdByBranch`）并批量删除；支持 `--dry-run`（仅列出不删）、`--yes`（跳过确认，CI 友好）；默认先列出待删项再二次确认（默认否）；非交互 shell 无 `--yes` 时安全失败；部分失败「继续 + 汇总并以非零退出」。
- `ai sandbox rm --purge`：承接原 `--all` 的项目级全量拆除（容器 + worktree + 工具状态 + shell config + share + 询问删镜像 + 停 VM），行为不变。
- `rmOne` 新增 `{ assumeYes, quiet }` 选项供批量路径复用并抑制逐项确认/框架输出；单分支删除路径行为零回归。
- 参数校验：`--all` ⊥ `--purge`、`--dry-run`/`--yes` 仅限 `--all`、`--all`/`--purge` 不接受分支参数；均报错非零退出。
- 同步更新 CLI 帮助（`index.ts`）与双语文档（`docs/en|zh-CN/sandbox.md`，含 breaking change 标注）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（`tsc` 编译通过）
2. `npm run typecheck`（类型检查通过）
3. `npm test`（完整测试套件）
4. 可选手动：`ai sandbox rm --help` 查看三态用法；`ai sandbox rm --all --dry-run` 预览无短号沙箱；`ai sandbox rm --all foo` / `ai sandbox rm --dry-run` 验证报错退出。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

新增 8 个 `--all` 用例：dry-run 列出不删、跳过有短号容器、无可删项 exit 0、与位置入参互斥、非 TTY 无 `--yes` 安全失败、`--dry-run` 误用报错、`--all --yes` 经 `rmOne` 执行 per-branch 状态清理、`rmUnbound` 以 `{assumeYes,quiet}` 委托并聚合失败；并更新 3 条既有断言（`rmOne` 确认结构、`rmAll`→`rmPurge`）。完整套件 1079 个用例通过、0 失败。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

迁移指引：依赖旧 `ai sandbox rm --all`（全量拆除）的脚本请改用 `ai sandbox rm --purge`。

---

**审查者注意事项 / Reviewer Notes:**

- `rmUnbound` 刻意以 `row.branch &&` 排除无 branch 标签容器（罕见/legacy），由 `--purge` 或手动 `docker rm` 兜底（已知限制）。
- 非 TTY 安全失败以 `process.stdin.isTTY` 判定，`--yes` 为非交互 shell 下唯一放行删除途径。

---

🤖 Generated with AI assistance