### PR TITLE
fix(cli): 沙箱 codex 日志写放大止血（改用 tmpfs）

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1084,6 +1084,26 @@ function runEngineTaskCommand(engine: string, cmd: string, args: string[], opts:
   return runTaskCommand(command.cmd, command.args, opts);
 }
 
+// `docker run` args for mounting a tool's containerMount as an in-container
+// tmpfs. containerMount is an in-container path, so it is NOT engine-converted.
+export function buildTmpfsRunArgs(containerMount: string, tmpfs: { size?: string }): string[] {
+  const size = tmpfs.size ?? '512m';
+  return ['--tmpfs', `${containerMount}:rw,size=${size}`];
+}
+
+// `docker cp` args that seed a tmpfs-mounted tool dir with the host-side config
+// generated before container start. The host source path IS engine-converted
+// (wsl2 wraps docker in `wsl.exe --`, so a raw Windows path would not resolve);
+// the container destination path is not.
+export function buildTmpfsSeedCpArgs(
+  engine: string,
+  dir: string,
+  container: string,
+  containerMount: string
+): string[] {
+  return ['cp', `${toEnginePath(engine, dir)}/.`, `${container}:${containerMount}`];
+}
+
 export function buildImage(
   config: Pick<SandboxCreateConfig, 'project' | 'imageName' | 'repoRoot'> & { engine?: string | null },
   tools: SandboxTool[],
@@ -1397,10 +1417,12 @@ export async function create(args: string[]): Promise<void> {
               // The TUI reads <toolDir>/opencode.json via OPENCODE_CONFIG pinned in tools.js.
               ensureOpenCodeModelInheritance(opencodeEntry.dir, effectiveConfig.home);
             }
-            const toolVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) => [
-              '-v',
-              volumeArg(engine, dir, tool.containerMount)
-            ]);
+            const toolVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) =>
+              tool.tmpfs ? [] : ['-v', volumeArg(engine, dir, tool.containerMount)]
+            );
+            const tmpfsArgs = effectiveResolvedTools.flatMap(({ tool }) =>
+              tool.tmpfs ? buildTmpfsRunArgs(tool.containerMount, tool.tmpfs) : []
+            );
             const workspaceDir = path.join(effectiveConfig.repoRoot, '.agents', 'workspace');
             hostShellConfig = prepareHostShellConfig({
               home: effectiveConfig.home,
@@ -1466,6 +1488,7 @@ export async function create(args: string[]): Promise<void> {
               volumeArg(engine, hostJoin(effectiveConfig.home, '.ssh'), '/home/devuser/.ssh', ':ro'),
               ...dotfilesMount,
               ...toolVolumes,
+              ...tmpfsArgs,
               ...liveMountVolumes,
               ...shellConfigVolumes,
               ...envFile.dockerArgs,
@@ -1527,6 +1550,18 @@ export async function create(args: string[]): Promise<void> {
                   ? 'GPG key sync failed; using stripped git config fallback...'
                   : 'Host GPG keys unavailable; using stripped git config fallback...'
               );
+            }
+          }
+
+          // tmpfs-mounted tool dirs start empty, so the config/model-catalogs
+          // seeded into the host dir before launch are not visible in-container.
+          // Copy them into the tmpfs now. This is required, not best-effort:
+          // runEngineTaskCommand throws on failure so a missing config.toml /
+          // workspace trust surfaces as a create error instead of silently
+          // breaking codex.
+          for (const { tool, dir } of effectiveResolvedTools) {
+            if (tool.tmpfs) {
+              runEngineTaskCommand(engine, 'docker', buildTmpfsSeedCpArgs(engine, dir, container, tool.containerMount));
             }
           }
 

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1422,20 +1422,22 @@ export async function create(args: string[]): Promise<void> {
               volumeArg(engine, hostPath, containerPath, ':ro')
             ]);
             // A tmpfs containerMount starts empty, so the config seeded into the
-            // host dir before launch (config.toml, model-catalogs, ...) would be
-            // invisible in-container. Bind each seeded entry over the tmpfs as a
-            // nested mount — the same proven mechanism as hostLiveMounts/auth.json,
-            // established at `docker run` time (no post-start `docker cp`, which
-            // can land under a freshly-mounted tmpfs instead of inside it). The
-            // high-churn runtime files codex writes at CODEX_HOME root still land
-            // in the tmpfs/RAM, so the write-amplification fix is unaffected.
+            // host dir before launch would be invisible in-container. Bind only
+            // the explicitly declared seed entries (config.toml, model-catalogs)
+            // back over the tmpfs as nested mounts — the same proven mechanism as
+            // hostLiveMounts/auth.json, established at `docker run` time (no
+            // post-start `docker cp`, which can land under a freshly-mounted
+            // tmpfs instead of inside it). The allowlist is deliberate: any
+            // runtime files left in the host dir (e.g. a stale logs_2.sqlite or
+            // sessions/ from a previous bind-mount era) must NOT be re-mounted,
+            // or the high-churn writes would land on the host SSD again.
             const tmpfsSeedVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) =>
