### PR TITLE
fix(meta): 修复 code-task 人工审查轮次误判

### DIFF
--- a/.agents/skills/code-task/reference/dual-mode.md
+++ b/.agents/skills/code-task/reference/dual-mode.md
@@ -10,7 +10,7 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 
 脚本扫描任务目录中的 `plan.md` / `plan-r{N}.md`、`review-plan.md` / `review-plan-r{N}.md`、`code.md` / `code-r{N}.md` 和 `review-code.md` / `review-code-r{N}.md`。
 
-## 8 个分支
+## 7 个分支
 
 > 分支按表中自上而下的顺序评估，命中即返回；后续分支不再判定。
 
@@ -19,11 +19,16 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 | 无 code 产物 | `init` | 0 | 初次实现，产物为 `code.md` |
 | 最新 review-plan 已批准（`通过` 或 `通过 + major/minor 建议`，即 `Approved` 或 `Approved-with-issues`），且其「审查输入」/「Review Input」字段引用的 plan 文件 == 任务目录中最新的 `plan(-r{N})?.md`，且最新 review-plan 的 mtime > 最新 code 的 mtime | `init` | 0 | plan 已在 code 之后被批准；进入新一轮实现，`next_round = code_max + 1`、`next_artifact = code-r{next_round}.md`。**不论 review-code 是否已审**，本分支均先命中。plan 与 review-plan 的轮次独立递增（如 `plan-r5` 可被 `review-plan-r4` 批准），通过 review-plan 的「审查输入」字段建立批准关系，不要求同号 |
 | `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
-| `rev_max > code_max` | `error` | 2 | 数据状态异常，需要人工检查 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |
 | 最新 review-code 为 Approved 但有 major/minor | `fix` | 0 | 可选修复模式 |
 | 最新 review-code 为 Changes Requested | `fix` | 0 | 必需修复模式 |
 | 最新 review-code 为 Rejected | `refused` | 1 | 需要重新设计，不进入局部修复 |
+
+> 上表 4 个 verdict 分支在 `rev_max >= code_max` 时命中，均以最新 `review-code-r{rev_max}` 的结论决定：
+> - `rev_max == code_max`：AI 修复轮（`code-task` 产出代码后由 `review-code` 审查同号产物）。
+> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码（#515）。此时 `fix` 模式的 `next_round = code_max + 1`。
+>
+> 若最新 `review-code` 的 verdict 无法解析，仍返回 `error`（exit 2），作为保留的异常拦截。
 
 ## verdict 解析
 

--- a/.agents/skills/code-task/reference/dual-mode.md
+++ b/.agents/skills/code-task/reference/dual-mode.md
@@ -26,7 +26,7 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 
 > 上表 4 个 verdict 分支在 `rev_max >= code_max` 时命中，均以最新 `review-code-r{rev_max}` 的结论决定：
 > - `rev_max == code_max`：AI 修复轮（`code-task` 产出代码后由 `review-code` 审查同号产物）。
-> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码（#515）。此时 `fix` 模式的 `next_round = code_max + 1`。
+> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码。此时 `fix` 模式的 `next_round = code_max + 1`。
 >
 > 若最新 `review-code` 的 verdict 无法解析，仍返回 `error`（exit 2），作为保留的异常拦截。
 

--- a/.agents/skills/code-task/scripts/detect-mode.js
+++ b/.agents/skills/code-task/scripts/detect-mode.js
@@ -84,20 +84,12 @@ function main() {
       return;
     }
 
-    if (revMax > codeMax) {
-      writeResult({
-        mode: "error",
-        code_max: codeMax,
-        rev_max: revMax,
-        verdict: null,
-        next_round: null,
-        next_artifact: null,
-        review_artifact: artifactName("review-code", revMax),
-        message: `Inconsistent state: review-code round ${revMax} > code round ${codeMax}. Manual inspection required.`
-      }, 2);
-      return;
-    }
-
+    // human-supplemented-review (#515): after a PR is opened, a maintainer may append a
+    // review-code-r{N} round against the existing latest code, so rev_max > code_max.
+    // This is NOT corruption — defer to the latest review's verdict instead of erroring.
+    // rev_max === code_max (AI fix round) and rev_max > code_max (human review round)
+    // both fall through to the verdict dispatch below; fix mode uses next_round = code_max + 1.
+    // An unparsable verdict still returns error (exit 2) as the retained anomaly guard.
     const reviewArtifact = artifactName("review-code", revMax);
     const verdictResult = parseVerdict(path.join(resolvedTaskDir, reviewArtifact));
     if (!verdictResult.ok) {

--- a/.agents/skills/code-task/scripts/detect-mode.js
+++ b/.agents/skills/code-task/scripts/detect-mode.js
@@ -84,7 +84,7 @@ function main() {
       return;
     }
 
-    // human-supplemented-review (#515): after a PR is opened, a maintainer may append a
+    // human-supplemented review: after a PR is opened, a maintainer may append a
     // review-code-r{N} round against the existing latest code, so rev_max > code_max.
     // This is NOT corruption — defer to the latest review's verdict instead of erroring.
     // rev_max === code_max (AI fix round) and rev_max > code_max (human review round)

--- a/templates/.agents/skills/code-task/reference/dual-mode.en.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.en.md
@@ -10,7 +10,7 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 
 The script scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N}.md`, `code.md` / `code-r{N}.md`, and `review-code.md` / `review-code-r{N}.md` in the task directory.
 
