### PR TITLE
refactor(cli): 优化 ai task log 输出格式：列对齐、字段补全与英文统一

### DIFF
--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -56,7 +56,7 @@
 
 **配对与渲染**（`ai task log`）：按 `{基名}` 把 started 与其后最近的同名 done 配成一行（同基名多次执行按时间升序 FIFO 配对）。STARTED 列显示 started 时间、DONE 列显示 done 时间；只有 started 无 done = 进行中（DONE 显示 `(in progress)`）；只有 done 无 started（历史日志）= 单态完成行。三种形态都合法、不报错。
 
-**人工计数**（`ai task log`）：审查步骤行把两项人工计数并入 NOTE 的 verdict 文本，逗号分隔、紧随 `blockers/major/minor`，按 task 语言本地化（中文 `人工校验点：{e}, 人工裁决：{h}`；英文 `Manual-verify: {e}, Human-decision: {h}`）。`人工裁决`（`{h}`）按 canonical 步骤名前缀（`Review Analysis` / `Review Plan` / `Review Code`）映射到 `analysis` / `plan` / `code`，统计 `## 审查分歧账本` 中对应阶段 `status ∈ {needs-human-decision, human-decided}` 的当前累计数量；`人工校验点`（`{e}`）解析 review done note 中的 `(+ {n} env-blocked)`（解析后从展示中去重），缺失为 `0`。非审查步骤不附加人工计数。
+**人工计数**（`ai task log`）：审查步骤行把两项人工计数并入 NOTE 的 verdict 文本，逗号分隔、紧随 `blockers/major/minor`，固定英文标签 `Manual-verify: {e}, Human-decision: {h}`（不随 task 语言本地化）。`Human-decision`（`{h}`）按 canonical 步骤名前缀（`Review Analysis` / `Review Plan` / `Review Code`）映射到 `analysis` / `plan` / `code`，统计 `## 审查分歧账本` 中对应阶段 `status ∈ {needs-human-decision, human-decided}` 的当前累计数量；`Manual-verify`（`{e}`）解析 review done note 中的 `(+ {n} env-blocked)`（解析后从展示中去重），缺失为 `0`。非审查步骤不附加人工计数。
 
 **gate**（`checkActivityLog`）：计算「最新 action / freshness」时跳过 `[started]` 行（升序与格式校验仍覆盖全部行），故 started 标记不会污染各 SKILL 的 `expected_action_pattern`。
 

--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -56,7 +56,7 @@
 
 **配对与渲染**（`ai task log`）：按 `{基名}` 把 started 与其后最近的同名 done 配成一行（同基名多次执行按时间升序 FIFO 配对）。STARTED 列显示 started 时间、DONE 列显示 done 时间；只有 started 无 done = 进行中（DONE 显示 `(in progress)`）；只有 done 无 started（历史日志）= 单态完成行。三种形态都合法、不报错。
 
-**人工计数**（`ai task log`）：审查步骤行把两项人工计数并入 NOTE 的 verdict 文本，逗号分隔、紧随 `blockers/major/minor`，固定英文标签 `Manual-verify: {e}, Human-decision: {h}`（不随 task 语言本地化）。`Human-decision`（`{h}`）按 canonical 步骤名前缀（`Review Analysis` / `Review Plan` / `Review Code`）映射到 `analysis` / `plan` / `code`，统计 `## 审查分歧账本` 中对应阶段 `status ∈ {needs-human-decision, human-decided}` 的当前累计数量；`Manual-verify`（`{e}`）解析 review done note 中的 `(+ {n} env-blocked)`（解析后从展示中去重），缺失为 `0`。非审查步骤不附加人工计数。
+**人工计数**（`ai task log`）：审查步骤行把两项人工计数并入 NOTE 的 verdict 文本，逗号分隔、紧随 `blockers/major/minor`，固定英文标签 `Manual-verify: {e}, Human-decision: {h}`。`Human-decision`（`{h}`）按 canonical 步骤名前缀（`Review Analysis` / `Review Plan` / `Review Code`）映射到 `analysis` / `plan` / `code`，统计 `## 审查分歧账本` 中对应阶段 `status ∈ {needs-human-decision, human-decided}` 的当前累计数量；`Manual-verify`（`{e}`）解析 review done note 中的 `(+ {n} env-blocked)`（解析后从展示中去重），缺失为 `0`。非审查步骤不附加人工计数。
 
 **gate**（`checkActivityLog`）：计算「最新 action / freshness」时跳过 `[started]` 行（升序与格式校验仍覆盖全部行），故 started 标记不会污染各 SKILL 的 `expected_action_pattern`。
 

