### PR TITLE
feat(meta): commit 在分支已有 PR 时自动推送

### DIFF
--- a/.agents/rules/issue-pr-commands.md
+++ b/.agents/rules/issue-pr-commands.md
@@ -186,6 +186,12 @@ gh pr view {pr-number} --json number,title,body,labels,state,milestone,url,files
 gh pr list --state {state} --base {base-branch} --json number,title,url,headRefName,baseRefName
 ```
 
+按 head 分支查询当前分支是否存在开放 PR（`commit` 推送收尾用）：
+
+```bash
+gh pr list --head "{branch}" --state open --json number,url --jq '.[0].url // empty'
+```
+
 创建 PR：
 
 ```bash

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -64,7 +64,27 @@ git diff
 - 提交后仅当 `pre_head == R` 且 `S == F` 时，在 task.md frontmatter 写入 `last_reviewed_commit: <new_head>`；否则不推进该字段
 - 不向后扫描更早的 Approved 产物；最高轮 `review-code` 产物是唯一权威来源
 
-## 5. 按需更新任务状态
+## 5. 推送到已有 PR（按需）
+
+提交完成后，如果当前分支已存在开放的 Pull Request，则把本次提交推送上去让 PR 自动更新；否则保持现状（首次推送仍由 `create-pr` 负责）。本步骤是用户已发起 `commit` 的推送收尾，不新增自动提交，也不在无 PR 时推送；与是否关联任务无关。
+
+> 检测当前分支是否有开放 PR、以及平台认证，统一按 `.agents/rules/issue-pr-commands.md` 执行；该规则不可用或检测失败时，按下方降级处理。
+
+a. 按 `.agents/rules/issue-pr-commands.md` 检测当前分支（head）是否存在开放 PR。
+
+b. 命中开放 PR -> 推送当前分支：
+
+```bash
+git push
+```
+
+c. 安全降级（不阻塞已完成的 `git commit`，仅提示用户）：
+   - 平台不可用 / 未认证 / 检测失败 / 未命中开放 PR -> 不推送，继续后续步骤。
+   - `git push` 失败（如需 `git pull --rebase`、无 upstream、网络异常）-> 保留本地提交，提示用户手动推送。
+
+把推送结果（pushed / skipped(no PR) / failed）并入下一步「更新任务状态」的 Activity Log 说明或用户输出。
+
+## 6. 按需更新任务状态
 
 获取当前时间：
 
@@ -81,7 +101,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 还有后续工作 -> 更新 task.md 后停止
 - 准备审查 -> `review-code {task-id}`
 
-## 6. 同步 Issue 元数据（按需）
+## 7. 同步 Issue 元数据（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `issue_number` 时，同步 `in:` label 和需求复选框到关联 Issue；否则跳过。
 
@@ -91,7 +111,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 7. 同步 PR 摘要（按需）
+## 8. 同步 PR 摘要（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上由 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记对应的摘要评论；否则跳过。
 
@@ -101,7 +121,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 8. 完成校验
+## 9. 完成校验
 
 如果本次操作关联了 `{task-id}`，运行完成校验，确认任务元数据和同步状态符合规范；如果没有任务上下文，跳过本步骤。
 

--- a/templates/.agents/rules/issue-pr-commands.github.en.md
+++ b/templates/.agents/rules/issue-pr-commands.github.en.md
@@ -186,6 +186,12 @@ List PRs:
 gh pr list --state {state} --base {base-branch} --json number,title,url,headRefName,baseRefName
 ```
 
+Find the open PR whose head is the current branch (used by the `commit` push wrap-up):
+
+```bash
+gh pr list --head "{branch}" --state open --json number,url --jq '.[0].url // empty'
+```
+
 Create a PR:
 
 ```bash

--- a/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
+++ b/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
@@ -186,6 +186,12 @@ gh pr view {pr-number} --json number,title,body,labels,state,milestone,url,files
 gh pr list --state {state} --base {base-branch} --json number,title,url,headRefName,baseRefName
 ```
 
+按 head 分支查询当前分支是否存在开放 PR（`commit` 推送收尾用）：
+
+```bash
+gh pr list --head "{branch}" --state open --json number,url --jq '.[0].url // empty'
+```
+
 创建 PR：
 
 ```bash

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -64,7 +64,27 @@ If this commit is associated with a task and a `review-code` artifact exists, re
 - After committing, write `last_reviewed_commit: <new_head>` to task.md frontmatter only when `pre_head == R` and `S == F`; otherwise do not advance that field
 - Do not scan backward to earlier Approved artifacts; the highest-round `review-code` artifact is the only authoritative source
 