-## Eight Branches
+## Seven Branches
 
 > Branches are evaluated top-down in this table; the first match returns and skips later rows.
 
@@ -19,11 +19,16 @@ The script scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N
 | no code artifact | `init` | 0 | initial implementation, output `code.md` |
 | latest review-plan is approved (`Approved` or `Approved-with-issues`, i.e. `Overall Verdict: Approved` regardless of findings counts), its "Review Input" / "审查输入" entry names the same plan file as the latest `plan(-r{N})?.md` in the task directory, and its mtime is newer than the latest code artifact | `init` | 0 | plan has been approved after the latest code; enter a new implementation round, `next_round = code_max + 1`, `next_artifact = code-r{next_round}.md`. This branch fires regardless of whether review-code exists or passes. Plan and review-plan rounds are independent counters (e.g. `plan-r5` may be approved by `review-plan-r4`); the link is established via the review-plan's "Review Input" entry, not by matching round numbers. |
 | `rev_max < code_max` | `error` | 2 | latest code round is unreviewed; run `review-code` first |
-| `rev_max > code_max` | `error` | 2 | inconsistent state; manual inspection required |
 | latest review-code is Approved with 0/0/0 | `refused` | 1 | already approved; do not run `code-task` again |
 | latest review-code is Approved with major/minor findings | `fix` | 0 | optional fix mode |
 | latest review-code is Changes Requested | `fix` | 0 | required fix mode |
 | latest review-code is Rejected | `refused` | 1 | re-plan instead of local fixing |
