### PR TITLE
feat(cli): 为 ai CLI 常用子命令增加单字母短别名

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -19,8 +19,8 @@ Commands:
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
-  sandbox         Manage Docker-based AI sandboxes
-  task            Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)
+  sandbox (alias: s)  Manage Docker-based AI sandboxes
+  task (alias: t)     Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)
   update          Update seed files and sync file registry for an existing project
   version         Show version
 
@@ -37,7 +37,15 @@ Examples:
   npx @fitlab-ai/agent-infra init
 `;
 
-const command = process.argv[2] || '';
+const COMMAND_ALIASES: Record<string, string> = {
+  s: 'sandbox',
+  t: 'task'
+};
+
+const rawCommand = process.argv[2] || '';
+const command = Object.hasOwn(COMMAND_ALIASES, rawCommand)
+  ? COMMAND_ALIASES[rawCommand]
+  : rawCommand;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -19,8 +19,8 @@ Commands:
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
-  sandbox (alias: s)  Manage Docker-based AI sandboxes
-  task (alias: t)     Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)
+  sandbox, s      Manage Docker-based AI sandboxes
+  task, t         Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)
   update          Update seed files and sync file registry for an existing project
   version         Show version
 

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -76,9 +76,28 @@ test("cli usage lists top-level command aliases (help and bare)", () => {
       encoding: "utf8"
     });
 
-    assert.match(output, /^\s+sandbox \(alias: s\)\s+Manage Docker-based AI sandboxes/m);
-    assert.match(output, /^\s+task \(alias: t\)\s+Read-only views/m);
+    assert.match(output, /^\s+sandbox, s\s+Manage Docker-based AI sandboxes/m);
+    assert.match(output, /^\s+task, t\s+Read-only views/m);
   }
+});
+
+test("cli usage keeps alias command descriptions aligned", () => {
+  const output = execFileSync(process.execPath, cliArgs("help"), {
+    encoding: "utf8"
+  });
+  const rows = [
+    ["merge", "Merge tasks"],
+    ["sandbox, s", "Manage Docker-based AI sandboxes"],
+    ["task, t", "Read-only views"],
+    ["update", "Update seed files"]
+  ] as const;
+  const descriptionColumns = rows.map(([command, description]) => {
+    const line = output.split("\n").find((candidate) => candidate.trimStart().startsWith(command));
+    assert.ok(line, `Expected command row for ${command}`);
+    return line.indexOf(description);
+  });
+
+  assert.equal(new Set(descriptionColumns).size, 1);
 });
 
 test("cli unknown command prints versioned usage and exits 1", () => {

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -70,6 +70,17 @@ test("cli usage header includes version (help and bare)", () => {
   }
 });
 
+test("cli usage lists top-level command aliases (help and bare)", () => {
+  for (const args of [["help"], []]) {
+    const output = execFileSync(process.execPath, cliArgs(...args), {
+      encoding: "utf8"
+    });
+
+    assert.match(output, /^\s+sandbox \(alias: s\)\s+Manage Docker-based AI sandboxes/m);
+    assert.match(output, /^\s+task \(alias: t\)\s+Read-only views/m);
+  }
+});
+
 test("cli unknown command prints versioned usage and exits 1", () => {
   const pkg = JSON.parse(read("package.json"));
   const result = spawnSync(process.execPath, cliArgs("definitely-not-a-real-command"), {
@@ -82,6 +93,37 @@ test("cli unknown command prints versioned usage and exits 1", () => {
     result.stdout.split("\n")[0] ?? "",
     new RegExp(`^agent-infra v${escapeRegExp(pkg.version)} - bootstrap`)
   );
+});
+
+test("cli single-letter aliases dispatch to the full top-level commands", () => {
+  const cases = [
+    ["s", "sandbox", /Usage: ai sandbox <command> \[options\]/],
+    ["t", "task", /Usage: ai task <command> \[options\]/]
+  ] as const;
+
+  for (const [alias, fullCommand, usage] of cases) {
+    const aliasResult = spawnSync(process.execPath, cliArgs(alias, "--help"), {
+      encoding: "utf8"
+    });
+    const fullResult = spawnSync(process.execPath, cliArgs(fullCommand, "--help"), {
+      encoding: "utf8"
+    });
+
+    assert.equal(aliasResult.status, fullResult.status);
+    assert.equal(aliasResult.stderr, fullResult.stderr);
+    assert.match(aliasResult.stdout, usage);
+  }
+});
+
+test("cli aliases do not change unknown command reporting", () => {
+  for (const command of ["x", "constructor"]) {
+    const result = spawnSync(process.execPath, cliArgs(command), {
+      encoding: "utf8"
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, new RegExp(`^Unknown command: ${escapeRegExp(command)}`));
+  }
 });
 
 test("cli --version and -v match the default version command output", () => {

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -62,5 +62,5 @@ test('top-level USAGE lists the task command under Commands', () => {
   const out = runCli(['help']);
   assert.equal(out.status, 0);
   assert.match(out.stdout, /Usage: ai <command>/);
-  assert.match(out.stdout, /^\s+task \(alias: t\)\s+Read-only views/m);
+  assert.match(out.stdout, /^\s+task, t\s+Read-only views/m);
 });

--- a/tests/integration/cli/task-help.test.ts
+++ b/tests/integration/cli/task-help.test.ts
@@ -62,5 +62,5 @@ test('top-level USAGE lists the task command under Commands', () => {
   const out = runCli(['help']);
   assert.equal(out.status, 0);
   assert.match(out.stdout, /Usage: ai <command>/);
-  assert.match(out.stdout, /^\s+task\s+Read-only views/m);
+  assert.match(out.stdout, /^\s+task \(alias: t\)\s+Read-only views/m);
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #500 👈👈

Closes #500

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

为顶层 `ai` CLI 的两个高频子命令增加交互式单字母短别名，降低手敲成本：

- `ai s ...` 等价于 `ai sandbox ...`
- `ai t ...` 等价于 `ai task ...`

采用**显式字面别名注册**而非「前缀唯一自动匹配」，避免未来新增子命令（如 `status`/`start`/`sync`/`test`）引入歧义与破坏性变更。别名仅用于交互式手敲；文档、示例与脚本仍统一使用全名。

## 📋 主要变更 / Brief Changelog

- **顶层别名归一化**（`bin/cli.ts`）：在进入命令 `switch` 前，用固定映射表把 `s`→`sandbox`、`t`→`task` 归一化；查表用 `Object.hasOwn` 守卫，只接受映射表自有键，避免 `constructor`/`__proto__` 等 `Object.prototype` 继承键劣化 unknown-command 报错。不改写 `process.argv`，子命令参数转发语义不变。
- **帮助标注**（`bin/cli.ts`）：顶层 USAGE 将 `sandbox`/`task` 两行标注为 `sandbox (alias: s)` / `task (alias: t)`；不改子命令帮助、不改文档示例、不改变 `ai --help` 现有 unknown-command 行为。
- **回归测试**（`tests/integration/cli/`）：新增 `ai s`/`ai t` 转发等价性、帮助别名标注、未注册单字母不被前缀匹配、以及 `ai constructor` 继承键保护用例；更新 `task-help.test.ts` 既有脆弱断言以适配别名标注。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `node --experimental-strip-types --no-warnings --test tests/integration/cli/cli.test.ts tests/integration/cli/task-help.test.ts tests/integration/cli/sandbox-core.test.ts`（91/91 通过）
3. `npm test`（1176 passed / 1 skipped / 0 failed）
4. 手动：`node dist/bin/cli.js s --help`、`node dist/bin/cli.js t --help`、`node dist/bin/cli.js constructor`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

别名集合刻意只含 `s`/`t` 两个精确字面映射，预留单字母命名空间，不引入可扩展的前缀解析或配置化机制。

---

Generated with AI assistance