### PR TITLE
feat(server): 接入飞书 adapter 并打通 /ping 端到端（子任务 B，#268）

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,29 +166,6 @@ The most-used lifecycle commands, in delivery order. The command prefix varies b
 
 See the full catalog — task status, release, security, and project-maintenance skills — in [Built-in AI Skills](./docs/en/skills.md).
 
-## Enable the Feishu bridge
-
-The local `ai server` daemon can host IM adapters. The Feishu (Lark) adapter connects over a long connection and routes group messages to the built-in command dispatcher — currently `/ping` replies `pong v<VERSION>`.
-
-1. In the [Feishu Open Platform](https://open.feishu.cn/app), create a **self-built app**.
-2. Grant the permissions `im:message`, `im:message.receive_v1`, and `im:chat`.
-3. Under **Events & callbacks**, enable **"Use long connection to receive events"** and subscribe to `im.message.receive_v1`.
-4. Copy the **App ID** and **App Secret** into `.agents/server.local.json` (this file is git-ignored; never commit the secret — a secret in the committed `.agents/server.json` is refused at startup):
-
-   ```json
-   {
-     "adapters": {
-       "feishu": {
-         "enabled": true,
-         "appId": "<your-app-id>",
-         "appSecret": "<your-app-secret>"
-       }
-     }
-   }
-   ```
-
-5. Run `ai server start`, then in a Feishu group `@bot /ping` — the bot replies `pong v<VERSION>`.
-
 ## What You Get
 
 After setup, your project gains a complete AI collaboration infrastructure:
@@ -214,6 +191,7 @@ In-depth guides live under [`docs/en/`](./docs/en/README.md):
 - [Architecture Overview](./docs/en/architecture.md) — bootstrap CLI, end-to-end flow, layered architecture
 - [Platform Support](./docs/en/platform-support.md) — macOS, Linux, Windows; sandbox engines and resources
 - [Sandbox](./docs/en/sandbox.md) — sandbox aliases, host-sandbox file exchange, user-level dotfiles channel
+- [Feishu Bridge](./docs/en/feishu-bridge.md) — configure the Feishu long-connection adapter and `/ping` verification
 - [Built-in AI Skills](./docs/en/skills.md) — the full skill catalog by use case
 - [Custom Skills](./docs/en/custom-skills.md) — create and sync project-specific skills
 - [Custom TUI Configuration](./docs/en/custom-tui.md) — adapt agent-infra to non-built-in AI TUIs

--- a/README.md
+++ b/README.md
@@ -166,6 +166,29 @@ The most-used lifecycle commands, in delivery order. The command prefix varies b
 
 See the full catalog — task status, release, security, and project-maintenance skills — in [Built-in AI Skills](./docs/en/skills.md).
 
+## Enable the Feishu bridge
+
+The local `ai server` daemon can host IM adapters. The Feishu (Lark) adapter connects over a long connection and routes group messages to the built-in command dispatcher — currently `/ping` replies `pong v<VERSION>`.
+
+1. In the [Feishu Open Platform](https://open.feishu.cn/app), create a **self-built app**.
+2. Grant the permissions `im:message`, `im:message.receive_v1`, and `im:chat`.
+3. Under **Events & callbacks**, enable **"Use long connection to receive events"** and subscribe to `im.message.receive_v1`.
+4. Copy the **App ID** and **App Secret** into `.agents/server.local.json` (this file is git-ignored; never commit the secret — a secret in the committed `.agents/server.json` is refused at startup):
+
+   ```json
+   {
+     "adapters": {
+       "feishu": {
+         "enabled": true,
+         "appId": "<your-app-id>",
+         "appSecret": "<your-app-secret>"
+       }
+     }
+   }
+   ```
+
+5. Run `ai server start`, then in a Feishu group `@bot /ping` — the bot replies `pong v<VERSION>`.
+
 ## What You Get
 
 After setup, your project gains a complete AI collaboration infrastructure:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,29 +166,6 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 完整清单（任务状态、发布、安全、项目维护等 skill）见 [内置 AI Skills](./docs/zh-CN/skills.md)。
 
-## 启用飞书桥接
-
-本地 `ai server` 守护进程可托管 IM adapter。飞书（Lark）adapter 通过长连接接入，把群消息路由到内置命令分发器——当前 `/ping` 回复 `pong v<VERSION>`。
-
-1. 在[飞书开放平台](https://open.feishu.cn/app)创建一个**自建应用**。
-2. 申请权限 `im:message`、`im:message.receive_v1`、`im:chat`。
-3. 在**事件与回调**中启用**“使用长连接接收事件”**，并订阅 `im.message.receive_v1`。
-4. 把 **App ID** 和 **App Secret** 填入 `.agents/server.local.json`（该文件已被 git 忽略；切勿提交密钥——已提交的 `.agents/server.json` 中若含密钥会在启动时被拒绝）：
-
-   ```json
-   {
-     "adapters": {
-       "feishu": {
-         "enabled": true,
-         "appId": "<your-app-id>",
-         "appSecret": "<your-app-secret>"
-       }
-     }
-   }
-   ```
-
-5. 运行 `ai server start`，然后在飞书群里 `@bot /ping`——机器人回复 `pong v<VERSION>`。
-
 ## 安装效果
 
 安装完成后，项目将获得完整的 AI 协作基础设施：
@@ -214,6 +191,7 @@ my-project/
 - [架构概览](./docs/zh-CN/architecture.md) — 引导 CLI、端到端流程、分层架构
 - [平台支持](./docs/zh-CN/platform-support.md) — macOS、Linux、Windows；沙箱引擎与资源配置
 - [沙箱](./docs/zh-CN/sandbox.md) — 沙箱 aliases、宿主-沙箱文件交换、用户级 dotfiles 通道
+- [飞书桥接](./docs/zh-CN/feishu-bridge.md) — 配置飞书长连接 adapter 并验证 `/ping`
 - [内置 AI Skills](./docs/zh-CN/skills.md) — 按使用场景分组的完整 skill 清单
 - [自定义 Skills](./docs/zh-CN/custom-skills.md) — 创建并同步项目专属 skill
 - [自定义 TUI 配置](./docs/zh-CN/custom-tui.md) — 适配非内置的 AI TUI

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,29 @@ CLI 会收集项目元数据，向所有支持的 AI TUI 安装 `update-agent-in
 
 完整清单（任务状态、发布、安全、项目维护等 skill）见 [内置 AI Skills](./docs/zh-CN/skills.md)。
 
+## 启用飞书桥接
+
+本地 `ai server` 守护进程可托管 IM adapter。飞书（Lark）adapter 通过长连接接入，把群消息路由到内置命令分发器——当前 `/ping` 回复 `pong v<VERSION>`。
+
+1. 在[飞书开放平台](https://open.feishu.cn/app)创建一个**自建应用**。
+2. 申请权限 `im:message`、`im:message.receive_v1`、`im:chat`。
+3. 在**事件与回调**中启用**“使用长连接接收事件”**，并订阅 `im.message.receive_v1`。
+4. 把 **App ID** 和 **App Secret** 填入 `.agents/server.local.json`（该文件已被 git 忽略；切勿提交密钥——已提交的 `.agents/server.json` 中若含密钥会在启动时被拒绝）：
+
+   ```json
+   {
+     "adapters": {
+       "feishu": {
+         "enabled": true,
+         "appId": "<your-app-id>",
+         "appSecret": "<your-app-secret>"
+       }
+     }
+   }
+   ```
+
+5. 运行 `ai server start`，然后在飞书群里 `@bot /ping`——机器人回复 `pong v<VERSION>`。
+
 ## 安装效果
 
 安装完成后，项目将获得完整的 AI 协作基础设施：

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -9,6 +9,7 @@ In-depth documentation for agent-infra. For positioning, install, and quick star
 - [Architecture Overview](./architecture.md) — bootstrap CLI, end-to-end flow, layered architecture
 - [Platform Support](./platform-support.md) — macOS, Linux, Windows; sandbox engines and resource configuration
 - [Sandbox](./sandbox.md) — sandbox aliases, host-sandbox file exchange, user-level dotfiles channel
+- [Feishu Bridge](./feishu-bridge.md) — configure the Feishu long-connection adapter and `/ping` verification
 - [Built-in AI Skills](./skills.md) — the full skill catalog by use case
 - [Custom Skills](./custom-skills.md) — create and sync project-specific skills
 - [Custom TUI Configuration](./custom-tui.md) — adapt agent-infra to non-built-in AI TUIs

--- a/docs/en/feishu-bridge.md
+++ b/docs/en/feishu-bridge.md
@@ -10,8 +10,6 @@ The local `ai server` daemon can host IM adapters. The Feishu adapter connects t
 2. Enable the Bot capability and add the bot to the test chat.
 3. Under Events & callbacks, choose long connection mode and subscribe to `im.message.receive_v1`.
 
-The adapter only handles `im.message.receive_v1`. Events such as `im.chat.access_event.bot_p2p_chat_entered_v1` prove that the long connection is alive, but they do not trigger `/ping`.
-
 ## Permissions
 
 Use the narrowest set that matches the chat types you want to test:
@@ -43,53 +41,6 @@ Put the app credentials in `.agents/server.local.json`. This file is git-ignored
 ```
 
 `appId` must match `cli_[0-9a-fA-F]{16}`. The daemon fails fast if `appId` or `appSecret` is missing.
-
-## Verify
-
-Build and run the current checkout when validating unpublished changes:
-
-```bash
-npm run build
-node dist/bin/cli.js server start
-node dist/bin/cli.js server status
-```
-
-Watch the latest server log:
-
-```bash
-latest_log=$(find ~/.agent-infra/logs -name server.log -exec ls -t {} + | head -1)
-tail -f "$latest_log"
-```
-
-Send a non-command first to confirm that message events reach the daemon:
-
-```text
-/hello
-```
-
-The log should show an unknown command. Then send:
-
-```text
-/ping
-```
-
-In a group chat, mention the bot:
-
-```text
-@bot /ping
-```
-
-The bot should reply:
-
-```text
-pong v<VERSION>
-```
-
-Stop the daemon when done:
-
-```bash
-node dist/bin/cli.js server stop
-```
 
 ## References
 

--- a/docs/en/feishu-bridge.md
+++ b/docs/en/feishu-bridge.md
@@ -1,0 +1,98 @@
+# Feishu Bridge
+
+[← Documentation](./README.md) · [中文](../zh-CN/feishu-bridge.md)
+
+The local `ai server` daemon can host IM adapters. The Feishu adapter connects to the Feishu Open Platform over the official SDK long connection and routes received messages to the built-in command dispatcher. The current minimal command is `/ping`, which replies `pong v<VERSION>`.
+
+## Create the App
+
+1. In the [Feishu Open Platform](https://open.feishu.cn/app), create a self-built app.
+2. Enable the Bot capability and add the bot to the test chat.
+3. Under Events & callbacks, choose long connection mode and subscribe to `im.message.receive_v1`.
+
+The adapter only handles `im.message.receive_v1`. Events such as `im.chat.access_event.bot_p2p_chat_entered_v1` prove that the long connection is alive, but they do not trigger `/ping`.
+
+## Permissions
+
+Use the narrowest set that matches the chat types you want to test:
+
+| Scenario | Required permissions |
+|----------|----------------------|
+| Direct chat `/ping` | `im.message.p2p_msg:readonly`, `im:message:send_as_bot` |
+| Group chat `@bot /ping` | `im.message.group_at_msg:readonly`, `im:message:send_as_bot` |
+| Both direct and group chat | `im.message.p2p_msg:readonly`, `im.message.group_at_msg:readonly`, `im:message:send_as_bot` |
+
+Some Feishu consoles may also show or auto-enable broader parent permissions such as `im:message`. The current adapter does not need chat metadata (`im:chat`) or message reaction permissions for `/ping`.
+
+After changing permissions or event subscriptions, publish the app version and make sure the app is installed in the tenant before testing.
+
+## Configure agent-infra
+
+Put the app credentials in `.agents/server.local.json`. This file is git-ignored. Do not commit app secrets; committed `.agents/server.json` files that contain secrets are refused at startup.
+
+```json
+{
+  "adapters": {
+    "feishu": {
+      "enabled": true,
+      "appId": "<your-app-id>",
+      "appSecret": "<your-app-secret>"
+    }
+  }
+}
+```
+
+`appId` must match `cli_[0-9a-fA-F]{16}`. The daemon fails fast if `appId` or `appSecret` is missing.
+
+## Verify
+
+Build and run the current checkout when validating unpublished changes:
+
+```bash
+npm run build
+node dist/bin/cli.js server start
+node dist/bin/cli.js server status
+```
+
+Watch the latest server log:
+
+```bash
+latest_log=$(find ~/.agent-infra/logs -name server.log -exec ls -t {} + | head -1)
+tail -f "$latest_log"
+```
+
+Send a non-command first to confirm that message events reach the daemon:
+
+```text
+/hello
+```
+
+The log should show an unknown command. Then send:
+
+```text
+/ping
+```
+
+In a group chat, mention the bot:
+
+```text
+@bot /ping
+```
+
+The bot should reply:
+
+```text
+pong v<VERSION>
+```
+
+Stop the daemon when done:
+
+```bash
+node dist/bin/cli.js server stop
+```
+
+## References
+
+- [Feishu long connection event subscription](https://open.feishu.cn/document/server-docs/event-subscription-guide/event-subscription-configure-/request-url-configuration-case?lang=en-US)
+- [Feishu `im.message.receive_v1` event](https://open.feishu.cn/document/server-docs/im-v1/message/events/receive?lang=en-US)
+- [Feishu bot FAQ](https://open.feishu.cn/document/faq/bot)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -9,6 +9,7 @@ agent-infra 的深度文档。定位、安装和快速上手请见 [主 README](
 - [架构概览](./architecture.md) — 引导 CLI、端到端流程、分层架构
 - [平台支持](./platform-support.md) — macOS、Linux、Windows；沙箱引擎与资源配置
 - [沙箱](./sandbox.md) — 沙箱 aliases、宿主-沙箱文件交换、用户级 dotfiles 通道
+- [飞书桥接](./feishu-bridge.md) — 配置飞书长连接 adapter 并验证 `/ping`
 - [内置 AI Skills](./skills.md) — 按使用场景分组的完整 skill 清单
 - [自定义 Skills](./custom-skills.md) — 创建并同步项目专属 skill
 - [自定义 TUI 配置](./custom-tui.md) — 适配非内置的 AI TUI

--- a/docs/zh-CN/feishu-bridge.md
+++ b/docs/zh-CN/feishu-bridge.md
@@ -10,8 +10,6 @@
 2. 启用机器人能力，并把机器人加入测试会话。
 3. 在事件与回调中选择长连接模式，并订阅 `im.message.receive_v1`。
 
-当前 adapter 只处理 `im.message.receive_v1`。`im.chat.access_event.bot_p2p_chat_entered_v1` 这类事件只能说明长连接可用，不会触发 `/ping`。
-
 ## 权限
 
 按要验证的会话类型使用最小权限：
@@ -43,53 +41,6 @@
 ```
 
 `appId` 必须符合 `cli_[0-9a-fA-F]{16}`。如果缺少 `appId` 或 `appSecret`，daemon 会 fail fast。
-
-## 验证
-
-验证尚未发布的当前 checkout 时，直接构建并运行本地构建产物：
-
-```bash
-npm run build
-node dist/bin/cli.js server start
-node dist/bin/cli.js server status
-```
-
-查看最新 server 日志：
-
-```bash
-latest_log=$(find ~/.agent-infra/logs -name server.log -exec ls -t {} + | head -1)
-tail -f "$latest_log"
-```
-
-先发送一个非命令消息，确认消息事件已进入 daemon：
-
-```text
-/hello
-```
-
-日志中应出现 unknown command。然后发送：
-
-```text
-/ping
-```
-
-群聊中需要 @ 机器人：
-
-```text
-@机器人 /ping
-```
-
-预期机器人回复：
-
-```text
-pong v<VERSION>
-```
-
-验证完成后停止 daemon：
-
-```bash
-node dist/bin/cli.js server stop
-```
 
 ## 参考
 

--- a/docs/zh-CN/feishu-bridge.md
+++ b/docs/zh-CN/feishu-bridge.md
@@ -1,0 +1,98 @@
+# 飞书桥接
+
+[← 文档](./README.md) · [English](../en/feishu-bridge.md)
+
+本地 `ai server` 守护进程可托管 IM adapter。飞书 adapter 通过官方 SDK 长连接接入飞书开放平台，并把收到的消息路由到内置命令分发器。当前最小命令是 `/ping`，回复 `pong v<VERSION>`。
+
+## 创建应用
+
+1. 在[飞书开放平台](https://open.feishu.cn/app)创建自建应用。
+2. 启用机器人能力，并把机器人加入测试会话。
+3. 在事件与回调中选择长连接模式，并订阅 `im.message.receive_v1`。
+
+当前 adapter 只处理 `im.message.receive_v1`。`im.chat.access_event.bot_p2p_chat_entered_v1` 这类事件只能说明长连接可用，不会触发 `/ping`。
+
+## 权限
+
+按要验证的会话类型使用最小权限：
+
+| 场景 | 必需权限 |
+|------|----------|
+| 单聊 `/ping` | `im.message.p2p_msg:readonly`、`im:message:send_as_bot` |
+| 群聊 `@机器人 /ping` | `im.message.group_at_msg:readonly`、`im:message:send_as_bot` |
+| 同时支持单聊和群聊 | `im.message.p2p_msg:readonly`、`im.message.group_at_msg:readonly`、`im:message:send_as_bot` |
+
+部分飞书控制台可能会展示或自动开通更宽的父级权限，例如 `im:message`。当前 `/ping` adapter 不需要群信息权限 `im:chat`，也不需要消息表情回复权限。
+
+修改权限或事件订阅后，需要发布应用版本，并确认应用已安装到当前企业，之后再测试。
+
+## 配置 agent-infra
+
+把应用凭证写入 `.agents/server.local.json`。该文件已被 git 忽略。不要提交密钥；如果已提交的 `.agents/server.json` 中包含密钥，启动时会被拒绝。
+
+```json
+{
+  "adapters": {
+    "feishu": {
+      "enabled": true,
+      "appId": "<your-app-id>",
+      "appSecret": "<your-app-secret>"
+    }
+  }
+}
+```
+
+`appId` 必须符合 `cli_[0-9a-fA-F]{16}`。如果缺少 `appId` 或 `appSecret`，daemon 会 fail fast。
+
+## 验证
+
+验证尚未发布的当前 checkout 时，直接构建并运行本地构建产物：
+
+```bash
+npm run build
+node dist/bin/cli.js server start
+node dist/bin/cli.js server status
+```
+
+查看最新 server 日志：
+
+```bash
+latest_log=$(find ~/.agent-infra/logs -name server.log -exec ls -t {} + | head -1)
+tail -f "$latest_log"
+```
+
+先发送一个非命令消息，确认消息事件已进入 daemon：
+
+```text
+/hello
+```
+
+日志中应出现 unknown command。然后发送：
+
+```text
+/ping
+```
+
+群聊中需要 @ 机器人：
+
+```text
+@机器人 /ping
+```
+
+预期机器人回复：
+
+```text
+pong v<VERSION>
+```
+
+验证完成后停止 daemon：
+
+```bash
+node dist/bin/cli.js server stop
+```
+
+## 参考
+
+- [飞书长连接事件订阅](https://open.feishu.cn/document/server-docs/event-subscription-guide/event-subscription-configure-/request-url-configuration-case?lang=zh-CN)
+- [飞书 `im.message.receive_v1` 事件](https://open.feishu.cn/document/server-docs/im-v1/message/events/receive?lang=zh-CN)
+- [飞书机器人常见问题](https://open.feishu.cn/document/faq/bot)

--- a/lib/server/adapters/feishu/index.ts
+++ b/lib/server/adapters/feishu/index.ts
@@ -1,0 +1,47 @@
+import type { Adapter, AdapterCtx, AdapterFactory, InboundMessage } from '../_contract.ts';
+import { createFeishuTransport, normalizeMessage } from './transport.ts';
+import type { FeishuTransport } from './transport.ts';
+
+// Assemble the feishu adapter. The transport is injectable so unit tests can
+// drive start/dispatch/reply/sendMessage against a fake transport without the
+// real SDK; production uses the default SDK-backed transport.
+export function createFeishuAdapter(
+  config: Record<string, unknown>,
+  transport: FeishuTransport = createFeishuTransport(config)
+): Adapter {
+  let ctx: AdapterCtx | null = null;
+
+  return {
+    name: 'feishu',
+    async start(adapterCtx) {
+      ctx = adapterCtx;
+      await transport.start(async (raw) => {
+        try {
+          const normalized = normalizeMessage(raw);
+          const message: InboundMessage = {
+            adapter: 'feishu',
+            userId: normalized.userId,
+            chatId: normalized.chatId,
+            text: normalized.text,
+            messageId: normalized.messageId,
+            raw: normalized.raw,
+            reply: (text) => transport.send(normalized.chatId, text)
+          };
+          await adapterCtx.dispatch(message);
+        } catch (error) {
+          ctx?.logger.err(`feishu: dropped message: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      });
+    },
+    async stop() {
+      await transport.stop();
+    },
+    async sendMessage(target, text) {
+      await transport.send(target.chatId, text);
+    }
+  };
+}
+
+const factory: AdapterFactory = (adapterConfig) => createFeishuAdapter(adapterConfig);
+
+export default factory;

--- a/lib/server/adapters/feishu/transport.ts
+++ b/lib/server/adapters/feishu/transport.ts
@@ -1,0 +1,128 @@
+import * as lark from '@larksuiteoapi/node-sdk';
+
+// Transport layer for the feishu adapter. All @larksuiteoapi/node-sdk surface is
+// confined here so the adapter body (index.ts) depends only on this narrow
+// interface plus the pure normalizeMessage(). That keeps normalize unit-testable
+// without the SDK and lets the adapter be assembled against a fake transport.
+
+export type FeishuTransport = {
+  // Begin receiving messages. onMessage is invoked with the raw SDK event for
+  // each inbound im.message.receive_v1.
+  start: (onMessage: (raw: unknown) => Promise<void>) => Promise<void>;
+  stop: () => Promise<void>;
+  send: (chatId: string, text: string) => Promise<void>;
+};
+
+export type NormalizedMessage = {
+  userId: string;
+  chatId: string;
+  text: string;
+  messageId: string;
+  raw: unknown;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+// Strip feishu mention placeholders (e.g. "@_user_1") that the platform injects
+// for @-mentions, then collapse surrounding whitespace. A group message like
+// "@_user_1 /ping" normalizes to "/ping" so the daemon dispatcher matches it.
+function stripMentions(text: string): string {
+  return text.replace(/@_user_\d+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// Parse an im.message.receive_v1 event into the daemon's shape. Pure: no SDK,
+// no IO. Throws on missing/invalid fields so the adapter can drop a single bad
+// message without crashing the long connection.
+export function normalizeMessage(event: unknown): NormalizedMessage {
+  const message = asRecord(asRecord(event).message);
+  const messageId = message.message_id;
+  const chatId = message.chat_id;
+  const content = message.content;
+  if (typeof messageId !== 'string' || typeof chatId !== 'string' || typeof content !== 'string') {
+    throw new Error('feishu: malformed im.message.receive_v1 event (missing message_id/chat_id/content)');
+  }
+
+  const senderId = asRecord(asRecord(asRecord(event).sender).sender_id);
+  const userId =
+    (typeof senderId.open_id === 'string' && senderId.open_id) ||
+    (typeof senderId.union_id === 'string' && senderId.union_id) ||
+    (typeof senderId.user_id === 'string' && senderId.user_id) ||
+    '';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('feishu: message.content is not valid JSON');
+  }
+  const rawText = asRecord(parsed).text;
+  if (typeof rawText !== 'string') {
+    throw new Error('feishu: unsupported message content (no text field)');
+  }
+
+  return { userId, chatId, text: stripMentions(rawText), messageId, raw: event };
+}
+
+function resolveDomain(value: unknown): number {
+  return value === 'lark' || value === 'Lark' ? lark.Domain.Lark : lark.Domain.Feishu;
+}
+
+// Build the real SDK-backed transport from adapter config. appId/appSecret come
+// from server config (appSecret only via server.local.json / env). The WSClient
+// long connection delivers events; the Client REST call sends replies.
+// Feishu self-built app IDs have this shape; the SDK's WSClient.start() silently
+// rejects anything else, so we validate up front to fail loudly instead.
+const APP_ID_PATTERN = /^cli_[0-9a-fA-F]{16}$/;
+
+export function createFeishuTransport(config: Record<string, unknown>): FeishuTransport {
+  const appId = String(config.appId ?? '').trim();
+  const appSecret = String(config.appSecret ?? '').trim();
+  const domain = resolveDomain(config.domain);
+
+  // Fail fast on missing or malformed credentials. The SDK only logs to its own
+  // logger and resolves WSClient.start() for an empty or malformed appId, so
+  // without these checks an enabled-but-misconfigured feishu adapter would be
+  // counted as loaded while the long connection never opens. Throwing here lets
+  // loadAdapters log `failed to load adapter "feishu": ...` and skip it.
+  if (appId === '' || appSecret === '') {
+    throw new Error(
+      'feishu: appId and appSecret are required; put appSecret in .agents/server.local.json or AGENT_INFRA_SERVER_adapters__feishu__appSecret'
+    );
+  }
+  if (!APP_ID_PATTERN.test(appId)) {
+    throw new Error('feishu: appId must match cli_[0-9a-fA-F]{16}');
+  }
+
+  const client = new lark.Client({ appId, appSecret, domain });
+  const wsClient = new lark.WSClient({ appId, appSecret, domain, loggerLevel: lark.LoggerLevel.warn });
+
+  return {
+    async start(onMessage) {
+      const eventDispatcher = new lark.EventDispatcher({}).register({
+        'im.message.receive_v1': async (data: unknown) => {
+          await onMessage(data);
+        }
+      });
+      wsClient.start({ eventDispatcher });
+    },
+    async stop() {
+      // Best-effort: close the long connection if the SDK exposes it. Never throw
+      // from shutdown — unloadAdapters isolates stop failures, but staying quiet
+      // keeps the daemon shutdown path clean.
+      const closable = wsClient as unknown as { close?: () => void };
+      try {
+        closable.close?.();
+      } catch {
+        // Ignore: the daemon is shutting down regardless.
+      }
+    },
+    async send(chatId, text) {
+      await client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: { receive_id: chatId, msg_type: 'text', content: JSON.stringify({ text }) }
+      });
+    }
+  };
+}

--- a/lib/server/plugin-loader.ts
+++ b/lib/server/plugin-loader.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { ServerConfig } from './config.ts';
 import type { Adapter, AdapterCtx } from './adapters/_contract.ts';
 
@@ -10,7 +12,17 @@ export type LoadAdaptersOptions = {
   importAdapter?: ImportAdapter;
 };
 
-const defaultImportAdapter: ImportAdapter = (name) => import(`./adapters/${name}/index.ts`);
+const defaultImportAdapter: ImportAdapter = (name) => {
+  // Test-only seam: when AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR is set (never in
+  // production), resolve the named adapter as a plain ESM `.js` from that
+  // fixtures dir. This lets a built daemon (`node dist/bin/cli.js`) load a test
+  // injection adapter on any node>=22 without depending on type stripping.
+  const testDir = process.env.AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR;
+  if (testDir) {
+    return import(pathToFileURL(path.join(testDir, name, 'index.js')).href);
+  }
+  return import(`./adapters/${name}/index.ts`);
+};
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/lib/server/server.schema.json
+++ b/lib/server/server.schema.json
@@ -34,6 +34,29 @@
     "adapters": {
       "type": "object",
       "description": "Per-adapter configuration. Only adapters with enabled=true are loaded.",
+      "properties": {
+        "feishu": {
+          "type": "object",
+          "description": "Feishu (Lark) IM adapter. The appSecret must NOT be committed here — put it in .agents/server.local.json or AGENT_INFRA_SERVER_adapters__feishu__appSecret.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "appId": {
+              "type": "string",
+              "description": "Feishu self-built app App ID."
+            },
+            "domain": {
+              "type": "string",
+              "enum": ["feishu", "lark"],
+              "default": "feishu",
+              "description": "Open platform domain: feishu (default) or lark."
+            }
+          },
+          "required": ["enabled"]
+        }
+      },
       "additionalProperties": {
         "type": "object",
         "properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.6.0",
+        "@larksuiteoapi/node-sdk": "^1.68.0",
         "cross-spawn": "^7.0.6",
         "picocolors": "1.1.1",
         "semver": "^7.8.1",
@@ -59,6 +60,21 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.68.0.tgz",
+      "integrity": "sha512-ip14+pWAv2La3bss4oDDtee2P5xBLDXuvmzhTvkxQMcPA5jCffFsler1TvNt4MyW6pexscj72AEWektyZwU9Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
       }
     },
     "node_modules/@lydell/node-pty": {
@@ -154,6 +170,63 @@
         "win32"
       ]
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
@@ -168,7 +241,6 @@
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -180,6 +252,64 @@
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -193,6 +323,74 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/fast-string-truncated-width": {
@@ -219,11 +417,210 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -239,6 +636,51 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -271,6 +713,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sisteransi": {
@@ -309,7 +823,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {
@@ -325,6 +838,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "1.6.0",
+    "@larksuiteoapi/node-sdk": "^1.68.0",
     "cross-spawn": "^7.0.6",
     "picocolors": "1.1.1",
     "semver": "^7.8.1",

--- a/tests/fixtures/server-adapters/ping-inject/index.js
+++ b/tests/fixtures/server-adapters/ping-inject/index.js
@@ -1,0 +1,27 @@
+// Test-only injection adapter for the e2e ping path. Plain ESM JavaScript (no
+// TypeScript) so a built daemon (`node dist/bin/cli.js`) can import it on any
+// node>=22 without type stripping. Loaded only when the daemon sets
+// AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR (never in production). On start it injects
+// a single "/ping" inbound message through the daemon dispatcher and writes the
+// reply back to the server log, where the e2e test asserts on it.
+export default function createPingInjectAdapter() {
+  return {
+    name: 'ping-inject',
+    async start(ctx) {
+      const message = {
+        adapter: 'ping-inject',
+        userId: 'test-user',
+        chatId: 'test-chat',
+        text: '/ping',
+        messageId: 'test-1',
+        raw: {},
+        reply: async (text) => {
+          ctx.logger.ok(`ping-inject reply: ${text}`);
+        }
+      };
+      await ctx.dispatch(message);
+    },
+    async stop() {},
+    async sendMessage() {}
+  };
+}

--- a/tests/integration/cli/server-e2e-ping.test.ts
+++ b/tests/integration/cli/server-e2e-ping.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { CLI_PATH, filePath, onPlatforms, gitSafeEnv, initIsolatedGitRepo } from '../../helpers.ts';
+import { VERSION } from '../../../lib/version.ts';
+
+// End-to-end /ping → pong proof (HD-1 / PL-1). A real built daemon subprocess
+// loads the plain-ESM test injection adapter from tests/fixtures via the
+// AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR seam, which injects a "/ping" message
+// through the actual loadAdapters → start → ctx.dispatch → reply path. The reply
+// is written to the server log, where this test asserts on it. No real feishu.
+
+const PROJECT = 'e2e-ping';
+const TEST_ADAPTERS_DIR = filePath('tests/fixtures/server-adapters');
+
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-e2e-ping-'));
+  initIsolatedGitRepo(dir);
+  fs.mkdirSync(path.join(dir, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.agents', '.airc.json'), JSON.stringify({ project: PROJECT }));
+  fs.writeFileSync(
+    path.join(dir, '.agents', 'server.json'),
+    JSON.stringify({ heartbeatMs: 100, adapters: { 'ping-inject': { enabled: true } } })
+  );
+  return dir;
+}
+
+// HOME pins runtime paths under the temp dir (hermetic); the test-adapters dir
+// env makes the built daemon resolve the .js fixture. start and stop must share
+// this exact cwd+env so stop reads the same pid file the daemon wrote.
+function serverEnv(dir: string): NodeJS.ProcessEnv {
+  return gitSafeEnv({ HOME: dir, USERPROFILE: dir, AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR: TEST_ADAPTERS_DIR });
+}
+
+function runServer(dir: string, ...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [CLI_PATH, 'server', ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: serverEnv(dir)
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+function findUnder(root: string, name: string): string | null {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    if (cur === undefined) break;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === name) return full;
+    }
+  }
+  return null;
+}
+
+function readLog(dir: string): string {
+  const logPath = findUnder(path.join(dir, '.agent-infra', 'logs', PROJECT), 'server.log');
+  if (logPath === null) return '';
+  try {
+    return fs.readFileSync(logPath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 8000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
+
+test(
+  'a daemon-injected /ping is dispatched and answered with pong v<VERSION>',
+  onPlatforms('linux', 'darwin'),
+  async () => {
+    const dir = makeRepo();
+    try {
+      const started = runServer(dir, 'start');
+      assert.equal(started.status, 0, started.stderr);
+
+      const expected = `ping-inject reply: pong ${VERSION}`;
+      const answered = await waitFor(() => readLog(dir).includes(expected));
+      assert.ok(answered, `expected the daemon log to contain "${expected}"; got:\n${readLog(dir)}`);
+    } finally {
+      runServer(dir, 'stop');
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+);

--- a/tests/unit/cli/server-feishu-adapter.test.ts
+++ b/tests/unit/cli/server-feishu-adapter.test.ts
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import feishuFactory, { createFeishuAdapter } from '../../../lib/server/adapters/feishu/index.ts';
+import { createFeishuTransport, normalizeMessage } from '../../../lib/server/adapters/feishu/transport.ts';
+import type { FeishuTransport } from '../../../lib/server/adapters/feishu/transport.ts';
+import type { AdapterCtx, InboundMessage } from '../../../lib/server/adapters/_contract.ts';
+
+// Build an im.message.receive_v1 event the way the SDK delivers it: content is a
+// JSON string, mentions are injected as "@_user_N" placeholders in the text.
+function receiveEvent(text: string): unknown {
+  return {
+    sender: { sender_id: { open_id: 'ou_123', union_id: 'on_123', user_id: 'u_123' } },
+    message: {
+      message_id: 'om_1',
+      chat_id: 'oc_chat',
+      chat_type: 'group',
+      message_type: 'text',
+      content: JSON.stringify({ text })
+    }
+  };
+}
+
+test('normalizeMessage maps a receive_v1 event and strips @-mentions', () => {
+  const normalized = normalizeMessage(receiveEvent('@_user_1 /ping'));
+  assert.equal(normalized.text, '/ping');
+  assert.equal(normalized.chatId, 'oc_chat');
+  assert.equal(normalized.messageId, 'om_1');
+  assert.equal(normalized.userId, 'ou_123');
+});
+
+test('normalizeMessage falls back through sender id types', () => {
+  const event = receiveEvent('hi') as { sender: { sender_id: Record<string, unknown> } };
+  delete event.sender.sender_id.open_id;
+  assert.equal(normalizeMessage(event).userId, 'on_123');
+});
+
+test('normalizeMessage throws on a malformed event (missing message fields)', () => {
+  assert.throws(() => normalizeMessage({ message: { chat_id: 'oc' } }), /malformed/);
+});
+
+test('normalizeMessage throws when content is not JSON', () => {
+  const event = { message: { message_id: 'om_1', chat_id: 'oc', content: 'not-json' } };
+  assert.throws(() => normalizeMessage(event), /not valid JSON/);
+});
+
+// A fake transport: records sends and exposes a hook to fire an inbound event,
+// standing in for the real long connection so the adapter wiring is testable
+// without the SDK.
+function fakeTransport(): {
+  transport: FeishuTransport;
+  sends: Array<{ chatId: string; text: string }>;
+  fire: (raw: unknown) => Promise<void>;
+  stopped: () => boolean;
+} {
+  const sends: Array<{ chatId: string; text: string }> = [];
+  let onMessage: ((raw: unknown) => Promise<void>) | null = null;
+  let stopped = false;
+  return {
+    sends,
+    stopped: () => stopped,
+    fire: async (raw) => {
+      if (!onMessage) throw new Error('transport not started');
+      await onMessage(raw);
+    },
+    transport: {
+      start: async (handler) => {
+        onMessage = handler;
+      },
+      stop: async () => {
+        stopped = true;
+      },
+      send: async (chatId, text) => {
+        sends.push({ chatId, text });
+      }
+    }
+  };
+}
+
+function makeCtx(dispatched: InboundMessage[]): AdapterCtx {
+  return {
+    config: {
+      repoRoot: '/tmp/none',
+      pidFile: '/tmp/none/server.pid',
+      log: { path: '/tmp/none/server.log', rotateAtBytes: 1024 },
+      heartbeatMs: 30_000,
+      adapters: {}
+    },
+    logger: { info: () => {}, ok: () => {}, err: () => {}, close: () => {} },
+    dispatch: async (message) => {
+      dispatched.push(message);
+    },
+    signal: new AbortController().signal
+  };
+}
+
+test('an inbound /ping dispatches a normalized message and reply routes to send', async () => {
+  const fake = fakeTransport();
+  const dispatched: InboundMessage[] = [];
+  const adapter = createFeishuAdapter({ appId: 'x' }, fake.transport);
+
+  await adapter.start(makeCtx(dispatched));
+  await fake.fire(receiveEvent('@_user_1 /ping'));
+
+  assert.equal(dispatched.length, 1);
+  assert.equal(dispatched[0]?.text, '/ping');
+  assert.equal(dispatched[0]?.adapter, 'feishu');
+
+  await dispatched[0]?.reply('pong v9.9.9');
+  assert.deepEqual(fake.sends, [{ chatId: 'oc_chat', text: 'pong v9.9.9' }]);
+});
+
+test('a malformed inbound message is dropped (logged) without dispatching', async () => {
+  const fake = fakeTransport();
+  const dispatched: InboundMessage[] = [];
+  const errors: string[] = [];
+  const ctx = makeCtx(dispatched);
+  ctx.logger.err = (message: string) => errors.push(message);
+  const adapter = createFeishuAdapter({ appId: 'x' }, fake.transport);
+
+  await adapter.start(ctx);
+  await fake.fire({ message: { chat_id: 'oc' } });
+
+  assert.deepEqual(dispatched, []);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0] ?? '', /feishu: dropped message/);
+});
+
+test('sendMessage and stop delegate to the transport', async () => {
+  const fake = fakeTransport();
+  const adapter = createFeishuAdapter({ appId: 'x' }, fake.transport);
+
+  await adapter.start(makeCtx([]));
+  await adapter.sendMessage({ chatId: 'oc_target' }, 'hello');
+  assert.deepEqual(fake.sends, [{ chatId: 'oc_target', text: 'hello' }]);
+
+  await adapter.stop();
+  assert.equal(fake.stopped(), true);
+});
+
+// CD-1: an enabled-but-misconfigured feishu adapter must fail loudly rather than
+// be counted as loaded while the long connection silently never opens.
+test('createFeishuTransport throws when appSecret is missing', () => {
+  assert.throws(
+    () => createFeishuTransport({ appId: 'cli_0123456789abcdef' }),
+    /appId and appSecret are required/
+  );
+});
+
+test('createFeishuTransport throws when appId is missing', () => {
+  assert.throws(() => createFeishuTransport({ appSecret: 's' }), /appId and appSecret are required/);
+});
+
+test('the default factory throws on missing credentials (so loadAdapters skips it)', () => {
+  assert.throws(() => feishuFactory({ enabled: true }), /appId and appSecret are required/);
+});
+
+// CD-2: a non-empty but malformed appId is silently rejected by the SDK, so the
+// adapter would otherwise load while the long connection never opens.
+test('createFeishuTransport throws on a malformed appId', () => {
+  assert.throws(
+    () => createFeishuTransport({ appId: 'not-a-cli-id', appSecret: 's' }),
+    /appId must match cli_\[0-9a-fA-F\]\{16\}/
+  );
+});
+
+test('the default factory throws on a malformed appId (so loadAdapters skips it)', () => {
+  assert.throws(
+    () => feishuFactory({ enabled: true, appId: 'not-a-cli-id', appSecret: 's' }),
+    /appId must match/
+  );
+});

--- a/tests/unit/core/release.test.ts
+++ b/tests/unit/core/release.test.ts
@@ -26,6 +26,7 @@ test("package metadata supports scoped npm publishing", () => {
   ]);
   assert.deepEqual(Object.keys(pkg.dependencies).sort(), [
     "@clack/prompts",
+    "@larksuiteoapi/node-sdk",
     "cross-spawn",
     "picocolors",
     "semver",


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #271 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`agent-infra-server` 总任务（#268）的**子任务 B**——在子任务 A（#547，已合并）的 daemon 骨架之上，注册第一个 IM adapter（飞书），把 `/ping → pong v<VERSION>` 端到端打通，验证整条「长连接入站 → normalize → dispatch → 回写」通道。

**不在本子任务范围**：命令协议、鉴权、ai CLI runner、流式回写（均属子任务 C）。daemon 侧 `/ping` 分发已由子任务 A 实现，本 PR 不改其分发逻辑、不 bump adapter 契约版本。

关键设计经两次人工/审查裁定收敛：HD-1（e2e 用测试专用注入 adapter 而非进程内 mock）、PL-1（注入 fixture 为纯 ESM `.js`，built daemon 任意 node≥22 可加载，不依赖 strip-types）、CD-1/CD-2（缺凭证 / 格式错误 appId 一律 fail-fast）。

## 📋 主要变更 / Brief Changelog

- **飞书 adapter**：`lib/server/adapters/feishu/transport.ts` 封装 `@larksuiteoapi/node-sdk`（`Client`/`WSClient`/`EventDispatcher`）并提供纯函数 `normalizeMessage`（解析 `im.message.receive_v1`、剥离 `@_user_N` 提及）；`index.ts` 以 transport 依赖注入缝装配 `start/stop/sendMessage`，把入站事件 normalize 成 `InboundMessage`（`reply` 回原 `chatId`）后交既有 `/ping` 分发。
- **凭证校验（CD-1/CD-2）**：`createFeishuTransport` 对 `appId/appSecret` 先 `trim` + 非空校验，并用 SDK 同款 `^cli_[0-9a-fA-F]{16}$` 校验 appId；不满足即抛错 → `loadAdapters` 记录 `failed to load adapter "feishu": ...` 并不计入 loaded（避免静默加载死连接）。
- **测试注入缝（HD-1/PL-1）**：`lib/server/plugin-loader.ts` 的 `defaultImportAdapter` 增加**仅测试设置**的 env 门控（`AGENT_INFRA_SERVER_TEST_ADAPTERS_DIR`）解析纯 ESM `.js` fixture；生产从不设置该 env、行为零变化。
- **配置/文档**：`lib/server/server.schema.json` 增 `adapters.feishu`（enabled/appId/domain，强调 appSecret 不入 committed）；`README.md` / `README.zh-CN.md` 新增「启用飞书桥接」双语章节。
- **依赖**：新增运行时依赖 `@larksuiteoapi/node-sdk@^1.68.0`（`release.test.ts` 依赖清单断言同步）。
- **测试**：`tests/unit/cli/server-feishu-adapter.test.ts`（12 例：normalize 正常/畸形、装配 dispatch/reply/sendMessage/stop、缺凭证/malformed appId fail-fast，全程 fake transport，SDK-free）+ `tests/integration/cli/server-e2e-ping.test.ts`（built daemon 子进程经 `.js` 注入 fixture 实跑 `loadAdapters→start→dispatch→reply`，断言 `pong v<VERSION>`）+ `tests/fixtures/server-adapters/ping-inject/index.js`。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test` → 1267 pass / 0 fail / 1 skip（预存平台守卫）。
2. mock e2e：`server-e2e-ping.test.ts` 起真实 daemon 子进程，从注入 adapter 发 `/ping`，断言日志含 `ping-inject reply: pong v<VERSION>`（不连真实飞书）。
3. 凭证校验：缺 `appId/appSecret` 或 appId 非 `cli_[0-9a-fA-F]{16}` 时，`loadAdapters` 返回 0 且项目 logger 报错（非静默加载）。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing（mock e2e；真实飞书链路见下）

## 📋 附加信息 / Additional Notes

**待人工验证（env-blocked，需真实飞书环境，CI 不覆盖）**：

- [ ] 在飞书开放平台配好自建应用 + 权限（`im:message`/`im:message.receive_v1`/`im:chat`）+ 长连接事件订阅后，按 README 把 App ID/Secret 写入 `.agents/server.local.json`，`ai server start`，群里 `@bot /ping` 确认回复 `pong v<VERSION>`。

---

Generated with AI assistance