### PR TITLE
fix(templates): 修复 working-only 规则导致的下游 README 悬空引用

### DIFF
--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -35,10 +35,9 @@
 - [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits 提交信息与 PR 规范。
 - [`release-commands.md`](release-commands.md) — 读取历史 release、查询已合并 PR、发布 Release notes。
 
-## 测试与跨平台
+## 测试
 
 - [`testing-discipline.md`](testing-discipline.md) — 测试编写纪律：结构性断言优先，禁止脆弱的措辞匹配。
-- [`cross-platform-tests.md`](cross-platform-tests.md) — 跨平台测试守卫：用 `onPlatforms()` 表达平台跳过。
 
 ## CLI
 

--- a/templates/.agents/rules/README.en.md
+++ b/templates/.agents/rules/README.en.md
@@ -36,10 +36,9 @@ so you can quickly find "which ones to read" without opening each file.
 - [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits message and PR conventions.
 - [`release-commands.md`](release-commands.md) — Read past releases, query merged PRs, publish release notes.
 
-## Testing & Cross-platform
+## Testing
 
 - [`testing-discipline.md`](testing-discipline.md) — Test-writing discipline: prefer structural asserts, no brittle wording matches.
-- [`cross-platform-tests.md`](cross-platform-tests.md) — Cross-platform test guards: express platform skips via `onPlatforms()`.
 
 ## CLI
 

--- a/templates/.agents/rules/README.zh-CN.md
+++ b/templates/.agents/rules/README.zh-CN.md
@@ -35,10 +35,9 @@
 - [`commit-and-pr.md`](commit-and-pr.md) — Conventional Commits 提交信息与 PR 规范。
 - [`release-commands.md`](release-commands.md) — 读取历史 release、查询已合并 PR、发布 Release notes。
 
-## 测试与跨平台
+## 测试
 
 - [`testing-discipline.md`](testing-discipline.md) — 测试编写纪律：结构性断言优先，禁止脆弱的措辞匹配。
-- [`cross-platform-tests.md`](cross-platform-tests.md) — 跨平台测试守卫：用 `onPlatforms()` 表达平台跳过。
 
 ## CLI
 

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -13,6 +13,7 @@ import {
   read,
   renderPlaceholders
 } from "../../helpers.ts";
+import { copySkillDir } from "../../../lib/render.ts";
 
 const highFrequencyCommands = [
   "analyze-task",
@@ -465,15 +466,51 @@ test("template JavaScript files do not contain shebang lines", () => {
   });
 });
 
-test("rules README index lists every rule file", () => {
+test("rules README index lists every distributed rule file", () => {
   const dir = ".agents/rules";
+  // Project-only (ejected) rules ship no template copy and are not distributed
+  // downstream, so they must not be required in the distributed README index.
+  const ejected = new Set(
+    ((JSON.parse(read(".agents/.airc.json")).files?.ejected ?? []) as string[])
+      .filter((entry) => entry.startsWith(`${dir}/`) && entry.endsWith(".md"))
+      .map((entry) => path.basename(entry, ".md"))
+  );
   const ruleNames = fs.readdirSync(dir)
     .filter((fileName) => fileName.endsWith(".md") && fileName !== "README.md")
     .map((fileName) => fileName.replace(/\.md$/, ""))
+    .filter((name) => !ejected.has(name))
     .sort();
   const index = read(`${dir}/README.md`);
 
   ruleNames.forEach((name) => {
     assert.ok(index.includes(name), `rules/README.md should reference ${name}`);
   });
+});
+
+test("rendered rules README references only distributed files", () => {
+  const collaborator = JSON.parse(read(".agents/.airc.json"));
+  const replacements = { project: collaborator.project, org: collaborator.org };
+
+  for (const language of ["en", "zh-CN"]) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rules-render-"));
+    try {
+      copySkillDir("templates/.agents/rules", tmp, replacements, language, "github");
+      const rendered = new Set(
+        fs.readdirSync(tmp).filter((fileName) => fileName.endsWith(".md"))
+      );
+      const readme = fs.readFileSync(path.join(tmp, "README.md"), "utf8");
+      const refs = [...readme.matchAll(/\]\(([^)]+\.md)\)/g)]
+        .map((match) => match[1])
+        .filter((ref): ref is string => ref !== undefined);
+
+      for (const ref of refs) {
+        assert.ok(
+          rendered.has(ref),
+          `${language} rendered rules README references ${ref}, but it is not among the rendered files`
+        );
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #496 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`cross-platform-tests.md` 是被刻意 eject 的 project-only 规则（无模板副本、不随 `ai init` / `update-agent-infra` 分发），但它仍被收录进分发用的 `.agents/rules/README.md` 索引。下游渲染后，README 引用了一个本地并不存在的文件，形成悬空引用（Issue #496）。

本 PR 选择**方向 3**：保持该规则 project-only，让分发用 README 只索引会被分发的规则，并补结构性测试永久守护回归。排除「补模板副本分发」（会逆转 #299/#376 把 agent-infra 自身测试基建规则推给下游的刻意决策）与「渲染期剔除」（需改双份 vendored 渲染逻辑，过度设计）。

## 📋 主要变更 / Brief Changelog

- 从三份 rules README（`README.en.md` / `README.zh-CN.md` 模板 + 上游工作副本 `.agents/rules/README.md`）移除指向未分发文件的 `cross-platform-tests.md` 悬空条目，并把仅余 `testing-discipline.md` 的小节标题由「测试与跨平台 / Testing & Cross-platform」收敛为「测试 / Testing」
- 保持该规则 project-only：保留 `.agents/.airc.json` 的 `ejected` 条目、不新增模板副本、不改渲染算法（`lib/render.ts` / `src/sync-templates.js`）、保留 `AGENTS.md` 对它的引用
- 放宽既有「rules README 索引列出每条规则」用例为「每条**分发**规则」——按 `files.ejected` 精确豁免 project-only 规则，保留「分发规则必被索引」的前向守护
- 新增结构性回归测试 `rendered rules README references only distributed files`：用真实渲染路径 `copySkillDir` 对 en/zh-CN 渲染模板，断言 README 内每个规则链接都能在渲染产物中找到对应文件

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` → 1149 pass / 0 fail / 1 skipped（平台门控跳过）
2. 新增回归用例遵循 RED-GREEN：修复前对 `en`/`zh-CN` 报缺失 `cross-platform-tests.md`（复现 Issue #496），移除悬空条目后转绿
3. `grep -rn "cross-platform-tests" templates/.agents/rules/ .agents/rules/README.md` 无输出；`AGENTS.md` 与 `.agents/.airc.json` 的 project-only 引用保留

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass（项目暂未配置 lint 工具）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

存量下游已渲染项目需各自重跑 `update-agent-infra` 才会移除其本地 README 的悬空条目；本 PR 保证自此版本起分发物不再产生悬空引用，无法回溯改写下游既有文件。

---

**审查者注意事项 / Reviewer Notes:**

- 三份 README 是否字面一致（由 `templates.test.ts` 的「template copies stay in sync」用例守护）。
- 放宽后的索引用例是否仍保有「分发规则必被索引」的前向守护（仅按 `.agents/.airc.json` 的 `files.ejected` 精确豁免）。

Generated with AI assistance