-## 5. Update Task Status When Applicable
+## 5. Push to the Existing PR When Applicable
+
+After the commit is created, if the current branch already has an open Pull Request, push the new commit so the PR updates automatically. Otherwise keep the current behavior (the first push is still handled by `create-pr`). This is the push wrap-up of a user-initiated `commit`: it adds no extra commit and never pushes when there is no PR; it applies whether or not a task is associated.
+
+> Detect whether the current branch has an open PR — and authenticate to the platform — per `.agents/rules/issue-pr-commands.md`; if that rule is unavailable or detection fails, follow the degradation below.
+
+a. Detect whether the current branch (head) has an open PR per `.agents/rules/issue-pr-commands.md`.
+
+b. On an open PR -> push the current branch:
+
+```bash
+git push
+```
+
+c. Safe degradation (never block an already completed `git commit`; only warn the user):
+   - Platform unavailable / unauthenticated / detection failed / no open PR -> do not push; continue.
+   - `git push` fails (needs `git pull --rebase`, no upstream, network error) -> keep the local commit and tell the user to push manually.
+
+Fold the push outcome (pushed / skipped(no PR) / failed) into the next step's "Update Task Status" Activity Log note or user output.
+
+## 6. Update Task Status When Applicable
 
 Get the current time:
 
@@ -81,7 +101,7 @@ Append the Commit Activity Log entry and choose exactly one next-step case:
 - more work remains -> update task.md and stop
 - ready for review -> `review-code {task-id}`
 
-## 6. Sync Issue Metadata When Applicable
+## 7. Sync Issue Metadata When Applicable
 
 When `{task-id}` exists and task.md contains a valid `issue_number`, sync the linked Issue `in:` labels and requirement checkboxes. Otherwise, skip this step.
 
@@ -91,7 +111,7 @@ When `{task-id}` exists and task.md contains a valid `issue_number`, sync the li
 
 Failure handling matches "Update Task Status When Applicable": warn, but do **not** block an already completed `git commit`.
 
-## 7. Sync PR Summary When Applicable
+## 8. Sync PR Summary When Applicable
 
 When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR summary comment marked with the PR summary marker defined in `.agents/rules/pr-sync.md` on the PR. Otherwise, skip this step.
 
@@ -101,7 +121,7 @@ When `{task-id}` exists and task.md contains a valid `pr_number`, refresh the PR
 
 Failure handling matches "Update Task Status When Applicable": warn, but do **not** block an already completed `git commit`.
 
-## 8. Verification Gate
+## 9. Verification Gate
 
 If this operation is associated with `{task-id}`, run the verification gate to confirm task metadata and sync state. If there is no task context, skip this step.
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -64,7 +64,27 @@ git diff
 - 提交后仅当 `pre_head == R` 且 `S == F` 时，在 task.md frontmatter 写入 `last_reviewed_commit: <new_head>`；否则不推进该字段
 - 不向后扫描更早的 Approved 产物；最高轮 `review-code` 产物是唯一权威来源
 
-## 5. 按需更新任务状态
+## 5. 推送到已有 PR（按需）
+
+提交完成后，如果当前分支已存在开放的 Pull Request，则把本次提交推送上去让 PR 自动更新；否则保持现状（首次推送仍由 `create-pr` 负责）。本步骤是用户已发起 `commit` 的推送收尾，不新增自动提交，也不在无 PR 时推送；与是否关联任务无关。
+
+> 检测当前分支是否有开放 PR、以及平台认证，统一按 `.agents/rules/issue-pr-commands.md` 执行；该规则不可用或检测失败时，按下方降级处理。
+
+a. 按 `.agents/rules/issue-pr-commands.md` 检测当前分支（head）是否存在开放 PR。
+
+b. 命中开放 PR -> 推送当前分支：
+
+```bash
+git push
+```
+
+c. 安全降级（不阻塞已完成的 `git commit`，仅提示用户）：
+   - 平台不可用 / 未认证 / 检测失败 / 未命中开放 PR -> 不推送，继续后续步骤。
+   - `git push` 失败（如需 `git pull --rebase`、无 upstream、网络异常）-> 保留本地提交，提示用户手动推送。
+
+把推送结果（pushed / skipped(no PR) / failed）并入下一步「更新任务状态」的 Activity Log 说明或用户输出。
+
+## 6. 按需更新任务状态
 
 获取当前时间：
 
@@ -81,7 +101,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - 还有后续工作 -> 更新 task.md 后停止
 - 准备审查 -> `review-code {task-id}`
 
-## 6. 同步 Issue 元数据（按需）
+## 7. 同步 Issue 元数据（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `issue_number` 时，同步 `in:` label 和需求复选框到关联 Issue；否则跳过。
 
