### PR TITLE
feat(cli): 为 ai task 新增 log 时间线子命令

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,7 +18,7 @@ Usage:
   agent-infra init            Initialize a new project with update-agent-infra seed command
   agent-infra merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   agent-infra sandbox         Manage Docker-based AI sandboxes
-  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat / status)
+  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat / status / log)
   agent-infra update          Update seed files and sync file registry for an existing project
   agent-infra version         Show version
 

--- a/lib/task/commands/log.ts
+++ b/lib/task/commands/log.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import { formatTable } from '../../table.ts';
+import { resolveTaskRef } from '../resolve-ref.ts';
+
+const USAGE = `Usage: ai task log <N | #N | TASK-id>
+
+Renders a task's activity log as a chronological timeline table.
+  <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
+
+Columns: # (timeline position) / TIME / STEP / AGENT / NOTE
+`;
+
+const TABLE_HEADERS = ['#', 'TIME', 'STEP', 'AGENT', 'NOTE'] as const;
+
+// The activity-log H2 heading is language-dependent (zh template / en template).
+const HEADING_RE = /^##\s+(活动日志|Activity Log)\s*$/;
+const NEXT_H2_RE = /^##\s/;
+// `- {time} — **{step}** by {agent} — {note}` ; the separator is an em-dash
+// (U+2014). STEP/AGENT are non-greedy so a note that itself contains ' — ' or
+// '→' is not mis-split; NOTE greedily takes the rest of the line.
+const ENTRY_RE =
+  /^- (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}) — \*\*(.+?)\*\* by (.+?) — (.*)$/;
+
+type LogEntry = { time: string; step: string; agent: string; note: string };
+
+function parseActivityLog(content: string): { sectionFound: boolean; entries: LogEntry[] } {
+  const lines = content.split('\n');
+  let i = 0;
+  while (i < lines.length && !HEADING_RE.test(lines[i]!)) i += 1;
+  if (i >= lines.length) return { sectionFound: false, entries: [] };
+  const parsed: { entry: LogEntry; epoch: number; order: number }[] = [];
+  for (let j = i + 1; j < lines.length; j += 1) {
+    if (NEXT_H2_RE.test(lines[j]!)) break;
+    const m = ENTRY_RE.exec(lines[j]!);
+    if (!m) continue; // skip blank / non-entry / malformed lines
+    parsed.push({
+      entry: { time: m[1]!, step: m[2]!, agent: m[3]!, note: m[4]! },
+      epoch: Date.parse(m[1]!.replace(' ', 'T')),
+      order: parsed.length
+    });
+  }
+  // Ascending by time; stable tie-break on original order for equal timestamps.
+  parsed.sort((a, b) => a.epoch - b.epoch || a.order - b.order);
+  return { sectionFound: true, entries: parsed.map((p) => p.entry) };
+}
+
+function log(args: string[] = []): void {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(USAGE);
+    if (args.length === 0) process.exitCode = 1;
+    return;
+  }
+  const resolved = resolveTaskRef(args[0]!);
+  if (!resolved.ok) {
+    process.stderr.write(`ai task log: ${resolved.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const content = fs.readFileSync(resolved.taskMdPath, 'utf8');
+  const { sectionFound, entries } = parseActivityLog(content);
+  if (!sectionFound) {
+    process.stderr.write(
+      `ai task log: no activity log section ('## 活动日志' or '## Activity Log') found in task ${resolved.taskId}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (entries.length === 0) {
+    process.stderr.write(`ai task log: no activity log entries found in task ${resolved.taskId}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const rows = entries.map((e, idx) => [String(idx + 1), e.time, e.step, e.agent, e.note]);
+  for (const line of formatTable(TABLE_HEADERS, rows, { zebra: Boolean(process.stdout.isTTY) })) {
+    process.stdout.write(`${line}\n`);
+  }
+  process.stdout.write(`Total: ${entries.length} entries\n`);
+}
+
+export { log, parseActivityLog };

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -3,6 +3,7 @@ const USAGE = `Usage: ai task <command> [options]
 Commands:
   cat <ref> <artifact | N>               Print a task artifact (by name or number)
   files <ref>                            List artifacts in a task dir (numbered)
+  log <ref>                              Render a task's activity log as a timeline
   ls [--all | --blocked | --completed]   List tasks (default: active)
   show <N | #N | TASK-id>                Print a task.md
   status <ref>                           Aggregated status view (metadata / artifacts / git / platform)
@@ -11,6 +12,7 @@ Examples:
   ai task cat 11 analysis
   ai task cat 11 3
   ai task files 11
+  ai task log 11
   ai task ls
   ai task show 11
   ai task show TASK-20260612-162737
@@ -51,6 +53,11 @@ export async function runTask(args: string[]): Promise<void> {
     case 'cat': {
       const { cat } = await import('./commands/cat.ts');
       cat(rest);
+      break;
+    }
+    case 'log': {
+      const { log } = await import('./commands/log.ts');
+      log(rest);
       break;
     }
     case 'status': {

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -40,6 +40,12 @@ test('ai task status --help prints subcommand USAGE', () => {
   assert.match(out.stdout, /Usage: ai task status/);
 });
 
+test('ai task log --help prints subcommand USAGE', () => {
+  const out = runCli(['task', 'log', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task log/);
+});
+
 test('ai task <unknown> reports error', () => {
   const out = runCli(['task', 'wat']);
   assert.equal(out.status, 1);

--- a/tests/integration/cli/task-log.test.ts
+++ b/tests/integration/cli/task-log.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string; activeDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-log-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  const activeDir = path.join(agentsDir, 'workspace', 'active');
+  fs.mkdirSync(activeDir, { recursive: true });
+  return { repoRoot, activeDir };
+}
+
+// `heading` is the activity-log H2 line; `entries` are raw '- ...' lines.
+function writeTask(activeDir: string, taskId: string, heading: string, entries: string[]): void {
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  const log = entries.length ? `${entries.join('\n')}\n` : '';
+  fs.writeFileSync(
+    path.join(dir, 'task.md'),
+    `---\nid: ${taskId}\nbranch: feat\n---\n# 任务：${taskId}\n\n${heading}\n\n${log}\n## 完成检查清单\n\n- [ ] done\n`
+  );
+}
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('ai task log <ref> renders the timeline table sorted ascending with a total', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000007';
+  // Intentionally out of order in the file to prove the command sorts by time.
+  writeTask(activeDir, taskId, '## 活动日志', [
+    '- 2026-06-18 14:00:00+08:00 — **Plan Task (Round 1)** by claude — Plan completed → plan.md',
+    '- 2026-06-16 15:06:43+08:00 — **Create Task** by claude — Task created from description'
+  ]);
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+
+  const out = runCli(['task', 'log', '1'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // Header columns.
+  assert.match(out.stdout, /#\s+TIME\s+STEP\s+AGENT\s+NOTE/);
+  // Row 1 is the earliest entry (Create Task), row 2 the later one (Plan Task).
+  assert.match(out.stdout, /^1\s+2026-06-16 15:06:43\+08:00\s+Create Task\s+claude\s+Task created/m);
+  assert.match(out.stdout, /^2\s+2026-06-18 14:00:00\+08:00\s+Plan Task \(Round 1\)\s+claude\s+Plan completed → plan\.md/m);
+  // Trailing total.
+  assert.match(out.stdout, /^Total: 2 entries$/m);
+});
+
+test('ai task log locates an English "## Activity Log" section', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000008';
+  writeTask(activeDir, taskId, '## Activity Log', [
+    '- 2026-06-16 15:06:43+08:00 — **Create Task** by codex — created'
+  ]);
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /^1\s+2026-06-16 15:06:43\+08:00\s+Create Task\s+codex\s+created/m);
+  assert.match(out.stdout, /^Total: 1 entries$/m);
+});
+
+test('ai task log fails when the task has no activity log section', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000009';
+  const dir = path.join(activeDir, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# 任务\n\n## 描述\n\nno log\n`);
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /ai task log:/);
+  assert.match(out.stderr, /no activity log section/);
+});
+
+test('ai task log fails when the activity log section has no entries', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000010';
+  writeTask(activeDir, taskId, '## 活动日志', []);
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /no activity log entries/);
+});
+
+test('ai task log rejects an unknown ref', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'log', 'not-a-task'], repoRoot);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /ai task log:/);
+});
+
+test('ai task log requires an argument', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'log'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task log/);
+});