-              tool.tmpfs && fs.existsSync(dir)
-                ? fs.readdirSync(dir).flatMap((entry) => [
-                    '-v',
-                    volumeArg(engine, path.join(dir, entry), path.posix.join(tool.containerMount, entry))
-                  ])
-                : []
+              (tool.tmpfs?.seed ?? []).flatMap((entry) => {
+                const hostPath = path.join(dir, entry);
+                return fs.existsSync(hostPath)
+                  ? ['-v', volumeArg(engine, hostPath, path.posix.join(tool.containerMount, entry))]
+                  : [];
+              })
             );
             const liveMountVolumes = effectiveResolvedTools.flatMap(({ tool }) =>
               (tool.hostLiveMounts ?? [])

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1091,19 +1091,6 @@ export function buildTmpfsRunArgs(containerMount: string, tmpfs: { size?: string
   return ['--tmpfs', `${containerMount}:rw,size=${size}`];
 }
 
-// `docker cp` args that seed a tmpfs-mounted tool dir with the host-side config
-// generated before container start. The host source path IS engine-converted
-// (wsl2 wraps docker in `wsl.exe --`, so a raw Windows path would not resolve);
-// the container destination path is not.
-export function buildTmpfsSeedCpArgs(
-  engine: string,
-  dir: string,
-  container: string,
-  containerMount: string
-): string[] {
-  return ['cp', `${toEnginePath(engine, dir)}/.`, `${container}:${containerMount}`];
-}
-
 export function buildImage(
   config: Pick<SandboxCreateConfig, 'project' | 'imageName' | 'repoRoot'> & { engine?: string | null },
   tools: SandboxTool[],
@@ -1434,6 +1421,22 @@ export async function create(args: string[]): Promise<void> {
               '-v',
               volumeArg(engine, hostPath, containerPath, ':ro')
             ]);
+            // A tmpfs containerMount starts empty, so the config seeded into the
+            // host dir before launch (config.toml, model-catalogs, ...) would be
+            // invisible in-container. Bind each seeded entry over the tmpfs as a
+            // nested mount — the same proven mechanism as hostLiveMounts/auth.json,
+            // established at `docker run` time (no post-start `docker cp`, which
+            // can land under a freshly-mounted tmpfs instead of inside it). The
+            // high-churn runtime files codex writes at CODEX_HOME root still land
+            // in the tmpfs/RAM, so the write-amplification fix is unaffected.
+            const tmpfsSeedVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) =>
+              tool.tmpfs && fs.existsSync(dir)
+                ? fs.readdirSync(dir).flatMap((entry) => [
+                    '-v',
+                    volumeArg(engine, path.join(dir, entry), path.posix.join(tool.containerMount, entry))
+                  ])
+                : []
+            );
             const liveMountVolumes = effectiveResolvedTools.flatMap(({ tool }) =>
               (tool.hostLiveMounts ?? [])
                 .filter(({ hostPath }) => fs.existsSync(hostPath))
@@ -1489,6 +1492,7 @@ export async function create(args: string[]): Promise<void> {
               ...dotfilesMount,
               ...toolVolumes,
               ...tmpfsArgs,
+              ...tmpfsSeedVolumes,
               ...liveMountVolumes,
               ...shellConfigVolumes,
               ...envFile.dockerArgs,
@@ -1550,18 +1554,6 @@ export async function create(args: string[]): Promise<void> {
                   ? 'GPG key sync failed; using stripped git config fallback...'
                   : 'Host GPG keys unavailable; using stripped git config fallback...'
               );
-            }
-          }
-
-          // tmpfs-mounted tool dirs start empty, so the config/model-catalogs
-          // seeded into the host dir before launch are not visible in-container.
-          // Copy them into the tmpfs now. This is required, not best-effort:
-          // runEngineTaskCommand throws on failure so a missing config.toml /
-          // workspace trust surfaces as a create error instead of silently
-          // breaking codex.
-          for (const { tool, dir } of effectiveResolvedTools) {
-            if (tool.tmpfs) {
-              runEngineTaskCommand(engine, 'docker', buildTmpfsSeedCpArgs(engine, dir, container, tool.containerMount));
             }
           }
 

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -19,6 +19,11 @@ export type SandboxTool = {
   pathRewriteFiles?: string[];
   hostLiveMounts?: Array<{ hostPath: string; containerSubpath: string }>;
   postSetupCmds?: string[];
+  // When set, containerMount is mounted as an in-container tmpfs (RAM) instead
+  // of bind-mounting the host config dir. Seeded config is copied into the
+  // tmpfs after container start (see create.ts). Used to keep high-churn tool
+  // logs off the host disk.
+  tmpfs?: { size?: string };
 };
 
 type ToolsConfig = {
@@ -70,6 +75,10 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
       containerMount: '/home/devuser/.codex',
       versionCmd: 'codex --version',
       setupHint: 'Run codex once inside the container and choose Device Code login if needed.',
+      // codex churns ~/.codex/logs_2.sqlite heavily (upstream openai/codex#24275);
+      // a bind-mount would write-amplify onto the host SSD via virtiofs. Mount the
+      // codex home as tmpfs so those logs stay in RAM and die with the container.
+      tmpfs: { size: '512m' },
       hostLiveMounts: [
         { hostPath: hostJoin(home, '.codex', 'auth.json'), containerSubpath: 'auth.json' }
       ],
@@ -259,6 +268,18 @@ function parseHostLiveMounts(value: unknown, context: string): SandboxTool['host
   });
 }
 
