### PR TITLE
chore(meta): post-review 门禁覆盖范围改为 fail-closed

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -103,20 +103,5 @@
   },
   "task": {
     "shortIdLength": 2
-  },
-  "review": {
-    "post_review_globs": [
-      ".agents/.airc.json",
-      ".agents/rules",
-      ".agents/scripts",
-      ".agents/skills",
-      ".agents/workflows",
-      ".git-hooks/pre-commit",
-      ".github/workflows",
-      "bin",
-      "lib",
-      "src",
-      "templates"
-    ]
   }
 }

--- a/.agents/scripts/lib/post-review-commit.js
+++ b/.agents/scripts/lib/post-review-commit.js
@@ -3,25 +3,22 @@ import path from "node:path";
 
 import { artifactName, maxRound } from "./review-artifacts.js";
 
-export const DEFAULT_POST_REVIEW_GLOBS = [
-  ".agents/skills",
-  ".agents/scripts",
-  ".agents/rules",
-  ".agents/workflows",
-  "bin",
-  "lib",
-  "src",
-  "templates"
-];
+// Paths excluded from the post-review coverage gate. Fail-closed: the gate
+// covers ALL tracked changes by default. This default denylist is EMPTY —
+// projects opt into exclusions explicitly via review.post_review_exclude_globs.
+export const DEFAULT_POST_REVIEW_EXCLUDES = [];
 
+// Returns git pathspecs selecting "all tracked changes except project excludes".
+// The leading ":/" makes coverage fail-closed (everything from the repo root);
+// each exclude becomes a top-level negative pathspec. Projects extend the
+// denylist via review.post_review_exclude_globs (union, deduped).
 export function resolvePostReviewGlobs(config = {}, reviewConfig = {}) {
-  if (Array.isArray(config.post_review_globs)) {
-    return config.post_review_globs;
-  }
-  if (Array.isArray(reviewConfig.post_review_globs)) {
-    return reviewConfig.post_review_globs;
-  }
-  return DEFAULT_POST_REVIEW_GLOBS;
+  const projectExcludes = [
+    ...(Array.isArray(reviewConfig.post_review_exclude_globs) ? reviewConfig.post_review_exclude_globs : []),
+    ...(Array.isArray(config.post_review_exclude_globs) ? config.post_review_exclude_globs : [])
+  ];
+  const excludes = [...new Set([...DEFAULT_POST_REVIEW_EXCLUDES, ...projectExcludes])];
+  return [":/", ...excludes.map((p) => `:(top,exclude)${p}`)];
 }
 
 export function findAuthoritativeReviewCodeArtifact(taskDir) {

--- a/templates/.agents/scripts/lib/post-review-commit.js
+++ b/templates/.agents/scripts/lib/post-review-commit.js
@@ -3,25 +3,22 @@ import path from "node:path";
 
 import { artifactName, maxRound } from "./review-artifacts.js";
 
-export const DEFAULT_POST_REVIEW_GLOBS = [
-  ".agents/skills",
-  ".agents/scripts",
-  ".agents/rules",
-  ".agents/workflows",
-  "bin",
-  "lib",
-  "src",
-  "templates"
-];
+// Paths excluded from the post-review coverage gate. Fail-closed: the gate
+// covers ALL tracked changes by default. This default denylist is EMPTY —
+// projects opt into exclusions explicitly via review.post_review_exclude_globs.
+export const DEFAULT_POST_REVIEW_EXCLUDES = [];
 
+// Returns git pathspecs selecting "all tracked changes except project excludes".
+// The leading ":/" makes coverage fail-closed (everything from the repo root);
+// each exclude becomes a top-level negative pathspec. Projects extend the
+// denylist via review.post_review_exclude_globs (union, deduped).
 export function resolvePostReviewGlobs(config = {}, reviewConfig = {}) {
-  if (Array.isArray(config.post_review_globs)) {
-    return config.post_review_globs;
-  }
-  if (Array.isArray(reviewConfig.post_review_globs)) {
-    return reviewConfig.post_review_globs;
-  }
-  return DEFAULT_POST_REVIEW_GLOBS;
+  const projectExcludes = [
+    ...(Array.isArray(reviewConfig.post_review_exclude_globs) ? reviewConfig.post_review_exclude_globs : []),
+    ...(Array.isArray(config.post_review_exclude_globs) ? config.post_review_exclude_globs : [])
+  ];
+  const excludes = [...new Set([...DEFAULT_POST_REVIEW_EXCLUDES, ...projectExcludes])];
+  return [":/", ...excludes.map((p) => `:(top,exclude)${p}`)];
 }
 
 export function findAuthoritativeReviewCodeArtifact(taskDir) {

--- a/tests/e2e/core/review-diff-fingerprint.test.ts
+++ b/tests/e2e/core/review-diff-fingerprint.test.ts
@@ -86,3 +86,47 @@ test("post-review globs are shared by the validator and fingerprint helper", () 
   assert.match(validator, /from "\.\/lib\/post-review-commit\.js"/);
   assert.match(validator, /resolvePostReviewGlobs\(config, loadReviewConfig\(\)\)/);
 });
+
+test("review diff fingerprint covers paths outside the legacy allowlist (fail-closed)", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-fingerprint-failclosed-", (tempRoot) => {
+    const baseline = setupRepo(tempRoot);
+    const clean = fingerprint(tempRoot, "worktree", baseline);
+
+    write(path.join(tempRoot, "scripts/x.js"), "// new generator change\n");
+    const changed = fingerprint(tempRoot, "worktree", baseline);
+    assert.notEqual(changed, clean);
+  });
+});
+
+test("review diff fingerprint covers package-lock.json by default", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-fingerprint-lockfile-", (tempRoot) => {
+    const baseline = setupRepo(tempRoot);
+    const clean = fingerprint(tempRoot, "worktree", baseline);
+
+    write(path.join(tempRoot, "package-lock.json"), "{}\n");
+    const changed = fingerprint(tempRoot, "worktree", baseline);
+    assert.notEqual(changed, clean);
+  });
+});
+
+test("review diff fingerprint honors project post_review_exclude_globs", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-fingerprint-exclude-", (tempRoot) => {
+    setupRepo(tempRoot);
+    write(
+      path.join(tempRoot, ".agents/.airc.json"),
+      JSON.stringify({ review: { post_review_exclude_globs: ["package-lock.json"] } }, null, 2) + "\n"
+    );
+    git(tempRoot, ["add", ".agents/.airc.json"]);
+    git(tempRoot, ["commit", "-qm", "add exclude config"]);
+    const baseline = git(tempRoot, ["rev-parse", "HEAD"]);
+    const clean = fingerprint(tempRoot, "worktree", baseline);
+
+    write(path.join(tempRoot, "package-lock.json"), "{}\n");
+    const excluded = fingerprint(tempRoot, "worktree", baseline);
+    assert.equal(excluded, clean);
+
+    write(path.join(tempRoot, "scripts/included.js"), "// not excluded\n");
+    const included = fingerprint(tempRoot, "worktree", baseline);
+    assert.notEqual(included, clean);
+  });
+});