+
+> The four verdict branches above fire when `rev_max >= code_max`, decided by the latest `review-code-r{rev_max}` verdict:
+> - `rev_max == code_max`: AI fix round (`review-code` reviews the same-numbered code artifact produced by `code-task`).
+> - `rev_max > code_max`: human-supplemented review round — after a PR is opened a maintainer appends a `review-code-r{N}` round against the existing latest code (#515). `fix` mode then uses `next_round = code_max + 1`.
+>
+> If the latest `review-code` verdict cannot be parsed, the script still returns `error` (exit 2) as the retained anomaly guard.
 
 ## Verdict Parsing
 

--- a/templates/.agents/skills/code-task/reference/dual-mode.en.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.en.md
@@ -26,7 +26,7 @@ The script scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N
 
 > The four verdict branches above fire when `rev_max >= code_max`, decided by the latest `review-code-r{rev_max}` verdict:
 > - `rev_max == code_max`: AI fix round (`review-code` reviews the same-numbered code artifact produced by `code-task`).
-> - `rev_max > code_max`: human-supplemented review round — after a PR is opened a maintainer appends a `review-code-r{N}` round against the existing latest code (#515). `fix` mode then uses `next_round = code_max + 1`.
+> - `rev_max > code_max`: human-supplemented review round — after a PR is opened a maintainer appends a `review-code-r{N}` round against the existing latest code. `fix` mode then uses `next_round = code_max + 1`.
 >
 > If the latest `review-code` verdict cannot be parsed, the script still returns `error` (exit 2) as the retained anomaly guard.
 

--- a/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
@@ -10,7 +10,7 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 
 脚本扫描任务目录中的 `plan.md` / `plan-r{N}.md`、`review-plan.md` / `review-plan-r{N}.md`、`code.md` / `code-r{N}.md` 和 `review-code.md` / `review-code-r{N}.md`。
 
-## 8 个分支
+## 7 个分支
 
 > 分支按表中自上而下的顺序评估，命中即返回；后续分支不再判定。
 
@@ -19,11 +19,16 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 | 无 code 产物 | `init` | 0 | 初次实现，产物为 `code.md` |
 | 最新 review-plan 已批准（`通过` 或 `通过 + major/minor 建议`，即 `Approved` 或 `Approved-with-issues`），且其「审查输入」/「Review Input」字段引用的 plan 文件 == 任务目录中最新的 `plan(-r{N})?.md`，且最新 review-plan 的 mtime > 最新 code 的 mtime | `init` | 0 | plan 已在 code 之后被批准；进入新一轮实现，`next_round = code_max + 1`、`next_artifact = code-r{next_round}.md`。**不论 review-code 是否已审**，本分支均先命中。plan 与 review-plan 的轮次独立递增（如 `plan-r5` 可被 `review-plan-r4` 批准），通过 review-plan 的「审查输入」字段建立批准关系，不要求同号 |
 | `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
-| `rev_max > code_max` | `error` | 2 | 数据状态异常，需要人工检查 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |
 | 最新 review-code 为 Approved 但有 major/minor | `fix` | 0 | 可选修复模式 |
 | 最新 review-code 为 Changes Requested | `fix` | 0 | 必需修复模式 |
 | 最新 review-code 为 Rejected | `refused` | 1 | 需要重新设计，不进入局部修复 |
+
+> 上表 4 个 verdict 分支在 `rev_max >= code_max` 时命中，均以最新 `review-code-r{rev_max}` 的结论决定：
+> - `rev_max == code_max`：AI 修复轮（`code-task` 产出代码后由 `review-code` 审查同号产物）。
+> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码（#515）。此时 `fix` 模式的 `next_round = code_max + 1`。
+>
+> 若最新 `review-code` 的 verdict 无法解析，仍返回 `error`（exit 2），作为保留的异常拦截。
 
 ## verdict 解析
 

--- a/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
@@ -26,7 +26,7 @@ node .agents/skills/code-task/scripts/detect-mode.js .agents/workspace/active/{t
 
 > 上表 4 个 verdict 分支在 `rev_max >= code_max` 时命中，均以最新 `review-code-r{rev_max}` 的结论决定：
 > - `rev_max == code_max`：AI 修复轮（`code-task` 产出代码后由 `review-code` 审查同号产物）。
-> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码（#515）。此时 `fix` 模式的 `next_round = code_max + 1`。
+> - `rev_max > code_max`：人工补审轮——PR 创建后维护者追加一轮 `review-code-r{N}` 审查既有最新代码。此时 `fix` 模式的 `next_round = code_max + 1`。
 >
 > 若最新 `review-code` 的 verdict 无法解析，仍返回 `error`（exit 2），作为保留的异常拦截。
 

--- a/templates/.agents/skills/code-task/scripts/detect-mode.js
+++ b/templates/.agents/skills/code-task/scripts/detect-mode.js
@@ -84,20 +84,12 @@ function main() {
       return;
     }
 
-    if (revMax > codeMax) {
-      writeResult({
-        mode: "error",
-        code_max: codeMax,
-        rev_max: revMax,
-        verdict: null,
-        next_round: null,
-        next_artifact: null,
-        review_artifact: artifactName("review-code", revMax),
-        message: `Inconsistent state: review-code round ${revMax} > code round ${codeMax}. Manual inspection required.`
-      }, 2);
-      return;
-    }
-
+    // human-supplemented-review (#515): after a PR is opened, a maintainer may append a
+    // review-code-r{N} round against the existing latest code, so rev_max > code_max.
+    // This is NOT corruption — defer to the latest review's verdict instead of erroring.
+    // rev_max === code_max (AI fix round) and rev_max > code_max (human review round)
+    // both fall through to the verdict dispatch below; fix mode uses next_round = code_max + 1.
+    // An unparsable verdict still returns error (exit 2) as the retained anomaly guard.
     const reviewArtifact = artifactName("review-code", revMax);
     const verdictResult = parseVerdict(path.join(resolvedTaskDir, reviewArtifact));
     if (!verdictResult.ok) {

--- a/templates/.agents/skills/code-task/scripts/detect-mode.js
+++ b/templates/.agents/skills/code-task/scripts/detect-mode.js
@@ -84,7 +84,7 @@ function main() {
       return;
     }
 
-    // human-supplemented-review (#515): after a PR is opened, a maintainer may append a
+    // human-supplemented review: after a PR is opened, a maintainer may append a
     // review-code-r{N} round against the existing latest code, so rev_max > code_max.
     // This is NOT corruption — defer to the latest review's verdict instead of erroring.
     // rev_max === code_max (AI fix round) and rev_max > code_max (human review round)

--- a/tests/e2e/core/code-task-dual-mode.test.ts
+++ b/tests/e2e/core/code-task-dual-mode.test.ts
@@ -64,7 +64,7 @@ test("code-task dual-mode: branch 2 - unreviewed code returns error", () => {
   assert.equal(result.output.review_artifact, "review-code.md");
 });
 
-// #515: a maintainer may append a review-code-r{N} round against the existing latest code
+// A maintainer may append a review-code-r{N} round against the existing latest code
 // (rev_max > code_max) after a PR is opened. This is not corruption — detect-mode defers to
 // the latest review's verdict instead of erroring. The branch is decided by verdict, so the
 // same five cases that apply to rev_max == code_max apply here.

--- a/tests/e2e/core/code-task-dual-mode.test.ts
+++ b/tests/e2e/core/code-task-dual-mode.test.ts
@@ -64,15 +64,72 @@ test("code-task dual-mode: branch 2 - unreviewed code returns error", () => {
   assert.equal(result.output.review_artifact, "review-code.md");
 });
 
-test("code-task dual-mode: branch 3 - review ahead of code returns error", () => {
+// #515: a maintainer may append a review-code-r{N} round against the existing latest code
+// (rev_max > code_max) after a PR is opened. This is not corruption — detect-mode defers to
+// the latest review's verdict instead of erroring. The branch is decided by verdict, so the
+// same five cases that apply to rev_max == code_max apply here.
+test("code-task dual-mode: human-supplemented review (Approved 0/0/0) refuses rerun", () => {
   const result = runDetect({
     "code.md": "# code",
     "review-code.md": zhReview("通过"),
     "review-code-r2.md": zhReview("通过")
   });
 
+  assert.equal(result.status, 1);
+  assert.equal(result.output.mode, "refused");
+  assert.equal(result.output.verdict, "Approved");
+});
+
+test("code-task dual-mode: human-supplemented review (Changes Requested) enters fix mode", () => {
+  const result = runDetect({
+    "code.md": "# code",
+    "review-code.md": zhReview("通过"),
+    "review-code-r2.md": zhReview("需要修改", "2 阻塞项，1 主要，0 次要 / **env-blocked**：0")
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.output.mode, "fix");
+  assert.equal(result.output.verdict, "Changes Requested");
+  assert.equal(result.output.next_artifact, "code-r2.md");
+  assert.equal(result.output.review_artifact, "review-code-r2.md");
+});
+
+test("code-task dual-mode: human-supplemented review (Approved-with-issues) enters optional fix mode", () => {
+  const result = runDetect({
+    "code.md": "# code",
+    "review-code.md": zhReview("通过"),
+    "review-code-r2.md": zhReview("通过", "0 阻塞项，1 主要，2 次要 / **env-blocked**：0")
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.output.mode, "fix");
+  assert.equal(result.output.verdict, "Approved-with-issues");
+  assert.equal(result.output.next_artifact, "code-r2.md");
+  assert.equal(result.output.review_artifact, "review-code-r2.md");
+});
+
+test("code-task dual-mode: human-supplemented review (Rejected) refuses local fix mode", () => {
+  const result = runDetect({
+    "code.md": "# code",
+    "review-code.md": zhReview("通过"),
+    "review-code-r2.md": zhReview("拒绝")
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.output.mode, "refused");
+  assert.equal(result.output.verdict, "Rejected");
+});
+
+test("code-task dual-mode: human-supplemented review with unparsable verdict still errors", () => {
+  const result = runDetect({
+    "code.md": "# code",
+    "review-code.md": zhReview("通过"),
+    "review-code-r2.md": "## 审查摘要\n\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要\n"
+  });
+
   assert.equal(result.status, 2);
   assert.equal(result.output.mode, "error");
+  assert.match(result.output.message, /cannot parse|unrecognized/);
 });
 
 test("code-task dual-mode: branch 4 - Approved with no findings refuses rerun", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #515 👈👈

Closes #515

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`code-task` 的 `detect-mode.js` 此前把「`review-code` 最高轮次 > `code` 最高轮次」一律判为 `error`（exit 2）。这会误伤一种合法流程：PR 创建后，人工 reviewer 追加一轮 `review-code-r{N}.md` 审查既有最新代码（`rev_max > code_max`，但无数据损坏），`code-task` 本应进入修复模式产出 `code-r{code_max+1}.md`，却被强制报错要求人工绕过。

本 PR 按人工裁决 **方案 A（最小改动）** 修复：放宽该分支，复用既有 verdict 分流，不引入 code artifact / diff fingerprint 绑定机制（方案 B 另立后续任务）。

## 📋 主要变更 / Brief Changelog

- **`detect-mode.js`（部署 + 模板，逐字节一致）**：删除 `rev_max > code_max` 的无条件 `error` 分支，使其 fall-through 到既有 verdict 分流——最新 `review-code-r{rev_max}` 为 Changes Requested / Approved-with-issues → `fix`（`next_round = code_max + 1`），Approved 0/0/0 / Rejected → `refused`，verdict 无法解析仍 → `error`（保留的异常拦截）。
- **`dual-mode` 文档（部署 zh + `dual-mode.zh-CN.md` / `dual-mode.en.md` 模板）**：分支表删除 `rev_max > code_max` 行、分支计数 8→7、新增 `rev_max >= code_max` 行为说明（区分 AI 修复轮与人工补审轮）。
- **回归测试（`tests/e2e/core/code-task-dual-mode.test.ts`）**：改写原 `branch 3` 用例为「人工补审 Approved 0/0/0 → refused」，新增 4 个人工补审场景（Changes Requested / Approved-with-issues / Rejected / verdict 不可解析）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `node --experimental-strip-types --no-warnings --test tests/e2e/core/code-task-dual-mode.test.ts`（20/20 通过；改测试未改代码时先 RED 5 个）
3. `node --experimental-strip-types --no-warnings --test tests/unit/templates/templates.test.ts`（13/13，部署/模板同步无漂移）
4. `npm test`（1183 passed / 1 skipped / 0 failed）
5. 手动复现 #515：`code.md` + `review-code.md`(通过) + `review-code-r2.md`(需要修改) → `mode: fix`、`next_artifact: code-r2.md`（exit 0），不再 `error`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

方案 B（让 `review-code` 产物记录被审 code artifact / diff fingerprint，校验「审查是否针对当前代码」）按人工裁决排除，另立后续任务跟进，不在本 PR 范围。

---

Generated with AI assistance