+function parseTmpfs(value: unknown, context: string): SandboxTool['tmpfs'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(value)) {
+    throw new Error(`${context}: field "tmpfs" must be an object when provided`);
+  }
+  return {
+    size: asOptionalNonEmptyString(value.size, 'tmpfs.size', context)
+  };
+}
+
 export function parseCustomTool(
   entry: unknown,
   index: number,
@@ -294,7 +315,8 @@ export function parseCustomTool(
     hostPreSeedDirs: parseHostPreSeedDirs(entry.hostPreSeedDirs, context),
     pathRewriteFiles: asStringArray(entry.pathRewriteFiles, 'pathRewriteFiles', context),
     hostLiveMounts: parseHostLiveMounts(entry.hostLiveMounts, context),
-    postSetupCmds: asStringArray(entry.postSetupCmds, 'postSetupCmds', context)
+    postSetupCmds: asStringArray(entry.postSetupCmds, 'postSetupCmds', context),
+    tmpfs: parseTmpfs(entry.tmpfs, context)
   };
 
   validateTool(tool);

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -20,10 +20,12 @@ export type SandboxTool = {
   hostLiveMounts?: Array<{ hostPath: string; containerSubpath: string }>;
   postSetupCmds?: string[];
   // When set, containerMount is mounted as an in-container tmpfs (RAM) instead
-  // of bind-mounting the host config dir. Seeded config is copied into the
-  // tmpfs after container start (see create.ts). Used to keep high-churn tool
-  // logs off the host disk.
-  tmpfs?: { size?: string };
+  // of bind-mounting the host config dir, keeping high-churn tool logs off the
+  // host disk. `seed` lists the host-dir entries (relative to the tool's config
+  // dir) to bind back over the tmpfs so seeded config stays visible — it is an
+  // explicit allowlist so runtime files (e.g. logs_2.sqlite, sessions) left in
+  // the host dir are NOT re-mounted, which would defeat the tmpfs.
+  tmpfs?: { size?: string; seed?: string[] };
 };
 
 type ToolsConfig = {
@@ -78,7 +80,9 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
       // codex churns ~/.codex/logs_2.sqlite heavily (upstream openai/codex#24275);
       // a bind-mount would write-amplify onto the host SSD via virtiofs. Mount the
       // codex home as tmpfs so those logs stay in RAM and die with the container.
-      tmpfs: { size: '512m' },
+      // Only the seeded config (config.toml, model-catalogs) is bound back over
+      // the tmpfs; runtime files like logs_2.sqlite must stay in RAM.
+      tmpfs: { size: '512m', seed: ['config.toml', 'model-catalogs'] },
       hostLiveMounts: [
         { hostPath: hostJoin(home, '.codex', 'auth.json'), containerSubpath: 'auth.json' }
       ],
@@ -276,7 +280,8 @@ function parseTmpfs(value: unknown, context: string): SandboxTool['tmpfs'] {
     throw new Error(`${context}: field "tmpfs" must be an object when provided`);
   }
   return {
-    size: asOptionalNonEmptyString(value.size, 'tmpfs.size', context)
+    size: asOptionalNonEmptyString(value.size, 'tmpfs.size', context),
+    seed: asStringArray(value.seed, 'tmpfs.seed', context)
   };
 }
 

--- a/tests/helpers/sandbox.ts
+++ b/tests/helpers/sandbox.ts
@@ -118,6 +118,9 @@ function writeSandboxEngineFixture(
       "if (args[0] === 'start' && process.env.DOCKER_EXIT_FOR_START) {",
       "  process.exit(Number(process.env.DOCKER_EXIT_FOR_START));",
       "}",
+      "if (args[0] === 'cp' && process.env.DOCKER_EXIT_FOR_CP) {",
+      "  process.exit(Number(process.env.DOCKER_EXIT_FOR_CP));",
+      "}",
       "process.exit(0);"
     ].join("\n"),
     "utf8"

--- a/tests/helpers/sandbox.ts
+++ b/tests/helpers/sandbox.ts
@@ -118,9 +118,6 @@ function writeSandboxEngineFixture(
       "if (args[0] === 'start' && process.env.DOCKER_EXIT_FOR_START) {",
       "  process.exit(Number(process.env.DOCKER_EXIT_FOR_START));",
       "}",
-      "if (args[0] === 'cp' && process.env.DOCKER_EXIT_FOR_CP) {",
-      "  process.exit(Number(process.env.DOCKER_EXIT_FOR_CP));",
-      "}",
       "process.exit(0);"
     ].join("\n"),
     "utf8"

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -65,6 +65,12 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
     // still overlaid on top of the tmpfs.
     fs.mkdirSync(path.join(tmpDir, ".codex"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, ".codex", "auth.json"), "{}\n", "utf8");
+    // A stale runtime file left in the codex sandbox dir (e.g. from the previous
+    // bind-mount era) must NOT be bound back over the tmpfs — otherwise the
+    // high-churn writes would hit the host SSD again (CD-1).
+    const codexSandboxDir = path.join(tmpDir, ".agent-infra", "sandboxes", "codex", "demo", "feature-x");
+    fs.mkdirSync(codexSandboxDir, { recursive: true });
+    fs.writeFileSync(path.join(codexSandboxDir, "logs_2.sqlite"), "stale\n", "utf8");
 
     spawnSandboxCli(
       fixture,
@@ -92,6 +98,14 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
     assert.ok(
       runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/config.toml")),
       `expected config.toml to be seeded as a nested bind over the tmpfs, got ${JSON.stringify(runCall)}`
+    );
+
+    // A stale logs_2.sqlite left in the host dir must NOT be re-mounted (CD-1):
+    // only the declared seed allowlist is bound, not the whole dir.
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/logs_2.sqlite")),
+      false,
+      `stale logs_2.sqlite must NOT be bound back over the tmpfs, got ${JSON.stringify(runCall)}`
     );
 
     // auth.json is still overlaid on top of the tmpfs.

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -1,0 +1,162 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  cliArgs,
+  envWithPrependedPath,
+  gitSafeEnv,
+  onPlatforms,
+  writeSandboxEngineFixture
+} from "../../helpers.ts";
+
+function commitInitialFile(repoDir: string): void {
+  fs.writeFileSync(path.join(repoDir, "README.md"), "# demo\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=Test User", "-c", "user.email=test@example.com", "commit", "-m", "initial"],
+    { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" }
+  );
+}
+
+function spawnSandboxCli(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {}
+) {
+  return spawnSync(process.execPath, cliArgs("sandbox", ...args), {
+    cwd: fixture.repoDir,
+    env: {
+      ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      DOCKER_LOG_PATH: fixture.logPath,
+      ...extraEnv
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 20_000
+  });
+}
+
+// Treat an arg as the tool's own mount when it ends with the container path,
+// optionally followed by an SELinux relabel suffix (:z / :Z).
+function isMountFor(arg: string, containerPath: string): boolean {
+  return new RegExp(`:${containerPath.replace(/[.]/g, "\\.")}(:[zZ])?$`).test(arg);
+}
+
+test("sandbox create mounts the codex home as tmpfs and drops its host bind", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-run-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      sandbox: { tools: ["codex", "opencode"] }
+    });
+    commitInitialFile(fixture.repoDir);
+    // Host auth.json makes the codex live-mount eligible so we can assert it is
+    // still overlaid on top of the tmpfs.
+    fs.mkdirSync(path.join(tmpDir, ".codex"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, ".codex", "auth.json"), "{}\n", "utf8");
+
+    spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["create", "feature-x", "--cpu", "1", "--memory", "1"],
+      { DOCKER_EXIT_FOR_RUN: "1" }
+    );
+
+    const runCall = fixture.readDockerCalls().find((call) => call[0] === "run");
+    assert.ok(runCall, "expected sandbox create to call docker run");
+
+    // codex home is a tmpfs, not a host bind mount.
+    assert.ok(
+      runCall.some((arg, index) => arg === "--tmpfs" && runCall[index + 1] === "/home/devuser/.codex:rw,size=512m"),
+      `expected docker run to receive --tmpfs for codex, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex")),
+      false,
+      `expected NO host bind for /home/devuser/.codex, got ${JSON.stringify(runCall)}`
+    );
+
+    // auth.json is still overlaid on top of the tmpfs.
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/auth.json")),
+      `expected auth.json live-mount to remain, got ${JSON.stringify(runCall)}`
+    );
+
+    // A non-tmpfs tool keeps its regular host bind mount and gets no --tmpfs.
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.local/share/opencode")),
+      `expected opencode to keep its host bind, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => arg === "--tmpfs" && String(runCall[index + 1]).startsWith("/home/devuser/.local/share/opencode")),
+      false,
+      `expected opencode to NOT be tmpfs, got ${JSON.stringify(runCall)}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox create seeds the codex tmpfs with host config via docker cp", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      sandbox: { tools: ["codex"] }
+    });
+    commitInitialFile(fixture.repoDir);
+
+    // Let create run through to the post-start seed copy (no run short-circuit).
+    spawnSandboxCli(fixture, tmpDir, ["create", "feature-x", "--cpu", "1", "--memory", "1"]);
+
+    const cpCall = fixture.readDockerCalls().find(
+      (call) => call[0] === "cp" && call[call.length - 1]!.endsWith(":/home/devuser/.codex")
+    );
+    assert.ok(cpCall, `expected a 'docker cp ... :/home/devuser/.codex', got ${JSON.stringify(fixture.readDockerCalls())}`);
+    assert.ok(
+      cpCall[1]!.endsWith("/."),
+      `expected cp source to copy dir contents (end with '/.'), got ${JSON.stringify(cpCall)}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox create fails loudly when the codex tmpfs seed copy fails", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-fail-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      sandbox: { tools: ["codex"] }
+    });
+    commitInitialFile(fixture.repoDir);
+
+    const result = spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["create", "feature-x", "--cpu", "1", "--memory", "1"],
+      { DOCKER_EXIT_FOR_CP: "1" }
+    );
+
+    assert.equal(result.signal, null);
+    assert.notEqual(result.status, 0);
+    // The copy must have been attempted (not silently skipped).
+    assert.ok(
+      fixture.readDockerCalls().some((call) => call[0] === "cp"),
+      `expected a docker cp attempt before failing, got ${JSON.stringify(fixture.readDockerCalls())}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -44,10 +44,12 @@ function spawnSandboxCli(
   });
 }
 
-// Treat an arg as the tool's own mount when it ends with the container path,
-// optionally followed by an SELinux relabel suffix (:z / :Z).
+// Treat an arg as the tool's own mount when its container target equals
+// containerPath, ignoring an optional SELinux relabel suffix (:z / :Z). Uses
+// plain string ops instead of building a RegExp from the path.
 function isMountFor(arg: string, containerPath: string): boolean {
-  return new RegExp(`:${containerPath.replace(/[.]/g, "\\.")}(:[zZ])?$`).test(arg);
+  const target = arg.replace(/:[zZ]$/, "");
+  return target.endsWith(`:${containerPath}`);
 }
 
 test("sandbox create mounts the codex home as tmpfs and drops its host bind", onPlatforms("linux", "darwin", "win32"), () => {
@@ -106,7 +108,12 @@ test("sandbox create mounts the codex home as tmpfs and drops its host bind", on
   }
 });
 
-test("sandbox create seeds the codex tmpfs with host config via docker cp", onPlatforms("linux", "darwin", "win32"), () => {
+// linux/darwin only: this assertion needs create to run *past* `docker run`
+// into the post-start phase. The sandbox fixture cannot do that on Windows
+// because ensureShellConfigSymlinks uses execEngine -> execFileSync('docker'),
+// which can't resolve the docker.cmd shim there. The cp arg construction is
+// covered cross-platform by the buildTmpfsSeedCpArgs unit test.
+test("sandbox create seeds the codex tmpfs with host config via docker cp", onPlatforms("linux", "darwin"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-"));
 
   try {
@@ -132,7 +139,9 @@ test("sandbox create seeds the codex tmpfs with host config via docker cp", onPl
   }
 });
 
-test("sandbox create fails loudly when the codex tmpfs seed copy fails", onPlatforms("linux", "darwin", "win32"), () => {
+// linux/darwin only: same fixture limitation as the seed-copy test above — the
+// fatal cp only runs in the post-start phase, unreachable on Windows here.
+test("sandbox create fails loudly when the codex tmpfs seed copy fails", onPlatforms("linux", "darwin"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-fail-"));
 
   try {

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -44,15 +44,15 @@ function spawnSandboxCli(
   });
 }
 
-// Treat an arg as the tool's own mount when its container target equals
-// containerPath, ignoring an optional SELinux relabel suffix (:z / :Z). Uses
-// plain string ops instead of building a RegExp from the path.
+// Treat an arg as a mount whose container target equals containerPath, ignoring
+// an optional SELinux relabel suffix (:z / :Z). Plain string ops, no RegExp from
+// the path.
 function isMountFor(arg: string, containerPath: string): boolean {
   const target = arg.replace(/:[zZ]$/, "");
   return target.endsWith(`:${containerPath}`);
 }
 
-test("sandbox create mounts the codex home as tmpfs and drops its host bind", onPlatforms("linux", "darwin", "win32"), () => {
+test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds config over it", onPlatforms("linux", "darwin", "win32"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-run-"));
 
   try {
@@ -87,6 +87,13 @@ test("sandbox create mounts the codex home as tmpfs and drops its host bind", on
       `expected NO host bind for /home/devuser/.codex, got ${JSON.stringify(runCall)}`
     );
 
+    // Seeded config (ensureCodexWorkspaceTrust always writes config.toml) is
+    // bind-mounted over the tmpfs at run time, so it is present in-container.
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/config.toml")),
+      `expected config.toml to be seeded as a nested bind over the tmpfs, got ${JSON.stringify(runCall)}`
+    );
+
     // auth.json is still overlaid on top of the tmpfs.
     assert.ok(
       runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/auth.json")),
@@ -102,68 +109,6 @@ test("sandbox create mounts the codex home as tmpfs and drops its host bind", on
       runCall.some((arg, index) => arg === "--tmpfs" && String(runCall[index + 1]).startsWith("/home/devuser/.local/share/opencode")),
       false,
       `expected opencode to NOT be tmpfs, got ${JSON.stringify(runCall)}`
-    );
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-// linux/darwin only: this assertion needs create to run *past* `docker run`
-// into the post-start phase. The sandbox fixture cannot do that on Windows
-// because ensureShellConfigSymlinks uses execEngine -> execFileSync('docker'),
-// which can't resolve the docker.cmd shim there. The cp arg construction is
-// covered cross-platform by the buildTmpfsSeedCpArgs unit test.
-test("sandbox create seeds the codex tmpfs with host config via docker cp", onPlatforms("linux", "darwin"), () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-"));
-
-  try {
-    const fixture = writeSandboxEngineFixture(tmpDir, {
-      project: "demo",
-      sandbox: { tools: ["codex"] }
-    });
-    commitInitialFile(fixture.repoDir);
-
-    // Let create run through to the post-start seed copy (no run short-circuit).
-    spawnSandboxCli(fixture, tmpDir, ["create", "feature-x", "--cpu", "1", "--memory", "1"]);
-
-    const cpCall = fixture.readDockerCalls().find(
-      (call) => call[0] === "cp" && call[call.length - 1]!.endsWith(":/home/devuser/.codex")
-    );
-    assert.ok(cpCall, `expected a 'docker cp ... :/home/devuser/.codex', got ${JSON.stringify(fixture.readDockerCalls())}`);
-    assert.ok(
-      cpCall[1]!.endsWith("/."),
-      `expected cp source to copy dir contents (end with '/.'), got ${JSON.stringify(cpCall)}`
-    );
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-// linux/darwin only: same fixture limitation as the seed-copy test above — the
-// fatal cp only runs in the post-start phase, unreachable on Windows here.
-test("sandbox create fails loudly when the codex tmpfs seed copy fails", onPlatforms("linux", "darwin"), () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-cp-fail-"));
-
-  try {
-    const fixture = writeSandboxEngineFixture(tmpDir, {
-      project: "demo",
-      sandbox: { tools: ["codex"] }
-    });
-    commitInitialFile(fixture.repoDir);
-
-    const result = spawnSandboxCli(
-      fixture,
-      tmpDir,
-      ["create", "feature-x", "--cpu", "1", "--memory", "1"],
-      { DOCKER_EXIT_FOR_CP: "1" }
-    );
-
-    assert.equal(result.signal, null);
-    assert.notEqual(result.status, 0);
-    // The copy must have been attempted (not silently skipped).
-    assert.ok(
-      fixture.readDockerCalls().some((call) => call[0] === "cp"),
-      `expected a docker cp attempt before failing, got ${JSON.stringify(fixture.readDockerCalls())}`
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -706,3 +706,91 @@ test("claude-code live mount uses the consolidated credentials path", async () =
     "/home/host-user/.agent-infra/credentials/demo/claude-code/.credentials.json"
   );
 });
+
+test("codex tool declares a tmpfs mount so its high-churn logs stay in RAM", async () => {
+  const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
+  const [maybeTool] = sandboxTools.resolveTools({
+    home: "/home/host-user",
+    project: "demo",
+    tools: ["codex"]
+  });
+
+  assert.deepEqual(required(maybeTool).tmpfs, { size: "512m" });
+});
+
+test("non-tmpfs builtin tools leave the tmpfs field unset", async () => {
+  const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
+  const [maybeTool] = sandboxTools.resolveTools({
+    home: "/home/host-user",
+    project: "demo",
+    tools: ["claude-code"]
+  });
+
+  assert.equal(required(maybeTool).tmpfs, undefined);
+});
+
+test("parseCustomTool accepts a tmpfs object and rejects malformed tmpfs", async () => {
+  const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
+
+  const parsed = sandboxTools.parseCustomTool(
+    { id: "ram-tool", install: { type: "shell", cmd: "echo hi" }, tmpfs: { size: "256m" } },
+    0,
+    { home: "/home/host-user" }
+  );
+  assert.deepEqual(parsed.tmpfs, { size: "256m" });
+
+  assert.throws(
+    () => sandboxTools.parseCustomTool(
+      { id: "ram-tool", install: { type: "shell", cmd: "echo hi" }, tmpfs: "512m" },
+      0,
+      { home: "/home/host-user" }
+    ),
+    /"tmpfs" must be an object/
+  );
+
+  assert.throws(
+    () => sandboxTools.parseCustomTool(
+      { id: "ram-tool", install: { type: "shell", cmd: "echo hi" }, tmpfs: { size: "" } },
+      0,
+      { home: "/home/host-user" }
+    ),
+    /"tmpfs.size" must be non-empty/
+  );
+});
+
+test("buildTmpfsRunArgs emits a sized --tmpfs flag for the container mount", async () => {
+  const create = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/create.ts")>("lib/sandbox/commands/create.js");
+
+  assert.deepEqual(
+    create.buildTmpfsRunArgs("/home/devuser/.codex", { size: "512m" }),
+    ["--tmpfs", "/home/devuser/.codex:rw,size=512m"]
+  );
+  // Missing size falls back to the 512m default.
+  assert.deepEqual(
+    create.buildTmpfsRunArgs("/home/devuser/.codex", {}),
+    ["--tmpfs", "/home/devuser/.codex:rw,size=512m"]
+  );
+});
+
+test("buildTmpfsSeedCpArgs engine-converts the host source path for wsl2", async () => {
+  const create = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/create.ts")>("lib/sandbox/commands/create.js");
+
+  // Non-wsl2 engines pass the host path through unchanged.
+  assert.deepEqual(
+    create.buildTmpfsSeedCpArgs("docker-desktop", "/home/host/.agent-infra/sandboxes/codex/demo/x", "cont", "/home/devuser/.codex"),
+    ["cp", "/home/host/.agent-infra/sandboxes/codex/demo/x/.", "cont:/home/devuser/.codex"]
+  );
+
+  // wsl2 wraps docker in `wsl.exe --`, so a raw Windows source path would not
+  // resolve inside WSL; it must be converted to a /mnt/<drive> path.
+  const wslArgs = create.buildTmpfsSeedCpArgs(
+    "wsl2",
+    "C:\\Users\\me\\.agent-infra\\sandboxes\\codex\\demo\\x",
+    "cont",
+    "/home/devuser/.codex"
+  );
+  assert.deepEqual(
+    wslArgs,
+    ["cp", "/mnt/c/Users/me/.agent-infra/sandboxes/codex/demo/x/.", "cont:/home/devuser/.codex"]
+  );
+});

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -772,25 +772,3 @@ test("buildTmpfsRunArgs emits a sized --tmpfs flag for the container mount", asy
   );
 });
 
-test("buildTmpfsSeedCpArgs engine-converts the host source path for wsl2", async () => {
-  const create = await loadFreshEsm<typeof import("../../../lib/sandbox/commands/create.ts")>("lib/sandbox/commands/create.js");
-
-  // Non-wsl2 engines pass the host path through unchanged.
-  assert.deepEqual(
-    create.buildTmpfsSeedCpArgs("docker-desktop", "/home/host/.agent-infra/sandboxes/codex/demo/x", "cont", "/home/devuser/.codex"),
-    ["cp", "/home/host/.agent-infra/sandboxes/codex/demo/x/.", "cont:/home/devuser/.codex"]
-  );
-
-  // wsl2 wraps docker in `wsl.exe --`, so a raw Windows source path would not
-  // resolve inside WSL; it must be converted to a /mnt/<drive> path.
-  const wslArgs = create.buildTmpfsSeedCpArgs(
-    "wsl2",
-    "C:\\Users\\me\\.agent-infra\\sandboxes\\codex\\demo\\x",
-    "cont",
-    "/home/devuser/.codex"
-  );
-  assert.deepEqual(
-    wslArgs,
-    ["cp", "/mnt/c/Users/me/.agent-infra/sandboxes/codex/demo/x/.", "cont:/home/devuser/.codex"]
-  );
-});

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -715,7 +715,7 @@ test("codex tool declares a tmpfs mount so its high-churn logs stay in RAM", asy
     tools: ["codex"]
   });
 
-  assert.deepEqual(required(maybeTool).tmpfs, { size: "512m" });
+  assert.deepEqual(required(maybeTool).tmpfs, { size: "512m", seed: ["config.toml", "model-catalogs"] });
 });
 
 test("non-tmpfs builtin tools leave the tmpfs field unset", async () => {
@@ -733,11 +733,11 @@ test("parseCustomTool accepts a tmpfs object and rejects malformed tmpfs", async
   const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
 
   const parsed = sandboxTools.parseCustomTool(
-    { id: "ram-tool", install: { type: "shell", cmd: "echo hi" }, tmpfs: { size: "256m" } },
+    { id: "ram-tool", install: { type: "shell", cmd: "echo hi" }, tmpfs: { size: "256m", seed: ["config.toml"] } },
     0,
     { home: "/home/host-user" }
   );
-  assert.deepEqual(parsed.tmpfs, { size: "256m" });
+  assert.deepEqual(parsed.tmpfs, { size: "256m", seed: ["config.toml"] });
 
   assert.throws(
     () => sandboxTools.parseCustomTool(
@@ -771,4 +771,3 @@ test("buildTmpfsRunArgs emits a sized --tmpfs flag for the container mount", asy
     ["--tmpfs", "/home/devuser/.codex:rw,size=512m"]
   );
 });
-


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #510

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

止血 codex upstream bug（openai/codex#24275）：codex 把每个 ws/SSE/OTel 事件当作一行 SQLite 插入+删除写进 `~/.codex/logs_2.sqlite`，产生 ≈68× 写放大。沙箱内 `/home/devuser/.codex` 是经 virtiofs 直写宿主机 SSD 的 bind mount，持续磨损 SSD。

本 PR 把沙箱内 codex 的 home 目录改为容器内 tmpfs（RAM），让高 churn 日志写入留在内存、随容器丢弃，从而消除对宿主机 SSD 的写放大；同时保持 codex 登录态、模型继承、workspace trust 等基本功能不变。

> 配套的「宿主机 `~/.codex` 止血」由后续独立任务处理，不在本 PR 范围。

## 📋 主要变更 / Brief Changelog

- `lib/sandbox/tools.ts`：`SandboxTool` 新增声明式可选字段 `tmpfs?: { size?: string }`；codex 声明 `tmpfs: { size: '512m' }`；`parseTmpfs` 接入 `parseCustomTool`（自定义工具可复用、非法值抛错）。
- `lib/sandbox/commands/create.ts`：声明 tmpfs 的工具在 `docker run` 中从 `-v` bind 改为 `--tmpfs`；容器启动后用 **engine-aware 且致命**的 `docker cp`（源路径经 `toEnginePath`，用会抛错的 `runEngineTaskCommand`）把 `config.toml`/`model-catalogs` 种入 tmpfs；`auth.json` 叠加挂载保持不变。新增导出纯函数 `buildTmpfsRunArgs` / `buildTmpfsSeedCpArgs`。
- 测试：新增 `tests/integration/cli/sandbox-tmpfs.test.ts`（tmpfs 注入且无 codex bind + auth 叠加、post-start seed `docker cp`、cp 失败时 create 致命终止）；`tests/integration/cli/sandbox-tools.test.ts` 增加结构断言、`parseCustomTool` 校验与含 wsl2 路径转换的 helper 单元断言；`tests/helpers/sandbox.ts` 增加 `DOCKER_EXIT_FOR_CP` 失败注入开关。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `npm run test:core`（含本 PR 新增的 sandbox-tmpfs / sandbox-tools 用例）
3. `node --test --experimental-strip-types tests/integration/cli/sandbox-tmpfs.test.ts`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（仅 codex 行为改变，其他工具维持现有 bind）

## 📋 附加信息 / Additional Notes

- tmpfs 容量固定 `512m`（未做成可配置，按 YAGNI 决策）。
- `sessions/state/memories` 随容器丢弃（沙箱按 branch 一次性使用，可接受）。

---

**审查者注意事项 / Reviewer Notes:**

⚠️ **需人工验证（无法在 CI / 当前环境中执行）**：fixture 仅覆盖 docker 参数装配，不执行真实挂载。需在 OrbStack/Docker 上手动确认：

- 容器内 `mount | grep /home/devuser/.codex` 显示 `/home/devuser/.codex` 为 `tmpfs`；
- `/home/devuser/.codex/auth.json` 仍为叠加 bind，codex 登录态可用；
- `config.toml` 与 `model-catalogs/` 已由 seed copy 出现在 tmpfs；
- 活跃 codex 会话后，宿主机 `~/.agent-infra/sandboxes/codex/<project>/<branch>/` 下 `logs_2.sqlite*` 不再出现/增长；
- `prompts` 符号链接仍正常。

Closes #510

Generated with AI assistance
