### PR TITLE
fix(meta): import-issue 导入时剥掉任务标题的 type(scope) 前缀

### DIFF
--- a/.agents/skills/import-issue/SKILL.md
+++ b/.agents/skills/import-issue/SKILL.md
@@ -40,7 +40,22 @@ description: "从 Issue 导入并创建任务"
 执行前先读取 `.agents/rules/issue-pr-commands.md`，并按其中的前置步骤完成认证和代码托管平台检测；随后按其中的 “读取 Issue” 命令获取 Issue 信息。
 
 提取：issue 编号、标题、描述、标签。
-任务标题直接使用 Issue 的原始标题（保持 Issue 标题的原始语言）。
+
+从 Issue 标题派生任务标题：按下方契约剥掉可选的单层前导 Conventional Commits 前缀，其余描述原文与原始语言保持不变。下方 fenced 契约是权威的、与语言无关的规则——在所有 `import-issue` 变体中保持逐字节一致：
+
+```
+# title-derivation-contract
+strip-prefix: type(scope):
+prefix-types: feat fix docs style refactor perf test build ci chore revert
+single-layer-only: true
+preserve-body-colon: true
+keep-when-no-prefix: true
+example-strip: "feat(meta): create-pr summary" => "create-pr summary"
+example-keep: "修复某问题" => "修复某问题"
+example-single-layer: "feat: add A: B" => "add A: B"
+```
+
+只剥第一层前缀，且仅当前导 token 是 `prefix-types` 之一、其后可带 `(scope)` 与 `!`，再接 `:` 和至少一个空格；描述正文中的冒号永远不算前缀。
 
 ### 2. 检查已有任务
 

--- a/templates/.agents/skills/import-issue/SKILL.en.md
+++ b/templates/.agents/skills/import-issue/SKILL.en.md
@@ -40,7 +40,22 @@ This skill **creates** task.md, so there is no file to write at the start. Captu
 Read `.agents/rules/issue-pr-commands.md` first, follow its prerequisite steps to complete authentication and code-hosting platform detection, then load the Issue data with its "Read an Issue" command.
 
 Extract: issue number, title, description, and labels.
-Use the Issue title as-is for the task title (preserve the Issue's original language).
+
+Derive the task title from the Issue title by stripping an optional single leading Conventional Commits prefix, following the contract below; preserve the rest of the description verbatim and in its original language. This fenced contract is the authoritative, language-neutral rule — keep it byte-for-byte identical across every `import-issue` variant:
+
+```
+# title-derivation-contract
+strip-prefix: type(scope):
+prefix-types: feat fix docs style refactor perf test build ci chore revert
+single-layer-only: true
+preserve-body-colon: true
+keep-when-no-prefix: true
+example-strip: "feat(meta): create-pr summary" => "create-pr summary"
+example-keep: "修复某问题" => "修复某问题"
+example-single-layer: "feat: add A: B" => "add A: B"
+```
+
+Strip only the first layer, and only when the leading token is a `prefix-types` value optionally followed by `(scope)` and a `!`, then `:` and at least one space; a colon inside the description is never a prefix.
 
 ### 2. Check for an Existing Task
 

--- a/templates/.agents/skills/import-issue/SKILL.zh-CN.md
+++ b/templates/.agents/skills/import-issue/SKILL.zh-CN.md
@@ -40,7 +40,22 @@ description: "从 Issue 导入并创建任务"
 执行前先读取 `.agents/rules/issue-pr-commands.md`，并按其中的前置步骤完成认证和代码托管平台检测；随后按其中的 “读取 Issue” 命令获取 Issue 信息。
 
 提取：issue 编号、标题、描述、标签。
-任务标题直接使用 Issue 的原始标题（保持 Issue 标题的原始语言）。
+
+从 Issue 标题派生任务标题：按下方契约剥掉可选的单层前导 Conventional Commits 前缀，其余描述原文与原始语言保持不变。下方 fenced 契约是权威的、与语言无关的规则——在所有 `import-issue` 变体中保持逐字节一致：
+
+```
+# title-derivation-contract
+strip-prefix: type(scope):
+prefix-types: feat fix docs style refactor perf test build ci chore revert
+single-layer-only: true
+preserve-body-colon: true
+keep-when-no-prefix: true
+example-strip: "feat(meta): create-pr summary" => "create-pr summary"
+example-keep: "修复某问题" => "修复某问题"
+example-single-layer: "feat: add A: B" => "add A: B"
+```
+
+只剥第一层前缀，且仅当前导 token 是 `prefix-types` 之一、其后可带 `(scope)` 与 `!`，再接 `:` 和至少一个空格；描述正文中的冒号永远不算前缀。
 
 ### 2. 检查已有任务
 

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -721,3 +721,61 @@ test("analyze-task brainstorming gate adds step 4 and whitelists analyze-task in
     "deployed no-mid-flow-questions rule should stay byte-identical to its zh-CN template variant"
   );
 });
