### PR TITLE
feat(server): ai server 骨架与 daemon 进程框架（子任务 A）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 .agents/workspace/logs/
 .agents/workspace/.merge-backup/
 
+# agent-infra-server local secrets and runtime PID/logs
+.agents/server.local.json
+.agents/server.pid
+.agents/server.log.*
+
 # Claude Code local settings
 .claude/settings.local.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 .agents/workspace/logs/
 .agents/workspace/.merge-backup/
 
-# agent-infra-server local secrets and runtime PID/logs
+# agent-infra-server local secrets (in-repo).
+# Runtime state (PID, logs) defaults to ~/.agent-infra/; the .log.* rule only
+# matters if log.path is overridden back into the repo.
 .agents/server.local.json
-.agents/server.pid
 .agents/server.log.*
 
 # Claude Code local settings

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,9 @@
 .agents/workspace/logs/
 .agents/workspace/.merge-backup/
 
-# agent-infra-server local secrets (in-repo).
-# Runtime state (PID, logs) defaults to ~/.agent-infra/; the .log.* rule only
-# matters if log.path is overridden back into the repo.
+# agent-infra-server local secrets (in-repo). Runtime state (PID, logs) lives
+# under ~/.agent-infra/, outside the repo, so it needs no ignore rule here.
 .agents/server.local.json
-.agents/server.log.*
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -20,6 +20,7 @@ Commands:
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
   sandbox, s      Manage Docker-based AI sandboxes
+  server          Run the local AI collaboration daemon (start/stop/status/logs)
   task, t         Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)
   update          Update seed files and sync file registry for an existing project
   version         Show version