--- a/tests/unit/cli/task-activity-log.test.ts
+++ b/tests/unit/cli/task-activity-log.test.ts
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseActivityLog } from '../../../lib/task/commands/log.ts';
+
+// Separator in real entries is an em-dash (U+2014), not an ASCII hyphen.
+const ZH = '## 活动日志';
+const EN = '## Activity Log';
+
+function md(heading: string, body: string): string {
+  return `---\nid: TASK-20260101-000001\n---\n# 任务\n\n${heading}\n\n${body}\n`;
+}
+
+test('parses a Chinese activity log section with multiple entries', () => {
+  const content = md(
+    ZH,
+    [
+      '- 2026-06-16 15:06:43+08:00 — **Create Task** by claude — Task created from description',
+      '- 2026-06-18 13:00:31+08:00 — **Analyze Task (Round 1)** by codex — Analysis done'
+    ].join('\n')
+  );
+  const { sectionFound, entries } = parseActivityLog(content);
+  assert.equal(sectionFound, true);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries[0], {
+    time: '2026-06-16 15:06:43+08:00',
+    step: 'Create Task',
+    agent: 'claude',
+    note: 'Task created from description'
+  });
+  assert.equal(entries[1]!.agent, 'codex');
+});
+
+test('locates the section language-agnostically (English heading)', () => {
+  const content = md(EN, '- 2026-06-16 15:06:43+08:00 — **Create Task** by claude — body');
+  const { sectionFound, entries } = parseActivityLog(content);
+  assert.equal(sectionFound, true);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]!.step, 'Create Task');
+});
+
+test('keeps a note that itself contains the arrow and the em-dash separator', () => {
+  const content = md(
+    ZH,
+    [
+      '- 2026-06-18 13:00:31+08:00 — **Analyze Task (Round 1)** by claude — Analysis completed → analysis.md',
+      '- 2026-06-10 00:38:44+08:00 — **Task Restored** by claude — Restored from Issue #419 — 5 artifacts'
+    ].join('\n')
+  );
+  const { entries } = parseActivityLog(content);
+  // Sorted ascending: Restored (Jun 10) before Analyze (Jun 18).
+  const restored = entries.find((e) => e.step === 'Task Restored')!;
+  const analyze = entries.find((e) => e.step === 'Analyze Task (Round 1)')!;
+  assert.equal(analyze.agent, 'claude');
+  assert.equal(analyze.note, 'Analysis completed → analysis.md');
+  // The ' — ' inside the note must NOT be mis-split into STEP/AGENT.
+  assert.equal(restored.agent, 'claude');
+  assert.equal(restored.note, 'Restored from Issue #419 — 5 artifacts');
+});
+
+test('sorts entries ascending by timestamp regardless of file order', () => {
+  const content = md(
+    ZH,
+    [
+      '- 2026-06-18 14:00:00+08:00 — **Third** by claude — c',
+      '- 2026-06-16 09:00:00+08:00 — **First** by claude — a',
+      '- 2026-06-17 12:00:00+08:00 — **Second** by claude — b'
+    ].join('\n')
+  );
+  const { entries } = parseActivityLog(content);
+  assert.deepEqual(
+    entries.map((e) => e.step),
+    ['First', 'Second', 'Third']
+  );
+});
+
+test('is a stable sort for equal timestamps (preserves original order)', () => {
+  const content = md(
+    ZH,
+    [
+      '- 2026-06-16 09:00:00+08:00 — **A1** by claude — first',
+      '- 2026-06-16 09:00:00+08:00 — **A2** by claude — second'
+    ].join('\n')
+  );
+  const { entries } = parseActivityLog(content);
+  assert.deepEqual(
+    entries.map((e) => e.step),
+    ['A1', 'A2']
+  );
+});
+
+test('skips blank, prose and malformed lines inside the section', () => {
+  const content = md(
+    ZH,
+    [
+      '- 2026-06-16 09:00:00+08:00 — **Valid** by claude — ok',
+      '',
+      'Some prose line that is not an entry.',
+      '- 2026-06-16 — **NoTime** by claude — missing time component',
+      '- missing the whole structure'
+    ].join('\n')
+  );
+  const { sectionFound, entries } = parseActivityLog(content);
+  assert.equal(sectionFound, true);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]!.step, 'Valid');
+});
+
+test('does not read entries past the next H2 boundary', () => {
+  const content =
+    `---\nid: x\n---\n# 任务\n\n${ZH}\n\n` +
+    '- 2026-06-16 09:00:00+08:00 — **InLog** by claude — yes\n\n' +
+    '## 完成检查清单\n\n' +
+    '- 2026-06-17 09:00:00+08:00 — **AfterLog** by claude — must be excluded\n';
+  const { entries } = parseActivityLog(content);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]!.step, 'InLog');
+});
+
+test('reports sectionFound=false when no activity log heading exists', () => {
+  const content = `---\nid: x\n---\n# 任务\n\n## 描述\n\nno log here\n`;
+  const { sectionFound, entries } = parseActivityLog(content);
+  assert.equal(sectionFound, false);
+  assert.equal(entries.length, 0);
+});
+
+test('distinguishes a present-but-empty section (no valid entries)', () => {
+  const content = `---\nid: x\n---\n# 任务\n\n${ZH}\n\n## 完成检查清单\n\n- [ ] item\n`;
+  const { sectionFound, entries } = parseActivityLog(content);
+  assert.equal(sectionFound, true);
+  assert.equal(entries.length, 0);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #469 👈👈

Closes #469

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

「ai task 详情命令」系列的第 3 个（仅依赖任务 1 #467 的 ref 解析器，与任务 2 #468 `status` 可并行）。任务的 `## 活动日志` / `## Activity Log` 段记录了每个 skill 执行的时间锚点，但用户回顾时必须用编辑器打开 `task.md` 滚动到日志段，无法用一条命令拿到结构化时间线。

本 PR 新增 `ai task log <ref>` 只读子命令：定位任务的活动日志段，解析每条条目，按时间正序渲染为时间线表格。命令纯只读、复用既有 `resolveTaskRef` / `formatTable`、不引入新依赖、对 `ls`/`show`/`files`/`cat`/`status` 零回归。

## 📋 主要变更 / Brief Changelog

- 新增 `lib/task/commands/log.ts`：导出命令壳 `log` 与可单测的纯函数 `parseActivityLog`。后者按 `/^##\s+(活动日志|Activity Log)\s*$/` 语言无关定位日志段，扫描到下一个 H2 或 EOF；每条 `- {time} — **{step}** by {agent} — {note}` 用正则解析（分隔符为 em-dash U+2014），STEP/AGENT 非贪婪、NOTE 贪婪收尾，避免 note 内的 ` — ` / `→` 被误切；时间戳解析为 epoch 后**稳定**升序排序（不假设文件内已有序）。
- 命令壳复用 `resolveTaskRef`（跨 active/blocked/completed/archive 定位）与 `formatTable`（zebra 仅 TTY），渲染 `# / TIME / STEP / AGENT / NOTE` 表格并打印 `Total: N entries`；区分「无日志段」与「段内无合规条目」两类错误，均 stderr 友好提示 + 非零退出。
- 接线：`lib/task/index.ts` 新增 `case 'log'` 路由与 USAGE 两行（按字母序插入）；`bin/cli.ts` 顶层 USAGE 文案补 `log`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（`tsc` 编译通过）
2. `npm run typecheck`（erasable-only TS，无 enum）
3. `npm test`（完整测试套件）
4. 手动：`ai task log <ref>` 对活动日志条目较多的任务（如 `TASK-20260609-192644`，47 条）跑一次，确认按时间正序渲染、末行总数正确；对无日志段 / 空日志段任务确认非零退出与提示。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

新增 16 个用例：单元（直接 import `parseActivityLog`，不起子进程）9 例，覆盖中/英 H2 段定位、多条解析、note 内 `→`/` — ` 不被误切、乱序输入升序排序、相同时间稳定排序、空行/散文/残缺行跳过、下一个 H2 边界截断、无段 vs 空段两类返回；集成（spawn CLI）6 例，覆盖排序后表格渲染 + 总数、英文 H2 端到端、无段/空段错误路径、未知 ref、缺参；并在 `task-help.test.ts` 追加 `log --help` 用例。完整套件 1115 个用例通过、0 失败（1 个既有平台守卫 skip）。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- `Total: N entries` 不做单复数处理（`1 entries`），与既有 `ls` 的 `Total: N tasks` 风格保持一致。
- 仅消费 `task.md` 的活动日志段；不消费 `.agents/workspace/logs/`（如未来存在），不做时间区间过滤 / 分页（YAGNI）。

---

**审查者注意事项 / Reviewer Notes:**

- 解析的唯一风险面是条目正则对 em-dash（U+2014）分隔符与 note 内特殊字符的鲁棒性，已由单元用例 `keeps a note that itself contains the arrow and the em-dash separator` 与 `does not read entries past the next H2 boundary` 定向覆盖。

---

Generated with AI assistance