@@ -91,7 +111,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 7. 同步 PR 摘要（按需）
+## 8. 同步 PR 摘要（按需）
 
 当 `{task-id}` 存在且 task.md 包含有效 `pr_number` 时，刷新 PR 上由 `.agents/rules/pr-sync.md` 中定义的 PR 摘要评论标记对应的摘要评论；否则跳过。
 
@@ -101,7 +121,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 失败处理与「按需更新任务状态」一致：警告但**不**阻塞已完成的 `git commit`。
 
-## 8. 完成校验
+## 9. 完成校验
 
 如果本次操作关联了 `{task-id}`，运行完成校验，确认任务元数据和同步状态符合规范；如果没有任务上下文，跳过本步骤。
 

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -779,3 +779,25 @@ test("import-issue step 1 declares a structured title-derivation contract", () =
     assert.equal(block, contracts[0], "title-derivation contract should be byte-identical across all import-issue variants");
   });
 });
+
+test("commit skill push-to-existing-PR step keeps level-2 steps numbered 1..9", () => {
+  // commit SKILL uses level-2 (`## N.`) step headings, which the generic
+  // consecutive-numbering test (level-3 `### N.`) does not cover. After
+  // inserting "Push to the Existing PR" as step 5, guard that all three
+  // variants stay consecutively numbered 1..9. Structural check only — no
+  // step-title/prose matching (see .agents/rules/testing-discipline.md).
+  const commitVariants = [
+    ".agents/skills/commit/SKILL.md",
+    "templates/.agents/skills/commit/SKILL.zh-CN.md",
+    "templates/.agents/skills/commit/SKILL.en.md"
+  ];
+
+  commitVariants.forEach((relativePath) => {
+    const stepNumbers = [...read(relativePath).matchAll(/^## (\d+)\. /gm)].map((match) => Number(match[1]));
+    assert.deepEqual(
+      stepNumbers,
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      `${relativePath} should keep level-2 steps consecutively numbered 1..9 after adding the push step`
+    );
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #524

Closes #524

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)

## 📝 变更目的 / Purpose of the Change

消除「建 PR 前的提交由 `create-pr` 顺带 `git push -u` 推送、建 PR 后的提交需用户手动推送」的行为不一致。

为 `commit` 技能补充「推送收尾」：提交完成后，若当前分支已存在开放 PR，则直接 `git push` 让 PR 自动更新；无 PR 则维持现状（首次推送仍由 `create-pr` 负责）。属于用户已发起 `commit` 语义内的收尾，不引入额外自动提交、不在无 PR 时推送；`gh` 不可用/未认证、检测失败、push 失败等情况安全降级（提示手动推送），不阻塞已完成的 `git commit`。

## 📋 主要变更 / Brief Changelog

- `commit` 技能新增步骤 5「推送到已有 PR（按需）」，旧步骤 5–8 顺延为 6–9；活动副本与双语模板源（`SKILL.md` / `SKILL.{en,zh-CN}.md`）等价更新。
- 平台特定命令保持平台无关纪律：步骤委托 `.agents/rules/issue-pr-commands.md`，并在该规则（含两份 github 平台模板）新增 `gh pr list --head` 的按 head 分支查询 PR 命令范式。
- 新增结构性测试，守护 `commit` 二级标题步骤编号连续为 1..9。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` —— 全量套件 1190 passed / 0 failed / 1 skipped（平台守卫用例）。
2. `cmp` 校验：活动副本 `SKILL.md` 与 `SKILL.zh-CN.md` 模板逐字节一致；部署规则与 `issue-pr-commands.github.zh-CN.md` 逐字节一致。
3. `platform-coupling` 守卫：三份 `commit` SKILL 文件不含 `gh`/`GitHub`/`.github/` 平台 token。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更
- [x] 你的 Pull Request 只解决一个 Issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述
- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 单元测试通过
- [x] 我已经更新了相应的文档（SKILL.md 即文档本体）
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

实现阶段相对方案有一处必要偏离（已在任务记录中说明）：`gh pr list --head` 检测命令由「内联在 SKILL」改为「下沉到 `.agents/rules/issue-pr-commands.md`」，原因是 `platform-coupling` 测试禁止 SKILL/reference 含平台 token；设计意图不变。

---

**审查者注意事项 / Reviewer Notes:**

- 重点关注步骤 5 的平台无关表述与 `commit → issue-pr-commands.md` 委托链是否清晰可执行。
- 本次为文档/技能层改动，运行时推送行为依赖 `gh` 可用性，端到端推送未做真机验证（与项目「平台命令在规则层」形态一致）。

Generated with AI assistance.