@@ -103,6 +104,16 @@ switch (command) {
     if (!imported) break;
     const { runSandbox } = imported;
     await runSandbox(process.argv.slice(3)).catch((e: unknown) => {
+      process.stderr.write(`Error: ${errorMessage(e)}\n`);
+      process.exit(1);
+    });
+    break;
+  }
+  case 'server': {
+    const imported = await importCommand('../lib/server/index.ts');
+    if (!imported) break;
+    const { runServer } = imported;
+    await runServer(process.argv.slice(3)).catch((e: unknown) => {
       process.stderr.write(`Error: ${errorMessage(e)}\n`);
       process.exit(1);
     });

--- a/lib/server/adapters/_contract.ts
+++ b/lib/server/adapters/_contract.ts
@@ -1,0 +1,42 @@
+import type { ServerConfig } from '../config.ts';
+import type { Logger } from '../logger.ts';
+
+// Adapter contract for agent-infra-server.
+//
+// This is a pure type + constant module: it carries no runtime logic and no
+// third-party imports. Subtask B (the feishu adapter) and subtask C (the
+// command protocol / runner) build against these shapes. Bump
+// ADAPTER_CONTRACT_VERSION on a breaking change so plugin-loader can reject
+// adapters compiled against an older contract.
+export const ADAPTER_CONTRACT_VERSION = 1;
+
+// A normalized inbound message handed to the daemon command dispatcher.
+export type InboundMessage = {
+  adapter: string;
+  userId: string;
+  chatId: string;
+  text: string;
+  messageId: string;
+  raw: unknown;
+  reply: (text: string) => Promise<void>;
+};
+
+// Runtime context passed to every adapter's start(). dispatch() is registered
+// by the daemon; signal aborts when the daemon shuts down.
+export type AdapterCtx = {
+  config: ServerConfig;
+  logger: Logger;
+  dispatch: (message: InboundMessage) => Promise<void>;
+  signal: AbortSignal;
+};
+
+// The interface every adapter factory's default export must produce.
+export type Adapter = {
+  name: string;
+  start: (ctx: AdapterCtx) => Promise<void>;
+  stop: () => Promise<void>;
+  sendMessage: (target: { chatId: string }, text: string) => Promise<void>;
+};
+
+// The shape of an adapter module's default export (a factory).
+export type AdapterFactory = (adapterConfig: Record<string, unknown>) => Adapter;

--- a/lib/server/config.ts
+++ b/lib/server/config.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+export type ServerLogConfig = {
+  path: string;
+  rotateAtBytes: number;
+};
+
+export type ServerAdapterConfig = {
+  enabled: boolean;
+  [key: string]: unknown;
+};
+
+export type ServerConfig = {
+  repoRoot: string;
+  log: ServerLogConfig;
+  heartbeatMs: number;
+  adapters: Record<string, ServerAdapterConfig>;
+  // command / auth are reserved for subtasks B/C; subtask A passes them
+  // through untouched without consuming them.
+  command?: Record<string, unknown>;
+  auth?: Record<string, unknown>;
+};
+
+export type ServerValidation =
+  | { ok: true }
+  | { ok: false; error: string; fields: string[] };
+
+const ENV_PREFIX = 'AGENT_INFRA_SERVER_';
+
+// Keys whose presence in the *committed* server.json is treated as a leaked
+// secret. Secrets belong in .agents/server.local.json or the environment.
+const SECRET_KEY_PATTERN = /secret|token|password|passwd|credential|apikey|api_key/i;
+
+const DEFAULT_LOG: ServerLogConfig = {
+  path: '.agents/server.log',
+  rotateAtBytes: 52_428_800 // 50 MiB
+};
+
+export const DEFAULT_SERVER_CONFIG: {
+  log: ServerLogConfig;
+  heartbeatMs: number;
+  adapters: Record<string, ServerAdapterConfig>;
+} = {
+  log: { ...DEFAULT_LOG },
+  heartbeatMs: 30_000,
+  adapters: {}
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function detectRepoRoot(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    throw new Error('server: current directory is not inside a git repository');
+  }
+}
+
+// Plain-object deep merge: objects recurse, everything else (arrays, scalars)
+// replaces. Intentionally small — server config is shallow and this avoids
+// coupling to lib/merge.ts, whose semantics target the task workspace.
+function deepMerge<T extends Record<string, unknown>>(base: T, override: Record<string, unknown>): T {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const current = result[key];
+    if (isPlainObject(current) && isPlainObject(value)) {
+      result[key] = deepMerge(current, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+function readJsonIfPresent(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  const parsed: unknown = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (!isPlainObject(parsed)) {
+    throw new Error(`server: ${path.basename(filePath)} must contain a JSON object`);
+  }
+  return parsed;
+}
+
+function coerceEnvValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw !== '' && !Number.isNaN(Number(raw))) return Number(raw);
+  return raw;
+}
+
+// Map AGENT_INFRA_SERVER_<path> env vars into a nested override object. The
+// path after the prefix uses `__` to separate nesting levels and is treated
+// case-sensitively (e.g. AGENT_INFRA_SERVER_adapters__dev__enabled=false ->
+// { adapters: { dev: { enabled: false } } }).
+function envOverrides(env: NodeJS.ProcessEnv): Record<string, unknown> {
+  const override: Record<string, unknown> = {};
+  for (const [key, rawValue] of Object.entries(env)) {
+    if (!key.startsWith(ENV_PREFIX) || rawValue === undefined) continue;
+    const segments = key.slice(ENV_PREFIX.length).split('__').filter(Boolean);
+    if (segments.length === 0) continue;
+    let cursor = override;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const segment = segments[i] as string;
+      const next = cursor[segment];
+      if (!isPlainObject(next)) {
+        cursor[segment] = {};
+      }
+      cursor = cursor[segment] as Record<string, unknown>;
+    }
+    cursor[segments[segments.length - 1] as string] = coerceEnvValue(rawValue);
+  }
+  return override;
+}
+
+// Collect dotted paths of secret-looking, non-empty string fields.
+function collectSecretFields(value: unknown, trail: string[] = []): string[] {
+  if (!isPlainObject(value)) return [];
+  const found: string[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    const here = [...trail, key];
+    if (SECRET_KEY_PATTERN.test(key) && typeof child === 'string' && child.trim() !== '') {
+      found.push(here.join('.'));
+    } else if (isPlainObject(child)) {
+      found.push(...collectSecretFields(child, here));
+    }
+  }
+  return found;
+}
+
+// Reject secrets that live in the committed server.json. server.local.json and
+// the environment are the sanctioned places for secrets and are not scanned.
+export function validateServerConfig(committed: Record<string, unknown>): ServerValidation {
+  const fields = collectSecretFields(committed);
+  if (fields.length > 0) {
+    return {
+      ok: false,
+      fields,
+      error:
+        `server: refusing to start — secret-like field(s) found in committed .agents/server.json: ${fields.join(', ')}. ` +
+        'Move them to .agents/server.local.json or AGENT_INFRA_SERVER_* environment variables.'
+    };
+  }
+  return { ok: true };
+}
+
+export function loadServerConfig({ rootDir }: { rootDir?: string } = {}): ServerConfig {
+  const repoRoot = rootDir ?? detectRepoRoot();
+  const agentsDir = path.join(repoRoot, '.agents');
+
+  const committed = readJsonIfPresent(path.join(agentsDir, 'server.json'));
+  const validation = validateServerConfig(committed);
+  if (!validation.ok) {
+    throw new Error(validation.error);
+  }
+  const local = readJsonIfPresent(path.join(agentsDir, 'server.local.json'));
+
+  let merged: Record<string, unknown> = deepMerge<Record<string, unknown>>(
+    { log: { ...DEFAULT_LOG }, heartbeatMs: DEFAULT_SERVER_CONFIG.heartbeatMs, adapters: {} },
+    committed
+  );
+  merged = deepMerge(merged, local);
+  merged = deepMerge(merged, envOverrides(process.env));
+
+  const log = isPlainObject(merged.log) ? merged.log : {};
+  const logPath = typeof log.path === 'string' ? log.path : DEFAULT_LOG.path;
+
+  return {
+    repoRoot,
+    log: {
+      path: path.isAbsolute(logPath) ? logPath : path.join(repoRoot, logPath),
+      rotateAtBytes: typeof log.rotateAtBytes === 'number' ? log.rotateAtBytes : DEFAULT_LOG.rotateAtBytes
+    },
+    heartbeatMs: typeof merged.heartbeatMs === 'number' ? merged.heartbeatMs : DEFAULT_SERVER_CONFIG.heartbeatMs,
+    adapters: isPlainObject(merged.adapters) ? (merged.adapters as Record<string, ServerAdapterConfig>) : {},
+    command: isPlainObject(merged.command) ? merged.command : undefined,
+    auth: isPlainObject(merged.auth) ? merged.auth : undefined
+  };
+}

--- a/lib/server/config.ts
+++ b/lib/server/config.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 
 export type ServerLogConfig = {
@@ -15,6 +17,8 @@ export type ServerAdapterConfig = {
 export type ServerConfig = {
   repoRoot: string;
   log: ServerLogConfig;
+  // Absolute path to the PID file, under ~/.agent-infra/run/<project>/server.pid.
+  pidFile: string;
   heartbeatMs: number;
   adapters: Record<string, ServerAdapterConfig>;
   // command / auth are reserved for subtasks B/C; subtask A passes them
@@ -33,23 +37,54 @@ const ENV_PREFIX = 'AGENT_INFRA_SERVER_';
 // secret. Secrets belong in .agents/server.local.json or the environment.
 const SECRET_KEY_PATTERN = /secret|token|password|passwd|credential|apikey|api_key/i;
 
-const DEFAULT_LOG: ServerLogConfig = {
-  path: '.agents/server.log',
-  rotateAtBytes: 52_428_800 // 50 MiB
-};
+const DEFAULT_ROTATE_BYTES = 52_428_800; // 50 MiB
 
 export const DEFAULT_SERVER_CONFIG: {
-  log: ServerLogConfig;
+  log: { rotateAtBytes: number };
   heartbeatMs: number;
   adapters: Record<string, ServerAdapterConfig>;
 } = {
-  log: { ...DEFAULT_LOG },
+  log: { rotateAtBytes: DEFAULT_ROTATE_BYTES },
   heartbeatMs: 30_000,
   adapters: {}
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Daemon runtime state (log + PID) lives OUTSIDE the repo, under the user's home
+// directory, keyed by the .airc.json "project" AND a stable hash of the repo
+// root path:
+//   ~/.agent-infra/logs/<project>/<repo-hash>/server.log
+//   ~/.agent-infra/run/<project>/<repo-hash>/server.pid
+// The <project> segment groups a project's checkouts for readability; the
+// <repo-hash> segment guarantees that two checkouts/worktrees of the same
+// project (same "project" but different absolute path) get ISOLATED runtime
+// dirs, so they never read/control each other's daemon. Using os.homedir() +
+// path.join keeps this correct on Windows too (C:\Users\<name>\.agent-infra\...).
+// An explicit log.path in server.json/.local/env still overrides the log default.
+function resolveProjectKey(repoRoot: string): string {
+  try {
+    const airc = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8')
+    ) as { project?: unknown };
+    if (typeof airc.project === 'string' && airc.project.trim() !== '') {
+      return airc.project.trim();
+    }
+  } catch {
+    // No .airc.json / unreadable → fall back to the repo directory name.
+  }
+  return path.basename(repoRoot);
+}
+
+// Short, stable, filesystem-safe discriminator for a checkout's absolute path.
+function repoKey(repoRoot: string): string {
+  return createHash('sha256').update(repoRoot).digest('hex').slice(0, 12);
+}
+
+function runtimePath(repoRoot: string, projectKey: string, kind: 'logs' | 'run', file: string): string {
+  return path.join(homedir(), '.agent-infra', kind, projectKey, repoKey(repoRoot), file);
 }
 
 function detectRepoRoot(): string {
@@ -162,20 +197,28 @@ export function loadServerConfig({ rootDir }: { rootDir?: string } = {}): Server
   const local = readJsonIfPresent(path.join(agentsDir, 'server.local.json'));
 
   let merged: Record<string, unknown> = deepMerge<Record<string, unknown>>(
-    { log: { ...DEFAULT_LOG }, heartbeatMs: DEFAULT_SERVER_CONFIG.heartbeatMs, adapters: {} },
+    { log: { rotateAtBytes: DEFAULT_ROTATE_BYTES }, heartbeatMs: DEFAULT_SERVER_CONFIG.heartbeatMs, adapters: {} },
     committed
   );
   merged = deepMerge(merged, local);
   merged = deepMerge(merged, envOverrides(process.env));
 
+  const projectKey = resolveProjectKey(repoRoot);
+
   const log = isPlainObject(merged.log) ? merged.log : {};
-  const logPath = typeof log.path === 'string' ? log.path : DEFAULT_LOG.path;
+  // No explicit log.path → default under ~/.agent-infra/logs/<project>/.
+  // Explicit relative path resolves against the repo root; absolute is used as-is.
+  const explicitPath = typeof log.path === 'string' ? log.path : null;
+  const resolvedLogPath = explicitPath === null
+    ? runtimePath(repoRoot, projectKey, 'logs', 'server.log')
+    : (path.isAbsolute(explicitPath) ? explicitPath : path.join(repoRoot, explicitPath));
 
   return {
     repoRoot,
+    pidFile: runtimePath(repoRoot, projectKey, 'run', 'server.pid'),
     log: {
-      path: path.isAbsolute(logPath) ? logPath : path.join(repoRoot, logPath),
-      rotateAtBytes: typeof log.rotateAtBytes === 'number' ? log.rotateAtBytes : DEFAULT_LOG.rotateAtBytes
+      path: resolvedLogPath,
+      rotateAtBytes: typeof log.rotateAtBytes === 'number' ? log.rotateAtBytes : DEFAULT_ROTATE_BYTES
     },
     heartbeatMs: typeof merged.heartbeatMs === 'number' ? merged.heartbeatMs : DEFAULT_SERVER_CONFIG.heartbeatMs,
     adapters: isPlainObject(merged.adapters) ? (merged.adapters as Record<string, ServerAdapterConfig>) : {},

--- a/lib/server/daemon.ts
+++ b/lib/server/daemon.ts
@@ -1,0 +1,74 @@
+import { VERSION } from '../version.ts';
+import { loadServerConfig } from './config.ts';
+import { createLogger } from './logger.ts';
+import { loadAdapters, unloadAdapters } from './plugin-loader.ts';
+import type { InboundMessage } from './adapters/_contract.ts';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// The daemon main loop. Runs in the detached child spawned by
+// process-control.start(), or in the foreground for debugging.
+//
+// Lifecycle (keep-alive / shutdown model):
+//   - The heartbeat interval is kept *ref'd*. It is both the keep-alive that
+//     holds the event loop open while subtask A has no adapters, and the
+//     observable signal that `ai server logs -f` shows.
+//   - runDaemon() awaits a shutdown promise that only resolves once a
+//     SIGINT/SIGTERM handler has finished graceful cleanup. We never unref()
+//     the only keep-alive timer (that would let the process exit immediately).
+export async function runDaemon(): Promise<void> {
+  let config;
+  try {
+    config = loadServerConfig();
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exit(1);
+  }
+
+  const logger = createLogger(config.log);
+  logger.info(`daemon starting agent-infra ${VERSION} pid=${process.pid}`);
+
+  const abortController = new AbortController();
+  let resolveShutdown: () => void = () => {};
+  const shutdown = new Promise<void>((resolve) => {
+    resolveShutdown = resolve;
+  });
+
+  // Minimal built-in dispatch: only `/ping` is recognized in subtask A. The
+  // full command protocol / auth lands in subtask C.
+  const dispatch = async (message: InboundMessage): Promise<void> => {
+    const text = message.text.trim();
+    if (text === '/ping') {
+      await message.reply(`pong ${VERSION}`);
+      return;
+    }
+    logger.info(`unknown command from ${message.adapter}:${message.userId}: ${text}`);
+  };
+
+  const ctx = { config, logger, dispatch, signal: abortController.signal };
+  const adapters = await loadAdapters(config, ctx);
+  logger.ok(`loaded ${adapters.length} adapter(s)`);
+
+  const heartbeat = setInterval(() => logger.info('heartbeat'), config.heartbeatMs);
+
+  let shuttingDown = false;
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info(`received ${signal}, shutting down`);
+    abortController.abort();
+    void (async () => {
+      await unloadAdapters(adapters);
+      clearInterval(heartbeat);
+      logger.close();
+      resolveShutdown();
+    })();
+  };
+  process.on('SIGINT', () => handleSignal('SIGINT'));
+  process.on('SIGTERM', () => handleSignal('SIGTERM'));
+
+  await shutdown;
+  process.exit(0);
+}

--- a/lib/server/index.ts
+++ b/lib/server/index.ts
@@ -1,0 +1,51 @@
+import { runDaemon } from './daemon.ts';
+import { start, stop, status, logs } from './process-control.ts';
+
+const USAGE = `Usage: ai server <command> [options]
+
+Commands:
+  start [--foreground]   Start the local daemon (detached; --foreground stays attached for debugging)
+  stop                   Stop the running daemon
+  status                 Show whether the daemon is running
+  logs [-f | --follow]   Print the daemon log ('-f' to follow new lines)
+  help                   Show this help message
+
+The daemon hosts IM adapters and command routing for agent-infra. Subtask A
+ships the process skeleton only: no adapters and no command protocol yet.`;
+
+export async function runServer(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+
+  if (!subcommand) {
+    process.stdout.write(`${USAGE}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  switch (subcommand) {
+    case 'start':
+      await start({ foreground: rest.includes('--foreground') });
+      break;
+    case 'stop':
+      await stop();
+      break;
+    case 'status':
+      status();
+      break;
+    case 'logs':
+      await logs({ follow: rest.includes('-f') || rest.includes('--follow') });
+      break;
+    // Internal entry point for the detached daemon child (not shown in USAGE).
+    case '__daemon':
+      await runDaemon();
+      break;
+    default:
+      process.stderr.write(`Unknown server command: ${subcommand}\n`);
+      process.stdout.write(`${USAGE}\n`);
+      process.exitCode = 1;
+  }
+}

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type LoggerOptions = {
+  path: string;
+  rotateAtBytes: number;
+};
+
+export type Logger = {
+  info: (message: string) => void;
+  ok: (message: string) => void;
+  err: (message: string) => void;
+  close: () => void;
+};
+
+// Startup-only rotation: if the existing log already exceeds the threshold,
+// move it aside to `<path>.1` before the daemon starts appending. We do not
+// rotate again while running — keeping a single append stream is simpler and
+// good enough for a local daemon log.
+function rotateIfOversized(logPath: string, rotateAtBytes: number): void {
+  try {
+    const { size } = fs.statSync(logPath);
+    if (size > rotateAtBytes) {
+      fs.renameSync(logPath, `${logPath}.1`);
+    }
+  } catch {
+    // No existing log file (or stat failed) → nothing to rotate.
+  }
+}
+
+export function createLogger({ path: logPath, rotateAtBytes }: LoggerOptions): Logger {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  rotateIfOversized(logPath, rotateAtBytes);
+
+  const write = (level: string, message: string): void => {
+    const line = `[${new Date().toISOString()}] [${level}] ${message}\n`;
+    fs.appendFileSync(logPath, line);
+  };
+
+  return {
+    info: (message) => write('INFO', message),
+    ok: (message) => write('OK', message),
+    err: (message) => write('ERROR', message),
+    // Synchronous appendFileSync keeps no open handle to flush; close() exists
+    // so the daemon shutdown path has a single, stable hook to call.
+    close: () => {}
+  };
+}

--- a/lib/server/plugin-loader.ts
+++ b/lib/server/plugin-loader.ts
@@ -1,0 +1,72 @@
+import type { ServerConfig } from './config.ts';
+import type { Adapter, AdapterCtx } from './adapters/_contract.ts';
+
+export type ImportAdapter = (name: string) => Promise<unknown>;
+
+export type LoadAdaptersOptions = {
+  // Test seam: override how an adapter module is resolved so enabled-adapter
+  // loading can be exercised without writing a fake adapter into the source
+  // tree. Production resolves `./adapters/<name>/index.ts`.
+  importAdapter?: ImportAdapter;
+};
+
+const defaultImportAdapter: ImportAdapter = (name) => import(`./adapters/${name}/index.ts`);
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAdapter(value: unknown): value is Adapter {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.name === 'string' &&
+    typeof candidate.start === 'function' &&
+    typeof candidate.stop === 'function' &&
+    typeof candidate.sendMessage === 'function'
+  );
+}
+
+// Load every adapter whose config has `enabled === true`. Each adapter is
+// loaded, instantiated and started in isolation: a failure in one adapter is
+// logged and skipped so it never blocks the others.
+export async function loadAdapters(
+  config: ServerConfig,
+  ctx: AdapterCtx,
+  options: LoadAdaptersOptions = {}
+): Promise<Adapter[]> {
+  const importAdapter = options.importAdapter ?? defaultImportAdapter;
+  const loaded: Adapter[] = [];
+
+  for (const [name, adapterConfig] of Object.entries(config.adapters)) {
+    if (adapterConfig?.enabled !== true) continue;
+    try {
+      const mod = (await importAdapter(name)) as { default?: unknown };
+      const factory = mod?.default;
+      if (typeof factory !== 'function') {
+        throw new Error(`adapter "${name}" has no default export factory`);
+      }
+      const instance: unknown = factory(adapterConfig);
+      if (!isAdapter(instance)) {
+        throw new Error(`adapter "${name}" does not satisfy the Adapter contract`);
+      }
+      await instance.start(ctx);
+      loaded.push(instance);
+    } catch (error) {
+      ctx.logger.err(`failed to load adapter "${name}": ${errorMessage(error)}`);
+    }
+  }
+
+  return loaded;
+}
+
+// Stop adapters in reverse load order, isolating per-adapter stop failures.
+export async function unloadAdapters(adapters: Adapter[]): Promise<void> {
+  for (const adapter of [...adapters].reverse()) {
+    try {
+      await adapter.stop();
+    } catch {
+      // A failing stop must not block the rest of shutdown.
+    }
+  }
+}

--- a/lib/server/process-control.ts
+++ b/lib/server/process-control.ts
@@ -1,0 +1,227 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn, execFileSync } from 'node:child_process';
+import { loadServerConfig } from './config.ts';
+import type { ServerConfig } from './config.ts';
+import { runDaemon } from './daemon.ts';
+
+export type StartOptions = { foreground?: boolean };
+export type LogsOptions = { follow?: boolean };
+
+// How to terminate the daemon on a given platform. Pure + exported so the
+// win32 branch can be asserted without running on Windows.
+export type StopCommand =
+  | { kind: 'signal'; signal: NodeJS.Signals }
+  | { kind: 'exec'; command: string; args: string[] };
+
+export function buildStopCommand(pid: number, platform: NodeJS.Platform): StopCommand {
+  if (platform === 'win32') {
+    return { kind: 'exec', command: 'taskkill', args: ['/PID', String(pid), '/T', '/F'] };
+  }
+  return { kind: 'signal', signal: 'SIGTERM' };
+}
+
+function pidFilePath(repoRoot: string): string {
+  return path.join(repoRoot, '.agents', 'server.pid');
+}
+
+// Liveness check that treats an exited-but-unreaped daemon as dead.
+//
+// The daemon is spawned detached and re-parented to init when `ai server start`
+// exits. After it terminates, `process.kill(pid, 0)` still succeeds until init
+// reaps the zombie. On Linux we therefore also check /proc state so status/stop
+// /start don't treat an already-exited daemon as running. macOS reaps orphans
+// via launchd and Windows has no zombies, so the kill(pid, 0) result is enough.
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    // EPERM means the process exists but we may not signal it → still alive.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+  if (process.platform === 'linux') {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      // The process state is the first token after the parenthesised comm.
+      const state = stat.slice(stat.lastIndexOf(')') + 1).trim().charAt(0);
+      if (state === 'Z') return false;
+    } catch {
+      return false; // /proc entry vanished → not alive
+    }
+  }
+  return true;
+}
+
+function readPid(repoRoot: string): number | null {
+  try {
+    const raw = fs.readFileSync(pidFilePath(repoRoot), 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function removePidFile(repoRoot: string): void {
+  try {
+    fs.unlinkSync(pidFilePath(repoRoot));
+  } catch {
+    // Already gone.
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function enabledAdapterNames(config: ServerConfig): string[] {
+  return Object.entries(config.adapters)
+    .filter(([, adapter]) => adapter?.enabled === true)
+    .map(([name]) => name);
+}
+
+export async function start({ foreground = false }: StartOptions = {}): Promise<void> {
+  const config = loadServerConfig();
+  const pidPath = pidFilePath(config.repoRoot);
+
+  // Zombie PID cleanup: a stale PID file from a crashed daemon must not block a
+  // fresh start.
+  const existing = readPid(config.repoRoot);
+  if (existing !== null && isProcessAlive(existing)) {
+    process.stdout.write(`server already running (pid ${existing})\n`);
+    return;
+  }
+  if (existing !== null) {
+    removePidFile(config.repoRoot);
+  }
+
+  if (foreground) {
+    await runDaemon();
+    return;
+  }
+
+  const cliEntry = process.argv[1];
+  if (!cliEntry) {
+    throw new Error('server: unable to determine CLI entry point for daemon spawn');
+  }
+
+  // Re-spawn ourselves detached. process.execArgv is forwarded so the dev path
+  // (node --experimental-strip-types ./bin/cli.ts) and the built path
+  // (node dist/bin/cli.js) both work.
+  const child = spawn(process.execPath, [...process.execArgv, cliEntry, 'server', '__daemon'], {
+    detached: true,
+    stdio: 'ignore'
+  });
+  child.unref();
+
+  if (typeof child.pid !== 'number') {
+    throw new Error('server: failed to spawn daemon process');
+  }
+  fs.mkdirSync(path.dirname(pidPath), { recursive: true });
+  fs.writeFileSync(pidPath, `${child.pid}\n`);
+  process.stdout.write(`server started (pid ${child.pid})\n`);
+}
+
+export async function stop(): Promise<void> {
+  const config = loadServerConfig();
+  const pid = readPid(config.repoRoot);
+
+  if (pid === null) {
+    process.stdout.write('server is not running (no pid file)\n');
+    return;
+  }
+  if (!isProcessAlive(pid)) {
+    removePidFile(config.repoRoot);
+    process.stdout.write('server is not running (removed stale pid file)\n');
+    return;
+  }
+
+  const command = buildStopCommand(pid, process.platform);
+  if (command.kind === 'exec') {
+    execFileSync(command.command, command.args);
+  } else {
+    process.kill(pid, command.signal);
+    const deadline = Date.now() + 5000;
+    while (isProcessAlive(pid) && Date.now() < deadline) {
+      await delay(100);
+    }
+    if (isProcessAlive(pid)) {
+      process.kill(pid, 'SIGKILL');
+    }
+  }
+
+  removePidFile(config.repoRoot);
+  process.stdout.write(`server stopped (pid ${pid})\n`);
+}
+
+export function status(): void {
+  const config = loadServerConfig();
+  const pid = readPid(config.repoRoot);
+
+  if (pid === null || !isProcessAlive(pid)) {
+    process.stdout.write('server: stopped\n');
+    if (pid !== null) {
+      process.stdout.write(`  (stale pid file references pid ${pid})\n`);
+    }
+    return;
+  }
+
+  let startedAt = 'unknown';
+  try {
+    startedAt = fs.statSync(pidFilePath(config.repoRoot)).mtime.toISOString();
+  } catch {
+    // Leave as unknown.
+  }
+  const adapters = enabledAdapterNames(config);
+  process.stdout.write(
+    `server: running\n` +
+      `  pid: ${pid}\n` +
+      `  started: ${startedAt}\n` +
+      `  adapters: ${adapters.length > 0 ? adapters.join(', ') : '(none)'}\n` +
+      `  log: ${config.log.path}\n`
+  );
+}
+
+export async function logs({ follow = false }: LogsOptions = {}): Promise<void> {
+  const config = loadServerConfig();
+  const logPath = config.log.path;
+
+  if (!fs.existsSync(logPath)) {
+    process.stdout.write('server: no log file yet\n');
+    return;
+  }
+
+  const initial = fs.readFileSync(logPath, 'utf8');
+  process.stdout.write(initial);
+  if (!follow) return;
+
+  let position = Buffer.byteLength(initial);
+  const watcher = fs.watch(logPath, () => {
+    try {
+      const { size } = fs.statSync(logPath);
+      if (size < position) position = 0; // truncated or rotated
+      if (size > position) {
+        const fd = fs.openSync(logPath, 'r');
+        try {
+          const buffer = Buffer.alloc(size - position);
+          fs.readSync(fd, buffer, 0, buffer.length, position);
+          process.stdout.write(buffer.toString('utf8'));
+        } finally {
+          fs.closeSync(fd);
+        }
+        position = size;
+      }
+    } catch {
+      // Transient read error during rotation; ignore and wait for next event.
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    process.on('SIGINT', () => {
+      watcher.close();
+      resolve();
+    });
+  });
+}

--- a/lib/server/process-control.ts
+++ b/lib/server/process-control.ts
@@ -21,9 +21,6 @@ export function buildStopCommand(pid: number, platform: NodeJS.Platform): StopCo
   return { kind: 'signal', signal: 'SIGTERM' };
 }
 
-function pidFilePath(repoRoot: string): string {
-  return path.join(repoRoot, '.agents', 'server.pid');
-}
 
 // Liveness check that treats an exited-but-unreaped daemon as dead.
 //
@@ -52,9 +49,9 @@ export function isProcessAlive(pid: number): boolean {
   return true;
 }
 
-function readPid(repoRoot: string): number | null {
+function readPid(pidFile: string): number | null {
   try {
-    const raw = fs.readFileSync(pidFilePath(repoRoot), 'utf8').trim();
+    const raw = fs.readFileSync(pidFile, 'utf8').trim();
     const pid = Number.parseInt(raw, 10);
     return Number.isInteger(pid) && pid > 0 ? pid : null;
   } catch {
@@ -62,9 +59,9 @@ function readPid(repoRoot: string): number | null {
   }
 }
 
-function removePidFile(repoRoot: string): void {
+function removePidFile(pidFile: string): void {
   try {
-    fs.unlinkSync(pidFilePath(repoRoot));
+    fs.unlinkSync(pidFile);
   } catch {
     // Already gone.
   }
@@ -84,17 +81,17 @@ function enabledAdapterNames(config: ServerConfig): string[] {
 
 export async function start({ foreground = false }: StartOptions = {}): Promise<void> {
   const config = loadServerConfig();
-  const pidPath = pidFilePath(config.repoRoot);
+  const pidPath = config.pidFile;
 
   // Zombie PID cleanup: a stale PID file from a crashed daemon must not block a
   // fresh start.
-  const existing = readPid(config.repoRoot);
+  const existing = readPid(pidPath);
   if (existing !== null && isProcessAlive(existing)) {
     process.stdout.write(`server already running (pid ${existing})\n`);
     return;
   }
   if (existing !== null) {
-    removePidFile(config.repoRoot);
+    removePidFile(pidPath);
   }
 
   if (foreground) {
@@ -126,14 +123,14 @@ export async function start({ foreground = false }: StartOptions = {}): Promise<
 
 export async function stop(): Promise<void> {
   const config = loadServerConfig();
-  const pid = readPid(config.repoRoot);
+  const pid = readPid(config.pidFile);
 
   if (pid === null) {
     process.stdout.write('server is not running (no pid file)\n');
     return;
   }
   if (!isProcessAlive(pid)) {
-    removePidFile(config.repoRoot);
+    removePidFile(config.pidFile);
     process.stdout.write('server is not running (removed stale pid file)\n');
     return;
   }
@@ -152,13 +149,13 @@ export async function stop(): Promise<void> {
     }
   }
 
-  removePidFile(config.repoRoot);
+  removePidFile(config.pidFile);
   process.stdout.write(`server stopped (pid ${pid})\n`);
 }
 
 export function status(): void {
   const config = loadServerConfig();
-  const pid = readPid(config.repoRoot);
+  const pid = readPid(config.pidFile);
 
   if (pid === null || !isProcessAlive(pid)) {
     process.stdout.write('server: stopped\n');
@@ -170,7 +167,7 @@ export function status(): void {
 
   let startedAt = 'unknown';
   try {
-    startedAt = fs.statSync(pidFilePath(config.repoRoot)).mtime.toISOString();
+    startedAt = fs.statSync(config.pidFile).mtime.toISOString();
   } catch {
     // Leave as unknown.
   }
@@ -180,6 +177,7 @@ export function status(): void {
       `  pid: ${pid}\n` +
       `  started: ${startedAt}\n` +
       `  adapters: ${adapters.length > 0 ? adapters.join(', ') : '(none)'}\n` +
+      `  pid file: ${config.pidFile}\n` +
       `  log: ${config.log.path}\n`
   );
 }

--- a/lib/server/server.schema.json
+++ b/lib/server/server.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/fitlab-ai/agent-infra/lib/server/server.schema.json",
+  "title": "agent-infra server configuration",
+  "description": "Schema for .agents/server.json. Secrets (appSecret, tokens, passwords) must NOT be committed here — put them in .agents/server.local.json or AGENT_INFRA_SERVER_* environment variables.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "log": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Log file path. Relative paths resolve against the repo root.",
+          "default": ".agents/server.log"
+        },
+        "rotateAtBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rotate the log to <path>.1 at startup if it already exceeds this size.",
+          "default": 52428800
+        }
+      }
+    },
+    "heartbeatMs": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Interval between daemon heartbeat log lines, in milliseconds.",
+      "default": 30000
+    },
+    "adapters": {
+      "type": "object",
+      "description": "Per-adapter configuration. Only adapters with enabled=true are loaded.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": ["enabled"]
+      }
+    },
+    "command": {
+      "type": "object",
+      "description": "Reserved for the command protocol (subtask C).",
+      "additionalProperties": true
+    },
+    "auth": {
+      "type": "object",
+      "description": "Reserved for the auth model (subtask C).",
+      "additionalProperties": true
+    }
+  }
+}

--- a/lib/server/server.schema.json
+++ b/lib/server/server.schema.json
@@ -15,8 +15,7 @@
       "properties": {
         "path": {
           "type": "string",
-          "description": "Log file path. Relative paths resolve against the repo root.",
-          "default": ".agents/server.log"
+          "description": "Log file path. Defaults to ~/.agent-infra/logs/<project>/<repo-hash>/server.log (outside the repo; the repo-hash isolates checkouts that share a project). Relative paths resolve against the repo root; absolute paths are used as-is."
         },
         "rotateAtBytes": {
           "type": "integer",

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -81,6 +81,19 @@ test("cli usage lists top-level command aliases (help and bare)", () => {
   }
 });
 
+test("cli server help prints server usage and exits 0", () => {
+  const result = spawnSync(process.execPath, cliArgs("server", "help"), {
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^Usage: ai server <command>/m);
+  assert.match(result.stdout, /^\s+start\b/m);
+  assert.match(result.stdout, /^\s+stop\b/m);
+  assert.match(result.stdout, /^\s+status\b/m);
+  assert.match(result.stdout, /^\s+logs\b/m);
+});
+
 test("cli usage keeps alias command descriptions aligned", () => {
   const output = execFileSync(process.execPath, cliArgs("help"), {
     encoding: "utf8"

--- a/tests/integration/cli/server-lifecycle.test.ts
+++ b/tests/integration/cli/server-lifecycle.test.ts
@@ -21,27 +21,68 @@ test('buildStopCommand uses taskkill on win32 and SIGTERM elsewhere', () => {
   assert.deepEqual(buildStopCommand(4321, 'darwin'), { kind: 'signal', signal: 'SIGTERM' });
 });
 
+const PROJECT = 'lifecycle';
+
 function makeRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-lifecycle-'));
   initIsolatedGitRepo(dir);
   fs.mkdirSync(path.join(dir, '.agents'), { recursive: true });
-  // Fast heartbeat so the test observes liveness quickly.
+  fs.writeFileSync(path.join(dir, '.agents', '.airc.json'), JSON.stringify({ project: PROJECT }));
+  // Fast heartbeat so the test observes liveness quickly. No log.path override:
+  // the test pins HOME to `dir` (see runServer), so the real default runtime
+  // paths (~/.agent-infra/{logs,run}/<project>/) resolve under the temp dir and
+  // stay hermetic.
   fs.writeFileSync(path.join(dir, '.agents', 'server.json'), JSON.stringify({ heartbeatMs: 100 }));
   return dir;
 }
 
+// The daemon resolves its runtime paths from os.homedir(); pinning HOME (and
+// USERPROFILE on Windows) to the temp dir keeps logs/PID out of the real home.
 function runServer(dir: string, ...args: string[]): { status: number | null; stdout: string; stderr: string } {
   const result = spawnSync(process.execPath, [CLI_PATH, 'server', ...args], {
     cwd: dir,
     encoding: 'utf8',
-    env: gitSafeEnv()
+    env: gitSafeEnv({ HOME: dir, USERPROFILE: dir })
   });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
+// The default runtime paths include an opaque per-repo-hash segment
+// (~/.agent-infra/<kind>/<project>/<repo-hash>/server.*), so locate the files by
+// searching under the pinned-HOME tree rather than reconstructing the hash.
+function findUnder(root: string, name: string): string | null {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    if (cur === undefined) break;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === name) return full;
+    }
+  }
+  return null;
+}
+
+function logPathOf(dir: string): string | null {
+  return findUnder(path.join(dir, '.agent-infra', 'logs', PROJECT), 'server.log');
+}
+
+function pidPathOf(dir: string): string | null {
+  return findUnder(path.join(dir, '.agent-infra', 'run', PROJECT), 'server.pid');
+}
+
 function readPid(dir: string): number | null {
+  const pidPath = pidPathOf(dir);
+  if (pidPath === null) return null;
   try {
-    const pid = Number.parseInt(fs.readFileSync(path.join(dir, '.agents', 'server.pid'), 'utf8').trim(), 10);
+    const pid = Number.parseInt(fs.readFileSync(pidPath, 'utf8').trim(), 10);
     return Number.isInteger(pid) ? pid : null;
   } catch {
     return null;
@@ -62,7 +103,6 @@ test(
   onPlatforms('linux', 'darwin'),
   async () => {
     const dir = makeRepo();
-    const logPath = path.join(dir, '.agents', 'server.log');
     let pid: number | null = null;
     try {
       const started = runServer(dir, 'start');
@@ -74,9 +114,10 @@ test(
       const livePid = pid;
 
       // PL-1: the daemon must stay alive and emit a heartbeat (not exit on start).
-      const beat = await waitFor(
-        () => fs.existsSync(logPath) && /\[INFO\] heartbeat/.test(fs.readFileSync(logPath, 'utf8'))
-      );
+      const beat = await waitFor(() => {
+        const logPath = logPathOf(dir);
+        return logPath !== null && /\[INFO\] heartbeat/.test(fs.readFileSync(logPath, 'utf8'));
+      });
       assert.ok(beat, 'a heartbeat line should appear in the log');
       assert.ok(isProcessAlive(livePid), 'daemon process should still be running before stop');
 
@@ -92,7 +133,7 @@ test(
       assert.equal(stopped.status, 0, stopped.stderr);
       const exited = await waitFor(() => !isProcessAlive(livePid));
       assert.ok(exited, 'daemon should exit after stop');
-      assert.equal(fs.existsSync(path.join(dir, '.agents', 'server.pid')), false, 'pid file removed on stop');
+      assert.equal(pidPathOf(dir), null, 'pid file removed on stop');
       pid = null;
     } finally {
       if (pid !== null && isProcessAlive(pid)) {
@@ -108,21 +149,25 @@ test(
 );
 
 test(
-  'server start clears a stale pid file left by a dead daemon',
+  'server start clears a stale pid file left by a crashed daemon',
   onPlatforms('linux', 'darwin'),
   async () => {
     const dir = makeRepo();
     let pid: number | null = null;
     try {
-      // A short-lived probe process gives a pid that is guaranteed dead.
-      const probe = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
-      const stalePid = probe.pid ?? 999_999;
-      fs.writeFileSync(path.join(dir, '.agents', 'server.pid'), `${stalePid}\n`);
+      // Start a daemon, then SIGKILL it WITHOUT `stop` so the pid file is left
+      // behind pointing at a now-dead process (a crash).
+      assert.equal(runServer(dir, 'start').status, 0);
+      const crashedPid = readPid(dir);
+      assert.ok(crashedPid !== null, 'first daemon should write a pid file');
+      process.kill(crashedPid, 'SIGKILL');
+      assert.ok(await waitFor(() => !isProcessAlive(crashedPid)), 'crashed daemon should be gone');
+      assert.ok(pidPathOf(dir) !== null, 'stale pid file should remain after a crash');
 
-      const started = runServer(dir, 'start');
-      assert.equal(started.status, 0, started.stderr);
+      // Starting again must detect the stale pid, clean it, and spawn a fresh daemon.
+      assert.equal(runServer(dir, 'start').status, 0);
       pid = readPid(dir);
-      assert.ok(pid !== null && pid !== stalePid, 'stale pid should be replaced by a fresh daemon pid');
+      assert.ok(pid !== null && pid !== crashedPid, 'stale pid should be replaced by a fresh daemon pid');
       assert.ok(await waitFor(() => isProcessAlive(pid as number)), 'fresh daemon should be alive');
     } finally {
       if (pid !== null && isProcessAlive(pid)) {

--- a/tests/integration/cli/server-lifecycle.test.ts
+++ b/tests/integration/cli/server-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { CLI_PATH, onPlatforms, gitSafeEnv, initIsolatedGitRepo, escapeRegExp } from '../../helpers.ts';
+import { buildStopCommand, isProcessAlive } from '../../../lib/server/process-control.ts';
+
+// buildStopCommand is pure, so both platform branches are asserted on every OS.
+// This is the win32 `taskkill` coverage that the platform-guarded lifecycle
+// tests below cannot provide on a Linux/macOS CI runner.
+test('buildStopCommand uses taskkill on win32 and SIGTERM elsewhere', () => {
+  assert.deepEqual(buildStopCommand(4321, 'win32'), {
+    kind: 'exec',
+    command: 'taskkill',
+    args: ['/PID', '4321', '/T', '/F']
+  });
+  assert.deepEqual(buildStopCommand(4321, 'linux'), { kind: 'signal', signal: 'SIGTERM' });
+  assert.deepEqual(buildStopCommand(4321, 'darwin'), { kind: 'signal', signal: 'SIGTERM' });
+});
+
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-lifecycle-'));
+  initIsolatedGitRepo(dir);
+  fs.mkdirSync(path.join(dir, '.agents'), { recursive: true });
+  // Fast heartbeat so the test observes liveness quickly.
+  fs.writeFileSync(path.join(dir, '.agents', 'server.json'), JSON.stringify({ heartbeatMs: 100 }));
+  return dir;
+}
+
+function runServer(dir: string, ...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [CLI_PATH, 'server', ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: gitSafeEnv()
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+function readPid(dir: string): number | null {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(path.join(dir, '.agents', 'server.pid'), 'utf8').trim(), 10);
+    return Number.isInteger(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
+
+test(
+  'server start stays alive and heartbeats, status reports running, stop shuts down cleanly',
+  onPlatforms('linux', 'darwin'),
+  async () => {
+    const dir = makeRepo();
+    const logPath = path.join(dir, '.agents', 'server.log');
+    let pid: number | null = null;
+    try {
+      const started = runServer(dir, 'start');
+      assert.equal(started.status, 0, started.stderr);
+      assert.match(started.stdout, /server started \(pid \d+\)/);
+
+      pid = readPid(dir);
+      assert.ok(pid !== null && pid > 0, 'pid file should contain a live pid');
+      const livePid = pid;
+
+      // PL-1: the daemon must stay alive and emit a heartbeat (not exit on start).
+      const beat = await waitFor(
+        () => fs.existsSync(logPath) && /\[INFO\] heartbeat/.test(fs.readFileSync(logPath, 'utf8'))
+      );
+      assert.ok(beat, 'a heartbeat line should appear in the log');
+      assert.ok(isProcessAlive(livePid), 'daemon process should still be running before stop');
+
+      const status = runServer(dir, 'status');
+      assert.match(status.stdout, /server: running/);
+      assert.match(status.stdout, new RegExp(`pid: ${escapeRegExp(String(livePid))}`));
+      assert.match(status.stdout, /adapters: \(none\)/);
+
+      const logs = runServer(dir, 'logs');
+      assert.match(logs.stdout, /\[INFO\] heartbeat/);
+
+      const stopped = runServer(dir, 'stop');
+      assert.equal(stopped.status, 0, stopped.stderr);
+      const exited = await waitFor(() => !isProcessAlive(livePid));
+      assert.ok(exited, 'daemon should exit after stop');
+      assert.equal(fs.existsSync(path.join(dir, '.agents', 'server.pid')), false, 'pid file removed on stop');
+      pid = null;
+    } finally {
+      if (pid !== null && isProcessAlive(pid)) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // best effort cleanup
+        }
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  'server start clears a stale pid file left by a dead daemon',
+  onPlatforms('linux', 'darwin'),
+  async () => {
+    const dir = makeRepo();
+    let pid: number | null = null;
+    try {
+      // A short-lived probe process gives a pid that is guaranteed dead.
+      const probe = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+      const stalePid = probe.pid ?? 999_999;
+      fs.writeFileSync(path.join(dir, '.agents', 'server.pid'), `${stalePid}\n`);
+
+      const started = runServer(dir, 'start');
+      assert.equal(started.status, 0, started.stderr);
+      pid = readPid(dir);
+      assert.ok(pid !== null && pid !== stalePid, 'stale pid should be replaced by a fresh daemon pid');
+      assert.ok(await waitFor(() => isProcessAlive(pid as number)), 'fresh daemon should be alive');
+    } finally {
+      if (pid !== null && isProcessAlive(pid)) {
+        runServer(dir, 'stop');
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+);

--- a/tests/unit/cli/server-adapter-contract.test.ts
+++ b/tests/unit/cli/server-adapter-contract.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ADAPTER_CONTRACT_VERSION } from '../../../lib/server/adapters/_contract.ts';
+
+// Structural tripwire: bumping the contract version is a deliberate, breaking
+// change for subtasks B/C, so it must be an intentional test update too.
+test('adapter contract exposes a stable integer version constant', () => {
+  assert.equal(typeof ADAPTER_CONTRACT_VERSION, 'number');
+  assert.equal(Number.isInteger(ADAPTER_CONTRACT_VERSION), true);
+  assert.equal(ADAPTER_CONTRACT_VERSION, 1);
+});

--- a/tests/unit/cli/server-config.test.ts
+++ b/tests/unit/cli/server-config.test.ts
@@ -30,21 +30,90 @@ test('loadServerConfig returns defaults when no server.json exists', () => {
     assert.equal(config.heartbeatMs, DEFAULT_SERVER_CONFIG.heartbeatMs);
     assert.equal(config.log.rotateAtBytes, DEFAULT_SERVER_CONFIG.log.rotateAtBytes);
     assert.deepEqual(config.adapters, {});
-    // default log path is resolved to an absolute path under the repo root
+    // default log + pid live OUTSIDE the repo, under
+    // ~/.agent-infra/{logs,run}/<project>/<repo-hash>/. No .airc.json here → the
+    // project key falls back to the repo directory name. The exact repo-hash
+    // segment is implementation detail, so assert structurally.
+    const logBase = path.join(os.homedir(), '.agent-infra', 'logs', path.basename(dir));
+    const runBase = path.join(os.homedir(), '.agent-infra', 'run', path.basename(dir));
+    assert.ok(config.log.path.startsWith(logBase + path.sep), config.log.path);
+    assert.ok(config.log.path.endsWith(`${path.sep}server.log`), config.log.path);
+    assert.ok(config.pidFile.startsWith(runBase + path.sep), config.pidFile);
+    assert.ok(config.pidFile.endsWith(`${path.sep}server.pid`), config.pidFile);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('server.json deep-merges rotateAtBytes while log.path keeps the home default', () => {
+  const dir = makeRepo({ log: { rotateAtBytes: 1024 }, adapters: { dev: { enabled: false } } });
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.log.rotateAtBytes, 1024);
+    // log.path not set in server.json → still defaults under the home dir (deep merge, not dropped)
+    const logBase = path.join(os.homedir(), '.agent-infra', 'logs', path.basename(dir));
+    assert.ok(config.log.path.startsWith(logBase + path.sep), config.log.path);
+    assert.ok(config.log.path.endsWith(`${path.sep}server.log`), config.log.path);
+    assert.deepEqual(config.adapters, { dev: { enabled: false } });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the default runtime directory is keyed by the .airc.json project', () => {
+  const dir = makeRepo();
+  fs.writeFileSync(path.join(dir, '.agents', '.airc.json'), JSON.stringify({ project: 'myproj' }));
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.ok(
+      config.log.path.startsWith(path.join(os.homedir(), '.agent-infra', 'logs', 'myproj') + path.sep),
+      config.log.path
+    );
+    assert.ok(
+      config.pidFile.startsWith(path.join(os.homedir(), '.agent-infra', 'run', 'myproj') + path.sep),
+      config.pidFile
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('two checkouts sharing a project get isolated runtime paths (repo-hash)', () => {
+  // CD-2: same .airc.json project, different repo roots → must NOT share PID/log.
+  const a = makeRepo();
+  const b = makeRepo();
+  fs.writeFileSync(path.join(a, '.agents', '.airc.json'), JSON.stringify({ project: 'shared' }));
+  fs.writeFileSync(path.join(b, '.agents', '.airc.json'), JSON.stringify({ project: 'shared' }));
+  try {
+    const ca = loadServerConfig({ rootDir: a });
+    const cb = loadServerConfig({ rootDir: b });
+    assert.notEqual(ca.pidFile, cb.pidFile, 'pid files must differ between checkouts');
+    assert.notEqual(ca.log.path, cb.log.path, 'log paths must differ between checkouts');
+    // both still grouped under the shared project directory
+    const sharedRun = path.join(os.homedir(), '.agent-infra', 'run', 'shared') + path.sep;
+    assert.ok(ca.pidFile.startsWith(sharedRun) && cb.pidFile.startsWith(sharedRun));
+  } finally {
+    fs.rmSync(a, { recursive: true, force: true });
+    fs.rmSync(b, { recursive: true, force: true });
+  }
+});
+
+test('an explicit relative log.path resolves against the repo root', () => {
+  const dir = makeRepo({ log: { path: '.agents/server.log' } });
+  try {
+    const config = loadServerConfig({ rootDir: dir });
     assert.equal(config.log.path, path.join(dir, '.agents', 'server.log'));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test('server.json deep-merges over defaults without dropping sibling defaults', () => {
-  const dir = makeRepo({ log: { rotateAtBytes: 1024 }, adapters: { dev: { enabled: false } } });
+test('an explicit absolute log.path is used as-is', () => {
+  const abs = path.join(os.tmpdir(), 'server-abs-log', 'daemon.log');
+  const dir = makeRepo({ log: { path: abs } });
   try {
     const config = loadServerConfig({ rootDir: dir });
-    assert.equal(config.log.rotateAtBytes, 1024);
-    // log.path is untouched by server.json → default preserved (deep merge, not replace)
-    assert.equal(config.log.path, path.join(dir, '.agents', 'server.log'));
-    assert.deepEqual(config.adapters, { dev: { enabled: false } });
+    assert.equal(config.log.path, abs);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/unit/cli/server-config.test.ts
+++ b/tests/unit/cli/server-config.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  loadServerConfig,
+  validateServerConfig,
+  DEFAULT_SERVER_CONFIG
+} from '../../../lib/server/config.ts';
+
+function makeRepo(serverJson?: unknown, localJson?: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-config-'));
+  fs.mkdirSync(path.join(dir, '.agents'), { recursive: true });
+  if (serverJson !== undefined) {
+    fs.writeFileSync(path.join(dir, '.agents', 'server.json'), JSON.stringify(serverJson));
+  }
+  if (localJson !== undefined) {
+    fs.writeFileSync(path.join(dir, '.agents', 'server.local.json'), JSON.stringify(localJson));
+  }
+  return dir;
+}
+
+test('loadServerConfig returns defaults when no server.json exists', () => {
+  const dir = makeRepo();
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.repoRoot, dir);
+    assert.equal(config.heartbeatMs, DEFAULT_SERVER_CONFIG.heartbeatMs);
+    assert.equal(config.log.rotateAtBytes, DEFAULT_SERVER_CONFIG.log.rotateAtBytes);
+    assert.deepEqual(config.adapters, {});
+    // default log path is resolved to an absolute path under the repo root
+    assert.equal(config.log.path, path.join(dir, '.agents', 'server.log'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('server.json deep-merges over defaults without dropping sibling defaults', () => {
+  const dir = makeRepo({ log: { rotateAtBytes: 1024 }, adapters: { dev: { enabled: false } } });
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.log.rotateAtBytes, 1024);
+    // log.path is untouched by server.json → default preserved (deep merge, not replace)
+    assert.equal(config.log.path, path.join(dir, '.agents', 'server.log'));
+    assert.deepEqual(config.adapters, { dev: { enabled: false } });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('server.local.json overrides server.json by deep merge', () => {
+  const dir = makeRepo(
+    { adapters: { dev: { enabled: false, appId: 'cli_xxx' } } },
+    { adapters: { dev: { enabled: true } } }
+  );
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    // local flips enabled but keeps appId from server.json (deep merge)
+    assert.deepEqual(config.adapters.dev, { enabled: true, appId: 'cli_xxx' });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('environment variables take highest precedence over both files', () => {
+  const dir = makeRepo({ heartbeatMs: 5000 });
+  const key = 'AGENT_INFRA_SERVER_heartbeatMs';
+  const previous = process.env[key];
+  process.env[key] = '777';
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.heartbeatMs, 777);
+  } finally {
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('nested env override builds the path and coerces booleans', () => {
+  const dir = makeRepo({ adapters: { dev: { enabled: true } } });
+  const key = 'AGENT_INFRA_SERVER_adapters__dev__enabled';
+  const previous = process.env[key];
+  process.env[key] = 'false';
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.adapters.dev?.enabled, false);
+  } finally {
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('committed secret in server.json is rejected at load time', () => {
+  const dir = makeRepo({ adapters: { feishu: { enabled: true, appSecret: 'leaked-xxx' } } });
+  try {
+    assert.throws(
+      () => loadServerConfig({ rootDir: dir }),
+      /secret-like field\(s\) found in committed .agents\/server\.json: adapters\.feishu\.appSecret/
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('validateServerConfig reports the offending secret field paths', () => {
+  const result = validateServerConfig({
+    adapters: { feishu: { enabled: true, appSecret: 'x' } },
+    token: 'y'
+  });
+  assert.equal(result.ok, false);
+  if (result.ok === false) {
+    assert.deepEqual(result.fields.sort(), ['adapters.feishu.appSecret', 'token']);
+  }
+});
+
+test('secrets in server.local.json are allowed (not scanned)', () => {
+  const dir = makeRepo(
+    { adapters: { feishu: { enabled: true } } },
+    { adapters: { feishu: { appSecret: 'kept-secret' } } }
+  );
+  try {
+    const config = loadServerConfig({ rootDir: dir });
+    assert.equal(config.adapters.feishu?.appSecret, 'kept-secret');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('empty secret-like fields in server.json do not trigger rejection', () => {
+  const result = validateServerConfig({ adapters: { feishu: { enabled: true, appSecret: '' } } });
+  assert.equal(result.ok, true);
+});

--- a/tests/unit/cli/server-logger.test.ts
+++ b/tests/unit/cli/server-logger.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createLogger } from '../../../lib/server/logger.ts';
+
+function tmpLog(): { dir: string; logPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-logger-'));
+  return { dir, logPath: path.join(dir, 'nested', 'server.log') };
+}
+
+test('createLogger appends level-prefixed lines and creates the parent directory', () => {
+  const { dir, logPath } = tmpLog();
+  try {
+    const logger = createLogger({ path: logPath, rotateAtBytes: 1_000_000 });
+    logger.info('hello');
+    logger.ok('ready');
+    logger.err('oops');
+    logger.close();
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 3);
+    assert.match(lines[0] ?? '', /^\[[^\]]+\] \[INFO\] hello$/);
+    assert.match(lines[1] ?? '', /^\[[^\]]+\] \[OK\] ready$/);
+    assert.match(lines[2] ?? '', /^\[[^\]]+\] \[ERROR\] oops$/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('an oversized existing log is rotated to .1 on startup', () => {
+  const { dir, logPath } = tmpLog();
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, 'X'.repeat(200));
+
+    const logger = createLogger({ path: logPath, rotateAtBytes: 100 });
+    logger.info('after rotation');
+    logger.close();
+
+    assert.equal(fs.readFileSync(`${logPath}.1`, 'utf8'), 'X'.repeat(200), 'old content moves to .1');
+    const current = fs.readFileSync(logPath, 'utf8');
+    assert.doesNotMatch(current, /X{200}/);
+    assert.match(current, /\[INFO\] after rotation/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a log under the threshold is not rotated', () => {
+  const { dir, logPath } = tmpLog();
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, 'small');
+
+    const logger = createLogger({ path: logPath, rotateAtBytes: 1_000_000 });
+    logger.info('appended');
+    logger.close();
+
+    assert.equal(fs.existsSync(`${logPath}.1`), false, 'no rotation file created');
+    const content = fs.readFileSync(logPath, 'utf8');
+    assert.match(content, /^small/);
+    assert.match(content, /\[INFO\] appended/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/cli/server-plugin-loader.test.ts
+++ b/tests/unit/cli/server-plugin-loader.test.ts
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadAdapters, unloadAdapters } from '../../../lib/server/plugin-loader.ts';
+import type { ImportAdapter } from '../../../lib/server/plugin-loader.ts';
+import type { ServerConfig, ServerAdapterConfig } from '../../../lib/server/config.ts';
+import type { Adapter, AdapterCtx } from '../../../lib/server/adapters/_contract.ts';
+
+function makeConfig(adapters: Record<string, ServerAdapterConfig>): ServerConfig {
+  return {
+    repoRoot: '/tmp/none',
+    log: { path: '/tmp/none/.agents/server.log', rotateAtBytes: 1024 },
+    heartbeatMs: 30_000,
+    adapters
+  };
+}
+
+function makeCtx(): { ctx: AdapterCtx; errors: string[] } {
+  const errors: string[] = [];
+  const ctx: AdapterCtx = {
+    config: makeConfig({}),
+    logger: {
+      info: () => {},
+      ok: () => {},
+      err: (message: string) => errors.push(message),
+      close: () => {}
+    },
+    dispatch: async () => {},
+    signal: new AbortController().signal
+  };
+  return { ctx, errors };
+}
+
+// A fake adapter whose lifecycle calls are recorded, returned as a module
+// with a default factory — exactly what the production importer would yield,
+// but resolved entirely in memory (never written under lib/server/adapters/).
+function fakeAdapterModule(name: string, calls: string[]): { default: () => Adapter } {
+  return {
+    default: () => ({
+      name,
+      start: async () => {
+        calls.push(`start:${name}`);
+      },
+      stop: async () => {
+        calls.push(`stop:${name}`);
+      },
+      sendMessage: async () => {}
+    })
+  };
+}
+
+test('enabled adapter is loaded and started with the daemon ctx', async () => {
+  const calls: string[] = [];
+  const { ctx } = makeCtx();
+  const importAdapter: ImportAdapter = async (name) => fakeAdapterModule(name, calls);
+
+  const loaded = await loadAdapters(makeConfig({ dev: { enabled: true } }), ctx, { importAdapter });
+
+  assert.equal(loaded.length, 1);
+  assert.equal(loaded[0]?.name, 'dev');
+  assert.deepEqual(calls, ['start:dev']);
+});
+
+test('disabled adapter is never imported', async () => {
+  const imported: string[] = [];
+  const { ctx } = makeCtx();
+  const importAdapter: ImportAdapter = async (name) => {
+    imported.push(name);
+    return fakeAdapterModule(name, []);
+  };
+
+  const loaded = await loadAdapters(makeConfig({ dev: { enabled: false } }), ctx, { importAdapter });
+
+  assert.deepEqual(loaded, []);
+  assert.deepEqual(imported, [], 'importAdapter must not be called for disabled adapters');
+});
+
+test('an import failure is isolated and does not block other adapters', async () => {
+  const calls: string[] = [];
+  const { ctx, errors } = makeCtx();
+  const importAdapter: ImportAdapter = async (name) => {
+    if (name === 'broken') throw new Error('module blew up');
+    return fakeAdapterModule(name, calls);
+  };
+
+  const loaded = await loadAdapters(
+    makeConfig({ broken: { enabled: true }, dev: { enabled: true } }),
+    ctx,
+    { importAdapter }
+  );
+
+  assert.deepEqual(loaded.map((a) => a.name), ['dev']);
+  assert.deepEqual(calls, ['start:dev']);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0] ?? '', /failed to load adapter "broken": module blew up/);
+});
+
+test('a start() failure is isolated and does not block other adapters', async () => {
+  const { ctx, errors } = makeCtx();
+  const importAdapter: ImportAdapter = async (name) => {
+    if (name === 'bad-start') {
+      return {
+        default: () => ({
+          name,
+          start: async () => {
+            throw new Error('start refused');
+          },
+          stop: async () => {},
+          sendMessage: async () => {}
+        })
+      };
+    }
+    return fakeAdapterModule(name, []);
+  };
+
+  const loaded = await loadAdapters(
+    makeConfig({ 'bad-start': { enabled: true }, dev: { enabled: true } }),
+    ctx,
+    { importAdapter }
+  );
+
+  assert.deepEqual(loaded.map((a) => a.name), ['dev']);
+  assert.match(errors[0] ?? '', /failed to load adapter "bad-start": start refused/);
+});
+
+test('a module without a default factory is rejected and isolated', async () => {
+  const { ctx, errors } = makeCtx();
+  const importAdapter: ImportAdapter = async () => ({ notDefault: true });
+
+  const loaded = await loadAdapters(makeConfig({ dev: { enabled: true } }), ctx, { importAdapter });
+
+  assert.deepEqual(loaded, []);
+  assert.match(errors[0] ?? '', /adapter "dev" has no default export factory/);
+});
+
+test('unloadAdapters stops adapters in reverse load order', async () => {
+  const calls: string[] = [];
+  const { ctx } = makeCtx();
+  const importAdapter: ImportAdapter = async (name) => fakeAdapterModule(name, calls);
+
+  const loaded = await loadAdapters(
+    makeConfig({ first: { enabled: true }, second: { enabled: true } }),
+    ctx,
+    { importAdapter }
+  );
+  await unloadAdapters(loaded);
+
+  assert.deepEqual(calls, ['start:first', 'start:second', 'stop:second', 'stop:first']);
+});

--- a/tests/unit/cli/server-plugin-loader.test.ts
+++ b/tests/unit/cli/server-plugin-loader.test.ts
@@ -9,7 +9,8 @@ import type { Adapter, AdapterCtx } from '../../../lib/server/adapters/_contract
 function makeConfig(adapters: Record<string, ServerAdapterConfig>): ServerConfig {
   return {
     repoRoot: '/tmp/none',
-    log: { path: '/tmp/none/.agents/server.log', rotateAtBytes: 1024 },
+    pidFile: '/tmp/none/.agent-infra/run/none/server.pid',
+    log: { path: '/tmp/none/.agent-infra/logs/none/server.log', rotateAtBytes: 1024 },
     heartbeatMs: 30_000,
     adapters
   };


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #270 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`agent-infra-server` 总任务（#268）的**子任务 A**——交付 `ai server` daemon 的"骨架"与进程管理基础。本 PR **只**搭进程框架与 adapter 扩展点契约，**不实现任何 IM adapter，也不实现任何命令协议/鉴权/runner**（那些是子任务 B/C）。

遵循已裁定的范围：**零新依赖**（HD-1 人工裁决，仅用 Node 内建）、全 TypeScript（erasable 语法）、测试落 tier×domain 桶（`tests/{unit,integration}/cli/`）。

## 📋 主要变更 / Brief Changelog

- **CLI 接入**：`bin/cli.ts` 新增 `case 'server'` 分支与 USAGE 行；`lib/server/index.ts` 导出 `runServer(args)` 路由 `start/stop/status/logs/help`（复用 sandbox/task 惰性加载范式）。
- **进程管理**：`lib/server/process-control.ts` 跨平台 detached 启停、PID 文件、已退出/僵尸进程清理；`isProcessAlive` 在 Linux 读 `/proc` 判僵尸态避免误判，`buildStopCommand` 纯函数承载 win32 `taskkill` / POSIX `SIGTERM` 分支。
- **daemon 生命周期**：`lib/server/daemon.ts` ref 心跳作 keep-alive + 可观测信号，`runDaemon()` `await` 由 `SIGINT/SIGTERM` 优雅清理后 resolve 的 shutdown promise，再 `process.exit(0)`。
- **配置**：`lib/server/config.ts` 三层深合并（`server.json ← server.local.json ← env`，前缀 `AGENT_INFRA_SERVER_`）、提交态 token 探测拒绝、repoRoot 探测；`server.schema.json` 供 IDE 校验。
- **扩展点**：`lib/server/plugin-loader.ts` 按 `enabled` 懒加载 + 错误隔离 + 可注入 `importAdapter` 测试缝；`lib/server/adapters/_contract.ts` 纯类型契约 + `ADAPTER_CONTRACT_VERSION`（不注册任何 adapter）。
- **可观测**：`lib/server/logger.ts` 追加日志 + 启动期 size rotation。
- **测试**：`tests/unit/cli/server-{config,plugin-loader,adapter-contract,logger}.test.ts` + `tests/integration/cli/server-lifecycle.test.ts`（经 `dist/bin/cli.js` spawn 的 start→status→logs→stop 全链路 + 僵尸 PID 清理，`onPlatforms()` 守卫）+ `cli.test.ts` 兜底 `ai server help`。
- **忽略规则**：`.gitignore` 追加 `.agents/server.local.json`、`.agents/server.pid`、`.agents/server.log.*`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` → 1245 pass / 0 fail / 1 skip（预存平台守卫）。
2. 手动：`ai server start` 起空 daemon → `ai server status` 显示运行中 → `ai server logs -f` 看到 heartbeat → `ai server stop` 干净关闭、PID 文件删除。
3. 配置：提交态 `server.json` 含 `appSecret` 等 secret 字段时启动被拒绝（exit 1，提示迁移到 `server.local.json`/env）。
4. 扩展点：注入 fake adapter 时 plugin-loader 加载（`enabled:true`）、禁用不加载（`enabled:false`）、import/start 抛错被隔离。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / Github issue filed（#270）
- [x] 你的 Pull Request 只解决一个 Issue / PR addresses just this issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body
- [x] 我的代码遵循项目的代码规范 / Code follows the project's standards
- [x] 我已经进行了自我代码审查 / Self-review performed
- [x] 我已经编写了必要的单元测试 / Unit tests written
- [x] 代码检查通过 / Lint checks pass（typecheck 通过）
- [x] 单元测试通过 / Unit tests pass
- [x] 我已经考虑了向后兼容性 / Backward compatibility considered（纯新增命令，不改既有分支）

## 📋 附加信息 / Additional Notes

- **零新依赖**（HD-1 人工裁决）：不引入 `ws` / `@larksuiteoapi/node-sdk`，依赖选型下沉子任务 B。
- 子任务 B 待办：`plugin-loader` 默认生产 import 路径（`.ts` vs 编译后 `.js`）在接入首个真实 adapter 时敲定（当前 A 不发布 adapter、测试注入 importer，不受影响）。

---

Generated with AI assistance