--- a/lib/task/commands/log.ts
+++ b/lib/task/commands/log.ts
@@ -10,9 +10,10 @@ completion time (or '(in progress)' while still running).
   <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
 
 Columns: # (row) / STEP / AGENT / STARTED / DONE / NOTE
-  Review-step NOTE also carries two localized human counts in the verdict list,
-  right after blockers/major/minor: manual-verify (env-blocked) and
-  human-decision (current ledger stage total).
+  A human-executed step shows AGENT as 'human' and, when it has no start marker,
+  a '-' STARTED placeholder. Review-step NOTE also carries two English human
+  counts in the verdict list, right after blockers/major/minor: manual-verify
+  (env-blocked) and human-decision (current ledger stage total).
 `;
 
 const TABLE_HEADERS = ['#', 'STEP', 'AGENT', 'STARTED', 'DONE', 'NOTE'] as const;
@@ -41,6 +42,11 @@ type StepRow = { step: string; agent: string; started: string; done: string; not
 // without the suffix. Pairing therefore keys on the base action (including any
 // `(Round N)`), so every round and every repeated execution pairs on its own.
 const STARTED_SUFFIX_RE = /\s*\[started\]\s*$/;
+// Short agent tokens that actually appear in activity logs for AI executors
+// (workflow recommended_agents claude/codex/gemini/cursor + enabled TUI opencode;
+// note these differ from the `.airc.json` long names claude-code/gemini-cli).
+// Any other executor token (a human name, possibly CJK) is treated as human.
+const KNOWN_AI_AGENTS = new Set(['claude', 'codex', 'gemini', 'opencode', 'cursor']);
 const HUMAN_DECISION_STATUSES = new Set(['needs-human-decision', 'human-decided']);
 const ENV_BLOCKED_RE = /\(\+\s*(\d+)\s+env-blocked\)/i;
 // Same match plus any leading whitespace, so folding the count into the verdict
@@ -148,22 +154,21 @@ function humanValidationCount(note: string): number {
   return match ? Number(match[1]) : 0;
 }
 
-// Labels follow the task's language; detect it from the activity-log heading
-// (the same zh/en split as HEADING_RE), defaulting to English.
-function activityLogLang(content: string): 'zh' | 'en' {
-  return /^##\s+活动日志\s*$/m.test(content) ? 'zh' : 'en';
+// A step is human-executed when its agent token is not a known AI token. Take
+// the first whitespace-delimited token and drop any trailing parenthetical
+// annotation (e.g. `季聿阶 (executed on host)` -> `季聿阶`) before the lookup.
+function isHumanAgent(agent: string): boolean {
+  const token = agent.trim().split(/\s+/)[0]?.replace(/\(.*$/, '') ?? '';
+  return token !== '' && !KNOWN_AI_AGENTS.has(token);
 }
 
 // Fold the two human counts into a review row's verdict NOTE: comma-joined, right
 // after the blockers/major/minor list and before the ` → artifact` link, mirroring
 // the review count line. The raw `(+ n env-blocked)` fragment is dropped so the
 // env-blocked number is not shown twice (it becomes the manual-verify count).
-function foldHumanCounts(note: string, decisions: number, envBlocked: number, lang: 'zh' | 'en'): string {
+function foldHumanCounts(note: string, decisions: number, envBlocked: number): string {
   const base = note.replace(ENV_BLOCKED_STRIP_RE, '');
-  const group =
-    lang === 'zh'
-      ? `人工校验点：${envBlocked}, 人工裁决：${decisions}`
-      : `Manual-verify: ${envBlocked}, Human-decision: ${decisions}`;
+  const group = `Manual-verify: ${envBlocked}, Human-decision: ${decisions}`;
   const arrow = base.indexOf(' → ');
   return arrow === -1 ? `${base}, ${group}` : `${base.slice(0, arrow)}, ${group}${base.slice(arrow)}`;
 }
@@ -196,13 +201,15 @@ function log(args: string[] = []): void {
   }
   const steps = pairEntries(entries);
   const humanDecisionCounts = countHumanDecisionsByStage(parseReviewLedger(content));
-  const lang = activityLogLang(content);
   const rows = steps.map((s, idx) => {
     const stage = reviewStageForStep(s.step);
     const note = stage
-      ? foldHumanCounts(s.note, humanDecisionCounts.get(stage) ?? 0, humanValidationCount(s.note), lang)
+      ? foldHumanCounts(s.note, humanDecisionCounts.get(stage) ?? 0, humanValidationCount(s.note))
       : s.note;
-    return [String(idx + 1), s.step, s.agent, s.started, s.done || (s.started ? '(in progress)' : ''), note];
+    const human = isHumanAgent(s.agent);
+    const agent = human ? 'human' : s.agent;
+    const started = s.started || (human ? '-' : '');
+    return [String(idx + 1), s.step, agent, started, s.done || (s.started ? '(in progress)' : ''), note];
   });
   for (const line of formatTable(TABLE_HEADERS, rows, { zebra: Boolean(process.stdout.isTTY) })) {
     process.stdout.write(`${line}\n`);
@@ -210,4 +217,4 @@ function log(args: string[] = []): void {
   process.stdout.write(`Total: ${steps.length} steps\n`);
 }
 
-export { log, parseActivityLog, pairEntries };
+export { log, parseActivityLog, pairEntries, isHumanAgent };

--- a/lib/task/commands/log.ts
+++ b/lib/task/commands/log.ts
@@ -11,9 +11,9 @@ completion time (or '(in progress)' while still running).
 
 Columns: # (row) / STEP / AGENT / STARTED / DONE / NOTE
   A human-executed step shows AGENT as 'human' and, when it has no start marker,
-  a '-' STARTED placeholder. Review-step NOTE also carries two English human
-  counts in the verdict list, right after blockers/major/minor: manual-verify
-  (env-blocked) and human-decision (current ledger stage total).
+  a '-' STARTED placeholder. Review-step NOTE also carries two human counts in
+  the verdict list, right after blockers/major/minor: manual-verify (env-blocked)
+  and human-decision (current ledger stage total).
 `;
 
 const TABLE_HEADERS = ['#', 'STEP', 'AGENT', 'STARTED', 'DONE', 'NOTE'] as const;
