### PR TITLE
feat(cli): 支持沙箱继承 Claude 模型配置

### DIFF
--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -22,6 +22,8 @@ When you run the sandbox from a remote Mac over SSH, use `ai cp <ssh-alias>` on 
 
 `ai sandbox exec` and `ai sandbox refresh` reconcile Claude Code credentials in both directions across the host credential store and every sandbox project copy under `~/.agent-infra/credentials/*`. When a long-running sandbox refreshes OAuth tokens first, the next entry or refresh command writes the freshest valid copy back to the host Keychain or `~/.claude/.credentials.json`; when the host is fresher, it updates the project copies. If every copy is stale, `ai sandbox refresh` probes `claude /status` and asks you to log in only when the probe cannot recover credentials.
 
+When Claude Code is enabled, `ai sandbox create` also merges model and API provider settings from the host `~/.claude/settings.json` into the sandbox Claude Code settings. Existing sandbox values take precedence, so local sandbox overrides are preserved. Credentials still use the dedicated credentials channel above; provider environment settings are copied only as Claude Code settings values.
+
 ## Host-sandbox file exchange
 
 `ai sandbox create` mounts two writable directories for dropping files between

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -22,6 +22,8 @@
 
 `ai sandbox exec` 和 `ai sandbox refresh` 会在宿主机凭证存储与 `~/.agent-infra/credentials/*` 下的所有沙箱项目副本之间做双向 reconcile。长时间运行的沙箱如果先刷新了 OAuth token，下一次进入或刷新命令会把最新有效副本回写到宿主 Keychain 或 `~/.claude/.credentials.json`；宿主机更新时也会继续覆盖项目副本。如果所有副本都已失效，`ai sandbox refresh` 会尝试 `claude /status` 探活，只有探活无法恢复时才提示重新登录。
 
+启用 Claude Code 时，`ai sandbox create` 还会把宿主机 `~/.claude/settings.json` 中的模型和 API provider 设置合并到沙箱内的 Claude Code settings。已有的沙箱值优先，因此沙箱内的本地覆盖会被保留。凭证仍使用上面的专用 credentials 通道；provider 环境设置只会作为 Claude Code settings 值复制。
+
 ## 宿主-沙箱文件交换
 
 `ai sandbox create` 会自动挂载两个可读写目录，方便宿主与容器之间互相 drop 文件，不污染 git 工作树：

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -740,6 +740,63 @@ function readHostJsonSafe(filePath: string): JsonObject | null {
   }
 }
 
