### PR TITLE
chore(meta): 约定一致性机械守卫（轻量三项）

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,6 @@
 export { filePath, exists, read, listFilesRecursive, listSkillNames } from "./helpers/paths.ts";
 export { CLI_PATH, cliArgs, pathWithPrependedBin, envWithPrependedPath } from "./helpers/cli.ts";
-export { gitSafeEnv, withGitSafeProcessEnv, initIsolatedGitRepo } from "./helpers/git.ts";
+export { gitSafeEnv, withGitSafeProcessEnv, initIsolatedGitRepo, listTrackedFiles } from "./helpers/git.ts";
 export { onPlatforms, supportsPosixModeBits, assertModeBits } from "./helpers/platform.ts";
 export { writeSandboxEngineFixture, writeNodeCommandShim } from "./helpers/sandbox.ts";
 export { langTemplate, renderPlaceholders, buildCommandSyncFiles, escapeRegExp, parseFrontmatter, skillDocPaths } from "./helpers/templates.ts";

--- a/tests/helpers/git.ts
+++ b/tests/helpers/git.ts
@@ -1,4 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 // =====================================================================
 // CRITICAL: tests that spawn real `git` commands MUST use gitSafeEnv()
@@ -77,8 +80,24 @@ function initIsolatedGitRepo(repoRoot: string, { remote = null }: { remote?: str
   }
 }
 
