### PR TITLE
chore(meta): sync-templates.js 三份拷贝一致性守卫

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -103,5 +103,20 @@
   },
   "task": {
     "shortIdLength": 2
+  },
+  "review": {
+    "post_review_globs": [
+      ".agents/.airc.json",
+      ".agents/rules",
+      ".agents/scripts",
+      ".agents/skills",
+      ".agents/workflows",
+      ".git-hooks/pre-commit",
+      ".github/workflows",
+      "bin",
+      "lib",
+      "src",
+      "templates"
+    ]
   }
 }

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -12,6 +12,13 @@ script_dir=$(
 # typecheck covers tests/ + scripts/ which the production `build` step skips.
 npm run typecheck
 
+# Guard against drift between the authoritative src/sync-templates.js
+# (+ lib/defaults.json) and its two build-inline-generated copies. Run BEFORE any
+# step that rebuilds them (test:core -> npm run build), so a committed-but-stale
+# derived copy is caught here instead of being silently regenerated. Mirrors the
+# CI pre-Build check.
+node scripts/build-inline.js --check
+
 # Run the project's core test layer before allowing the commit.
 # package.json#scripts.test:core covers the core unit and structural checks
 # while skipping the slowest platform-sync contract suites (those run in CI).

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify inline build output is committed
+        run: node scripts/build-inline.js --check
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #540 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [x] 🧹 代码清理 / Code cleanup（CI/hook 守卫，熵减）

## 📝 变更目的 / Purpose of the Change

`sync-templates.js` 有三份拷贝：权威源 `src/sync-templates.js`，以及两份由 `scripts/build-inline.js` 把 `DEFAULTS` 内联生成的派生拷贝（`.agents/...` 与 `templates/.agents/...`）。

既有的 `build-inline.js --check`（以及 `tests/integration/cli/cli.test.ts` 的 `build output is up-to-date` 测试）**已存在**，但在所有执行路径里都被前置的 `npm run build`（其末步会重写两份派生文件）抵消——`--check` 永远比对刚生成的文件，因此**无法捕获“已提交派生文件漂移”**（手改派生拷贝、或改了 `src`/`lib/defaults.json` 忘记重建就提交）。该守卫退化为只验证 build 单次幂等。

本 PR 把同一个 `--check` 接到**任何会重建派生文件的步骤之前**，使漂移在 CI 与本地提交时刻红灯。方向由人工裁定（`HD-1` 选项 3）：复用既有 `--check`，不新增 git-blob parity 测试。

## 📋 主要变更 / Brief Changelog

- `.github/workflows/unit-tests.yml`：在 `Build`（`npm run build`）步骤**前**新增 `Verify inline build output is committed`（`node scripts/build-inline.js --check`），对 `actions/checkout` 的提交树断言派生一致性。
- `.git-hooks/pre-commit`：在 `npm run test:core`（内部 `npm run build` 会重写派生文件）**前**新增同一 `--check`，把漂移挡在提交时刻而非 push 后。
- `.agents/.airc.json`：新增 `review.post_review_globs`，把本轮交付路径（`.github/workflows`、`.git-hooks/pre-commit`，并自含 `.agents/.airc.json`）纳入 post-review 指纹与 complete-task post-review 门禁覆盖。

不改三份 `sync-templates.js`、不改 `scripts/build-inline.js`、保留既有 `build output is up-to-date` 测试（断言 build 幂等，属不同属性）。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 正向（不误报）：干净树 `node scripts/build-inline.js --check` → exit 0。
2. 负向（能红灯）：`printf '\n' >> .agents/skills/update-agent-infra/scripts/sync-templates.js` → `node scripts/build-inline.js --check` → exit 1。
3. 非破坏性恢复：`node scripts/build-inline.js`（权威生成器）→ `--check` exit 0 → `git diff --exit-code -- <派生路径>` exit 0（不使用 `git checkout --` / `git reset --hard`）。
4. 回归：`npm run test:core` → 991 pass / 0 fail / 1 skipped。

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests（按 `HD-1` 复用既有 `--check`，不新增 git-blob 测试）
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / Github issue filed（#540）
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body
- [x] 我的代码遵循项目的代码规范 / Code follows the project's standards
- [x] 我已经进行了自我代码审查 / Self-review performed
- [x] 所有现有测试都通过 / Unit tests pass

## 📋 附加信息 / Additional Notes

- **范围边界**：不扩展到其它 workflow（如 `pack-smoke.yml`，跑打包产物、无 `src/`/`scripts/`，加 `--check` 无意义且会失败）。
- **贡献者影响（预期）**：改了 `src/sync-templates.js` 或 `lib/defaults.json` 后须 `node scripts/build-inline.js`（或 `npm run build`）重建并提交派生文件，否则 pre-commit 与 CI 红灯；`build-inline.js` 错误信息自带修复指引（`Run: node scripts/build-inline.js`）。
- **可逆性**：均为新增（1 个 CI 步骤 + 1 行 hook 命令 + 1 段配置），回退即删除。

---

Generated with AI assistance
