### PR TITLE
fix(meta): 对齐 Node 22 承诺并限制类型依赖升级

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
-        "@types/node": "^24.0.0",
+        "@types/node": "^22.20.0",
         "@types/semver": "^7.7.1",
         "typescript": "~6.0"
       },
@@ -238,12 +238,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -872,9 +872,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
-    "@types/node": "^24.0.0",
+    "@types/node": "^22.20.0",
     "@types/semver": "^7.7.1",
     "typescript": "~6.0"
   },

--- a/tests/unit/core/release.test.ts
+++ b/tests/unit/core/release.test.ts
@@ -1,8 +1,58 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import * as semver from "semver";
+import { parse } from "yaml";
 
 import { CLI_PATH, cliArgs, filePath, read } from "../../helpers.ts";
+
+type WorkflowStep = {
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type ReleaseWorkflow = {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+};
+
+type DependabotUpdate = {
+  "package-ecosystem"?: string;
+  directory?: string;
+  ignore?: Array<{
+    "dependency-name"?: string;
+    "update-types"?: string[];
+  }>;
+};
+
+type DependabotConfig = {
+  updates?: DependabotUpdate[];
+};
+
+type LockPackage = {
+  dev?: boolean;
+  engines?: {
+    node?: string;
+  };
+  version?: string;
+};
+
+type PackageLock = {
+  packages: Record<string, LockPackage & {
+    devDependencies?: Record<string, string>;
+  }>;
+};
+
+function requireMinVersion(range: string, label: string) {
+  const version = semver.minVersion(range);
+  assert.ok(version, `${label} must be a valid semver range`);
+  return version;
+}
+
+function requireVersion(versionText: string, label: string) {
+  const version = semver.parse(versionText);
+  assert.ok(version, `${label} must be a valid semver version`);
+  return version;
+}
 
 test("package metadata supports scoped npm publishing", () => {
   const pkg = JSON.parse(read("package.json"));
@@ -36,6 +86,49 @@ test("package metadata supports scoped npm publishing", () => {
   assert.match(pkg.scripts.prepublishOnly, /npm run build/);
   assert.match(pkg.scripts.prepublishOnly, /--test/);
   assert.match(pkg.scripts.prepublishOnly, /tests\/\*\*\/\*\.test\.ts/);
+});
+
+test("Node baseline stays aligned across metadata and automation", () => {
+  const pkg = JSON.parse(read("package.json"));
+  const lock = JSON.parse(read("package-lock.json")) as PackageLock;
+
+  const engineRange = pkg.engines.node;
+  assert.equal(requireMinVersion(engineRange, "package engines.node").major, 22);
+  assert.equal(semver.satisfies("21.999.0", engineRange), false);
+
+  const typesNodeRange = pkg.devDependencies["@types/node"];
+  assert.equal(requireMinVersion(typesNodeRange, "package @types/node range").major, 22);
+  assert.equal(semver.intersects(typesNodeRange, ">=23.0.0"), false);
+
+  const rootTypesNodeRange = lock.packages[""]?.devDependencies?.["@types/node"];
+  assert.equal(requireMinVersion(rootTypesNodeRange ?? "", "lockfile root @types/node range").major, 22);
+
+  const lockedTypesNodeVersion = lock.packages["node_modules/@types/node"]?.version;
+  assert.equal(requireVersion(lockedTypesNodeVersion ?? "", "lockfile @types/node version").major, 22);
+
+  const releaseWorkflow = parse(read(".github/workflows/release.yml")) as ReleaseWorkflow;
+  const releaseSteps = releaseWorkflow.jobs?.["npm-publish"]?.steps ?? [];
+  const setupNodeStep = releaseSteps.find((step) => step.uses === "actions/setup-node@v6");
+  assert.ok(setupNodeStep, "actions/setup-node@v6 step not found in release workflow");
+  assert.equal(String(setupNodeStep?.with?.["node-version"]), "22");
+
+  const dependabot = parse(read(".github/dependabot.yml")) as DependabotConfig;
+  const npmUpdates = dependabot.updates?.find(
+    (update) => update["package-ecosystem"] === "npm" && update.directory === "/"
+  );
+  assert.ok(
+    npmUpdates?.ignore?.some(
+      (entry) =>
+        entry["dependency-name"] === "@types/node" &&
+        entry["update-types"]?.includes("version-update:semver-major")
+    )
+  );
+
+  const runtimeEngineConflicts = Object.entries(lock.packages)
+    .filter(([packagePath, meta]) => packagePath !== "" && !meta.dev && meta.engines?.node)
+    .filter(([, meta]) => !semver.intersects(meta.engines?.node ?? "", ">=22 <23"))
+    .map(([packagePath, meta]) => [packagePath, meta.engines?.node]);
+  assert.deepEqual(runtimeEngineConflicts, []);
 });
 
 test("CLI help advertises scoped npm install commands and Homebrew", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #566 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [x] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

对齐项目公开承诺的 Node.js 22 支持基线与开发期类型依赖、release workflow、Dependabot 自动升级策略。此前 `@types/node` 已处于 24 major，Dependabot PR #564 又尝试升级到 Node 26 类型线，会让 TypeScript 开发期可见高于 Node 22 baseline 的 API。

## 📋 主要变更 / Brief Changelog

- 将 `@types/node` 调整到 Node 22 major，并同步 `package-lock.json` 中的 `undici-types`。
- 将 release workflow 的 `actions/setup-node@v6` 版本从 Node 24 回落到 Node 22。
- 为 Dependabot npm block 增加 `@types/node` semver-major ignore，避免再次自动创建高 major 类型升级 PR。
- 增加结构性测试，覆盖 `engines.node`、`@types/node` manifest/lockfile、release workflow、Dependabot ignore，以及运行时依赖 Node 22 engine 交集。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run test:smoke`
2. `npm run typecheck`
3. `npm run test:core`
4. Commit hook: `npm run typecheck`
5. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #566 milestone `0.8.1`.
- Dependabot PR #564 upgrades `@types/node` to Node 26 major and should not be merged after this fix.
- Dependabot ignore behavior itself should be observed on the next scheduled Dependabot run.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on whether the structural test expresses the Node 22 minimum baseline without blocking Node 23+ runtime support, and whether the Dependabot ignore only blocks semver-major updates for `@types/node`.

Generated with AI assistance