+// List repo-tracked files matching the given git pathspecs, relative to the
+// repository root. Callers can pass exclude pathspecs (e.g. ":!:node_modules/**")
+// to scope the result. Uses gitSafeEnv() so it never touches an outer repo.
+function listTrackedFiles(...patterns: string[]): string[] {
+  const result = spawnSync("git", ["ls-files", "-z", ...patterns], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr}`);
+  }
+  return result.stdout.split("\0").filter((line) => line.length > 0);
+}
+
 export {
   gitSafeEnv,
   initIsolatedGitRepo,
+  listTrackedFiles,
   withGitSafeProcessEnv
 };

--- a/tests/unit/templates/bilingual-parity.test.ts
+++ b/tests/unit/templates/bilingual-parity.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { exists, listTrackedFiles } from "../../helpers.ts";
+
+// Repo-wide bilingual documentation parity guard.
+//
+// Two baseline conventions coexist:
+//   1. Co-located `X.en.md` <-> `X.zh-CN.md` (used under .agents/ and templates/).
+//   2. Top-level repo docs use `X.md` as the English baseline paired with
+//      `X.zh-CN.md` (there is no `X.en.md` for these).
+//
+// The top-level baselines are an explicit allowlist rather than a heuristic, so
+// the guard never demands a translation for the many `.md` files (source
+// SKILL.md, rules, task fixtures, ...) that legitimately have no zh-CN variant.
+const TOP_LEVEL_BASELINES = ["README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md"];
+
+const tracked = new Set(
+  listTrackedFiles("*.en.md", "*.zh-CN.md", ":!:node_modules/**", ":!:dist/**")
+);
+
+test("every .en.md has a sibling .zh-CN.md", () => {
+  [...tracked]
+    .filter((file) => file.endsWith(".en.md"))
+    .forEach((file) => {
+      const zh = file.replace(/\.en\.md$/, ".zh-CN.md");
+      assert.ok(tracked.has(zh), `${file} is missing its translation ${zh}`);
+    });
+});
+
+test("every .zh-CN.md has an English baseline", () => {
+  [...tracked]
+    .filter((file) => file.endsWith(".zh-CN.md"))
+    .forEach((file) => {
+      const enSibling = file.replace(/\.zh-CN\.md$/, ".en.md");
+      const baseline = file.replace(/\.zh-CN\.md$/, ".md");
+      const isTopLevelBaseline = !file.includes("/") && TOP_LEVEL_BASELINES.includes(baseline);
+      assert.ok(
+        tracked.has(enSibling) || (isTopLevelBaseline && exists(baseline)),
+        `${file} has no English baseline (${enSibling} or top-level ${baseline})`
+      );
+    });
+});
+
+test("top-level baseline docs provide zh-CN translations", () => {
+  TOP_LEVEL_BASELINES.filter((baseline) => exists(baseline)).forEach((baseline) => {
+    const zh = baseline.replace(/\.md$/, ".zh-CN.md");
+    assert.ok(exists(zh), `${baseline} is missing its translation ${zh}`);
+  });
+});

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -74,13 +74,22 @@ test("SKILL.md reference paths point to existing files", () => {
   });
 });
 
-test("template SKILL.md files provide zh-CN variants", () => {
-  listFilesRecursive("templates/.agents/skills")
-    .filter((relativePath) => /\/SKILL\.en\.md$/.test(relativePath))
-    .forEach((relativePath) => {
-      const zhVariant = relativePath.replace(/SKILL\.en\.md$/, "SKILL.zh-CN.md");
-      assert.ok(exists(zhVariant), `Missing zh-CN skill variant: ${zhVariant}`);
-    });
+// Soft size guard: SKILL.md bodies should stay lean (long rules/templates/scripts
+// belong in reference/ or scripts/). Per the design decision this is a visibility
+// signal, not a red light — oversize files emit a diagnostic but never fail.
+const SKILL_SOFT_LINE_LIMIT = 300;
+
+test("source SKILL.md files stay within the soft size limit", (t) => {
+  listSkillNames().forEach((name) => {
+    const relativePath = `.agents/skills/${name}/SKILL.md`;
+    const lineCount = read(relativePath).split("\n").length;
+    if (lineCount > SKILL_SOFT_LINE_LIMIT) {
+      t.diagnostic(
+        `${relativePath} is ${lineCount} lines (> ${SKILL_SOFT_LINE_LIMIT} soft limit); ` +
+        "consider splitting detail into reference/."
+      );
+    }
+  });
 });
 
 test("template skill content does not reference deprecated lifecycle names", () => {

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -499,6 +499,20 @@ test("rules README index lists every distributed rule file", () => {
   });
 });
 
+test("source rules README references only existing rule files", () => {
+  // Reverse of the index check above: every same-directory `.md` link in the
+  // source README must resolve to a real rule file. Catches dangling entries
+  // left behind when a rule is renamed or deleted. Links containing a path
+  // separator (cross-directory / external) are out of scope for the index.
+  const dir = ".agents/rules";
+  const index = read(`${dir}/README.md`);
+  const referencedNames = [...index.matchAll(/\]\(([^)/]+\.md)\)/g)].map((match) => match[1]);
+
+  [...new Set(referencedNames)].forEach((name) => {
+    assert.ok(exists(`${dir}/${name}`), `rules/README.md references missing rule file: ${name}`);
+  });
+});
+
 test("rendered rules README references only distributed files", () => {
   const collaborator = JSON.parse(read(".agents/.airc.json"));
   const replacements = { project: collaborator.project, org: collaborator.org };


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #538

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

把三条目前只靠「维护提醒 / README 文字」自觉维护的约定，固化为随 `unit-tests` CI 运行的回归测试，实现可持续的「熵减」防退化。`sync-templates.js` 三份拷贝一致性守卫改动较重，单独立项，不在本 PR 范围内。

分析阶段证实并经人工裁决（HD-1/2/3）修正了原始 Issue 的两处前提偏差：

- **Guard 1** 不能用字面「严格相等」——会误报 ejected 的 `cross-platform-tests.md`，故改为 ejected-aware + 源 README dangling 反向校验。
- **Guard 2** 的 `.zh-CN`(157)/`.en`(153) 4 个差额是 4 个顶层 `X.md` 基线、并非孤儿，全仓双向成对性当前已干净。

三守卫落地后均为绿灯 / 无告警，本质是「锁定现状、防止未来退化」。

## 📋 主要变更 / Brief Changelog

- **Guard 1（rules 索引）** `tests/unit/templates/templates.test.ts`：新增源 `.agents/rules/README.md` dangling 反向校验（同目录裸文件名链接须指向存在文件），与既有 `:481` 正向 ejected-aware 校验并列、不替换。
- **Guard 2（双语成对）** 新建 `tests/unit/templates/bilingual-parity.test.ts`：`git ls-files` 全仓 `.en.md`↔`.zh-CN.md` 双向 + 顶层白名单 `X.md`↔`X.zh-CN.md` 三向校验；删除并吸收 `skills.test.ts` 中被覆盖的 zh-CN 子集断言。
- **Guard 3（SKILL.md 体积）** `tests/unit/templates/skills.test.ts`：源 `SKILL.md` 300 行软限制，超限用 `t.diagnostic()` 告警但**不**失败（HD-1，可见性信号非红灯；当前最长 294 行 → 无告警）。
- **共享 helper** `tests/helpers/git.ts` 新增 `listTrackedFiles()`（`git ls-files -z` + `gitSafeEnv()` 防污染外层 repo），并在 `tests/helpers.ts` barrel 导出。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build` —— 通过
2. `npm test` —— 1222 通过 / 0 失败 / 1 跳过（既有 win32 平台守卫）
3. 内存伪造违例验证三守卫均会真实拦截（dangling 链接 / 孤儿 `.en.md` / >300 行诊断），确认非 no-op

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📋 附加信息 / Additional Notes

- 改动保持测试层闭环，未触碰业务 / CLI 代码或 CI 配置（`unit-tests` 已覆盖 `tests/unit/**`）。
- Guard 2 顶层白名单为显式常量（HD-3）；未来新增需翻译的顶层文档需手工加入。

---

**审查者注意事项 / Reviewer Notes:**

- Guard 1 正则 `\]\(([^)/]+\.md)\)` 有意只匹配同目录裸文件名链接（排除跨目录 / 外部链接），符合「索引项 dangling」语义。
- Guard 3 作为软告警（不 fail）是 HD-1 的明确取舍。

Generated with AI assistance