--- a/tests/e2e/core/validate-artifact-post-review-commit.test.ts
+++ b/tests/e2e/core/validate-artifact-post-review-commit.test.ts
@@ -217,3 +217,29 @@ test("post-review-commit blocks when the task is not inside a git repository", o
     assert.equal(payload.status, "blocked");
   });
 });
+
+test("post-review-commit fails for a commit outside the legacy allowlist (fail-closed coverage)", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-prc-failclosed-", (tempRoot) => {
+    const { taskDir } = setupRepo(tempRoot);
+    const baseline = commitCodePath(tempRoot, ".agents/skills/x.md", "base\n", "base");
+    write(path.join(taskDir, "task.md"), buildTask());
+    write(path.join(taskDir, "review-code.md"), buildReviewCode(baseline));
+    commitCodePath(tempRoot, "scripts/build-inline.js", "// generated\n", "post-review change to a previously-uncovered path");
+
+    const { payload } = runCheck(taskDir);
+    assert.equal(payload.status, "fail");
+  });
+});
+
+test("post-review-commit covers package-lock.json by default (no hardcoded exclusion)", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-prc-lockfile-", (tempRoot) => {
+    const { taskDir } = setupRepo(tempRoot);
+    const baseline = commitCodePath(tempRoot, ".agents/skills/x.md", "base\n", "base");
+    write(path.join(taskDir, "task.md"), buildTask());
+    write(path.join(taskDir, "review-code.md"), buildReviewCode(baseline));
+    commitCodePath(tempRoot, "package-lock.json", "{}\n", "post-review lockfile bump");
+
+    const { payload } = runCheck(taskDir);
+    assert.equal(payload.status, "fail");
+  });
+});

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -209,6 +209,8 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/skills/update-agent-infra/scripts/sync-templates.js", "templates/.agents/skills/update-agent-infra/scripts/sync-templates.js"],
     [".agents/scripts/validate-artifact.js", "templates/.agents/scripts/validate-artifact.js"],
     [".agents/scripts/lib/review-artifacts.js", "templates/.agents/scripts/lib/review-artifacts.js"],
