### PR TITLE
fix(cli): dedupe review human counts in task log

### DIFF
--- a/lib/task/commands/log.ts
+++ b/lib/task/commands/log.ts
@@ -50,6 +50,7 @@ const ENV_BLOCKED_RE = /\(\+\s*(\d+)\s+env-blocked\)/i;
 // Same match plus any leading whitespace, so folding the count into the verdict
 // text drops the redundant `(+ n env-blocked)` fragment without leaving a gap.
 const ENV_BLOCKED_STRIP_RE = /\s*\(\+\s*\d+\s+env-blocked\)/i;
+const HUMAN_COUNTS_STRIP_RE = /(?:,\s*)?\bManual-verify:\s*\d+,\s*Human-decision:\s*\d+/gi;
 const REVIEW_STAGE_PREFIXES: { prefix: string; stage: ReviewStage }[] = [
   { prefix: 'Review Analysis', stage: 'analysis' },
   { prefix: 'Review Plan', stage: 'plan' },
@@ -144,7 +145,11 @@ function isHumanAgent(agent: string): boolean {
 // the review count line. The raw `(+ n env-blocked)` fragment is dropped so the
 // env-blocked number is not shown twice (it becomes the manual-verify count).
 function foldHumanCounts(note: string, decisions: number, envBlocked: number): string {
-  const base = note.replace(ENV_BLOCKED_STRIP_RE, '');
+  const base = note
+    .replace(ENV_BLOCKED_STRIP_RE, '')
+    .replace(HUMAN_COUNTS_STRIP_RE, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
   const group = `Manual-verify: ${envBlocked}, Human-decision: ${decisions}`;
   const arrow = base.indexOf(' → ');
   return arrow === -1 ? `${base}, ${group}` : `${base.slice(0, arrow)}, ${group}${base.slice(arrow)}`;

--- a/tests/integration/cli/task-log.test.ts
+++ b/tests/integration/cli/task-log.test.ts
@@ -180,6 +180,29 @@ test('ai task log folds English human counts for an English task', () => {
   );
 });
 
+test('ai task log replaces pre-existing human counts on canonical review steps', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000017';
+  writeTask(
+    activeDir,
+    taskId,
+    '## 活动日志',
+    [
+      '- 2026-06-18 14:00:00+08:00 — **Review Plan (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 9, Human-decision: 8 (+ 2 env-blocked) → review-plan.md'
+    ],
+    ['| HD-1 | plan | - | decision | needs-human-decision | plan.md#HD-1 |']
+  );
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(
+    out.stdout,
+    /^1\s+Review Plan \(Round 1\)\s+claude\s+2026-06-18 14:00:00\+08:00\s+Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-verify: 2, Human-decision: 1 → review-plan\.md/m
+  );
+  assert.equal(out.stdout.match(/Manual-verify:/g)?.length, 1);
+  assert.equal(out.stdout.match(/Human-decision:/g)?.length, 1);
+});
+
 test('ai task log renders a human-executed review row as `human` with a `-` STARTED placeholder', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000015';


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #555 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Fix duplicated `Manual-verify` and `Human-decision` fields in `ai task log` / `ai t log` review-step NOTE output. Historical activity log notes can already contain these fields, and the renderer was appending a newly computed pair without removing the stale pair first.

## 📋 主要变更 / Brief Changelog

- Strip pre-existing `Manual-verify: N, Human-decision: N` text before folding current review human counts into NOTE output.
- Keep `Manual-verify` sourced from `(+ N env-blocked)` and `Human-decision` sourced from the current review ledger.
- Add an integration regression test that verifies stale values are replaced and the final output contains each field exactly once.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --test tests/integration/cli/task-log.test.ts`
2. `npm test`
3. Commit hook: `npm run typecheck`
4. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #555 milestone `0.8.1`.
- The fix is limited to canonical review-step rendering; it does not migrate historical `task.md` activity logs.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on whether the cleanup regex is narrow enough to remove only the fixed English human-count pair, and whether `Manual-verify` still comes from the original `(+ N env-blocked)` fragment rather than stale note text.

Generated with AI assistance
