### PR TITLE
fix(cli): 修复 Claude API 认证时 tmux 误报登录过期

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1438,9 +1438,9 @@ export async function create(args: string[]): Promise<void> {
             if (claudeCodeEntry) {
               ensureClaudeOnboarding(claudeCodeEntry.dir, effectiveConfig.home);
               ensureClaudeSettings(claudeCodeEntry.dir, effectiveConfig.home);
-              // prepareClaudeCredentials wrote the shared credentials file
-              // before this point. If credentials were missing, the
-              // claude-code entry was removed from effectiveResolvedTools.
+              // prepareClaudeCredentials wrote OAuth credentials or confirmed
+              // provider/API settings are enough for Claude Code. If no usable
+              // auth was present, the claude-code entry was removed above.
             }
             const codexEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'codex');
             if (codexEntry) {

--- a/lib/sandbox/commands/enter.ts
+++ b/lib/sandbox/commands/enter.ts
@@ -9,6 +9,7 @@ import { detectEngine } from '../engine.ts';
 import {
   formatCredentialWarnings,
   formatRemaining,
+  hasClaudeProviderAuth,
   reconcileClaudeCredentials,
   redactCommandError,
   validateClaudeCredentialsEnvOverride
@@ -93,8 +94,12 @@ export function runSandboxInteractive(params: {
 
 export function formatCredentialSyncStatus(
   result: ReturnType<typeof reconcileClaudeCredentials>,
-  isTTY = process.stderr.isTTY
+  isTTY = process.stderr.isTTY,
+  providerAuthAvailable = false
 ): string | null {
+  if (providerAuthAvailable && (result.status === 'STALE_ACCESS' || result.status === 'MISSING')) {
+    return null;
+  }
   if (result.status === 'STALE_ACCESS') {
     return 'Warning: Claude Code credentials on host appear stale. Run "ai sandbox refresh" or "claude /login" to renew.\n';
   }
@@ -158,8 +163,9 @@ export async function enter(args: string[]): Promise<number> {
   if (config.tools.includes('claude-code')) {
     try {
       // Scan all projects so a refresh from a neighbouring sandbox can still flow back to the host.
+      const providerAuthAvailable = hasClaudeProviderAuth(config.home);
       const result = reconcileClaudeCredentials(config.home);
-      const message = formatCredentialSyncStatus(result);
+      const message = formatCredentialSyncStatus(result, process.stderr.isTTY, providerAuthAvailable);
       if (message) {
         process.stderr.write(message);
       }

--- a/lib/sandbox/credentials.ts
+++ b/lib/sandbox/credentials.ts
@@ -55,6 +55,11 @@ type InspectOptions = {
   envFn?: EnvFn;
 };
 
+type ProviderAuthOptions = {
+  readFn?: ReadFn;
+  existsFn?: ExistsFn;
+};
+
 type WriteHostOptions = {
   execFn?: ExecFn;
   mkdirFn?: typeof fs.mkdirSync;
@@ -113,6 +118,14 @@ const REDACTION_PATTERNS = [
   { pattern: /gh[psoru]_[A-Za-z0-9]{30,}/g, replacement: '[REDACTED github token]' },
   { pattern: /Bearer\s+[A-Za-z0-9._~+/=-]{20,}/gi, replacement: 'Bearer [REDACTED]' }
 ];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'unknown error';
@@ -216,6 +229,35 @@ export function validateClaudeCredentialsEnvOverride(env: NodeJS.ProcessEnv = pr
     throw new Error(
       'Invalid AGENT_INFRA_CLAUDE_CREDENTIALS_FILE value. Expected an absolute file path.'
     );
+  }
+}
+
+export function hasClaudeProviderAuthInSettings(settings: unknown): boolean {
+  if (!isRecord(settings)) {
+    return false;
+  }
+
+  const env = isRecord(settings.env) ? settings.env : {};
+  return hasNonEmptyString(env.ANTHROPIC_AUTH_TOKEN)
+    || hasNonEmptyString(env.ANTHROPIC_API_KEY)
+    || hasNonEmptyString(settings.apiKeyHelper);
+}
+
+export function hasClaudeProviderAuth(home: string, options: ProviderAuthOptions = {}): boolean {
+  const {
+    readFn = (targetPath) => fs.readFileSync(targetPath, 'utf8'),
+    existsFn = fs.existsSync
+  } = options;
+  const settingsPath = path.join(home, '.claude', 'settings.json');
+
+  if (!existsFn(settingsPath)) {
+    return false;
+  }
+
+  try {
+    return hasClaudeProviderAuthInSettings(JSON.parse(readFn(settingsPath)));
+  } catch {
+    return false;
   }
 }
 
@@ -595,12 +637,21 @@ export function prepareClaudeCredentials(
   resolvedTools: ResolvedTool[],
   extractFn: (home: string) => string | null = extractClaudeCredentialsBlob,
   writeFn: (home: string, project: string, blob: string) => void = writeClaudeCredentialsFile,
-  inspectFn: (home: string) => CredentialInspection = inspectClaudeKeychainStatus
+  inspectFn: (home: string) => CredentialInspection = inspectClaudeKeychainStatus,
+  providerAuthFn: (home: string) => boolean = hasClaudeProviderAuth
 ): ClaudeCredentialOutcome {
   const claudeCodeEntry = resolvedTools.find(({ tool }) => tool.id === 'claude-code');
   if (!claudeCodeEntry) {
     return { status: 'NOT_APPLICABLE' };
   }
+
+  const providerAuthAvailable = () => {
+    try {
+      return providerAuthFn(home);
+    } catch {
+      return false;
+    }
+  };
 
   let blob: string | null = null;
   const hasCustomInspectFn = inspectFn !== inspectClaudeKeychainStatus;
@@ -612,7 +663,7 @@ export function prepareClaudeCredentials(
         blob = inspection.blob;
         break;
       case 'MISSING':
-        return { status: 'SKIPPED' };
+        return providerAuthAvailable() ? { status: 'OK' } : { status: 'SKIPPED' };
       case 'KEYCHAIN_LOCKED':
         throw new Error([
           'Claude Code credentials are stored in the macOS keychain, but the keychain is locked.',
@@ -620,6 +671,9 @@ export function prepareClaudeCredentials(
           buildLockedGuidance()
         ].join('\n'));
       case 'STALE_ACCESS':
+        if (providerAuthAvailable()) {
+          return { status: 'OK' };
+        }
         throw new Error([
           'Claude Code credentials on host are invalid or expired.',
           '',
@@ -648,7 +702,7 @@ export function prepareClaudeCredentials(
   } else {
     blob = extractFn(home);
     if (!blob) {
-      return { status: 'SKIPPED' };
+      return providerAuthAvailable() ? { status: 'OK' } : { status: 'SKIPPED' };
     }
   }
 

--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -61,6 +61,19 @@ RUN cat > /usr/local/bin/cc-token-status <<'SCRIPT' && chmod +x /usr/local/bin/c
 #!/bin/sh
 set -eu
 
+SETTINGS_FILE="/home/devuser/.claude/settings.json"
+if [ -r "$SETTINGS_FILE" ] && jq -e '
+  def has_nonempty($v):
+    if ($v | type) == "string" then ($v | gsub("^\\s+|\\s+$"; "") | length) > 0 else false end;
+  (if type == "object" then . else {} end) as $settings
+  | (if ($settings.env | type) == "object" then $settings.env else {} end) as $env
+  | has_nonempty($env.ANTHROPIC_AUTH_TOKEN)
+    or has_nonempty($env.ANTHROPIC_API_KEY)
+    or has_nonempty($settings.apiKeyHelper)
+' "$SETTINGS_FILE" >/dev/null 2>&1; then
+  exit 0
+fi
+
 CRED_FILE="/home/devuser/.claude/.credentials.json"
 [ -r "$CRED_FILE" ] || exit 0
 

--- a/tests/e2e/cli/sandbox-credentials.test.ts
+++ b/tests/e2e/cli/sandbox-credentials.test.ts
@@ -257,6 +257,48 @@ test("credential path helpers and writer manage the shared credential file", asy
   }
 });
 
+test("Claude provider auth detection accepts settings env tokens and apiKeyHelper", async () => {
+  const credentials = await loadFreshEsm<typeof import("../../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+
+  assert.equal(credentials.hasClaudeProviderAuthInSettings({
+    env: { ANTHROPIC_AUTH_TOKEN: "  token-value  " }
+  }), true);
+  assert.equal(credentials.hasClaudeProviderAuthInSettings({
+    env: { ANTHROPIC_API_KEY: "  api-key  " }
+  }), true);
+  assert.equal(credentials.hasClaudeProviderAuthInSettings({
+    apiKeyHelper: "  op read item  "
+  }), true);
+  assert.equal(credentials.hasClaudeProviderAuthInSettings({
+    env: { ANTHROPIC_AUTH_TOKEN: "  ", ANTHROPIC_API_KEY: "" },
+    apiKeyHelper: " "
+  }), false);
+  assert.equal(credentials.hasClaudeProviderAuthInSettings({
+    env: { ANTHROPIC_AUTH_TOKEN: 123 },
+    apiKeyHelper: ["helper"]
+  }), false);
+  assert.equal(credentials.hasClaudeProviderAuthInSettings("not-json-object"), false);
+});
+
+test("Claude provider auth detection reads settings.json conservatively", async () => {
+  const credentials = await loadFreshEsm<typeof import("../../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-claude-provider-auth-"));
+  const settingsPath = path.join(tmpDir, ".claude", "settings.json");
+
+  try {
+    assert.equal(credentials.hasClaudeProviderAuth(tmpDir), false);
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, "{", "utf8");
+    assert.equal(credentials.hasClaudeProviderAuth(tmpDir), false);
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      env: { ANTHROPIC_API_KEY: "sk-ant-api-key" }
+    }), "utf8");
+    assert.equal(credentials.hasClaudeProviderAuth(tmpDir), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("prepareClaudeCredentials writes credentials only when claude-code is enabled", async () => {
   const credentials = await loadFreshEsm<typeof import("../../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
   const writes: Array<[string, string, string]> = [];
@@ -302,6 +344,51 @@ test("prepareClaudeCredentials returns SKIPPED and writes nothing when credentia
   );
 
   assert.deepEqual(outcome, { status: "SKIPPED" });
+  assert.equal(writeCalled, false);
+});
+
+test("prepareClaudeCredentials accepts provider auth when OAuth credentials are missing or stale", async () => {
+  const credentials = await loadFreshEsm<typeof import("../../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+
+  for (const inspection of [
+    { status: "MISSING" as const },
+    { status: "STALE_ACCESS" as const }
+  ]) {
+    let writeCalled = false;
+    const outcome = credentials.prepareClaudeCredentials(
+      "/Users/demo",
+      "agent-infra",
+      [{ tool: { id: "claude-code" } }],
+      () => null,
+      () => {
+        writeCalled = true;
+      },
+      () => inspection,
+      () => true
+    );
+
+    assert.deepEqual(outcome, { status: "OK" });
+    assert.equal(writeCalled, false);
+  }
+});
+
+test("prepareClaudeCredentials accepts provider auth when keychain extraction is empty", async () => {
+  const credentials = await loadFreshEsm<typeof import("../../../lib/sandbox/credentials.ts")>("lib/sandbox/credentials.js");
+  let writeCalled = false;
+
+  const outcome = credentials.prepareClaudeCredentials(
+    "/Users/demo",
+    "agent-infra",
+    [{ tool: { id: "claude-code" } }],
+    () => null,
+    () => {
+      writeCalled = true;
+    },
+    credentials.inspectClaudeKeychainStatus,
+    () => true
+  );
+
+  assert.deepEqual(outcome, { status: "OK" });
   assert.equal(writeCalled, false);
 });
 

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -353,6 +353,14 @@ test("composeDockerfile configures tmux extended keys and terminal env forwardin
     assert.match(content, /set -g status-interval 1/);
     assert.match(content, /set -g status-right-length 80/);
     assert.match(content, /\/usr\/local\/bin\/cc-token-status/);
+    assert.match(content, /SETTINGS_FILE="\/home\/devuser\/\.claude\/settings\.json"/);
+    assert.match(content, /ANTHROPIC_AUTH_TOKEN/);
+    assert.match(content, /ANTHROPIC_API_KEY/);
+    assert.match(content, /apiKeyHelper/);
+    assert.ok(
+      content.indexOf('SETTINGS_FILE="/home/devuser/.claude/settings.json"')
+        < content.indexOf('CRED_FILE="/home/devuser/.claude/.credentials.json"')
+    );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -70,7 +70,11 @@ type SandboxCreateModule = {
 };
 type EnterModule = {
   terminalEnvFlags(env?: NodeJS.ProcessEnv): string[];
-  formatCredentialSyncStatus(result: { status: string }): string;
+  formatCredentialSyncStatus(
+    result: { status: string; authoritative?: string | null; expiresAt?: unknown; filesWritten?: string[]; warnings?: unknown[] },
+    isTTY?: boolean,
+    providerAuthAvailable?: boolean
+  ): string | null;
   clipboardBridgeDisabled(env?: NodeJS.ProcessEnv): boolean;
   runSandboxInteractive(params: {
     engine: string;
@@ -116,6 +120,23 @@ test("sandbox exec formats host keychain unavailable credential sync warnings", 
   assert.equal(
     sandboxEnter.formatCredentialSyncStatus({ status: "KEYCHAIN_ERROR" }),
     'Warning: Host keychain is unavailable; Claude credential sync skipped. Run "ai sandbox refresh" for details.\n'
+  );
+});
+
+test("sandbox exec suppresses missing OAuth warnings when Claude provider auth exists", async () => {
+  const sandboxEnter = await loadFreshEsm<EnterModule>("lib/sandbox/commands/enter.js");
+
+  assert.equal(
+    sandboxEnter.formatCredentialSyncStatus({ status: "MISSING" }, false, true),
+    null
+  );
+  assert.equal(
+    sandboxEnter.formatCredentialSyncStatus({ status: "STALE_ACCESS" }, false, true),
+    null
+  );
+  assert.match(
+    sandboxEnter.formatCredentialSyncStatus({ status: "KEYCHAIN_LOCKED" }, false, true) ?? "",
+    /Host keychain is unavailable/
   );
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #559 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Fix a false Claude Code auth-expiry signal in sandbox tmux sessions when Claude Code is usable through provider/API authentication inherited from host settings. The previous status script and host reconcile warnings only considered OAuth credentials, so API/provider mode could still display stale or missing OAuth warnings.

## 📋 主要变更 / Brief Changelog

- Detect Claude provider/API auth from `~/.claude/settings.json` via `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and `apiKeyHelper`.
- Allow sandbox creation and sandbox exec warning formatting to treat provider auth as usable when OAuth credentials are missing or stale.
- Update the in-container `cc-token-status` script to suppress OAuth expiry output when provider auth is configured.
- Add regression coverage for provider detection, create/exec auth handling, and Dockerfile tmux status script structure.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build && node --experimental-strip-types --no-warnings --test tests/e2e/cli/sandbox-credentials.test.ts tests/integration/cli/sandbox-tools.test.ts tests/integration/cli/sandbox-dockerfile.test.ts`
2. `npm run test:core`
3. Commit hook: `npm run typecheck`
4. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #559 milestone `0.8.1`.
- No end-to-end Docker/tmux manual run was performed; coverage is through targeted regression tests, full core tests, and commit hooks.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on whether provider-auth detection stays conservative, whether keychain errors remain visible, and whether the shell `jq` logic in `cc-token-status` matches the TypeScript detector.

Generated with AI assistance