@@ -156,7 +156,7 @@ function humanValidationCount(note: string): number {
 
 // A step is human-executed when its agent token is not a known AI token. Take
 // the first whitespace-delimited token and drop any trailing parenthetical
-// annotation (e.g. `季聿阶 (executed on host)` -> `季聿阶`) before the lookup.
+// annotation (e.g. `张三 (executed on host)` -> `张三`) before the lookup.
 function isHumanAgent(agent: string): boolean {
   const token = agent.trim().split(/\s+/)[0]?.replace(/\(.*$/, '') ?? '';
   return token !== '' && !KNOWN_AI_AGENTS.has(token);

--- a/tests/integration/cli/task-log.test.ts
+++ b/tests/integration/cli/task-log.test.ts
@@ -185,7 +185,7 @@ test('ai task log renders a human-executed review row as `human` with a `-` STAR
   const taskId = 'TASK-20260101-000015';
   // A human review entry: CJK executor name, done-only (no start marker).
   writeTask(activeDir, taskId, '## 活动日志', [
-    '- 2026-06-18 15:32:53+08:00 — **Human Review** by 季聿阶 — Verdict: Changes Requested, blockers: 1, major: 0, minor: 0 → human-review.md'
+    '- 2026-06-18 15:32:53+08:00 — **Human Review** by 张三 — Verdict: Changes Requested, blockers: 1, major: 0, minor: 0 → human-review.md'
   ]);
 
   const out = runCli(['task', 'log', taskId], repoRoot);

--- a/tests/integration/cli/task-log.test.ts
+++ b/tests/integration/cli/task-log.test.ts
@@ -115,7 +115,7 @@ test('ai task log locates an English "## Activity Log" section', () => {
   assert.match(out.stdout, /^Total: 1 steps$/m);
 });
 
-test('ai task log folds localized human counts into the NOTE on canonical review steps (zh)', () => {
+test('ai task log folds English human counts into the NOTE on canonical review steps, even for a zh task', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000013';
   writeTask(
@@ -141,23 +141,24 @@ test('ai task log folds localized human counts into the NOTE on canonical review
   const out = runCli(['task', 'log', taskId], repoRoot);
   assert.equal(out.status, 0, out.stderr);
   // Human counts join the verdict count list (comma-separated, after minor, before ->),
-  // and the redundant `(+ N env-blocked)` fragment is removed. analysis stage has 2
+  // and the redundant `(+ N env-blocked)` fragment is removed. Labels are always English
+  // even though the task uses a Chinese activity-log heading. analysis stage has 2
   // human-decision rows (HD-1 + HD-2); both Round 1 and Round 2 show that stage total.
   assert.match(
     out.stdout,
-    /^1\s+Review Analysis \(Round 1\)\s+claude\s+2026-06-18 14:00:00\+08:00\s+2026-06-18 14:15:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, 人工校验点：2, 人工裁决：2 → review-analysis\.md/m
+    /^1\s+Review Analysis \(Round 1\)\s+claude\s+2026-06-18 14:00:00\+08:00\s+2026-06-18 14:15:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 2, Human-decision: 2 → review-analysis\.md/m
   );
   assert.match(
     out.stdout,
-    /^2\s+Review Analysis \(Round 2\)\s+claude\s+2026-06-18 15:00:00\+08:00\s+2026-06-18 15:10:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, 人工校验点：0, 人工裁决：2 → review-analysis-r2\.md/m
+    /^2\s+Review Analysis \(Round 2\)\s+claude\s+2026-06-18 15:00:00\+08:00\s+2026-06-18 15:10:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 0, Human-decision: 2 → review-analysis-r2\.md/m
   );
   assert.match(
     out.stdout,
-    /^3\s+Review Plan \(Round 1\)\s+claude\s+2026-06-18 16:00:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, 人工校验点：1, 人工裁决：1 → review-plan\.md/m
+    /^3\s+Review Plan \(Round 1\)\s+claude\s+2026-06-18 16:00:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 1, Human-decision: 1 → review-plan\.md/m
   );
 });
 
-test('ai task log localizes the folded human counts for an English task', () => {
+test('ai task log folds English human counts for an English task', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000014';
   writeTask(
@@ -177,6 +178,45 @@ test('ai task log localizes the folded human counts for an English task', () => 
     out.stdout,
     /^1\s+Review Code \(Round 1\)\s+claude\s+2026-06-18 16:00:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 1, Human-decision: 1 → review-code\.md/m
   );
+});
+
+test('ai task log renders a human-executed review row as `human` with a `-` STARTED placeholder', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000015';
+  // A human review entry: CJK executor name, done-only (no start marker).
+  writeTask(activeDir, taskId, '## 活动日志', [
+    '- 2026-06-18 15:32:53+08:00 — **Human Review** by 季聿阶 — Verdict: Changes Requested, blockers: 1, major: 0, minor: 0 → human-review.md'
+  ]);
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // AGENT normalized to `human` (drops the CJK name -> columns stay aligned);
+  // STARTED shows the `-` placeholder since the human step has no start marker.
+  // `Human Review` is not a canonical review prefix, so NOTE carries no human counts.
+  assert.match(
+    out.stdout,
+    /^1\s+Human Review\s+human\s+-\s+2026-06-18 15:32:53\+08:00\s+Verdict: Changes Requested, blockers: 1, major: 0, minor: 0 → human-review\.md/m
+  );
+  assert.match(out.stdout, /^Total: 1 steps$/m);
+});
+
+test('ai task log keeps an AI agent (cursor) as-is with an empty STARTED on a legacy done-only row', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000016';
+  // cursor is a known AI executor; a done-only row must NOT be mistaken for human.
+  writeTask(activeDir, taskId, '## 活动日志', [
+    '- 2026-06-18 14:00:00+08:00 — **Code Task (Round 1)** by cursor — Code implemented → code.md'
+  ]);
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  // AGENT stays `cursor` (not `human`); STARTED stays empty (not `-`), so the next
+  // populated column after the empty STARTED is the DONE timestamp.
+  assert.match(
+    out.stdout,
+    /^1\s+Code Task \(Round 1\)\s+cursor\s+2026-06-18 14:00:00\+08:00\s+Code implemented → code\.md/m
+  );
+  assert.match(out.stdout, /^Total: 1 steps$/m);
 });
 
 test('ai task log fails when the task has no activity log section', () => {

--- a/tests/unit/cli/task-activity-log.test.ts
+++ b/tests/unit/cli/task-activity-log.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseActivityLog, pairEntries } from '../../../lib/task/commands/log.ts';
+import { parseActivityLog, pairEntries, isHumanAgent } from '../../../lib/task/commands/log.ts';
 
 // Separator in real entries is an em-dash (U+2014), not an ASCII hyphen.
 const ZH = '## 活动日志';
@@ -129,6 +129,21 @@ test('distinguishes a present-but-empty section (no valid entries)', () => {
   const { sectionFound, entries } = parseActivityLog(content);
   assert.equal(sectionFound, true);
   assert.equal(entries.length, 0);
+});
+
+// --- isHumanAgent: classify the executor token of a step ---
+
+test('isHumanAgent treats every known AI token as non-human', () => {
+  // The full AI token set: workflow recommended_agents + the opencode TUI.
+  for (const ai of ['claude', 'codex', 'gemini', 'opencode', 'cursor']) {
+    assert.equal(isHumanAgent(ai), false, ai);
+  }
+});
+
+test('isHumanAgent treats human executors (incl. CJK names and annotations) as human', () => {
+  for (const human of ['季聿阶', '季聿阶 (executed on host)', 'Alice', 'human']) {
+    assert.equal(isHumanAgent(human), true, human);
+  }
 });
 
 // --- pairEntries: collapse started/done markers into per-step rows ---

--- a/tests/unit/cli/task-activity-log.test.ts
+++ b/tests/unit/cli/task-activity-log.test.ts
@@ -141,7 +141,7 @@ test('isHumanAgent treats every known AI token as non-human', () => {
 });
 
 test('isHumanAgent treats human executors (incl. CJK names and annotations) as human', () => {
-  for (const human of ['季聿阶', '季聿阶 (executed on host)', 'Alice', 'human']) {
+  for (const human of ['张三', '张三 (executed on host)', 'Alice', 'human']) {
     assert.equal(isHumanAgent(human), true, human);
   }
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #518

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

优化 `ai task log` 的表格输出（以 task 11 输出为参照），集中修复展示层的三个问题，使「列对齐正确、字段完整、文案统一英文」。改动严格限制在 `ai task log` 展示层，不改任务数据结构/语义、不触碰共享表格格式化器 `lib/table.ts`。

- **#1 列对齐**：Human Review 行 AGENT 列原本直显人工中文名（如「季聿阶」），CJK 显示宽度与列宽计算（按 UTF-16 长度）不一致，导致该行及后续列整体错位。
- **#2 字段缺失**：人工审查行只有 DONE、缺 STARTED。
- **#3 文案语言**：审查行 NOTE 折入的人工计数标签按任务语言本地化为中文，与整体英文风格不统一。

## 📋 主要变更 / Brief Changelog

- `lib/task/commands/log.ts`：新增 `KNOWN_AI_AGENTS`（`claude/codex/gemini/opencode/cursor`）与纯函数 `isHumanAgent()`；用同一 `isHuman` 判定同时驱动 #1（人工执行者 AGENT 归一为 `human`，消除 CJK 导致的错位）与 #2（人工行缺 STARTED 时显示 `-` 占位，纯展示层、不伪造时间）。
- `lib/task/commands/log.ts`：`foldHumanCounts` 删除按任务语言本地化分支，固定输出英文 `Manual-verify: {e}, Human-decision: {h}`（#3）；连带删除失去唯一调用方的孤儿函数 `activityLogLang()` 与 `lang` 变量，并更新 `USAGE` 文案。
- `.agents/rules/task-management.md`：把「人工计数」单一事实源同步为「固定英文标签、不随 task 语言本地化」，与实现保持一致。
- 测试：新增 `isHumanAgent` 真值表单测（含 `cursor → false`）；新增 Human Review 行端到端用例（AGENT=`human`、STARTED=`-`、对齐）与 `cursor` legacy done-only 回归用例；更新原 zh/en 集成用例为恒英文标签。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `npm test`（全量 1188 条，1187 pass / 1 skipped / 0 fail）
3. 人工核对触发本 Issue 的真实任务：`node --experimental-strip-types ./bin/cli.ts task log TASK-20260622-001716`，确认第 14 行 Human Review 的 AGENT=`human`、STARTED=`-`、后续列对齐恢复，审查行 NOTE 为英文 `Manual-verify/Human-decision`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code where needed

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / Breaking changes documented (无破坏性变更)
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（AI legacy done-only 行 STARTED 仍为空，零回归）

## 📋 附加信息 / Additional Notes

- 严格保持展示层边界：未改 `lib/table.ts` 共享格式化器（其余 `task ls` / `task files` / `sandbox ls` 零影响），未改任务数据结构/语义。
- 已知局限（留待独立任务）：`lib/table.ts` 的显示宽度缺陷仍潜伏，仅当有人违反约定在 STEP 等被补位列写入 CJK 时才会重现；新增 AI 工具需同步 `KNOWN_AI_AGENTS` 集合。

---

**审查者注意事项 / Reviewer Notes:**

- 重点确认 `isHumanAgent` 以「执行者 token 是否已知 AI」判定人工（而非按步骤名前缀），故 `Human Decision by codex` 仍显示 `codex`、`by cursor` 仍显示 `cursor`、不被误归一为 `human`。

---

Generated with AI assistance