### PR TITLE
feat(meta): create-pr 收尾并列提示 watch-pr 与 complete-task

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -128,7 +128,16 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
   - Codex CLI：$watch-pr {task-ref}
 ```
 
-`watch-pr` 全绿后会再引导 `complete-task {task-ref}`。
+或者，若想跳过 CI 监控、直接归档任务，改用 `complete-task`：
+
+```
+下一步（备选）- 跳过监控、直接归档任务：
+  - Claude Code / OpenCode：/complete-task {task-ref}
+  - Gemini CLI：/agent-infra:complete-task {task-ref}
+  - Codex CLI：$complete-task {task-ref}
+```
+
+`watch-pr` 为主路径，全绿后会再引导 `complete-task {task-ref}`；上面的 `complete-task` 备选块仅用于跳过 CI 监控、直接归档——两者并不等价。
 
 ## 注意事项
 

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -128,7 +128,16 @@ Next step - Watch PR checks (auto self-heal until required checks are green):
   - Codex CLI: $watch-pr {task-ref}
 ```
 
-Once green, `watch-pr` then guides toward `complete-task {task-ref}`.
+Alternatively, to skip CI monitoring and archive the task right away, use `complete-task` instead:
+
+```
+Next step (alternative) - Skip monitoring and archive the task directly:
+  - Claude Code / OpenCode: /complete-task {task-ref}
+  - Gemini CLI: /agent-infra:complete-task {task-ref}
+  - Codex CLI: $complete-task {task-ref}
+```
+
+`watch-pr` is the primary path; once checks are green it guides you toward `complete-task {task-ref}`. Run the `complete-task` block above directly only when you intend to skip monitoring — the two are not equivalent.
 
 ## Notes
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -128,7 +128,16 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
   - Codex CLI：$watch-pr {task-ref}
 ```
 
-`watch-pr` 全绿后会再引导 `complete-task {task-ref}`。
+或者，若想跳过 CI 监控、直接归档任务，改用 `complete-task`：
+
+```
+下一步（备选）- 跳过监控、直接归档任务：
+  - Claude Code / OpenCode：/complete-task {task-ref}
+  - Gemini CLI：/agent-infra:complete-task {task-ref}
+  - Codex CLI：$complete-task {task-ref}
+```
+
+`watch-pr` 为主路径，全绿后会再引导 `complete-task {task-ref}`；上面的 `complete-task` 备选块仅用于跳过 CI 监控、直接归档——两者并不等价。
 
 ## 注意事项
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #487 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`create-pr` 步骤 10「告知用户」正常 PR 流程（`prFlow` 缺省 / `"required"`）此前只渲染 `watch-pr` 命令块，`complete-task` 仅以一句末行旁白带过，**没有可复制命令块**；而同技能 `prFlow: "disabled"` 分支反而直接给出 `complete-task` 命令块。结果：想跳过 CI 监控、直接归档的用户在正常流程里拿不到现成命令，且与 `disabled` 分支不一致。

按已与用户确认的方案「`watch-pr` 为主 + `complete-task` 备选并列」补齐该缺口：主推 `watch-pr` 不变，在其下新增 `complete-task` 备选命令块，并保留「`watch-pr` 全绿后会再引导 `complete-task`」的顺序语义，明确主→备非等价。

## 📋 主要变更 / Brief Changelog

- 在 `templates/.agents/skills/create-pr/SKILL.en.md` 与 `SKILL.zh-CN.md` 步骤 10 正常路径，于 `watch-pr` 主块之后新增独立的 `complete-task` 备选 fenced 命令块（定位「跳过监控、直接归档」），覆盖全部标准 TUI（Claude Code/OpenCode、Gemini CLI、Codex CLI）；`customTUIs` 由步骤 10 既有渲染期指令自动覆盖
- 同步部署副本 `.agents/skills/create-pr/SKILL.md`（zh-CN 内容，与模板逐字一致）
- 保留并强化「`watch-pr` 全绿后会再引导 `complete-task`」顺序语义，点明两条命令并非等价
- `{task-ref}` 仍按 `.agents/rules/next-step-output.md` 渲染为短号 `#NN`，未改动该规则文件

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` → 1157 pass / 0 fail / 1 skipped（平台门控跳过），无回归
2. `git diff --stat` 确认改动仅限三份目标 SKILL 文件，且每份仅在步骤 10 末尾
3. 三份文件步骤 10 正常路径均含 `watch-pr` 与 `complete-task` 两个独立命令块；zh-CN 模板与部署副本 `cmp` 逐字一致

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

> 说明：本次为纯文档（SKILL.md 文案）改动，无业务逻辑可加单测；按项目测试纪律（禁止对 SKILL 文案做关键词语义断言）不新增绑定措辞的测试，依赖既有结构性测试不回归。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [ ] 我已经编写了必要的单元测试 / I have written necessary unit-tests（纯文档改动，无新增单测）
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明（本 PR 无破坏性变更）/ Breaking changes documented (none here)
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

向后兼容：纯文案新增，不改步骤编号、段落标题或 frontmatter，不触及 `watch-pr` 主块与 `next-step-output.md` 渲染规则；单 commit 可整体回退。

---

**审查者注意事项 / Reviewer Notes:**

- 三份文件步骤 10 正常路径是否均出现 `watch-pr` 与 `complete-task` 两个独立命令块，且 en 与 zh-CN/部署副本语义同构
- 是否保留「`watch-pr` 全绿后会再引导 `complete-task`」顺序语义并明确主→备非等价
- zh-CN 模板与部署副本 `.agents/skills/create-pr/SKILL.md` 是否逐字一致

Generated with AI assistance.