+    [".agents/scripts/lib/post-review-commit.js", "templates/.agents/scripts/lib/post-review-commit.js"],
+    [".agents/scripts/review-diff-fingerprint.js", "templates/.agents/scripts/review-diff-fingerprint.js"],
     [".agents/workflows/feature-development.yaml", "templates/.agents/workflows/feature-development.en.yaml"],
     [".agents/workflows/bug-fix.yaml", "templates/.agents/workflows/bug-fix.en.yaml"],
     [".agents/workflows/refactoring.yaml", "templates/.agents/workflows/refactoring.en.yaml"],


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #546

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)

## 📝 变更目的 / Purpose of the Change

把 post-review 防夹带门禁的「覆盖判定」从一份残缺、fail-open 的 allowlist，改成 fail-closed 设计：默认覆盖全部跟踪变更，排除项仅由项目显式 opt-in。

此前 `resolvePostReviewGlobs` 使用「替换语义 + 残缺 allowlist」：allowlist 之外的审查后改动（如 `scripts/build-inline.js`、`tests/`、`package.json`、根文档）会被静默放行（fail-open），且零覆盖会算出空 diff 哈希、与「真无改动」无法区分。该逻辑被 `review-diff-fingerprint.js` 与 `validate-artifact.js` 共享，并随 `templates/` 分发到所有下游项目。

按 Issue 中人工裁决（HD-1）采用方案 B（denylist / fail-closed），默认排除清单保持为空，避免给下游埋入默认豁免口子。

## 📋 主要变更 / Brief Changelog

- `resolvePostReviewGlobs` 改为 fail-closed：返回 `[":/"]`（覆盖全部跟踪变更），`DEFAULT_POST_REVIEW_EXCLUDES` 为空，项目经 `review.post_review_exclude_globs` 显式追加排除（映射为 `:(top,exclude)`，并集去重）。两个消费者保持原样、无需改动。
- 删除本仓库 `.agents/.airc.json` 中已废弃的 `review.post_review_globs` allowlist；共享库镜像同步到 `templates/`。
- 新增 5 个 e2e 行为用例（覆盖扩张、`package-lock.json` 默认覆盖、项目 opt-in 排除）+ 2 条模板 parity 守卫。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`（Node ≥ 22）
2. 重点关注 `tests/e2e/core/validate-artifact-post-review-commit.test.ts` 与 `tests/e2e/core/review-diff-fingerprint.test.ts` 中新增的 fail-closed 用例

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass（全量 1227 pass / 0 fail / 1 platform-skip）
- [x] 我已经进行了手动测试 / I have performed manual testing（`resolvePostReviewGlobs` 返回值 + git pathspec 实测）

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue / Your PR addresses just this issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- **向后兼容**：下游项目 `.airc.json` 中残留的 `review.post_review_globs` 在同步新脚本后静默失效，门禁回到「全覆盖」——属 fail-closed 安全方向（只会覆盖更多、不会更少）。`.airc.json` 不随 `templates/` 分发，无需迁移脚本。
- **文档**：经核查，相关 SKILL 文档不含 allowlist 语义，仅有中性占位符 `<post-review-globs>`（出现在审查者读全量上下文处，fail-closed 下解析为 `:/` ≈ 全覆盖，更贴切），故未做措辞改动。

---

**审查者注意事项 / Reviewer Notes:**

- `:/` + `:(top,exclude)` pathspec 在本机 git 2.43 实测可用；为下游可移植性显式保留正向 `:/`。
- 默认排除清单为空是 HD-1 / PL-1 的核心裁决（`package-lock.json` 等也纳入默认覆盖，排除需项目显式 opt-in）。

Generated with AI assistance
