### PR TITLE
fix(cli): 修复沙箱内 Codex 仍初始化 MCP

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -915,6 +915,42 @@ function resolveHostCatalogPath(value: unknown, hostHomeDir: string): string | n
   }
 }
 
+const CODEX_DISABLED_FEATURE_FLAGS = ['apps', 'enable_mcp_apps'] as const;
+
+function removeCodexMcpServers(sandboxParsed: JsonObject): boolean {
+  if (!Object.hasOwn(sandboxParsed, 'mcp_servers')) {
+    return false;
+  }
+  delete sandboxParsed.mcp_servers;
+  return true;
+}
+
+function inheritDisabledCodexFeatureFlags(sandboxParsed: JsonObject, hostParsed: JsonObject): boolean {
+  if (!isJsonObjectRecord(hostParsed.features)) {
+    return false;
+  }
+  if (Object.hasOwn(sandboxParsed, 'features') && !isJsonObjectRecord(sandboxParsed.features)) {
+    return false;
+  }
+
+  let sandboxFeatures = sandboxParsed.features as JsonObject | undefined;
+  let changed = false;
+  for (const key of CODEX_DISABLED_FEATURE_FLAGS) {
+    if (hostParsed.features[key] !== false) {
+      continue;
+    }
+    if (!sandboxFeatures) {
+      sandboxFeatures = {};
+      sandboxParsed.features = sandboxFeatures;
+    }
+    if (sandboxFeatures[key] !== false) {
+      sandboxFeatures[key] = false;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 export function ensureCodexModelInheritance(
   toolDir: string,
   hostHomeDir?: string,
@@ -947,13 +983,15 @@ export function ensureCodexModelInheritance(
     }
   }
 
+  let changed = removeCodexMcpServers(sandboxParsed);
+  changed = inheritDisabledCodexFeatureFlags(sandboxParsed, hostParsed) || changed;
+
   const inheritSpecs: Array<readonly [string, 'string' | 'number']> = [
     ['model', 'string'],
     ['model_reasoning_effort', 'string'],
     ['model_auto_compact_token_limit', 'number']
   ];
 
-  let changed = false;
   for (const [key, type] of inheritSpecs) {
     if (Object.hasOwn(sandboxParsed, key)) {
       continue;

--- a/tests/integration/cli/sandbox-inheritance.test.ts
+++ b/tests/integration/cli/sandbox-inheritance.test.ts
@@ -652,6 +652,94 @@ test("ensureCodexModelInheritance creates config with host model fields", async 
   }
 });
 
+test("ensureCodexModelInheritance removes MCP servers and inherits only disabled Codex features", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-mcp-clean-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-mcp-clean-"));
+  const configPath = path.join(tmpDir, "config.toml");
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      [
+        'model = "gpt-5.5"',
+        "",
+        "[features]",
+        "apps = false",
+        "enable_mcp_apps = false",
+        "future_feature = true",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    fs.writeFileSync(
+      configPath,
+      [
+        "[features]",
+        "apps = true",
+        "enable_mcp_apps = true",
+        "other_experiment = true",
+        "",
+        "[mcp_servers.demo]",
+        'command = "node"',
+        'args = ["server.js"]',
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+
+    const data = toml.parse(fs.readFileSync(configPath, "utf8")) as {
+      model?: string;
+      features?: Record<string, unknown>;
+      mcp_servers?: unknown;
+    };
+    assert.equal(data.model, "gpt-5.5");
+    assert.equal(data.features?.apps, false);
+    assert.equal(data.features?.enable_mcp_apps, false);
+    assert.equal(data.features?.other_experiment, true);
+    assert.equal(data.features?.future_feature, undefined);
+    assert.equal(data.mcp_servers, undefined);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
+test("ensureCodexModelInheritance does not copy enabled Codex features", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-enabled-features-"));
+  const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-host-enabled-features-"));
+  const configPath = path.join(tmpDir, "config.toml");
+
+  try {
+    fs.mkdirSync(path.join(hostHome, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(hostHome, ".codex", "config.toml"),
+      [
+        "[features]",
+        "apps = true",
+        "enable_mcp_apps = true",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    fs.writeFileSync(configPath, 'model = "gpt-5.4"\n', "utf8");
+
+    sandboxCreate.ensureCodexModelInheritance(tmpDir, hostHome);
+
+    const data = toml.parse(fs.readFileSync(configPath, "utf8")) as {
+      features?: Record<string, unknown>;
+    };
+    assert.equal(data.features, undefined);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(hostHome, { recursive: true, force: true });
+  }
+});
+
 test("ensureCodexModelInheritance keeps model fields before workspace trust section", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-codex-model-order-"));

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -69,8 +69,12 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
     // bind-mount era) must NOT be bound back over the tmpfs — otherwise the
     // high-churn writes would hit the host SSD again (CD-1).
     const codexSandboxDir = path.join(tmpDir, ".agent-infra", "sandboxes", "codex", "demo", "feature-x");
-    fs.mkdirSync(codexSandboxDir, { recursive: true });
+    fs.mkdirSync(path.join(codexSandboxDir, "mcp"), { recursive: true });
+    fs.mkdirSync(path.join(codexSandboxDir, "sessions"), { recursive: true });
     fs.writeFileSync(path.join(codexSandboxDir, "logs_2.sqlite"), "stale\n", "utf8");
+    fs.writeFileSync(path.join(codexSandboxDir, "mcp.json"), "{}\n", "utf8");
+    fs.writeFileSync(path.join(codexSandboxDir, "mcp", "server.json"), "{}\n", "utf8");
+    fs.writeFileSync(path.join(codexSandboxDir, "sessions", "session.jsonl"), "{}\n", "utf8");
 
     spawnSandboxCli(
       fixture,
@@ -106,6 +110,21 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
       runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/logs_2.sqlite")),
       false,
       `stale logs_2.sqlite must NOT be bound back over the tmpfs, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/mcp.json")),
+      false,
+      `stale mcp.json must NOT be bound back over the tmpfs, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/mcp")),
+      false,
+      `stale mcp directory must NOT be bound back over the tmpfs, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/sessions")),
+      false,
+      `stale sessions directory must NOT be bound back over the tmpfs, got ${JSON.stringify(runCall)}`
     );
 
     // auth.json is still overlaid on top of the tmpfs.


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #571 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

沙箱创建流程需要继承 Codex 模型、认证和信任配置，但不应把宿主机上已禁用的 Apps/connectors/MCP 能力重新启用或保留运行时残留。本次变更让沙箱内 Codex 配置继承更明确，避免 MCP 服务在新沙箱内继续初始化。

## 📋 主要变更 / Brief Changelog

- 删除沙箱 Codex 配置中的 `mcp_servers`，避免 MCP server 定义进入沙箱 tmpfs seed。
- 仅继承宿主机中显式禁用的 Codex Apps/MCP feature flags，避免启用态配置外溢。
- 补充集成测试覆盖 MCP 配置清理、禁用 feature flags 继承和 MCP/session 运行时残留不挂载。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `npm test`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

N/A

---

**审查者注意事项 / Reviewer Notes:**

重点关注 Codex 配置清理是否只移除 MCP server 定义和显式禁用的 feature flags，未影响模型继承、workspace trust、认证凭据和现有 tmpfs 行为。

Generated with AI assistance