+
+test("import-issue step 1 declares a structured title-derivation contract", () => {
+  // Structural guard for the CC-prefix stripping rule (Issue #494). The assertable
+  // object is a fenced, language-neutral contract block parsed by key (not prose
+  // tokens), so it verifies the strip *direction* and the boundary semantics rather
+  // than just word presence — per .agents/rules/testing-discipline.md (structural
+  // checks, no keyword-semantic assertions). A doc reading "do not strip ..." cannot
+  // satisfy strip-prefix + the removal examples below.
+  const REQUIRED_KEYS = [
+    "strip-prefix",
+    "prefix-types",
+    "single-layer-only",
+    "preserve-body-colon",
+    "keep-when-no-prefix"
+  ];
+  const contracts: string[] = [];
+
+  skillDocPaths("import-issue").forEach((relativePath) => {
+    const content = read(relativePath);
+    const step1 = content.match(/^### 1\. [\s\S]*?(?=^### \d+\. )/m)?.[0] || "";
+    assert.ok(step1, `${relativePath} should expose a step 1 section`);
+
+    const block = step1.match(/```[a-z]*\n# title-derivation-contract\n([\s\S]*?)\n```/m)?.[1];
+    assert.ok(block, `${relativePath} step 1 should declare a fenced "# title-derivation-contract" block`);
+
+    const entries: Record<string, string> = {};
+    const examples: string[] = [];
+    block!.split("\n").forEach((line) => {
+      const match = line.match(/^([a-z][a-z-]*):[ \t]*(.*)$/);
+      if (!match) return;
+      const key = match[1];
+      if (key === undefined) return;
+      const value = match[2] ?? "";
+      if (key.startsWith("example")) examples.push(value);
+      else entries[key] = value;
+    });
+
+    REQUIRED_KEYS.forEach((key) => {
+      assert.ok(key in entries, `${relativePath} contract should declare "${key}"`);
+    });
+    assert.match(entries["strip-prefix"] ?? "", /type\(scope\)/, `${relativePath} strip-prefix should target the type(scope) prefix`);
+    assert.equal(entries["single-layer-only"], "true", `${relativePath} should strip only one prefix layer`);
+    assert.equal(entries["preserve-body-colon"], "true", `${relativePath} should preserve description colons`);
+    assert.equal(entries["keep-when-no-prefix"], "true", `${relativePath} should keep titles that have no prefix`);
+    assert.ok(
+      examples.filter((example) => example.includes("=>")).length >= 3,
+      `${relativePath} contract should include >=3 transform examples (strip / keep / single-layer)`
+    );
+
+    contracts.push(block!.trim());
+  });
+
+  assert.ok(contracts.length >= 1, "import-issue should expose at least one skill doc variant");
+  // Language-neutral contract: identical across deployed + EN + zh-CN variants (no drift).
+  contracts.forEach((block) => {
+    assert.equal(block, contracts[0], "title-derivation contract should be byte-identical across all import-issue variants");
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #494

Closes #494

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)

## 📝 变更目的 / Purpose of the Change

`import-issue` 从 Issue 标题派生任务标题时未剥掉前导 `type(scope):` Conventional Commits 前缀，导致 `ai task ls` 中导入的任务标题带 CC 前缀，与 `create-task` 创建的纯描述标题不一致（实证 #487 / #488）。本 PR 让 `import-issue` 步骤 1 在派生任务标题时剥掉可选的单层 CC 前缀，使两类任务标题一致。

## 📋 主要变更 / Brief Changelog

- `import-issue` 步骤 1 改为按一个**语言无关、三变体逐字节一致**的 `title-derivation-contract` 契约块派生任务标题：剥掉可选的单层前导 CC 前缀（`type:` / `type(scope):`，type 限白名单，冒号后需空格），无前缀原样保留，正文冒号不误剥，只剥一层。
- 同步更新三处文档：`templates/.agents/skills/import-issue/SKILL.en.md`、`SKILL.zh-CN.md` 以及已部署镜像 `.agents/skills/import-issue/SKILL.md`（与 zh-CN 模板逐字节锁步）。
- 新增结构化契约测试守卫 `tests/unit/templates/skills.test.ts`：解析契约块的键值/示例并校验三变体一致性（结构性断言，不绑定散文措辞）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test --experimental-strip-types tests/unit/templates/skills.test.ts tests/unit/templates/templates.test.ts`
2. `npm run typecheck`
3. `npm test`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（全量 1190 pass / 0 fail / 1 skipped）

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body
- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经编写了必要的单元测试 / I have written necessary unit-tests
- [x] 单元测试通过 / Unit tests pass
- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

`import-issue` 为 AI 执行的文档型 skill，契约块既是 AI 派生标题的权威规则，也是测试解析对象；故测试守卫为结构化契约校验，而非真实导入流程的行为测试。

---

Generated with AI assistance