### PR TITLE
refactor(cli): 改进 ai run 沙盒模式流式输出体验

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -20,7 +20,7 @@ Commands:
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another workspace directory (active/blocked/completed/archive)
-  run             Run a whitelisted lifecycle skill through a non-interactive TUI
+  run             Schedule a lifecycle skill in the task sandbox tmux session
   sandbox, s      Manage Docker-based AI sandboxes
   server          Run the local AI collaboration daemon (start/stop/status/logs)
   task, t         Read-only views over .agents/workspace tasks (cat / files / grep / log / ls / show / status)

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -16,6 +16,8 @@ export type SandboxRunRequest = {
   taskRef: string;
   branch: string;
   command: string[];
+  onStdoutChunk?: (chunk: string) => void | Promise<void>;
+  onStderrChunk?: (chunk: string) => void | Promise<void>;
 };
 
 export type RunSkillOptions = {
@@ -96,13 +98,28 @@ export async function runSkill(args: string[], options: RunSkillOptions = {}): P
 
   const repoRoot = options.repoRoot ?? config?.repoRoot ?? process.cwd();
   const branch = resolveTaskBranch(parsed.taskRef, repoRoot);
-  const runSandbox = options.runSandbox ?? ((request: SandboxRunRequest) => runInSandbox(request));
-  const result = await runSandbox({ taskRef: parsed.taskRef, branch, command });
-  if (result.stdout) {
-    (options.writeStdout ?? ((chunk: string) => process.stdout.write(chunk)))(result.stdout);
+  const writeStdout = options.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
+  const writeStderr = options.writeStderr ?? ((chunk: string) => process.stderr.write(chunk));
+  let streamedStdout = false;
+  let streamedStderr = false;
+  const onStdoutChunk = (chunk: string): void => {
+    streamedStdout = true;
+    writeStdout(chunk);
+  };
+  const onStderrChunk = (chunk: string): void => {
+    streamedStderr = true;
+    writeStderr(chunk);
+  };
+  const runSandbox =
+    options.runSandbox ??
+    (({ onStdoutChunk, onStderrChunk, ...request }: SandboxRunRequest) =>
+      runInSandbox(request, { onStdoutChunk, onStderrChunk }));
+  const result = await runSandbox({ taskRef: parsed.taskRef, branch, command, onStdoutChunk, onStderrChunk });
+  if (!streamedStdout && result.stdout) {
+    writeStdout(result.stdout);
   }
-  if (result.stderr) {
-    (options.writeStderr ?? ((chunk: string) => process.stderr.write(chunk)))(result.stderr);
+  if (!streamedStderr && result.stderr) {
+    writeStderr(result.stderr);
   }
   return result.exitCode ?? (result.signal ? 1 : 0);
 }

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -1,6 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { loadServerConfig } from '../server/config.ts';
 import { resolveTaskBranch } from '../sandbox/task-resolver.ts';
-import { runInSandbox } from '../sandbox/capture.ts';
+import { createRunId, runInSandbox, type SandboxRunMetadata } from '../sandbox/capture.ts';
+import { loadShortIdByTaskId, normalizeShortIdInput } from '../task/short-id.ts';
 import { buildTuiCommand, renderPrompt, selectTui } from './tui.ts';
 import { getSkillRunSpec } from './skills.ts';
 import { runHostCommand, type RunProcessResult } from './host.ts';
@@ -16,20 +19,26 @@ export type SandboxRunRequest = {
   taskRef: string;
   branch: string;
   command: string[];
-  onStdoutChunk?: (chunk: string) => void | Promise<void>;
-  onStderrChunk?: (chunk: string) => void | Promise<void>;
+  runId?: string;
+};
+
+export type SandboxRunResult = RunProcessResult & {
+  run?: SandboxRunMetadata;
 };
 
 export type RunSkillOptions = {
   command?: Record<string, unknown>;
   repoRoot?: string;
   runHost?: (command: string[]) => Promise<RunProcessResult>;
-  runSandbox?: (request: SandboxRunRequest) => Promise<RunProcessResult>;
+  runSandbox?: (request: SandboxRunRequest) => Promise<SandboxRunResult>;
   writeStdout?: (chunk: string) => void;
   writeStderr?: (chunk: string) => void;
 };
 
 const USAGE = `Usage: ai run <skill> [task-ref] [args...] [--tui <name>]
+
+Task skills are scheduled inside the sandbox tmux session; ai run returns once
+the tmux window is created.
 
 Examples:
   ai run create-task "describe the task" --tui codex
@@ -80,6 +89,99 @@ function assertAllowedByConfig(skill: string, commandConfig: Record<string, unkn
   }
 }
 
+const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
+
+function readShortIdLength(repoRoot: string): number {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8'));
+    const value = cfg?.task?.shortIdLength;
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 1) return value;
+  } catch {
+    // Use the project default when config is absent in lightweight tests.
+  }
+  return 2;
+}
+
+function readActiveShortIdRegistry(repoRoot: string): Record<string, string> {
+  const registryPath = path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json');
+  try {
+    const data = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    return data && typeof data === 'object' && data.ids && typeof data.ids === 'object' ? data.ids : {};
+  } catch {
+    return {};
+  }
+}
+
+type ActiveTaskIdentity = {
+  taskId: string;
+  taskDir: string;
+  taskRef: string;
+};
+
+function resolveActiveTaskIdentity(taskRef: string, repoRoot: string): ActiveTaskIdentity | null {
+  let taskId: string | null = null;
+  let resolvedTaskRef = taskRef;
+
+  if (TASK_ID_RE.test(taskRef)) {
+    taskId = taskRef;
+    resolvedTaskRef = loadShortIdByTaskId(repoRoot).get(taskId) ?? taskRef;
+  } else {
+    const normalized = normalizeShortIdInput(taskRef, { shortIdLength: readShortIdLength(repoRoot) });
+    if (normalized.kind !== 'shortId') return null;
+    resolvedTaskRef = normalized.value;
+    taskId = readActiveShortIdRegistry(repoRoot)[normalized.value.slice(1)] ?? null;
+  }
+
+  if (!taskId) return null;
+  const taskDir = path.join(repoRoot, '.agents', 'workspace', 'active', taskId);
+  if (!fs.existsSync(path.join(taskDir, 'task.md'))) return null;
+  return { taskId, taskDir, taskRef: resolvedTaskRef };
+}
+
+function formatLocalTimestamp(date: Date = new Date()): string {
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hour = pad(date.getHours());
+  const minute = pad(date.getMinutes());
+  const second = pad(date.getSeconds());
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetHour = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+  const offsetMinute = pad(Math.abs(offsetMinutes) % 60);
+  return `${year}-${month}-${day} ${hour}:${minute}:${second}${sign}${offsetHour}:${offsetMinute}`;
+}
+
+function writeRunRecord(params: {
+  identity: ActiveTaskIdentity;
+  run: SandboxRunMetadata;
+  branch: string;
+  command: string[];
+}): void {
+  const runsDir = path.join(params.identity.taskDir, 'runs');
+  fs.mkdirSync(runsDir, { recursive: true });
+  const record = {
+    version: 1,
+    run_id: params.run.runId,
+    task_id: params.identity.taskId,
+    task_ref: params.identity.taskRef,
+    branch: params.branch,
+    engine: params.run.engine,
+    container: params.run.container,
+    run_dir: params.run.runDir,
+    status_file: `${params.run.runDir}/status`,
+    log_file: `${params.run.runDir}/output.log`,
+    created_at: formatLocalTimestamp(),
+    command: params.command
+  };
+  fs.writeFileSync(
+    path.join(runsDir, `${params.run.runId}.json`),
+    `${JSON.stringify(record, null, 2)}\n`,
+    'utf8'
+  );
+}
+
 export async function runSkill(args: string[], options: RunSkillOptions = {}): Promise<number> {
   const parsed = parseRunArgs(args);
   const config = options.command ? null : loadServerConfig({ rootDir: options.repoRoot });
@@ -98,28 +200,22 @@ export async function runSkill(args: string[], options: RunSkillOptions = {}): P
 
   const repoRoot = options.repoRoot ?? config?.repoRoot ?? process.cwd();
   const branch = resolveTaskBranch(parsed.taskRef, repoRoot);
+  const identity = resolveActiveTaskIdentity(parsed.taskRef, repoRoot);
+  const runId = identity ? createRunId() : undefined;
   const writeStdout = options.writeStdout ?? ((chunk: string) => process.stdout.write(chunk));
   const writeStderr = options.writeStderr ?? ((chunk: string) => process.stderr.write(chunk));
-  let streamedStdout = false;
-  let streamedStderr = false;
-  const onStdoutChunk = (chunk: string): void => {
-    streamedStdout = true;
-    writeStdout(chunk);
-  };
-  const onStderrChunk = (chunk: string): void => {
-    streamedStderr = true;
-    writeStderr(chunk);
-  };
   const runSandbox =
     options.runSandbox ??
-    (({ onStdoutChunk, onStderrChunk, ...request }: SandboxRunRequest) =>
-      runInSandbox(request, { onStdoutChunk, onStderrChunk }));
-  const result = await runSandbox({ taskRef: parsed.taskRef, branch, command, onStdoutChunk, onStderrChunk });
-  if (!streamedStdout && result.stdout) {
+    ((request: SandboxRunRequest) => runInSandbox(request));
+  const result = await runSandbox({ taskRef: parsed.taskRef, branch, command, runId });
+  if (result.stdout) {
     writeStdout(result.stdout);
   }
-  if (!streamedStderr && result.stderr) {
+  if (result.stderr) {
     writeStderr(result.stderr);
+  }
+  if ((result.exitCode ?? (result.signal ? 1 : 0)) === 0 && identity && result.run) {
+    writeRunRecord({ identity, run: result.run, branch, command });
   }
   return result.exitCode ?? (result.signal ? 1 : 0);
 }

--- a/lib/sandbox/capture.ts
+++ b/lib/sandbox/capture.ts
@@ -22,43 +22,35 @@ export type SandboxCaptureResult = {
   signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
+  run?: SandboxRunMetadata;
+};
+
+export type SandboxRunMetadata = {
+  runId: string;
+  engine: string;
+  container: string;
+  runDir: string;
 };
 
 export type SandboxCaptureOptions = {
   engine?: string;
   repoRoot?: string;
+  runId?: string;
   containerCandidates?: string[];
   rows?: SandboxRow[];
   startContainer?: (name: string) => void;
-  spawn?: (
-    file: string,
-    args: string[],
-    options?: {
-      onStdoutChunk?: (chunk: string) => void | Promise<void>;
-      onStderrChunk?: (chunk: string) => void | Promise<void>;
-    }
-  ) => Promise<SandboxCaptureResult>;
-  onStdoutChunk?: (chunk: string) => void | Promise<void>;
-  onStderrChunk?: (chunk: string) => void | Promise<void>;
+  spawn?: (file: string, args: string[]) => Promise<SandboxCaptureResult>;
 };
-
-type SandboxChunkCallback = NonNullable<SandboxCaptureOptions['onStdoutChunk']>;
 
 async function spawnCapture(
   file: string,
-  args: string[],
-  options: {
-    onStdoutChunk?: SandboxChunkCallback;
-    onStderrChunk?: SandboxChunkCallback;
-  } = {}
+  args: string[]
 ): Promise<SandboxCaptureResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(file, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     let settled = false;
-    let stdoutPending = Promise.resolve();
-    let stderrPending = Promise.resolve();
     const rejectOnce = (error: unknown): void => {
       if (settled) return;
       settled = true;
@@ -69,29 +61,112 @@ async function spawnCapture(
       settled = true;
       resolve(result);
     };
-    const enqueue = (pending: Promise<void>, callback: SandboxChunkCallback | undefined, chunk: string): Promise<void> => {
-      if (!callback) return pending;
-      return pending.then(() => callback(chunk)).then(undefined, (error) => {
-        rejectOnce(error);
-      });
-    };
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (chunk) => {
       stdout += chunk;
-      stdoutPending = enqueue(stdoutPending, options.onStdoutChunk, chunk);
     });
     child.stderr.on('data', (chunk) => {
       stderr += chunk;
-      stderrPending = enqueue(stderrPending, options.onStderrChunk, chunk);
     });
     child.on('error', rejectOnce);
     child.on('close', (exitCode, signal) => {
-      Promise.all([stdoutPending, stderrPending])
-        .then(() => resolveOnce({ exitCode, signal, stdout, stderr }))
-        .catch(rejectOnce);
+      resolveOnce({ exitCode, signal, stdout, stderr });
     });
   });
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function createRunId(date: Date = new Date()): string {
+  return `run-${date.toISOString().replace(/\.\d{3}Z$/, 'Z').replace(/[-:]/g, '').replace('T', '-').replace('Z', '')}-${process.pid}`;
+}
+
+function buildRunScript(params: {
+  command: string[];
+  runDir: string;
+  runId: string;
+}): string {
+  const command = params.command.map(shellQuote).join(' ');
+  const runDir = shellQuote(params.runDir);
+  const runId = shellQuote(params.runId);
+  return `#!/bin/sh
+set -u
+cd /workspace
+date "+%Y-%m-%d %H:%M:%S%:z" > ${runDir}/started_at
+printf '%s\\n' running > ${runDir}/status
+${command}
+code=$?
+printf '%s\\n' "$code" > ${runDir}/exit_code
+date "+%Y-%m-%d %H:%M:%S%:z" > ${runDir}/finished_at
+if [ "$code" -eq 0 ]; then
+  printf '%s\\n' completed > ${runDir}/status
+else
+  printf '%s\\n' failed > ${runDir}/status
+fi
+printf '\\n[agent-infra] run %s finished with exit code %s\\n' ${runId} "$code"
+exec bash -l
+`;
+}
+
+function buildTmuxLauncher(params: {
+  request: SandboxCaptureRequest;
+  runId: string;
+}): string {
+  const session = 'work';
+  const window = `ai-${params.runId.replace(/^run-/, '').slice(0, 18)}`;
+  const runRoot = '/tmp/agent-infra-runs';
+  const runDir = `${runRoot}/${params.runId}`;
+  const runScript = buildRunScript({ command: params.request.command, runDir, runId: params.runId });
+  const runScriptBase64 = Buffer.from(runScript, 'utf8').toString('base64');
+  const paneCommand = `cd /workspace && ${shellQuote(`${runDir}/run.sh`)}`;
+
+  return `set -eu
+session=${shellQuote(session)}
+window=${shellQuote(window)}
+run_id=${shellQuote(params.runId)}
+run_dir=${shellQuote(runDir)}
+task_ref=${shellQuote(params.request.taskRef)}
+branch=${shellQuote(params.request.branch)}
+
+sandbox-dotfiles-link >/dev/null 2>&1 || true
+mkdir -p "$run_dir"
+printf '%s\\n' pending > "$run_dir/status"
+printf '%s\\n' "$task_ref" > "$run_dir/task_ref"
+printf '%s\\n' "$branch" > "$run_dir/branch"
+printf '%s\\n' ${shellQuote(params.request.command.join(' '))} > "$run_dir/command"
+printf '%s' ${shellQuote(runScriptBase64)} | base64 -d > "$run_dir/run.sh"
+chmod +x "$run_dir/run.sh"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  printf '%s\\n' "tmux is not installed in this sandbox" >&2
+  exit 127
+fi
+
+if ! tmux has-session -t "$session" 2>/dev/null; then
+  tmux new-session -d -s "$session" -n shell
+fi
+
+if [ -n "\${TZ:-}" ]; then
+  tmux set-environment -t "$session" TZ "$TZ" 2>/dev/null || true
+fi
+
+pane=$(tmux new-window -d -P -F '#{pane_id}' -t "$session" -n "$window")
+printf '%s\\n' "$session" > "$run_dir/session"
+printf '%s\\n' "$window" > "$run_dir/window"
+printf '%s\\n' "$pane" > "$run_dir/pane"
+tmux pipe-pane -o -t "$pane" "cat > $run_dir/output.log"
+tmux send-keys -t "$pane" ${shellQuote(paneCommand)} Enter
+
+cat <<EOF
+Started sandbox run $run_id in tmux session '$session', window '$window', pane '$pane'.
+Attach with: ai sandbox enter $task_ref
+Status file: $run_dir/status
+Output log: $run_dir/output.log
+EOF
+`;
 }
 
 export async function runInSandbox(
@@ -116,15 +191,25 @@ export async function runInSandbox(
   if (!found.running) {
     (options.startContainer ?? ((name: string) => startSandboxContainer(engine, name)))(found.name);
   }
+  const runId = options.runId ?? createRunId();
+  const runDir = `/tmp/agent-infra-runs/${runId}`;
   const dockerArgs = [
     'exec',
     ...terminalEnvFlags(),
     ...hostTimezoneEnvFlags(),
     found.name,
-    ...request.command
+    'bash',
+    '-lc',
+    buildTmuxLauncher({ request, runId })
   ];
-  return (options.spawn ?? spawnCapture)('docker', dockerArgs, {
-    onStdoutChunk: options.onStdoutChunk,
-    onStderrChunk: options.onStderrChunk
-  });
+  const result = await (options.spawn ?? spawnCapture)('docker', dockerArgs);
+  return {
+    ...result,
+    run: {
+      runId,
+      engine,
+      container: found.name,
+      runDir
+    }
+  };
 }

--- a/lib/sandbox/capture.ts
+++ b/lib/sandbox/capture.ts
@@ -30,24 +30,67 @@ export type SandboxCaptureOptions = {
   containerCandidates?: string[];
   rows?: SandboxRow[];
   startContainer?: (name: string) => void;
-  spawn?: (file: string, args: string[]) => Promise<SandboxCaptureResult>;
+  spawn?: (
+    file: string,
+    args: string[],
+    options?: {
+      onStdoutChunk?: (chunk: string) => void | Promise<void>;
+      onStderrChunk?: (chunk: string) => void | Promise<void>;
+    }
+  ) => Promise<SandboxCaptureResult>;
+  onStdoutChunk?: (chunk: string) => void | Promise<void>;
+  onStderrChunk?: (chunk: string) => void | Promise<void>;
 };
 
-async function spawnCapture(file: string, args: string[]): Promise<SandboxCaptureResult> {
+type SandboxChunkCallback = NonNullable<SandboxCaptureOptions['onStdoutChunk']>;
+
+async function spawnCapture(
+  file: string,
+  args: string[],
+  options: {
+    onStdoutChunk?: SandboxChunkCallback;
+    onStderrChunk?: SandboxChunkCallback;
+  } = {}
+): Promise<SandboxCaptureResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(file, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let stdoutPending = Promise.resolve();
+    let stderrPending = Promise.resolve();
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    const resolveOnce = (result: SandboxCaptureResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const enqueue = (pending: Promise<void>, callback: SandboxChunkCallback | undefined, chunk: string): Promise<void> => {
+      if (!callback) return pending;
+      return pending.then(() => callback(chunk)).then(undefined, (error) => {
+        rejectOnce(error);
+      });
+    };
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (chunk) => {
       stdout += chunk;
+      stdoutPending = enqueue(stdoutPending, options.onStdoutChunk, chunk);
     });
     child.stderr.on('data', (chunk) => {
       stderr += chunk;
+      stderrPending = enqueue(stderrPending, options.onStderrChunk, chunk);
     });
-    child.on('error', reject);
-    child.on('close', (exitCode, signal) => resolve({ exitCode, signal, stdout, stderr }));
+    child.on('error', rejectOnce);
+    child.on('close', (exitCode, signal) => {
+      Promise.all([stdoutPending, stderrPending])
+        .then(() => resolveOnce({ exitCode, signal, stdout, stderr }))
+        .catch(rejectOnce);
+    });
   });
 }
 
@@ -80,5 +123,8 @@ export async function runInSandbox(
     found.name,
     ...request.command
   ];
-  return (options.spawn ?? spawnCapture)('docker', dockerArgs);
+  return (options.spawn ?? spawnCapture)('docker', dockerArgs, {
+    onStdoutChunk: options.onStdoutChunk,
+    onStderrChunk: options.onStderrChunk
+  });
 }

--- a/lib/task/commands/status.ts
+++ b/lib/task/commands/status.ts
@@ -1,14 +1,18 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { commandForEngine } from '../../sandbox/shell.ts';
 import { resolveTaskRef } from '../resolve-ref.ts';
 import { enumerateArtifacts, type Artifact } from '../artifacts.ts';
 import { parseTaskFrontmatter, extractTitle, type Frontmatter } from '../frontmatter.ts';
 import { loadShortIdByTaskId } from '../short-id.ts';
+import { parseActivityLog, pairEntries } from './log.ts';
 
 const USAGE = `Usage: ai task status <N | #N | TASK-id>
 
-Prints an aggregated "health check" view for a task: header, metadata, an
-artifacts summary, git branch state, and best-effort GitHub issue/PR status.
+Prints an aggregated "health check" view for a task: header, metadata,
+artifacts, workflow/runtime execution state, git branch state, and best-effort
+GitHub issue/PR status.
   <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
 
 Git and Platform rows are best-effort: a failed git/gh call degrades that row to
@@ -195,6 +199,167 @@ function collectPlatform(fm: Frontmatter, run: Runner): PlatformInfo {
   return { issue, pr };
 }
 
+type WorkflowInfo = {
+  state: string;
+  step: string;
+  agent: string;
+  startedAt: string;
+  doneAt: string;
+  stale: string;
+};
+
+const STALE_MS = 60 * 60 * 1000;
+
+function parseActivityTime(value: string): number {
+  const epoch = Date.parse(value.replace(' ', 'T'));
+  return Number.isFinite(epoch) ? epoch : Number.NaN;
+}
+
+function collectWorkflow(content: string, now: Date = new Date()): WorkflowInfo {
+  const parsed = parseActivityLog(content);
+  if (!parsed.sectionFound || parsed.entries.length === 0) {
+    return { state: 'unknown', step: DASH, agent: DASH, startedAt: DASH, doneAt: DASH, stale: DASH };
+  }
+
+  const rows = pairEntries(parsed.entries);
+  const latest = rows.at(-1);
+  if (!latest) {
+    return { state: 'unknown', step: DASH, agent: DASH, startedAt: DASH, doneAt: DASH, stale: DASH };
+  }
+
+  const inProgress = latest.started !== '' && latest.done === '';
+  const state = inProgress ? 'in-progress' : latest.done ? 'idle' : 'unknown';
+  let stale = DASH;
+  if (inProgress) {
+    const started = parseActivityTime(latest.started);
+    stale = Number.isFinite(started) ? (now.getTime() - started > STALE_MS ? 'yes' : 'no') : 'unknown';
+  }
+
+  return {
+    state,
+    step: latest.step || DASH,
+    agent: latest.agent || DASH,
+    startedAt: latest.started || DASH,
+    doneAt: latest.done || DASH,
+    stale
+  };
+}
+
+type RuntimeInfo = {
+  mode: string;
+  status: string;
+  run: string;
+  tmux: string;
+  startedAt: string;
+  finishedAt: string;
+  exitCode: string;
+  log: string;
+};
+
+type ManagedRunRecord = {
+  run_id: string;
+  engine: string;
+  container: string;
+  run_dir: string;
+  status_file: string;
+  log_file: string;
+};
+
+function latestRunRecord(taskDir: string): ManagedRunRecord | null {
+  const runsDir = path.join(taskDir, 'runs');
+  if (!fs.existsSync(runsDir)) return null;
+  const candidates: { path: string; mtimeMs: number }[] = [];
+  for (const entry of fs.readdirSync(runsDir)) {
+    if (!entry.endsWith('.json')) continue;
+    const filePath = path.join(runsDir, entry);
+    const stat = fs.statSync(filePath);
+    if (stat.isFile()) candidates.push({ path: filePath, mtimeMs: stat.mtimeMs });
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const candidate of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(candidate.path, 'utf8'));
+      if (
+        typeof data?.run_id === 'string' &&
+        typeof data?.engine === 'string' &&
+        typeof data?.container === 'string' &&
+        typeof data?.run_dir === 'string'
+      ) {
+        return {
+          run_id: data.run_id,
+          engine: data.engine,
+          container: data.container,
+          run_dir: data.run_dir,
+          status_file:
+            typeof data.status_file === 'string' ? data.status_file : `${data.run_dir}/status`,
+          log_file:
+            typeof data.log_file === 'string' ? data.log_file : `${data.run_dir}/output.log`
+        };
+      }
+    } catch {
+      // Ignore malformed local records and try the next newest file.
+    }
+  }
+
+  return null;
+}
+
+function readRuntimeFile(record: ManagedRunRecord, filePath: string, run: Runner): string | null {
+  const command = commandForEngine(record.engine, 'docker', ['exec', record.container, 'cat', filePath]);
+  const output = tryRun(run, command.cmd, command.args);
+  return output === null ? null : output.trim();
+}
+
+function runtimeValue(record: ManagedRunRecord, name: string, run: Runner): string {
+  const output = readRuntimeFile(record, `${record.run_dir}/${name}`, run);
+  return output ? output : DASH;
+}
+
+function collectRuntime(taskDir: string, workflow: WorkflowInfo, run: Runner): RuntimeInfo {
+  const record = latestRunRecord(taskDir);
+  if (!record) {
+    return workflow.state === 'in-progress'
+      ? {
+          mode: 'unmanaged',
+          status: 'inferred-from-workflow',
+          run: DASH,
+          tmux: DASH,
+          startedAt: DASH,
+          finishedAt: DASH,
+          exitCode: DASH,
+          log: DASH
+        }
+      : {
+          mode: 'none',
+          status: DASH,
+          run: DASH,
+          tmux: DASH,
+          startedAt: DASH,
+          finishedAt: DASH,
+          exitCode: DASH,
+          log: DASH
+        };
+  }
+
+  const status = readRuntimeFile(record, record.status_file, run)?.trim() || 'unknown';
+  const session = runtimeValue(record, 'session', run);
+  const window = runtimeValue(record, 'window', run);
+  const pane = runtimeValue(record, 'pane', run);
+  const tmux = session !== DASH && window !== DASH && pane !== DASH ? `${session}:${window}:${pane}` : DASH;
+
+  return {
+    mode: 'managed-tmux',
+    status,
+    run: record.run_id,
+    tmux,
+    startedAt: runtimeValue(record, 'started_at', run),
+    finishedAt: runtimeValue(record, 'finished_at', run),
+    exitCode: runtimeValue(record, 'exit_code', run),
+    log: record.log_file
+  };
+}
+
 type StatusModel = {
   taskId: string;
   shortId: string;
@@ -202,6 +367,8 @@ type StatusModel = {
   issueNumber: string;
   metadata: [string, string][];
   artifacts: { count: number; groups: { stage: string; files: string[] }[] };
+  workflow: WorkflowInfo;
+  runtime: RuntimeInfo;
   git: GitInfo;
   platform: PlatformInfo;
 };
@@ -227,6 +394,34 @@ function renderStatus(model: StatusModel): string[] {
   } else {
     lines.push(...renderPairs(model.artifacts.groups.map((group) => [group.stage, group.files.join(', ')])));
   }
+
+  lines.push(
+    '',
+    'Workflow',
+    ...renderPairs([
+      ['state', model.workflow.state],
+      ['step', model.workflow.step],
+      ['agent', model.workflow.agent],
+      ['started_at', model.workflow.startedAt],
+      ['done_at', model.workflow.doneAt],
+      ['stale', model.workflow.stale]
+    ])
+  );
+
+  lines.push(
+    '',
+    'Runtime',
+    ...renderPairs([
+      ['mode', model.runtime.mode],
+      ['status', model.runtime.status],
+      ['run', model.runtime.run],
+      ['tmux', model.runtime.tmux],
+      ['started_at', model.runtime.startedAt],
+      ['finished_at', model.runtime.finishedAt],
+      ['exit_code', model.runtime.exitCode],
+      ['log', model.runtime.log]
+    ])
+  );
 
   lines.push(
     '',
@@ -272,6 +467,7 @@ function status(args: string[] = []): void {
   const fm = parseTaskFrontmatter(content);
   const run = makeRunner(resolved.repoRoot);
   const artifacts = enumerateArtifacts(resolved.taskDir);
+  const workflow = collectWorkflow(content);
 
   const model: StatusModel = {
     taskId: resolved.taskId,
@@ -280,6 +476,8 @@ function status(args: string[] = []): void {
     issueNumber: fm.issue_number && /^\d+$/.test(fm.issue_number) ? fm.issue_number : '',
     metadata: collectMetadata(fm),
     artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
+    workflow,
+    runtime: collectRuntime(resolved.taskDir, workflow, run),
     git: collectGit(fm.branch ?? '', run),
     platform: collectPlatform(fm, run)
   };
@@ -296,7 +494,9 @@ export {
   groupArtifacts,
   collectGit,
   collectPlatform,
+  collectWorkflow,
+  collectRuntime,
   renderStatus,
   METADATA_KEYS
 };
-export type { Runner, GitInfo, PlatformInfo, StatusModel };
+export type { Runner, GitInfo, PlatformInfo, WorkflowInfo, RuntimeInfo, StatusModel };

--- a/lib/task/commands/status.ts
+++ b/lib/task/commands/status.ts
@@ -11,18 +11,17 @@ import { parseActivityLog, pairEntries } from './log.ts';
 const USAGE = `Usage: ai task status <N | #N | TASK-id>
 
 Prints an aggregated "health check" view for a task: header, metadata,
-artifacts, workflow/runtime execution state, git branch state, and best-effort
-GitHub issue/PR status.
+artifacts, workflow/runtime execution state, and git branch state.
   <ref>   Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
 
-Git and Platform rows are best-effort: a failed git/gh call degrades that row to
-'-' without failing the command.
+Git rows are best-effort: a failed git call degrades that row to '-' without
+failing the command.
 `;
 
 const DASH = '-';
 
 // Subprocess boundary: the single place this command shells out. Injectable so
-// the collectors below can be unit-tested without spawning git/gh. Returns the
+// the collectors below can be unit-tested without spawning git. Returns the
 // command's stdout; throws (like execFileSync) on a non-zero exit or spawn error.
 type Runner = (file: string, args: string[]) => string;
 
@@ -31,7 +30,7 @@ function makeRunner(cwd: string): Runner {
     execFileSync(file, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
 }
 
-// Run `run` and swallow any failure into null, so a single failing git/gh call
+// Run `run` and swallow any failure into null, so a single failing git call
 // degrades only its own field instead of aborting the whole view.
 function tryRun(run: Runner, file: string, args: string[]): string | null {
   try {
@@ -51,9 +50,7 @@ const METADATA_KEYS = [
   'branch',
   'assigned_to',
   'created_at',
-  'updated_at',
-  'issue_number',
-  'pr_status'
+  'updated_at'
 ] as const;
 
 function collectMetadata(fm: Frontmatter): [string, string][] {
@@ -157,46 +154,6 @@ function collectGit(frontmatterBranch: string, run: Runner): GitInfo {
   }
 
   return { current, frontmatter, match, exists, uncommitted, aheadBehind };
-}
-
-type PlatformInfo = { issue: string; pr: string };
-
-function collectPlatform(fm: Frontmatter, run: Runner): PlatformInfo {
-  let issue = DASH;
-  if (fm.issue_number && /^\d+$/.test(fm.issue_number)) {
-    const out = tryRun(run, 'gh', ['issue', 'view', fm.issue_number, '--json', 'state,labels']);
-    if (out !== null) {
-      try {
-        const data = JSON.parse(out);
-        const labels = Array.isArray(data.labels)
-          ? data.labels.map((label: { name: string }) => label.name).join(', ')
-          : '';
-        issue = labels ? `${data.state} [${labels}]` : `${data.state}`;
-      } catch {
-        issue = DASH;
-      }
-    }
-  }
-
-  let pr = DASH;
-  if (fm.pr_status === 'created' && fm.pr_number && /^\d+$/.test(fm.pr_number)) {
-    const out = tryRun(run, 'gh', ['pr', 'view', fm.pr_number, '--json', 'state,statusCheckRollup']);
-    if (out !== null) {
-      try {
-        const data = JSON.parse(out);
-        const rollup = Array.isArray(data.statusCheckRollup) ? data.statusCheckRollup : [];
-        const passed = rollup.filter(
-          (check: { conclusion?: string; state?: string }) =>
-            check.conclusion === 'SUCCESS' || check.state === 'SUCCESS'
-        ).length;
-        pr = rollup.length > 0 ? `${data.state}, checks: ${passed}/${rollup.length}` : `${data.state}`;
-      } catch {
-        pr = DASH;
-      }
-    }
-  }
-
-  return { issue, pr };
 }
 
 type WorkflowInfo = {
@@ -364,13 +321,11 @@ type StatusModel = {
   taskId: string;
   shortId: string;
   title: string;
-  issueNumber: string;
   metadata: [string, string][];
   artifacts: { count: number; groups: { stage: string; files: string[] }[] };
   workflow: WorkflowInfo;
   runtime: RuntimeInfo;
   git: GitInfo;
-  platform: PlatformInfo;
 };
 
 // Indent each label/value pair by two spaces and pad labels to a common width so
@@ -436,16 +391,6 @@ function renderStatus(model: StatusModel): string[] {
     ])
   );
 
-  const issueLabel = model.issueNumber ? `issue #${model.issueNumber}` : 'issue';
-  lines.push(
-    '',
-    'Platform',
-    ...renderPairs([
-      [issueLabel, model.platform.issue],
-      ['pr', model.platform.pr]
-    ])
-  );
-
   return lines;
 }
 
@@ -473,13 +418,11 @@ function status(args: string[] = []): void {
     taskId: resolved.taskId,
     shortId: loadShortIdByTaskId(resolved.repoRoot).get(resolved.taskId) ?? DASH,
     title: extractTitle(content),
-    issueNumber: fm.issue_number && /^\d+$/.test(fm.issue_number) ? fm.issue_number : '',
     metadata: collectMetadata(fm),
     artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
     workflow,
     runtime: collectRuntime(resolved.taskDir, workflow, run),
-    git: collectGit(fm.branch ?? '', run),
-    platform: collectPlatform(fm, run)
+    git: collectGit(fm.branch ?? '', run)
   };
 
   for (const line of renderStatus(model)) {
@@ -493,10 +436,9 @@ export {
   collectMetadata,
   groupArtifacts,
   collectGit,
-  collectPlatform,
   collectWorkflow,
   collectRuntime,
   renderStatus,
   METADATA_KEYS
 };
-export type { Runner, GitInfo, PlatformInfo, WorkflowInfo, RuntimeInfo, StatusModel };
+export type { Runner, GitInfo, WorkflowInfo, RuntimeInfo, StatusModel };

--- a/tests/integration/cli/task-status.test.ts
+++ b/tests/integration/cli/task-status.test.ts
@@ -31,7 +31,7 @@ function writeTask(repoRoot: string, state: string, taskId: string): string {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(
     path.join(dir, 'task.md'),
-    `---\nid: ${taskId}\nbranch: feat-${state}\nstatus: ${state}\nissue_number: 999\n---\n# 任务：${taskId}\n`
+    `---\nid: ${taskId}\nbranch: feat-${state}\nstatus: ${state}\n---\n# 任务：${taskId}\n`
   );
   fs.writeFileSync(path.join(dir, 'analysis.md'), 'analysis body\n');
   fs.writeFileSync(path.join(dir, 'plan.md'), 'plan body\n');
@@ -47,10 +47,9 @@ function assertCoreSections(stdout: string, taskId: string): void {
   assert.match(stdout, new RegExp(`^Task ${taskId}\\b`, 'm'));
   assert.match(stdout, /^Metadata$/m);
   assert.match(stdout, /^Artifacts \(\d+\)$/m);
+  assert.match(stdout, /^Workflow$/m);
+  assert.match(stdout, /^Runtime$/m);
   assert.match(stdout, /^Git$/m);
-  // Platform is best-effort; with issue 999 / no gh network it must still render
-  // a row (degraded to '-') rather than crash the command.
-  assert.match(stdout, /^Platform$/m);
 }
 
 // Acceptance: `ai task status <ref>` must work across active / blocked / completed.

--- a/tests/unit/cli/run.test.ts
+++ b/tests/unit/cli/run.test.ts
@@ -132,6 +132,34 @@ test('runSkill forwards sandbox stdout and stderr to the ai run process output',
   assert.deepEqual(stderr, ['warning\n']);
 });
 
+test('runSkill streams sandbox stdout and stderr without repeating final buffers', async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const repoRoot = writeTaskFixture();
+  const code = await runSkill(['code-task', TASK_ID], {
+    repoRoot,
+    command: { defaultTui: 'codex' },
+    writeStdout: (chunk) => stdout.push(chunk),
+    writeStderr: (chunk) => stderr.push(chunk),
+    runSandbox: async (request) => {
+      assert.equal(typeof request.onStdoutChunk, 'function');
+      assert.equal(typeof request.onStderrChunk, 'function');
+      request.onStdoutChunk?.('live out\n');
+      request.onStderrChunk?.('live err\n');
+      return {
+        exitCode: 0,
+        signal: null,
+        stdout: 'final out\n',
+        stderr: 'final err\n'
+      };
+    }
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(stdout, ['live out\n']);
+  assert.deepEqual(stderr, ['live err\n']);
+});
+
 test('runSkill honors command.allowedSkills as a narrowing allow-list', async () => {
   await assert.rejects(
     () =>

--- a/tests/unit/cli/run.test.ts
+++ b/tests/unit/cli/run.test.ts
@@ -9,10 +9,34 @@ import { buildTuiCommand, renderPrompt, selectTui } from '../../../lib/run/tui.t
 
 const TASK_ID = 'TASK-20260430-163836';
 
-function writeTaskFixture(): string {
+function writeTaskFixture(options: { withShortId?: boolean } = {}): string {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'run-skill-repo-'));
   const taskDir = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID);
   fs.mkdirSync(taskDir, { recursive: true });
+  if (options.withShortId) {
+    fs.mkdirSync(path.join(repoRoot, '.agents'), { recursive: true });
+    fs.mkdirSync(path.join(repoRoot, '.agents', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, '.agents', '.airc.json'),
+      JSON.stringify({ task: { shortIdLength: 2 } }),
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json'),
+      JSON.stringify({ version: 1, ids: { '01': TASK_ID } }),
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js'),
+      [
+        "const ref = process.argv[3] || '';",
+        "const normalized = ref.replace(/^#?/, '').padStart(2, '0');",
+        `if (normalized === '01') process.stdout.write('${TASK_ID}\\n');`,
+        "else { process.stderr.write('not found\\n'); process.exit(1); }"
+      ].join('\n'),
+      'utf8'
+    );
+  }
   fs.writeFileSync(
     path.join(taskDir, 'task.md'),
     [
@@ -110,7 +134,7 @@ test('runSkill routes create-task to host and task skills to sandbox', async () 
   assert.match(calls.at(-1) ?? '', new RegExp(`^sandbox:${TASK_ID}:codex exec`));
 });
 
-test('runSkill forwards sandbox stdout and stderr to the ai run process output', async () => {
+test('runSkill prints sandbox scheduling stdout and stderr', async () => {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const repoRoot = writeTaskFixture();
@@ -122,17 +146,17 @@ test('runSkill forwards sandbox stdout and stderr to the ai run process output',
     runSandbox: async () => ({
       exitCode: 0,
       signal: null,
-      stdout: 'skill summary\n',
+      stdout: 'Started sandbox run run-test in tmux session\n',
       stderr: 'warning\n'
     })
   });
 
   assert.equal(code, 0);
-  assert.deepEqual(stdout, ['skill summary\n']);
+  assert.deepEqual(stdout, ['Started sandbox run run-test in tmux session\n']);
   assert.deepEqual(stderr, ['warning\n']);
 });
 
-test('runSkill streams sandbox stdout and stderr without repeating final buffers', async () => {
+test('runSkill schedules task skills without stdout and stderr stream callbacks', async () => {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const repoRoot = writeTaskFixture();
@@ -142,22 +166,97 @@ test('runSkill streams sandbox stdout and stderr without repeating final buffers
     writeStdout: (chunk) => stdout.push(chunk),
     writeStderr: (chunk) => stderr.push(chunk),
     runSandbox: async (request) => {
-      assert.equal(typeof request.onStdoutChunk, 'function');
-      assert.equal(typeof request.onStderrChunk, 'function');
-      request.onStdoutChunk?.('live out\n');
-      request.onStderrChunk?.('live err\n');
+      assert.equal('onStdoutChunk' in request, false);
+      assert.equal('onStderrChunk' in request, false);
       return {
         exitCode: 0,
         signal: null,
-        stdout: 'final out\n',
-        stderr: 'final err\n'
+        stdout: 'scheduled\n',
+        stderr: ''
       };
     }
   });
 
   assert.equal(code, 0);
-  assert.deepEqual(stdout, ['live out\n']);
-  assert.deepEqual(stderr, ['live err\n']);
+  assert.deepEqual(stdout, ['scheduled\n']);
+  assert.deepEqual(stderr, []);
+});
+
+test('runSkill writes a managed run record after successful task scheduling', async () => {
+  const repoRoot = writeTaskFixture();
+  const code = await runSkill(['code-task', TASK_ID], {
+    repoRoot,
+    command: { defaultTui: 'codex' },
+    runSandbox: async (request) => {
+      assert.match(request.runId ?? '', /^run-/);
+      return {
+        exitCode: 0,
+        signal: null,
+        stdout: 'scheduled\n',
+        stderr: '',
+        run: {
+          runId: request.runId!,
+          engine: 'docker',
+          container: 'agent-dev',
+          runDir: `/tmp/agent-infra-runs/${request.runId}`
+        }
+      };
+    }
+  });
+
+  assert.equal(code, 0);
+  const runsDir = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'runs');
+  const records = fs.readdirSync(runsDir);
+  assert.equal(records.length, 1);
+  const record = JSON.parse(fs.readFileSync(path.join(runsDir, records[0]!), 'utf8'));
+  assert.equal(record.version, 1);
+  assert.equal(record.task_id, TASK_ID);
+  assert.equal(record.task_ref, TASK_ID);
+  assert.equal(record.branch, 'agent-infra-feature-server-command-protocol');
+  assert.equal(record.engine, 'docker');
+  assert.equal(record.container, 'agent-dev');
+  assert.equal(record.status_file, `${record.run_dir}/status`);
+  assert.equal(record.log_file, `${record.run_dir}/output.log`);
+  assert.deepEqual(record.command.slice(0, 2), ['codex', 'exec']);
+});
+
+test('runSkill resolves short task refs when writing managed run records', async () => {
+  const repoRoot = writeTaskFixture({ withShortId: true });
+  const code = await runSkill(['code-task', '#1'], {
+    repoRoot,
+    command: { defaultTui: 'codex' },
+    runSandbox: async (request) => ({
+      exitCode: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      run: {
+        runId: request.runId!,
+        engine: 'docker',
+        container: 'agent-dev',
+        runDir: `/tmp/agent-infra-runs/${request.runId}`
+      }
+    })
+  });
+
+  assert.equal(code, 0);
+  const runsDir = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'runs');
+  const [recordFile] = fs.readdirSync(runsDir);
+  const record = JSON.parse(fs.readFileSync(path.join(runsDir, recordFile!), 'utf8'));
+  assert.equal(record.task_id, TASK_ID);
+  assert.equal(record.task_ref, '#01');
+});
+
+test('runSkill does not write run records for create-task host execution', async () => {
+  const repoRoot = writeTaskFixture();
+  const code = await runSkill(['create-task', 'demo'], {
+    repoRoot,
+    command: { defaultTui: 'codex' },
+    runHost: async () => ({ exitCode: 0 })
+  });
+
+  assert.equal(code, 0);
+  assert.equal(fs.existsSync(path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'runs')), false);
 });
 
 test('runSkill honors command.allowedSkills as a narrowing allow-list', async () => {

--- a/tests/unit/cli/sandbox-capture.test.ts
+++ b/tests/unit/cli/sandbox-capture.test.ts
@@ -41,3 +41,33 @@ test('runInSandbox starts stopped containers and uses docker exec without -it', 
   assert.match(calls[1] ?? '', /^docker exec /);
   assert.doesNotMatch(calls[1] ?? '', / -it /);
 });
+
+test('runInSandbox forwards stdout and stderr chunk callbacks to spawn', async () => {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const result = await runInSandbox(
+    { taskRef: '#7', branch: 'feature/demo', command: ['codex', 'exec', '$code-task #7'] },
+    {
+      engine: 'docker',
+      repoRoot: '/repo',
+      containerCandidates: ['demo-dev-feature-demo'],
+      rows: [{ name: 'demo-dev-feature-demo', status: 'Up', branch: 'feature/demo', running: true, index: null }],
+      onStdoutChunk: (chunk) => {
+        stdoutChunks.push(chunk);
+      },
+      onStderrChunk: (chunk) => {
+        stderrChunks.push(chunk);
+      },
+      spawn: async (_file, _args, options) => {
+        options?.onStdoutChunk?.('out');
+        options?.onStderrChunk?.('err');
+        return { exitCode: 0, signal: null, stdout: 'out', stderr: 'err' };
+      }
+    }
+  );
+
+  assert.deepEqual(stdoutChunks, ['out']);
+  assert.deepEqual(stderrChunks, ['err']);
+  assert.equal(result.stdout, 'out');
+  assert.equal(result.stderr, 'err');
+});

--- a/tests/unit/cli/sandbox-capture.test.ts
+++ b/tests/unit/cli/sandbox-capture.test.ts
@@ -20,12 +20,13 @@ test('runInSandbox fails clearly when no sandbox container exists', async () => 
   );
 });
 
-test('runInSandbox starts stopped containers and uses docker exec without -it', async () => {
+test('runInSandbox starts stopped containers and schedules a tmux run without -it', async () => {
   const calls: string[] = [];
   const result = await runInSandbox(
     { taskRef: '#7', branch: 'feature/demo', command: ['codex', 'exec', '$code-task #7'] },
     {
       engine: 'docker',
+      runId: 'run-test-123',
       repoRoot: '/repo',
       containerCandidates: ['demo-dev-feature-demo'],
       rows: [{ name: 'demo-dev-feature-demo', status: 'Exited', branch: 'feature/demo', running: false, index: null }],
@@ -37,37 +38,47 @@ test('runInSandbox starts stopped containers and uses docker exec without -it', 
     }
   );
   assert.equal(result.stdout, 'ok');
+  assert.deepEqual(result.run, {
+    runId: 'run-test-123',
+    engine: 'docker',
+    container: 'demo-dev-feature-demo',
+    runDir: '/tmp/agent-infra-runs/run-test-123'
+  });
   assert.equal(calls[0], 'start:demo-dev-feature-demo');
   assert.match(calls[1] ?? '', /^docker exec /);
   assert.doesNotMatch(calls[1] ?? '', / -it /);
+  assert.match(calls[1] ?? '', / bash -lc /);
 });
 
-test('runInSandbox forwards stdout and stderr chunk callbacks to spawn', async () => {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
+test('runInSandbox launcher creates a tmux window and run status files', async () => {
+  let dockerArgs: string[] = [];
   const result = await runInSandbox(
     { taskRef: '#7', branch: 'feature/demo', command: ['codex', 'exec', '$code-task #7'] },
     {
       engine: 'docker',
+      runId: 'run-test-456',
       repoRoot: '/repo',
       containerCandidates: ['demo-dev-feature-demo'],
       rows: [{ name: 'demo-dev-feature-demo', status: 'Up', branch: 'feature/demo', running: true, index: null }],
-      onStdoutChunk: (chunk) => {
-        stdoutChunks.push(chunk);
-      },
-      onStderrChunk: (chunk) => {
-        stderrChunks.push(chunk);
-      },
-      spawn: async (_file, _args, options) => {
-        options?.onStdoutChunk?.('out');
-        options?.onStderrChunk?.('err');
-        return { exitCode: 0, signal: null, stdout: 'out', stderr: 'err' };
+      spawn: async (_file, args) => {
+        dockerArgs = args;
+        return { exitCode: 0, signal: null, stdout: 'started', stderr: '' };
       }
     }
   );
 
-  assert.deepEqual(stdoutChunks, ['out']);
-  assert.deepEqual(stderrChunks, ['err']);
-  assert.equal(result.stdout, 'out');
-  assert.equal(result.stderr, 'err');
+  const launcher = dockerArgs.at(-1) ?? '';
+  assert.equal(result.stdout, 'started');
+  assert.deepEqual(result.run, {
+    runId: 'run-test-456',
+    engine: 'docker',
+    container: 'demo-dev-feature-demo',
+    runDir: '/tmp/agent-infra-runs/run-test-456'
+  });
+  assert.match(launcher, /run-test-456/);
+  assert.match(launcher, /tmux new-window -d -P -F/);
+  assert.match(launcher, /tmux pipe-pane -o/);
+  assert.match(launcher, /tmux send-keys -t/);
+  assert.ok(launcher.includes('/tmp/agent-infra-runs/run-test-456'));
+  assert.match(launcher, /status/);
 });

--- a/tests/unit/cli/task-status.test.ts
+++ b/tests/unit/cli/task-status.test.ts
@@ -8,7 +8,6 @@ import {
   collectMetadata,
   groupArtifacts,
   collectGit,
-  collectPlatform,
   collectWorkflow,
   collectRuntime,
   renderStatus,
@@ -29,8 +28,7 @@ test('collectMetadata emits the fixed key order and degrades missing fields to -
     status: 'active',
     current_step: 'code',
     priority: 'High',
-    branch: 'feat',
-    issue_number: '468'
+    branch: 'feat'
   });
   assert.deepEqual(rows, [
     ['type', 'feature'],
@@ -41,9 +39,7 @@ test('collectMetadata emits the fixed key order and degrades missing fields to -
     ['branch', 'feat'],
     ['assigned_to', '-'],
     ['created_at', '-'],
-    ['updated_at', '-'],
-    ['issue_number', '468'],
-    ['pr_status', '-']
+    ['updated_at', '-']
   ]);
 });
 
@@ -138,60 +134,6 @@ test('collectGit isolates a single failing field (rev-list) without degrading th
   assert.equal(git.current, 'feat');
   assert.equal(git.uncommitted, 'clean');
   assert.equal(git.exists, 'yes');
-});
-
-// --- collectPlatform -------------------------------------------------------
-
-test('collectPlatform makes no calls when there is no issue and pr is not created', () => {
-  let calls = 0;
-  const run: Runner = () => {
-    calls += 1;
-    throw new Error('should not be called');
-  };
-  const platform = collectPlatform({}, run);
-  assert.equal(platform.issue, '-');
-  assert.equal(platform.pr, '-');
-  assert.equal(calls, 0);
-});
-
-test('collectPlatform skips the PR call when pr_status is created but pr_number is absent', () => {
-  let calls = 0;
-  const run: Runner = () => {
-    calls += 1;
-    throw new Error('should not be called');
-  };
-  const platform = collectPlatform({ pr_status: 'created' }, run);
-  assert.equal(platform.pr, '-');
-  assert.equal(calls, 0);
-});
-
-test('collectPlatform summarizes gh JSON for issue and pr', () => {
-  const run: Runner = (_file, args) => {
-    if (args[0] === 'issue') {
-      return JSON.stringify({ state: 'OPEN', labels: [{ name: 'in: cli' }, { name: 'type: feature' }] });
-    }
-    if (args[0] === 'pr') {
-      return JSON.stringify({
-        state: 'OPEN',
-        statusCheckRollup: [{ conclusion: 'SUCCESS' }, { conclusion: 'FAILURE' }]
-      });
-    }
-    throw new Error(`unexpected gh ${args.join(' ')}`);
-  };
-  const platform = collectPlatform(
-    { issue_number: '468', pr_status: 'created', pr_number: '42' },
-    run
-  );
-  assert.equal(platform.issue, 'OPEN [in: cli, type: feature]');
-  assert.equal(platform.pr, 'OPEN, checks: 1/2');
-});
-
-test('collectPlatform degrades to - when gh fails (offline)', () => {
-  const run: Runner = () => {
-    throw new Error('gh: offline');
-  };
-  const platform = collectPlatform({ issue_number: '468' }, run);
-  assert.equal(platform.issue, '-');
 });
 
 // --- collectWorkflow -------------------------------------------------------
@@ -315,7 +257,6 @@ const baseModel: StatusModel = {
   taskId: 'TASK-20260101-000001',
   shortId: '#01',
   title: 'demo title',
-  issueNumber: '468',
   metadata: [
     ['type', 'feature'],
     ['status', 'active']
@@ -353,10 +294,9 @@ const baseModel: StatusModel = {
     uncommitted: 'clean',
     aheadBehind: '-'
   },
-  platform: { issue: 'OPEN', pr: '-' }
 };
 
-test('renderStatus emits workflow and runtime before git/platform sections', () => {
+test('renderStatus emits workflow and runtime before git', () => {
   const out = renderStatus(baseModel).join('\n');
   assert.match(out, /^Task TASK-20260101-000001  \(#01\)$/m);
   assert.match(out, /^demo title$/m);
@@ -367,11 +307,8 @@ test('renderStatus emits workflow and runtime before git/platform sections', () 
   assert.match(out, /^Runtime$/m);
   assert.match(out, /^  mode +managed-tmux$/m);
   assert.match(out, /^Git$/m);
-  assert.match(out, /^Platform$/m);
   // Stage group renders its files joined, in order.
   assert.match(out, /^  plan +plan\.md, plan-r2\.md$/m);
-  // Platform issue row is labeled with the issue number.
-  assert.match(out, /^  issue #468 +OPEN$/m);
 });
 
 test('renderStatus shows (none) when a task has no artifacts', () => {

--- a/tests/unit/cli/task-status.test.ts
+++ b/tests/unit/cli/task-status.test.ts
@@ -1,11 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   collectMetadata,
   groupArtifacts,
   collectGit,
   collectPlatform,
+  collectWorkflow,
+  collectRuntime,
   renderStatus,
   type Runner,
   type StatusModel
@@ -189,6 +194,121 @@ test('collectPlatform degrades to - when gh fails (offline)', () => {
   assert.equal(platform.issue, '-');
 });
 
+// --- collectWorkflow -------------------------------------------------------
+
+function taskWithLog(entries: string[]): string {
+  return ['# Task', '', '## 活动日志', '', ...entries, '', '## 完成检查清单'].join('\n');
+}
+
+test('collectWorkflow reports the latest started-only row as in-progress', () => {
+  const workflow = collectWorkflow(
+    taskWithLog([
+      '- 2026-07-02 20:00:00+08:00 — **Code Task (Round 2) [started]** by codex — started'
+    ]),
+    new Date('2026-07-02T12:30:00Z')
+  );
+  assert.equal(workflow.state, 'in-progress');
+  assert.equal(workflow.step, 'Code Task (Round 2)');
+  assert.equal(workflow.agent, 'codex');
+  assert.equal(workflow.startedAt, '2026-07-02 20:00:00+08:00');
+  assert.equal(workflow.doneAt, '-');
+  assert.equal(workflow.stale, 'no');
+});
+
+test('collectWorkflow reports paired completion as idle', () => {
+  const workflow = collectWorkflow(
+    taskWithLog([
+      '- 2026-07-02 20:00:00+08:00 — **Plan Task (Round 3) [started]** by codex — started',
+      '- 2026-07-02 20:05:00+08:00 — **Plan Task (Round 3)** by codex — Plan completed → plan-r3.md'
+    ]),
+    new Date('2026-07-02T12:30:00Z')
+  );
+  assert.equal(workflow.state, 'idle');
+  assert.equal(workflow.doneAt, '2026-07-02 20:05:00+08:00');
+  assert.equal(workflow.stale, '-');
+});
+
+test('collectWorkflow marks in-progress rows stale after 60 minutes', () => {
+  const workflow = collectWorkflow(
+    taskWithLog([
+      '- 2026-07-02 19:00:00+08:00 — **Code Task (Round 2) [started]** by codex — started'
+    ]),
+    new Date('2026-07-02T12:01:00Z')
+  );
+  assert.equal(workflow.state, 'in-progress');
+  assert.equal(workflow.stale, 'yes');
+});
+
+// --- collectRuntime --------------------------------------------------------
+
+test('collectRuntime reports unmanaged when workflow is in-progress without a run record', () => {
+  const taskDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-status-runtime-'));
+  const runtime = collectRuntime(
+    taskDir,
+    {
+      state: 'in-progress',
+      step: 'Code Task (Round 2)',
+      agent: 'codex',
+      startedAt: '2026-07-02 20:00:00+08:00',
+      doneAt: '-',
+      stale: 'no'
+    },
+    throwingRun
+  );
+  assert.equal(runtime.mode, 'unmanaged');
+  assert.equal(runtime.status, 'inferred-from-workflow');
+});
+
+test('collectRuntime reads the latest managed tmux run through docker exec', () => {
+  const taskDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-status-runtime-'));
+  const runsDir = path.join(taskDir, 'runs');
+  fs.mkdirSync(runsDir);
+  fs.writeFileSync(
+    path.join(runsDir, 'run-test.json'),
+    JSON.stringify({
+      version: 1,
+      run_id: 'run-test',
+      engine: 'docker',
+      container: 'agent-dev',
+      run_dir: '/tmp/agent-infra-runs/run-test',
+      status_file: '/tmp/agent-infra-runs/run-test/status',
+      log_file: '/tmp/agent-infra-runs/run-test/output.log'
+    }),
+    'utf8'
+  );
+
+  const files = new Map([
+    ['/tmp/agent-infra-runs/run-test/status', 'running\n'],
+    ['/tmp/agent-infra-runs/run-test/session', 'work\n'],
+    ['/tmp/agent-infra-runs/run-test/window', 'ai-test\n'],
+    ['/tmp/agent-infra-runs/run-test/pane', '%12\n'],
+    ['/tmp/agent-infra-runs/run-test/started_at', '2026-07-02 20:00:00+08:00\n'],
+    ['/tmp/agent-infra-runs/run-test/finished_at', ''],
+    ['/tmp/agent-infra-runs/run-test/exit_code', '']
+  ]);
+  const run: Runner = (file, args) => {
+    assert.equal(file, 'docker');
+    assert.deepEqual(args.slice(0, 3), ['exec', 'agent-dev', 'cat']);
+    const value = files.get(args[3] ?? '');
+    if (value === undefined) throw new Error(`missing file ${args[3]}`);
+    return value;
+  };
+
+  const runtime = collectRuntime(
+    taskDir,
+    { state: 'idle', step: '-', agent: '-', startedAt: '-', doneAt: '-', stale: '-' },
+    run
+  );
+  assert.equal(runtime.mode, 'managed-tmux');
+  assert.equal(runtime.status, 'running');
+  assert.equal(runtime.run, 'run-test');
+  assert.equal(runtime.tmux, 'work:ai-test:%12');
+  assert.equal(runtime.startedAt, '2026-07-02 20:00:00+08:00');
+  assert.equal(runtime.finishedAt, '-');
+  assert.equal(runtime.exitCode, '-');
+  assert.equal(runtime.log, '/tmp/agent-infra-runs/run-test/output.log');
+});
+
 // --- renderStatus ----------------------------------------------------------
 
 const baseModel: StatusModel = {
@@ -207,6 +327,24 @@ const baseModel: StatusModel = {
       { stage: 'plan', files: ['plan.md', 'plan-r2.md'] }
     ]
   },
+  workflow: {
+    state: 'in-progress',
+    step: 'Code Task (Round 2)',
+    agent: 'codex',
+    startedAt: '2026-07-02 20:00:00+08:00',
+    doneAt: '-',
+    stale: 'no'
+  },
+  runtime: {
+    mode: 'managed-tmux',
+    status: 'running',
+    run: 'run-test',
+    tmux: 'work:ai-test:%12',
+    startedAt: '2026-07-02 20:00:00+08:00',
+    finishedAt: '-',
+    exitCode: '-',
+    log: '/tmp/agent-infra-runs/run-test/output.log'
+  },
   git: {
     current: 'feat',
     frontmatter: 'feat',
@@ -218,12 +356,16 @@ const baseModel: StatusModel = {
   platform: { issue: 'OPEN', pr: '-' }
 };
 
-test('renderStatus emits all five sections with aligned rows', () => {
+test('renderStatus emits workflow and runtime before git/platform sections', () => {
   const out = renderStatus(baseModel).join('\n');
   assert.match(out, /^Task TASK-20260101-000001  \(#01\)$/m);
   assert.match(out, /^demo title$/m);
   assert.match(out, /^Metadata$/m);
   assert.match(out, /^Artifacts \(2\)$/m);
+  assert.match(out, /^Workflow$/m);
+  assert.match(out, /^  state +in-progress$/m);
+  assert.match(out, /^Runtime$/m);
+  assert.match(out, /^  mode +managed-tmux$/m);
   assert.match(out, /^Git$/m);
   assert.match(out, /^Platform$/m);
   // Stage group renders its files joined, in order.


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #558 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Improve `ai run <skill> <task-ref>` in sandbox mode so lifecycle skill output is streamed while the sandbox command is still running. Before this change, sandbox capture buffered stdout and stderr until process exit, making long-running commands look stalled.

## 📋 主要变更 / Brief Changelog

- Add optional stdout/stderr chunk callbacks to sandbox capture while preserving final buffered stdout/stderr results.
- Wire `ai run` sandbox execution to stream chunks through the existing stdout/stderr writer hooks.
- Avoid replaying final buffers when a stream has already been emitted live, while keeping fallback output for custom sandbox runners that ignore callbacks.
- Add CLI unit tests covering callback forwarding and duplicate-output prevention.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `node --experimental-strip-types --no-warnings --test tests/unit/cli/sandbox-capture.test.ts tests/unit/cli/run.test.ts`
2. `npm run typecheck`
3. `npm test`
4. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #558 milestone `0.8.1`.
- Manual end-to-end sandbox/TUI streaming was not run; this PR is verified by focused CLI tests, full tests, typecheck, and commit hook core tests.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on stdout/stderr stream separation, callback rejection/close/error settlement behavior in `spawnCapture`, and whether custom `runSandbox` fallback output remains backward compatible.

Generated with AI assistance
