### PR TITLE
feat(cli): 为 ai task 新增 grep 跨任务搜索子命令

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,7 +18,7 @@ Usage:
   agent-infra init            Initialize a new project with update-agent-infra seed command
   agent-infra merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   agent-infra sandbox         Manage Docker-based AI sandboxes
-  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat / status / log)
+  agent-infra task            Read-only views over .agents/workspace tasks (ls / show / files / cat / status / log / grep)
   agent-infra update          Update seed files and sync file registry for an existing project
   agent-infra version         Show version
 

--- a/lib/task/commands/grep.ts
+++ b/lib/task/commands/grep.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveTaskRef, detectRepoRoot, enumerateTaskDirs } from '../resolve-ref.ts';
+import { enumerateArtifacts, resolveArtifact } from '../artifacts.ts';
+import { loadShortIdByTaskId } from '../short-id.ts';
+
+const USAGE = `Usage: ai task grep <pattern> [ref] [artifact | N]
+
+Literal (non-regex) line search across task artifacts.
+  <pattern>          Literal substring to match (NOT a regex). Case-sensitive by default.
+  [ref]              Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
+                     Omit to scan every task under active / blocked / completed
+                     (archive is skipped). With a ref, narrows to that single task
+                     (a TASK-id ref can also resolve an archived task).
+  [artifact | N]     Only valid with <ref>. Artifact filename (with or without '.md')
+                     or the number from 'ai task files'. Narrows to a single artifact.
+
+Options:
+  -i, --ignore-case  Case-insensitive matching.
+  --                 Treat the rest as positional (use for patterns starting with '-').
+
+Output: '{taskId} [#short] {fileStem}:{line}: {matched-line}' (short id only for active tasks).
+Exits 1 with no output when nothing matches.
+`;
+
+function makeMatcher(pattern: string, ignoreCase: boolean): (line: string) => boolean {
+  if (ignoreCase) {
+    const needle = pattern.toLowerCase();
+    return (line) => line.toLowerCase().includes(needle);
+  }
+  return (line) => line.includes(pattern);
+}
+
+// Split content into lines with grep-like semantics: a trailing newline does
+// not yield a phantom final empty line, but genuine interior blank lines stay.
+function splitLines(content: string): string[] {
+  const lines = content.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+function scanArtifact(
+  taskId: string,
+  shortToken: string | undefined,
+  artifactPath: string,
+  matcher: (line: string) => boolean,
+  emit: (line: string) => void
+): number {
+  const content = fs.readFileSync(artifactPath, 'utf8');
+  const stem = path.basename(artifactPath).replace(/\.md$/, '');
+  const prefix = shortToken ? `${taskId} ${shortToken}` : taskId;
+  let count = 0;
+  splitLines(content).forEach((line, i) => {
+    if (matcher(line)) {
+      emit(`${prefix} ${stem}:${i + 1}: ${line}\n`);
+      count++;
+    }
+  });
+  return count;
+}
+
+function grep(args: string[] = []): void {
+  const positional: string[] = [];
+  let ignoreCase = false;
+  let optsEnded = false;
+  for (const a of args) {
+    if (!optsEnded && a === '--') { optsEnded = true; continue; }
+    if (!optsEnded && (a === '-h' || a === '--help')) {
+      process.stdout.write(USAGE);
+      return;
+    }
+    if (!optsEnded && (a === '-i' || a === '--ignore-case')) { ignoreCase = true; continue; }
+    if (!optsEnded && a.startsWith('-') && a !== '-') {
+      process.stderr.write(`ai task grep: unknown flag: ${a}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    positional.push(a);
+  }
+
+  if (positional.length === 0) {
+    process.stdout.write(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+  if (positional.length > 3) {
+    process.stderr.write('ai task grep: too many arguments\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  const [pattern, ref, artifactOrN] = positional;
+  const matcher = makeMatcher(pattern!, ignoreCase);
+  const chunks: string[] = [];
+  const emit = (line: string) => chunks.push(line);
+  let total = 0;
+
+  if (ref === undefined) {
+    // No ref: full scan across active / blocked / completed (no archive).
+    let repoRoot: string;
+    try {
+      repoRoot = detectRepoRoot();
+    } catch (e) {
+      process.stderr.write(`ai task grep: ${(e as Error).message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    const shortMap = loadShortIdByTaskId(repoRoot);
+    for (const { taskId, taskDir } of enumerateTaskDirs(repoRoot)) {
+      const shortToken = shortMap.get(taskId);
+      for (const a of enumerateArtifacts(taskDir)) {
+        total += scanArtifact(taskId, shortToken, a.path, matcher, emit);
+      }
+    }
+  } else {
+    const resolved = resolveTaskRef(ref);
+    if (!resolved.ok) {
+      process.stderr.write(`ai task grep: ${resolved.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    const shortToken = loadShortIdByTaskId(resolved.repoRoot).get(resolved.taskId);
+    if (artifactOrN !== undefined) {
+      let artifactPath: string;
+      try {
+        artifactPath = resolveArtifact(resolved.taskDir, artifactOrN);
+      } catch (e) {
+        process.stderr.write(`ai task grep: ${(e as Error).message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      total += scanArtifact(resolved.taskId, shortToken, artifactPath, matcher, emit);
+    } else {
+      for (const a of enumerateArtifacts(resolved.taskDir)) {
+        total += scanArtifact(resolved.taskId, shortToken, a.path, matcher, emit);
+      }
+    }
+  }
+
+  if (total === 0) {
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(chunks.join(''));
+}
+
+export { grep };

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -3,6 +3,7 @@ const USAGE = `Usage: ai task <command> [options]
 Commands:
   cat <ref> <artifact | N>               Print a task artifact (by name or number)
   files <ref>                            List artifacts in a task dir (numbered)
+  grep <pattern> [ref] [artifact | N]    Literal search across task artifacts (omit ref to scan all)
   log <ref>                              Render a task's activity log as a timeline
   ls [--all | --blocked | --completed]   List tasks (default: active)
   show <N | #N | TASK-id>                Print a task.md
@@ -12,6 +13,8 @@ Examples:
   ai task cat 11 analysis
   ai task cat 11 3
   ai task files 11
+  ai task grep resolveArtifact
+  ai task grep resolveArtifact 11
   ai task log 11
   ai task ls
   ai task show 11
@@ -53,6 +56,11 @@ export async function runTask(args: string[]): Promise<void> {
     case 'cat': {
       const { cat } = await import('./commands/cat.ts');
       cat(rest);
+      break;
+    }
+    case 'grep': {
+      const { grep } = await import('./commands/grep.ts');
+      grep(rest);
       break;
     }
     case 'log': {

--- a/lib/task/resolve-ref.ts
+++ b/lib/task/resolve-ref.ts
@@ -93,6 +93,27 @@ function findTaskMd(repoRoot: string, taskId: string): string | null {
 }
 
 /**
+ * Enumerate every task directory under the flat workspace states
+ * (active / blocked / completed) — archive is intentionally excluded so a
+ * full-tree scan never pulls in cold data. Ordered by state, then task id
+ * ascending, giving callers a deterministic traversal.
+ */
+function enumerateTaskDirs(repoRoot: string): { taskId: string; taskDir: string }[] {
+  const out: { taskId: string; taskDir: string }[] = [];
+  for (const sub of FLAT_WORKSPACE_DIRS) {
+    const base = path.join(repoRoot, '.agents', 'workspace', sub);
+    if (!fs.existsSync(base)) continue;
+    for (const entry of fs.readdirSync(base).sort()) {
+      if (!TASK_ID_RE.test(entry)) continue;
+      const taskDir = path.join(base, entry);
+      if (!fs.existsSync(path.join(taskDir, 'task.md'))) continue;
+      out.push({ taskId: entry, taskDir });
+    }
+  }
+  return out;
+}
+
+/**
  * Resolve a task ref (bare short id, `#N`, or `TASK-YYYYMMDD-HHMMSS`) to its
  * task directory across active / blocked / completed / archive.
  *
@@ -135,5 +156,5 @@ function resolveTaskRef(arg: string): ResolveRefResult {
   return { ok: true, repoRoot, taskId, taskDir: path.dirname(taskMdPath), taskMdPath };
 }
 
-export { resolveTaskRef, TASK_ID_RE };
+export { resolveTaskRef, detectRepoRoot, enumerateTaskDirs, TASK_ID_RE };
 export type { ResolveRefResult };

--- a/tests/integration/cli/task-grep.test.ts
+++ b/tests/integration/cli/task-grep.test.ts
@@ -1,0 +1,239 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CLI_PATH } from '../../helpers.ts';
+
+const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
+
+function mkFixture(): { repoRoot: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-grep-'));
+  spawnSync('git', ['init', '--quiet'], { cwd: repoRoot });
+  const agentsDir = path.join(repoRoot, '.agents');
+  fs.mkdirSync(path.join(agentsDir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(agentsDir, 'scripts', 'task-short-id.js'));
+  fs.writeFileSync(
+    path.join(agentsDir, '.airc.json'),
+    JSON.stringify({ project: 'demo', task: { shortIdLength: 2 } })
+  );
+  for (const state of ['active', 'blocked', 'completed']) {
+    fs.mkdirSync(path.join(agentsDir, 'workspace', state), { recursive: true });
+  }
+  return { repoRoot };
+}
+
+// Write a task dir with the given artifacts under a flat workspace state.
+function writeTask(
+  repoRoot: string,
+  state: 'active' | 'blocked' | 'completed',
+  taskId: string,
+  files: Record<string, string>
+): void {
+  const dir = path.join(repoRoot, '.agents', 'workspace', state, taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  if (!files['task.md']) {
+    fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\n`);
+  }
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+}
+
+// Write a task dir under the archive YYYY/MM/DD layout.
+function writeArchiveTask(repoRoot: string, taskId: string, files: Record<string, string>): void {
+  const dir = path.join(repoRoot, '.agents', 'workspace', 'archive', '2026', '06', '18', taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  if (!files['task.md']) {
+    fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\n`);
+  }
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+}
+
+function alloc(repoRoot: string, taskId: string): void {
+  spawnSync('node', [SCRIPT, 'alloc', taskId], { cwd: repoRoot, encoding: 'utf8' });
+}
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('matches a literal pattern and prints taskId, short id, file stem and line number', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  writeTask(repoRoot, 'active', taskId, { 'analysis.md': 'first line\nhas needle here\nlast line\n' });
+  alloc(repoRoot, taskId);
+
+  const out = runCli(['task', 'grep', 'needle'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // Active task carries its short id (#01); line number is 1-based; stem drops '.md'.
+  assert.equal(out.stdout, `${taskId} #01 analysis:2: has needle here\n`);
+});
+
+test('no ref scans active + blocked + completed; only active rows carry a short id', () => {
+  const { repoRoot } = mkFixture();
+  const a = 'TASK-20260101-000001';
+  const b = 'TASK-20260101-000002';
+  const c = 'TASK-20260101-000003';
+  writeTask(repoRoot, 'active', a, { 'analysis.md': 'KEYWORD in active\n' });
+  writeTask(repoRoot, 'blocked', b, { 'analysis.md': 'KEYWORD in blocked\n' });
+  writeTask(repoRoot, 'completed', c, { 'analysis.md': 'KEYWORD in completed\n' });
+  alloc(repoRoot, a);
+
+  const out = runCli(['task', 'grep', 'KEYWORD'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  const lines = out.stdout.trimEnd().split('\n');
+  assert.equal(lines.length, 3);
+  assert.ok(lines.some((l) => l === `${a} #01 analysis:1: KEYWORD in active`));
+  // blocked / completed tasks have released their short id -> token omitted.
+  assert.ok(lines.some((l) => l === `${b} analysis:1: KEYWORD in blocked`));
+  assert.ok(lines.some((l) => l === `${c} analysis:1: KEYWORD in completed`));
+});
+
+test('-i / --ignore-case toggles case sensitivity', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  writeTask(repoRoot, 'active', taskId, { 'analysis.md': 'lowercase needle\n' });
+  alloc(repoRoot, taskId);
+
+  // Case-sensitive by default: no match -> exit 1, empty stdout.
+  const sensitive = runCli(['task', 'grep', 'NEEDLE'], repoRoot);
+  assert.equal(sensitive.status, 1);
+  assert.equal(sensitive.stdout, '');
+
+  // -i matches.
+  const ignore = runCli(['task', 'grep', '-i', 'NEEDLE'], repoRoot);
+  assert.equal(ignore.status, 0, ignore.stderr);
+  assert.match(ignore.stdout, /analysis:1: lowercase needle/);
+
+  // --ignore-case is the long form.
+  const ignoreLong = runCli(['task', 'grep', '--ignore-case', 'NEEDLE'], repoRoot);
+  assert.equal(ignoreLong.status, 0, ignoreLong.stderr);
+});
+
+test('pattern is matched literally, not as a regex', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  writeTask(repoRoot, 'active', taskId, {
+    'analysis.md': 'literal a.c here\nregex would match abc\nbracket [x] here\nbare x here\nstar a*c here\ngreedy aaac here\n'
+  });
+  alloc(repoRoot, taskId);
+
+  const dot = runCli(['task', 'grep', 'a.c'], repoRoot);
+  assert.equal(dot.status, 0, dot.stderr);
+  assert.match(dot.stdout, /literal a\.c here/);
+  assert.doesNotMatch(dot.stdout, /match abc/); // '.' must NOT match 'b'
+
+  const bracket = runCli(['task', 'grep', '[x]'], repoRoot);
+  assert.equal(bracket.status, 0, bracket.stderr);
+  assert.match(bracket.stdout, /bracket \[x\] here/);
+  assert.doesNotMatch(bracket.stdout, /bare x here/); // '[x]' must NOT match a bare 'x'
+
+  const star = runCli(['task', 'grep', 'a*c'], repoRoot);
+  assert.equal(star.status, 0, star.stderr);
+  assert.match(star.stdout, /star a\*c here/);
+  assert.doesNotMatch(star.stdout, /greedy aaac here/); // 'a*c' must NOT match 'aaac'
+});
+
+test('a ref narrows the scan to a single task', () => {
+  const { repoRoot } = mkFixture();
+  const a = 'TASK-20260101-000001';
+  const b = 'TASK-20260101-000002';
+  writeTask(repoRoot, 'active', a, { 'analysis.md': 'shared KEYWORD a\n' });
+  writeTask(repoRoot, 'active', b, { 'analysis.md': 'shared KEYWORD b\n' });
+  alloc(repoRoot, a);
+  alloc(repoRoot, b);
+
+  const out = runCli(['task', 'grep', 'KEYWORD', a], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /KEYWORD a/);
+  assert.doesNotMatch(out.stdout, /KEYWORD b/);
+});
+
+test('an artifact selector (name or number) narrows the scan to a single file', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  const dir = path.join(repoRoot, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${taskId}\nbranch: feat\n---\n# ${taskId}\nKEYWORD task\n`);
+  fs.writeFileSync(path.join(dir, 'analysis.md'), 'KEYWORD analysis\n');
+  // task.md is artifact #1, analysis.md is #2 (oldest mtime first).
+  fs.utimesSync(path.join(dir, 'task.md'), 1000, 1000);
+  fs.utimesSync(path.join(dir, 'analysis.md'), 2000, 2000);
+  alloc(repoRoot, taskId);
+
+  const byName = runCli(['task', 'grep', 'KEYWORD', taskId, 'analysis'], repoRoot);
+  assert.equal(byName.status, 0, byName.stderr);
+  assert.match(byName.stdout, /analysis:1: KEYWORD analysis/);
+  assert.doesNotMatch(byName.stdout, /KEYWORD task/);
+
+  const byNumber = runCli(['task', 'grep', 'KEYWORD', taskId, '2'], repoRoot);
+  assert.equal(byNumber.status, 0, byNumber.stderr);
+  assert.equal(byNumber.stdout, byName.stdout);
+});
+
+test('no match exits 1 with empty stdout', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  writeTask(repoRoot, 'active', taskId, { 'analysis.md': 'nothing relevant\n' });
+  alloc(repoRoot, taskId);
+
+  const out = runCli(['task', 'grep', 'does-not-exist-zzz'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.equal(out.stdout, '');
+});
+
+test('a full-tree scan (no ref) does not reach archived tasks', () => {
+  const { repoRoot } = mkFixture();
+  const live = 'TASK-20260101-000001';
+  const archived = 'TASK-20259999-000099';
+  writeTask(repoRoot, 'active', live, { 'analysis.md': 'ARCHKEY live\n' });
+  writeArchiveTask(repoRoot, archived, { 'analysis.md': 'ARCHKEY archived\n' });
+  alloc(repoRoot, live);
+
+  const out = runCli(['task', 'grep', 'ARCHKEY'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /ARCHKEY live/);
+  assert.doesNotMatch(out.stdout, /ARCHKEY archived/);
+});
+
+test('a TASK-id ref does reach an archived task', () => {
+  const { repoRoot } = mkFixture();
+  const archived = 'TASK-20259999-000099';
+  writeArchiveTask(repoRoot, archived, { 'analysis.md': 'ARCHKEY archived\n' });
+
+  const out = runCli(['task', 'grep', 'ARCHKEY', archived], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // Archived task has no short id -> token omitted.
+  assert.equal(out.stdout, `${archived} analysis:1: ARCHKEY archived\n`);
+});
+
+test('-- ends option parsing so a pattern can start with a dash', () => {
+  const { repoRoot } = mkFixture();
+  const taskId = 'TASK-20260101-000001';
+  writeTask(repoRoot, 'active', taskId, { 'analysis.md': 'flag like -i token\nplain line\n' });
+  alloc(repoRoot, taskId);
+
+  const out = runCli(['task', 'grep', '--', '-i'], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(out.stdout, /analysis:1: flag like -i token/);
+  assert.doesNotMatch(out.stdout, /plain line/);
+});
+
+test('grep --help prints usage and exits zero', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'grep', '--help'], repoRoot);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task grep/);
+});
+
+test('grep with no pattern prints usage and exits non-zero', () => {
+  const { repoRoot } = mkFixture();
+  const out = runCli(['task', 'grep'], repoRoot);
+  assert.equal(out.status, 1);
+  assert.match(out.stdout, /Usage: ai task grep/);
+});

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -46,6 +46,12 @@ test('ai task log --help prints subcommand USAGE', () => {
   assert.match(out.stdout, /Usage: ai task log/);
 });
 
+test('ai task grep --help prints subcommand USAGE', () => {
+  const out = runCli(['task', 'grep', '--help']);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /Usage: ai task grep/);
+});
+
 test('ai task <unknown> reports error', () => {
   const out = runCli(['task', 'wat']);
   assert.equal(out.status, 1);


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #470 👈👈

Closes #470

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

"ai task 详情命令" 4 任务系列的收尾。回顾「我在哪个任务的哪个产物里写过 X」此前必须离开 `ai task` 命令空间、手写 `rg`/`grep` 路径。本 PR 把该回顾能力做成 `ai task` 一等公民 `grep` 子命令，并与系列任务 1 的 ref 解析 / artifact 序号契约自然衔接。

## 📋 主要变更 / Brief Changelog

- 新增 `ai task grep <pattern> [ref] [artifact|N]`（`lib/task/commands/grep.ts`）：**字面量**（非正则）行级搜索，范围随位置参数渐进收窄 —— 无 `ref` 跨全部任务 → 带 `ref` 限定单任务 → 再带 `artifact|N` 限定单文件。
- 在 `lib/task/resolve-ref.ts` 新增并导出 `enumerateTaskDirs`（跨 active/blocked/completed 枚举任务目录，**排除 archive**），并导出既有 `detectRepoRoot`；复用任务 1 的 `enumerateArtifacts` / `resolveArtifact` / `resolveTaskRef` 与短号原语。
- 语义细节：默认大小写敏感，`-i` / `--ignore-case` 切换；`--` 终止选项解析（支持 `-` 开头的 pattern）；输出 `{taskId} {short?} {fileStem}:{line}: {matched-line}`（短号仅 active 任务有）；无匹配退出码 1 且 stdout 为空；无 `ref` 不扫 archive，带 `TASK-id` ref 仍可命中 archive 单任务。
- 更新 `bin/cli.ts` 与 `lib/task/index.ts` 的 USAGE，注册 `grep` 路由。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`（`tsc` 编译通过，erasable syntax 合规）
2. `npm test`（完整测试套件）
3. 手动三档收窄：`ai task grep <pattern>` → `ai task grep <pattern> <ref>` → `ai task grep <pattern> <ref> <N>`，确认输出逐档收窄；`ai task grep <absent>; echo $?` 输出空且退出码 1。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

新增 `tests/integration/cli/task-grep.test.ts`（12 用例：模式匹配、`-i` 切换、元字符字面量防 `RegExp` 回归、ref 收窄、artifact|N 收窄、无匹配退出码 1、archive 不被全量扫描、带 ref 命中 archive、`--` 终止选项、`--help`/无 pattern）；扩展 `task-help.test.ts`。完整套件 1128 用例通过 / 0 失败 / 1 既有 skip。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation (USAGE)
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（本次无破坏性变更）/ Breaking changes documented (none here)
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 纯新增子命令 + 一处增量导出，不改动 `ls`/`show`/`files`/`cat`/`status`/`log` 既有行为。
- 按方案「范围外」约定，**未**顺手重构 `lib/task/commands/ls.ts` 内既有的 `detectRepoRoot` 重复实现（与本需求无关，留待独立清理）。

---

Generated with AI assistance.