+const CLAUDE_SETTINGS_INHERIT_TOP_LEVEL_KEYS = [
+  'model',
+  'fallbackModel',
+  'availableModels',
+  'modelOverrides',
+  'enforceAvailableModels',
+  'advisorModel',
+  'apiKeyHelper',
+  'effortLevel'
+];
+
+function isJsonObjectRecord(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeMissingStringEnvFields(target: JsonObject, source: JsonObject): boolean {
+  if (!isJsonObjectRecord(source.env)) {
+    return false;
+  }
+  if (Object.hasOwn(target, 'env') && !isJsonObjectRecord(target.env)) {
+    return false;
+  }
+
+  let targetEnv = target.env as JsonObject | undefined;
+  let changed = false;
+  for (const [key, value] of Object.entries(source.env)) {
+    if (typeof value !== 'string' || value === '') {
+      continue;
+    }
+    if (!targetEnv) {
+      targetEnv = {};
+      target.env = targetEnv;
+    }
+    if (!Object.hasOwn(targetEnv, key)) {
+      targetEnv[key] = value;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function mergeMissingTopLevelSettings(target: JsonObject, source: JsonObject): boolean {
+  let changed = false;
+  for (const key of CLAUDE_SETTINGS_INHERIT_TOP_LEVEL_KEYS) {
+    if (!Object.hasOwn(source, key) || Object.hasOwn(target, key)) {
+      continue;
+    }
+    const value = source[key];
+    if (value === null || value === undefined || value === '') {
+      continue;
+    }
+    target[key] = value;
+    changed = true;
+  }
+  return changed;
+}
+
 export function ensureClaudeOnboarding(toolDir: string, hostHomeDir?: string): void {
   const claudeJsonPath = path.join(toolDir, '.claude.json');
   let data: JsonObject & {
@@ -810,7 +867,7 @@ export function ensureClaudeOnboarding(toolDir: string, hostHomeDir?: string): v
 
 export function ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void {
   const settingsPath = path.join(toolDir, 'settings.json');
-  let data: JsonObject & { skipDangerousModePermissionPrompt?: boolean; effortLevel?: string } = {};
+  let data: JsonObject & { skipDangerousModePermissionPrompt?: boolean } = {};
   if (fs.existsSync(settingsPath)) {
     try {
       data = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as typeof data;
@@ -825,14 +882,9 @@ export function ensureClaudeSettings(toolDir: string, hostHomeDir?: string): voi
   }
   if (hostHomeDir) {
     const hostSettings = readHostJsonSafe(path.join(hostHomeDir, '.claude', 'settings.json'));
-    if (
-      hostSettings
-      && typeof hostSettings.effortLevel === 'string'
-      && hostSettings.effortLevel !== ''
-      && !Object.hasOwn(data, 'effortLevel')
-    ) {
-      data.effortLevel = hostSettings.effortLevel;
-      changed = true;
+    if (hostSettings) {
+      changed = mergeMissingStringEnvFields(data, hostSettings) || changed;
+      changed = mergeMissingTopLevelSettings(data, hostSettings) || changed;
     }
   }
   if (changed) {

--- a/tests/integration/cli/sandbox-inheritance.test.ts
+++ b/tests/integration/cli/sandbox-inheritance.test.ts
@@ -445,6 +445,191 @@ test("ensureClaudeSettings skips empty host effort level", async () => {
   }
 });
 
+test("ensureClaudeSettings inherits host provider env and model settings", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-provider-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-provider-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".claude", "settings.json"),
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.deepseek.example/anthropic",
+          ANTHROPIC_AUTH_TOKEN: "test-token-redacted",
+          ANTHROPIC_MODEL: "deepseek-v4-pro[1m]",
+          ANTHROPIC_OPUS_MODEL: "deepseek-v4-pro[1m]",
+          ANTHROPIC_SONNET_MODEL: "deepseek-v4-flash",
+          ANTHROPIC_HAIKU_MODEL: "deepseek-v4-flash",
+          ANTHROPIC_SMALL_FAST_MODEL: "deepseek-v4-flash",
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+        },
+        model: "deepseek-v4-pro[1m]",
+        fallbackModel: "deepseek-v4-flash",
+        availableModels: ["deepseek-v4-pro[1m]", "deepseek-v4-flash"],
+        modelOverrides: {
+          opus: "deepseek-v4-pro[1m]",
+          sonnet: "deepseek-v4-flash",
+          haiku: "deepseek-v4-flash",
+          subagent: "deepseek-v4-flash"
+        },
+        enforceAvailableModels: true,
+        advisorModel: "deepseek-v4-flash",
+        apiKeyHelper: "printf test-token-redacted",
+        theme: "dark"
+      }),
+      "utf8"
+    );
+
+    sandboxCreate.ensureClaudeSettings(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "settings.json"), "utf8"));
+    assert.deepEqual(data.env, {
+      ANTHROPIC_BASE_URL: "https://api.deepseek.example/anthropic",
+      ANTHROPIC_AUTH_TOKEN: "test-token-redacted",
+      ANTHROPIC_MODEL: "deepseek-v4-pro[1m]",
+      ANTHROPIC_OPUS_MODEL: "deepseek-v4-pro[1m]",
+      ANTHROPIC_SONNET_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_HAIKU_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_SMALL_FAST_MODEL: "deepseek-v4-flash",
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+    });
+    assert.equal(data.model, "deepseek-v4-pro[1m]");
+    assert.equal(data.fallbackModel, "deepseek-v4-flash");
+    assert.deepEqual(data.availableModels, ["deepseek-v4-pro[1m]", "deepseek-v4-flash"]);
+    assert.deepEqual(data.modelOverrides, {
+      opus: "deepseek-v4-pro[1m]",
+      sonnet: "deepseek-v4-flash",
+      haiku: "deepseek-v4-flash",
+      subagent: "deepseek-v4-flash"
+    });
+    assert.equal(data.enforceAvailableModels, true);
+    assert.equal(data.advisorModel, "deepseek-v4-flash");
+    assert.equal(data.apiKeyHelper, "printf test-token-redacted");
+    assert.equal(Object.hasOwn(data, "theme"), false);
+    assert.equal(data.skipDangerousModePermissionPrompt, true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeSettings preserves sandbox provider fields and fills missing env", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-provider-keep-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-provider-keep-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".claude", "settings.json"),
+      JSON.stringify({
+        env: {
+          ANTHROPIC_MODEL: "host-model",
+          ANTHROPIC_SMALL_FAST_MODEL: "host-fast-model"
+        },
+        model: "host-top-level-model",
+        fallbackModel: "host-fallback-model"
+      }),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({
+        skipDangerousModePermissionPrompt: true,
+        env: {
+          ANTHROPIC_MODEL: "sandbox-model"
+        },
+        model: "sandbox-top-level-model"
+      }),
+      "utf8"
+    );
+
+    sandboxCreate.ensureClaudeSettings(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "settings.json"), "utf8"));
+    assert.deepEqual(data.env, {
+      ANTHROPIC_MODEL: "sandbox-model",
+      ANTHROPIC_SMALL_FAST_MODEL: "host-fast-model"
+    });
+    assert.equal(data.model, "sandbox-top-level-model");
+    assert.equal(data.fallbackModel, "host-fallback-model");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeSettings skips invalid host env values and non-object sandbox env", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-provider-invalid-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-provider-invalid-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".claude", "settings.json"),
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.example.test",
+          ANTHROPIC_AUTH_TOKEN: "",
+          ANTHROPIC_MODEL: ["not", "a", "string"],
+          ANTHROPIC_SMALL_FAST_MODEL: false
+        }
+      }),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({
+        skipDangerousModePermissionPrompt: true,
+        env: "keep-local-env-value"
+      }),
+      "utf8"
+    );
+
+    sandboxCreate.ensureClaudeSettings(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "settings.json"), "utf8"));
+    assert.equal(data.env, "keep-local-env-value");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeSettings skips non-object host env without defaulting effort env", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-host-env-invalid-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-env-invalid-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".claude"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".claude", "settings.json"), JSON.stringify({ env: "invalid" }), "utf8");
+    sandboxCreate.ensureClaudeSettings(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "settings.json"), "utf8"));
+    assert.equal(Object.hasOwn(data, "env"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureClaudeSettings skips malformed host settings", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-settings-malformed-host-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-host-malformed-settings-"));
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".claude"), { recursive: true });
+    fs.writeFileSync(path.join(hostHome, ".claude", "settings.json"), "{not-json:test-token-redacted", "utf8");
+    sandboxCreate.ensureClaudeSettings(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "settings.json"), "utf8"));
+    assert.deepEqual(data, { skipDangerousModePermissionPrompt: true });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
 test("ensureCodexModelInheritance creates config with host model fields", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-model-"));


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #554 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

让 `ai sandbox create` 在启用 Claude Code 时继承宿主机 `~/.claude/settings.json` 中的模型和 API provider 配置，使沙箱内 Claude Code 能复用与宿主一致的 Anthropic-compatible/provider 设置，同时保留沙箱本地覆盖。

## 📋 主要变更 / Brief Changelog

- 扩展 `ensureClaudeSettings`，按 first-write 语义继承 host Claude Code provider `env` 和模型/API 顶层 allowlist 字段。
- 增加 Claude settings provider 继承测试，覆盖 DeepSeek 示例映射、sandbox 值保留、非法值跳过和损坏 host settings。
- 更新 sandbox 英文与中文文档，说明 settings 继承和 credentials 专用通道边界。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --experimental-strip-types --no-warnings --test "tests/integration/cli/sandbox-inheritance.test.ts"`
2. `npm run build`
3. `npm run test:smoke`
4. `npm run test:core`
5. `npm test`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

N/A

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 Claude Code settings `env` 合并边界：只继承非空字符串值、sandbox 已有值优先、sandbox `env` 非对象时不覆盖，并确认实现没有 DeepSeek 专用分支。

Generated with AI assistance
