### PR TITLE
fix(sandbox): 修复沙箱人工裁决命令提示不可用

### DIFF
--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -16,7 +16,8 @@
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode"
+      "opencode",
+      "agent-infra"
     ],
     "dockerfile": null,
     "vm": {

--- a/.agents/.airc.json
+++ b/.agents/.airc.json
@@ -13,11 +13,11 @@
       "node22"
     ],
     "tools": [
+      "agent-infra",
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode",
-      "agent-infra"
+      "opencode"
     ],
     "dockerfile": null,
     "vm": {

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -260,7 +260,7 @@ args: "<task-id>"   # 可选
 | 占位符 | 替换为 | 示例 |
 |--------|--------|------|
 | `${skillName}` | skill 命令名，例如 `review-code` 或 `commit`。 | `<your-cli> ${skillName}` -> `<your-cli> review-code` |
-| `${projectName}` | `.airc.json` 中的 `project` 值，适用于带命名空间的命令。 | `/${projectName}:${skillName}` -> `/agent-infra:review-code` |
+| `${projectName}` | `.airc.json` 中的 `project` 值，适用于带命名空间的命令。 | `/${projectName}:${skillName}` -> `/your-project:review-code` |
 
 不带命名空间的自定义 TUI：
 
@@ -280,7 +280,7 @@ args: "<task-id>"   # 可选
 
 ```json
 {
-  "project": "agent-infra",
+  "project": "your-project",
   "customTUIs": [
     {
       "name": "<your-tui-name>",
@@ -295,7 +295,7 @@ args: "<task-id>"   # 可选
 
 ## 沙箱自定义工具（Sandbox Custom Tools）
 
-上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 选择列表。
+`customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 CLI 或工具（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 或 `customTUIs` 配置。
 
 ### 必填字段
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -295,7 +295,7 @@ args: "<task-id>"   # 可选
 
 ## 沙箱自定义工具（Sandbox Custom Tools）
 
-上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
+上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 选择列表。
 
 ### 必填字段
 

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -29,11 +29,11 @@ const DEFAULTS = {
       "node22"
     ],
     "tools": [
+      "agent-infra",
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode",
-      "agent-infra"
+      "opencode"
     ],
     "dockerfile": null,
     "vm": {
@@ -87,8 +87,9 @@ const DEFAULTS = {
 };
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
-const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const DEFAULT_SANDBOX_TOOLS = [AGENT_INFRA_SANDBOX_TOOL, ...LEGACY_DEFAULT_SANDBOX_TOOLS];
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -141,7 +142,7 @@ function migrateSandboxTools(cfg) {
   }
   cfg.sandbox = {
     ...cfg.sandbox,
-    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+    tools: [...DEFAULT_SANDBOX_TOOLS]
   };
   return true;
 }

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -32,7 +32,8 @@ const DEFAULTS = {
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode"
+      "opencode",
+      "agent-infra"
     ],
     "dockerfile": null,
     "vm": {
@@ -86,6 +87,8 @@ const DEFAULTS = {
 };
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -121,6 +124,26 @@ function isPathOwnedByDisabledTUI(rel, enabledSet) {
     }
   }
   return false;
+}
+
+function isLegacyDefaultSandboxTools(value) {
+  if (!Array.isArray(value) || value.length !== LEGACY_DEFAULT_SANDBOX_TOOLS.length) {
+    return false;
+  }
+  const tools = new Set(value);
+  return LEGACY_DEFAULT_SANDBOX_TOOLS.every(tool => tools.has(tool));
+}
+
+function migrateSandboxTools(cfg) {
+  const tools = cfg.sandbox?.tools;
+  if (!isLegacyDefaultSandboxTools(tools)) {
+    return false;
+  }
+  cfg.sandbox = {
+    ...cfg.sandbox,
+    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+  };
+  return true;
 }
 
 function norm(p) { return p.replace(/\\/g, '/'); }
@@ -1296,6 +1319,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   ) > 0;
 
   const prevVersion = cfg.templateVersion;
+  const sandboxToolsMigrated = migrateSandboxTools(cfg);
 
   cfg.files.managed = managed;
   cfg.files.merged  = merged;
@@ -1303,7 +1327,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   cfg.templateVersion = version;
   delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource || sandboxToolsMigrated;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -6,6 +6,8 @@
 
 `ai sandbox create` now bootstraps the host-side aliases file at `~/.agent-infra/aliases/sandbox.sh` on first run. The generated file includes ready-to-edit yolo shortcuts for Claude, Codex, Gemini CLI, and OpenCode, and every sandbox syncs that file into `/home/devuser/.bash_aliases`.
 
+The default sandbox image also installs the agent-infra CLI npm package, exposing both `ai` and `agent-infra` on the container `PATH`. This lets task commands such as `ai task decisions <task-ref>` run from inside the sandbox against the mounted `/workspace`. Existing sandbox images and containers need a refreshed rebuild and recreation before they pick up this newly managed tool.
+
 The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the host, `ai sandbox create` injects the token into the container as `GH_TOKEN`, so `gh` commands work inside the sandbox without extra setup.
 
 `ai sandbox rebuild` keeps Docker's build cache by default, so it quickly retags the sandbox image without refreshing every package. Use `ai sandbox rebuild --refresh` when you want to upgrade the image: it passes `--no-cache --pull` to Docker, pulls the current Ubuntu base image, and reruns the apt, tmux build, and global npm install layers. Claude Code updates are disabled inside the container, and OpenCode startup update checks are disabled; `--refresh` is the routine upgrade path for sandbox-managed tools. Manual `opencode upgrade` remains outside this guard. The default `python3` provided by the Ubuntu 24.04 sandbox base is Python 3.12, so scripts that hard-code Python 3.10 paths may need adjustment.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -6,6 +6,8 @@
 
 `ai sandbox create` 在首次运行时会自动生成宿主机侧的 `~/.agent-infra/aliases/sandbox.sh`。该文件内置了 Claude、Codex、Gemini CLI 和 OpenCode 的 yolo 快捷命令模板，你可以直接修改；每次创建沙箱时，这个文件都会同步到容器内的 `/home/devuser/.bash_aliases`。
 
+默认沙箱镜像也会安装 agent-infra CLI npm 包，并把 `ai` 与 `agent-infra` 暴露在容器 `PATH` 上。因此 `ai task decisions <task-ref>` 这类任务命令可以在沙箱内直接针对挂载的 `/workspace` 执行。已有沙箱镜像和容器需要刷新重建并重新创建后，才会获得这个新增的托管工具。
+
 沙箱镜像也会预装 `gh`。如果宿主机上的 `gh auth token` 能成功返回 token，`ai sandbox create` 会把它以 `GH_TOKEN` 环境变量注入容器，让你在沙箱里直接使用 `gh`，无需额外登录配置。
 
 `ai sandbox rebuild` 默认保留 Docker build cache，因此会快速重打沙箱镜像，不会刷新每个软件包。需要升级镜像时使用 `ai sandbox rebuild --refresh`：它会向 Docker 传入 `--no-cache --pull`，重新拉取当前 Ubuntu 基础镜像，并重跑 apt、tmux 编译和全局 npm 安装层。容器内 Claude Code 更新已关闭，OpenCode 启动时更新检查也已关闭；`--refresh` 是沙箱托管工具的常规升级入口。手动 `opencode upgrade` 不受该保护覆盖。Ubuntu 24.04 沙箱基础镜像提供的默认 `python3` 是 Python 3.12，因此硬编码 Python 3.10 路径的脚本可能需要调整。

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -11,7 +11,8 @@
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode"
+      "opencode",
+      "agent-infra"
     ],
     "dockerfile": null,
     "vm": {

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -8,11 +8,11 @@
       "node22"
     ],
     "tools": [
+      "agent-infra",
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode",
-      "agent-infra"
+      "opencode"
     ],
     "dockerfile": null,
     "vm": {

--- a/lib/sandbox/config.ts
+++ b/lib/sandbox/config.ts
@@ -12,7 +12,7 @@ import type { SandboxTool } from './tools.ts';
 const DEFAULTS = Object.freeze({
   engine: null,
   runtimes: ['node22'],
-  tools: ['claude-code', 'codex', 'gemini-cli', 'opencode'],
+  tools: ['claude-code', 'codex', 'gemini-cli', 'opencode', 'agent-infra'],
   dockerfile: null,
   vm: {
     cpu: null,

--- a/lib/sandbox/config.ts
+++ b/lib/sandbox/config.ts
@@ -12,7 +12,7 @@ import type { SandboxTool } from './tools.ts';
 const DEFAULTS = Object.freeze({
   engine: null,
   runtimes: ['node22'],
-  tools: ['claude-code', 'codex', 'gemini-cli', 'opencode', 'agent-infra'],
+  tools: ['agent-infra', 'claude-code', 'codex', 'gemini-cli', 'opencode'],
   dockerfile: null,
   vm: {
     cpu: null,

--- a/lib/sandbox/runtimes/node20.dockerfile
+++ b/lib/sandbox/runtimes/node20.dockerfile
@@ -1,3 +1,3 @@
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN bash -o pipefail -c 'curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://deb.nodesource.com/setup_20.x | bash -' && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/lib/sandbox/runtimes/node22.dockerfile
+++ b/lib/sandbox/runtimes/node22.dockerfile
@@ -1,3 +1,3 @@
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+RUN bash -o pipefail -c 'curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://deb.nodesource.com/setup_22.x | bash -' && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -124,6 +124,15 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
         { hostPath: hostJoin(home, '.gemini', 'settings.json'), sandboxName: 'settings.json' },
         { hostPath: hostJoin(home, '.gemini', 'google_accounts.json'), sandboxName: 'google_accounts.json' }
       ]
+    },
+    'agent-infra': {
+      id: 'agent-infra',
+      name: 'agent-infra CLI',
+      install: { type: 'npm', cmd: '@fitlab-ai/agent-infra@latest' },
+      sandboxBase: hostJoin(home, '.agent-infra', 'sandboxes', 'agent-infra'),
+      containerMount: '/home/devuser/.agent-infra-cli',
+      versionCmd: 'ai version --raw',
+      setupHint: 'Provides the ai and agent-infra CLI commands inside the sandbox.'
     }
   };
 }

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -40,8 +40,9 @@ const defaults = JSON.parse(
 
 const CONFIG_DIR = '.agents';
 const CONFIG_PATH = path.join(CONFIG_DIR, '.airc.json');
-const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const DEFAULT_SANDBOX_TOOLS = [AGENT_INFRA_SANDBOX_TOOL, ...LEGACY_DEFAULT_SANDBOX_TOOLS];
 
 // One-time migration of the legacy project-level PR switch to the three-state
 // `prFlow` preference. `true` (the old default / "PR flow on") maps to the
@@ -77,7 +78,7 @@ function migrateSandboxTools(config: UpdateConfig): boolean {
   }
   config.sandbox = {
     ...config.sandbox,
-    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+    tools: [...DEFAULT_SANDBOX_TOOLS]
   };
   return true;
 }

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -40,6 +40,8 @@ const defaults = JSON.parse(
 
 const CONFIG_DIR = '.agents';
 const CONFIG_PATH = path.join(CONFIG_DIR, '.airc.json');
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
 
 // One-time migration of the legacy project-level PR switch to the three-state
 // `prFlow` preference. `true` (the old default / "PR flow on") maps to the
@@ -58,6 +60,26 @@ function migratePrFlow(config: UpdateConfig): 'required' | 'disabled' | null {
     return 'disabled';
   }
   return null;
+}
+
+function isLegacyDefaultSandboxTools(value: unknown): value is string[] {
+  if (!Array.isArray(value) || value.length !== LEGACY_DEFAULT_SANDBOX_TOOLS.length) {
+    return false;
+  }
+  const tools = new Set(value);
+  return LEGACY_DEFAULT_SANDBOX_TOOLS.every((tool) => tools.has(tool));
+}
+
+function migrateSandboxTools(config: UpdateConfig): boolean {
+  const tools = config.sandbox?.tools;
+  if (!isLegacyDefaultSandboxTools(tools)) {
+    return false;
+  }
+  config.sandbox = {
+    ...config.sandbox,
+    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+  };
+  return true;
 }
 
 function isPathOwnedByOtherPlatform(relativePath: string, platformType: string): boolean {
@@ -215,6 +237,7 @@ async function cmdUpdate(): Promise<void> {
   const taskAdded = !config.task;
   const labelsAdded = !config.labels;
   const prFlowMigrated = migratePrFlow(config);
+  const sandboxToolsMigrated = !sandboxAdded && migrateSandboxTools(config);
   let configChanged = changed;
 
   if (platformAdded) {
@@ -238,6 +261,10 @@ async function cmdUpdate(): Promise<void> {
   }
 
   if (prFlowMigrated) {
+    configChanged = true;
+  }
+
+  if (sandboxToolsMigrated) {
     configChanged = true;
   }
 
@@ -267,6 +294,9 @@ async function cmdUpdate(): Promise<void> {
       if (prFlowMigrated) {
         info(`Migrated legacy requiresPullRequest to prFlow="${prFlowMigrated}" in ${CONFIG_PATH}.`);
       }
+      if (sandboxToolsMigrated) {
+        info(`Migrated default sandbox.tools to include ${AGENT_INFRA_SANDBOX_TOOL} in ${CONFIG_PATH}.`);
+      }
     } else {
       info(`File registry changed in ${CONFIG_PATH}.`);
     }
@@ -284,6 +314,9 @@ async function cmdUpdate(): Promise<void> {
     }
     if (hasNewEntries && prFlowMigrated) {
       info(`Migrated legacy requiresPullRequest to prFlow="${prFlowMigrated}" in ${CONFIG_PATH}.`);
+    }
+    if (hasNewEntries && sandboxToolsMigrated) {
+      info(`Migrated default sandbox.tools to include ${AGENT_INFRA_SANDBOX_TOOL} in ${CONFIG_PATH}.`);
     }
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n', 'utf8');
     ok(`Updated ${CONFIG_PATH}`);

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -24,8 +24,9 @@ const DEFAULTS = JSON.parse(
 );
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
-const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const DEFAULT_SANDBOX_TOOLS = [AGENT_INFRA_SANDBOX_TOOL, ...LEGACY_DEFAULT_SANDBOX_TOOLS];
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -78,7 +79,7 @@ function migrateSandboxTools(cfg) {
   }
   cfg.sandbox = {
     ...cfg.sandbox,
-    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+    tools: [...DEFAULT_SANDBOX_TOOLS]
   };
   return true;
 }

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -24,6 +24,8 @@ const DEFAULTS = JSON.parse(
 );
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -59,6 +61,26 @@ function isPathOwnedByDisabledTUI(rel, enabledSet) {
     }
   }
   return false;
+}
+
+function isLegacyDefaultSandboxTools(value) {
+  if (!Array.isArray(value) || value.length !== LEGACY_DEFAULT_SANDBOX_TOOLS.length) {
+    return false;
+  }
+  const tools = new Set(value);
+  return LEGACY_DEFAULT_SANDBOX_TOOLS.every(tool => tools.has(tool));
+}
+
+function migrateSandboxTools(cfg) {
+  const tools = cfg.sandbox?.tools;
+  if (!isLegacyDefaultSandboxTools(tools)) {
+    return false;
+  }
+  cfg.sandbox = {
+    ...cfg.sandbox,
+    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+  };
+  return true;
 }
 
 function norm(p) { return p.replace(/\\/g, '/'); }
@@ -1234,6 +1256,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   ) > 0;
 
   const prevVersion = cfg.templateVersion;
+  const sandboxToolsMigrated = migrateSandboxTools(cfg);
 
   cfg.files.managed = managed;
   cfg.files.merged  = merged;
@@ -1241,7 +1264,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   cfg.templateVersion = version;
   delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource || sandboxToolsMigrated;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -260,7 +260,7 @@ Supported `invoke` placeholders:
 | Placeholder | Replaced with | Example |
 |-------------|---------------|---------|
 | `${skillName}` | The skill command name, such as `review-code` or `commit`. | `<your-cli> ${skillName}` -> `<your-cli> review-code` |
-| `${projectName}` | The `.airc.json` `project` value. Use this for namespaced commands. | `/${projectName}:${skillName}` -> `/agent-infra:review-code` |
+| `${projectName}` | The `.airc.json` `project` value. Use this for namespaced commands. | `/${projectName}:${skillName}` -> `/your-project:review-code` |
 
 Non-namespaced custom TUI:
 
@@ -280,7 +280,7 @@ Namespaced custom TUI:
 
 ```json
 {
-  "project": "agent-infra",
+  "project": "your-project",
   "customTUIs": [
     {
       "name": "<your-tui-name>",
@@ -295,7 +295,7 @@ Namespaced custom TUI:
 
 ## Sandbox Custom Tools
 
-`customTUIs` (above) generates slash-command files but does not change the sandbox image. To install a non-npm TUI (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in sandbox tools (`claude-code`, `codex`, `opencode`, `gemini-cli`, `agent-infra`) keep working unchanged; `agent-infra` only provides the in-sandbox `ai` / `agent-infra` CLI and is not part of the `tuis` selector.
+`customTUIs` generates slash-command files but does not change the sandbox image. To install a non-npm CLI or tool (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in sandbox tools (`claude-code`, `codex`, `opencode`, `gemini-cli`, `agent-infra`) keep working unchanged; `agent-infra` only provides the in-sandbox `ai` / `agent-infra` CLI and is not part of `tuis` or `customTUIs`.
 
 ### Required fields
 

--- a/templates/.agents/README.en.md
+++ b/templates/.agents/README.en.md
@@ -295,7 +295,7 @@ Namespaced custom TUI:
 
 ## Sandbox Custom Tools
 
-`customTUIs` (above) generates slash-command files but does not change the sandbox image. To install a non-npm TUI (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in tools (`claude-code`, `codex`, `opencode`, `gemini-cli`) keep working unchanged.
+`customTUIs` (above) generates slash-command files but does not change the sandbox image. To install a non-npm TUI (pip / cargo / curl-based / pre-built binary) into the sandbox image and live-mount its credentials, declare it under `sandbox.customTools` in `.agents/.airc.json`. Built-in sandbox tools (`claude-code`, `codex`, `opencode`, `gemini-cli`, `agent-infra`) keep working unchanged; `agent-infra` only provides the in-sandbox `ai` / `agent-infra` CLI and is not part of the `tuis` selector.
 
 ### Required fields
 

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -260,7 +260,7 @@ args: "<task-id>"   # 可选
 | 占位符 | 替换为 | 示例 |
 |--------|--------|------|
 | `${skillName}` | skill 命令名，例如 `review-code` 或 `commit`。 | `<your-cli> ${skillName}` -> `<your-cli> review-code` |
-| `${projectName}` | `.airc.json` 中的 `project` 值，适用于带命名空间的命令。 | `/${projectName}:${skillName}` -> `/agent-infra:review-code` |
+| `${projectName}` | `.airc.json` 中的 `project` 值，适用于带命名空间的命令。 | `/${projectName}:${skillName}` -> `/your-project:review-code` |
 
 不带命名空间的自定义 TUI：
 
@@ -280,7 +280,7 @@ args: "<task-id>"   # 可选
 
 ```json
 {
-  "project": "agent-infra",
+  "project": "your-project",
   "customTUIs": [
     {
       "name": "<your-tui-name>",
@@ -295,7 +295,7 @@ args: "<task-id>"   # 可选
 
 ## 沙箱自定义工具（Sandbox Custom Tools）
 
-上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 选择列表。
+`customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 CLI 或工具（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 或 `customTUIs` 配置。
 
 ### 必填字段
 

--- a/templates/.agents/README.zh-CN.md
+++ b/templates/.agents/README.zh-CN.md
@@ -295,7 +295,7 @@ args: "<task-id>"   # 可选
 
 ## 沙箱自定义工具（Sandbox Custom Tools）
 
-上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建的四个工具（`claude-code` / `codex` / `opencode` / `gemini-cli`）行为保持不变。
+上文 `customTUIs` 只负责生成 slash-command 文件，**不影响沙箱镜像**。如果要把一个非 npm 分发的 TUI（pip / cargo / curl 脚本 / 裸二进制）装进沙箱镜像、并 live-mount 它的凭证目录，需要在 `.agents/.airc.json` 的 `sandbox.customTools` 中声明。内建 sandbox 工具（`claude-code` / `codex` / `opencode` / `gemini-cli` / `agent-infra`）行为保持不变；其中 `agent-infra` 只提供沙箱内 `ai` / `agent-infra` CLI，不属于 `tuis` 选择列表。
 
 ### 必填字段
 

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -29,11 +29,11 @@ const DEFAULTS = {
       "node22"
     ],
     "tools": [
+      "agent-infra",
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode",
-      "agent-infra"
+      "opencode"
     ],
     "dockerfile": null,
     "vm": {
@@ -87,8 +87,9 @@ const DEFAULTS = {
 };
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
-const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const DEFAULT_SANDBOX_TOOLS = [AGENT_INFRA_SANDBOX_TOOL, ...LEGACY_DEFAULT_SANDBOX_TOOLS];
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -141,7 +142,7 @@ function migrateSandboxTools(cfg) {
   }
   cfg.sandbox = {
     ...cfg.sandbox,
-    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+    tools: [...DEFAULT_SANDBOX_TOOLS]
   };
   return true;
 }

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -32,7 +32,8 @@ const DEFAULTS = {
       "claude-code",
       "codex",
       "gemini-cli",
-      "opencode"
+      "opencode",
+      "agent-infra"
     ],
     "dockerfile": null,
     "vm": {
@@ -86,6 +87,8 @@ const DEFAULTS = {
 };
 
 const PACKAGE_NAME = '@fitlab-ai/agent-infra';
+const LEGACY_DEFAULT_SANDBOX_TOOLS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
 // Add a new identifier here only after shipping matching .{platform}. template variants.
 const KNOWN_PLATFORMS = new Set(['github']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
@@ -121,6 +124,26 @@ function isPathOwnedByDisabledTUI(rel, enabledSet) {
     }
   }
   return false;
+}
+
+function isLegacyDefaultSandboxTools(value) {
+  if (!Array.isArray(value) || value.length !== LEGACY_DEFAULT_SANDBOX_TOOLS.length) {
+    return false;
+  }
+  const tools = new Set(value);
+  return LEGACY_DEFAULT_SANDBOX_TOOLS.every(tool => tools.has(tool));
+}
+
+function migrateSandboxTools(cfg) {
+  const tools = cfg.sandbox?.tools;
+  if (!isLegacyDefaultSandboxTools(tools)) {
+    return false;
+  }
+  cfg.sandbox = {
+    ...cfg.sandbox,
+    tools: [...tools, AGENT_INFRA_SANDBOX_TOOL]
+  };
+  return true;
 }
 
 function norm(p) { return p.replace(/\\/g, '/'); }
@@ -1296,6 +1319,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   ) > 0;
 
   const prevVersion = cfg.templateVersion;
+  const sandboxToolsMigrated = migrateSandboxTools(cfg);
 
   cfg.files.managed = managed;
   cfg.files.merged  = merged;
@@ -1303,7 +1327,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
   cfg.templateVersion = version;
   delete cfg.templateSource;
 
-  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource;
+  report.configUpdated = hasChanges || prevVersion !== version || hadTemplateSource || sandboxToolsMigrated;
 
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n', 'utf8');
 

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -207,7 +207,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.deepEqual(config.sandbox, {
       engine: DEFAULT_SANDBOX_ENGINE,
       runtimes: ["node22"],
-      tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
+      tools: ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }
     }, "init should generate default sandbox config");
@@ -618,7 +618,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     assert.deepEqual(updated.sandbox, {
       engine: null,
       runtimes: ["node22"],
-      tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
+      tools: ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }
     }, "update should backfill default sandbox config");
@@ -659,7 +659,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
   }
 });
 
-test("agent-infra update appends agent-infra to legacy default sandbox tools", () => {
+test("agent-infra update migrates legacy default sandbox tools to canonical order", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-update-sandbox-tools-"));
   const config = {
     project: "seedproj",
@@ -700,11 +700,11 @@ test("agent-infra update appends agent-infra to legacy default sandbox tools", (
 
     assert.match(output, /Migrated default sandbox\.tools to include agent-infra/);
     assert.deepEqual(updated.sandbox.tools, [
-      "opencode",
+      "agent-infra",
       "claude-code",
-      "gemini-cli",
       "codex",
-      "agent-infra"
+      "gemini-cli",
+      "opencode"
     ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -207,7 +207,7 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.deepEqual(config.sandbox, {
       engine: DEFAULT_SANDBOX_ENGINE,
       runtimes: ["node22"],
-      tools: ["claude-code", "codex", "gemini-cli", "opencode"],
+      tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }
     }, "init should generate default sandbox config");
@@ -618,7 +618,7 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     assert.deepEqual(updated.sandbox, {
       engine: null,
       runtimes: ["node22"],
-      tools: ["claude-code", "codex", "gemini-cli", "opencode"],
+      tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
       dockerfile: null,
       vm: { cpu: null, memory: null, disk: null }
     }, "update should backfill default sandbox config");
@@ -654,6 +654,58 @@ test("agent-infra update refreshes seed files and syncs file registry", () => {
     assert.ok(
       fs.existsSync(path.join(tmpDir, ".opencode", "commands", "update-agent-infra.md"))
     );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("agent-infra update appends agent-infra to legacy default sandbox tools", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-update-sandbox-tools-"));
+  const config = {
+    project: "seedproj",
+    org: "seedorg",
+    language: "en",
+    templateVersion: "stale",
+    files: {
+      managed: [],
+      merged: [],
+      ejected: []
+    },
+    sandbox: {
+      engine: null,
+      runtimes: ["node22"],
+      tools: ["opencode", "claude-code", "gemini-cli", "codex"],
+      dockerfile: null,
+      vm: { cpu: null, memory: null, disk: null }
+    }
+  };
+
+  try {
+    fs.mkdirSync(path.join(tmpDir, ".agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".agents", ".airc.json"),
+      JSON.stringify(config, null, 2) + "\n",
+      "utf8"
+    );
+
+    const output = execFileSync(process.execPath, cliArgs("update"), {
+      cwd: tmpDir,
+      stdio: "pipe",
+      encoding: "utf8"
+    });
+
+    const updated = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, ".agents", ".airc.json"), "utf8")
+    );
+
+    assert.match(output, /Migrated default sandbox\.tools to include agent-infra/);
+    assert.deepEqual(updated.sandbox.tools, [
+      "opencode",
+      "claude-code",
+      "gemini-cli",
+      "codex",
+      "agent-infra"
+    ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/sandbox-config.test.ts
+++ b/tests/integration/cli/sandbox-config.test.ts
@@ -34,7 +34,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.equal(config.containerPrefix, "demo-dev");
     assert.equal(config.imageName, "demo-sandbox:latest");
     assert.deepEqual(config.runtimes, ["node22"]);
-    assert.deepEqual(config.tools, ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"]);
+    assert.deepEqual(config.tools, ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"]);
     assert.equal(config.engine, null);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME ?? "", ".agent-infra", "worktrees", "demo"));

--- a/tests/integration/cli/sandbox-config.test.ts
+++ b/tests/integration/cli/sandbox-config.test.ts
@@ -34,7 +34,7 @@ test("loadConfig derives sandbox defaults from .agents/.airc.json", async () => 
     assert.equal(config.containerPrefix, "demo-dev");
     assert.equal(config.imageName, "demo-sandbox:latest");
     assert.deepEqual(config.runtimes, ["node22"]);
-    assert.deepEqual(config.tools, ["claude-code", "codex", "gemini-cli", "opencode"]);
+    assert.deepEqual(config.tools, ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"]);
     assert.equal(config.engine, null);
     assert.deepEqual(config.vm, { cpu: null, memory: null, disk: null });
     assert.equal(config.worktreeBase, path.join(process.env.HOME ?? "", ".agent-infra", "worktrees", "demo"));

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -126,6 +126,25 @@ test("composeDockerfile joins runtime fragments in order", async () => {
   }
 });
 
+test("node runtime setup fails fast on NodeSource download errors", async () => {
+  const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-node-runtime-"));
+
+  try {
+    const dockerfilePath = sandboxDockerfile.composeDockerfile({
+      repoRoot: tmpDir,
+      project: "demo",
+      runtimes: ["node22"],
+      dockerfile: null
+    });
+    const content = fs.readFileSync(dockerfilePath, "utf8");
+
+    assert.match(content, /bash -o pipefail -c 'curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https:\/\/deb\.nodesource\.com\/setup_22\.x \| bash -'/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 // Intent: each package in AI_TOOL_PACKAGES gets its own `npm install -g <pkg>`
 // invocation, so npm's batch-install path (which drops platform-specific
 // optionalDependencies for `npm:` aliased packages — Issue #293) is not

--- a/tests/integration/cli/sandbox-install-script.test.ts
+++ b/tests/integration/cli/sandbox-install-script.test.ts
@@ -34,6 +34,20 @@ test("toolNpmPackagesArg returns space-separated npm packages and ignores shell 
   assert.equal(sandboxTools.toolNpmPackagesArg([SHELL_TOOL]), "");
 });
 
+test("toolNpmPackagesArg includes the agent-infra builtin package", async () => {
+  const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
+  const [agentInfra] = sandboxTools.resolveTools({
+    home: "/home/host-user",
+    project: "demo",
+    tools: ["agent-infra"]
+  });
+
+  assert.equal(sandboxTools.toolNpmPackagesArg([agentInfra!]), "@fitlab-ai/agent-infra@latest");
+  assert.deepEqual(sandboxTools.imageSignatureFields([agentInfra!]), [
+    { id: "agent-infra", install: { type: "npm", cmd: "@fitlab-ai/agent-infra@latest" } }
+  ]);
+});
+
 test("toolShellInstallScript returns empty string when no shell tools are present", async () => {
   const sandboxTools = await loadFreshEsm<SandboxToolsModule>("lib/sandbox/tools.js");
 

--- a/tests/integration/cli/sandbox-show.test.ts
+++ b/tests/integration/cli/sandbox-show.test.ts
@@ -12,7 +12,7 @@ import type { SandboxConfig } from '../../../lib/sandbox/config.ts';
 
 type ShowModule = typeof import('../../../lib/sandbox/commands/show.ts');
 
-const BUILTIN_TOOL_IDS = ['claude-code', 'codex', 'gemini-cli', 'opencode'];
+const BUILTIN_TOOL_IDS = ['claude-code', 'codex', 'gemini-cli', 'opencode', 'agent-infra'];
 
 function makeConfig(home: string): SandboxConfig {
   return {

--- a/tests/integration/cli/sandbox-show.test.ts
+++ b/tests/integration/cli/sandbox-show.test.ts
@@ -12,7 +12,7 @@ import type { SandboxConfig } from '../../../lib/sandbox/config.ts';
 
 type ShowModule = typeof import('../../../lib/sandbox/commands/show.ts');
 
-const BUILTIN_TOOL_IDS = ['claude-code', 'codex', 'gemini-cli', 'opencode', 'agent-infra'];
+const BUILTIN_TOOL_IDS = ['agent-infra', 'claude-code', 'codex', 'gemini-cli', 'opencode'];
 
 function makeConfig(home: string): SandboxConfig {
   return {

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -691,13 +691,17 @@ test("resolveTools consolidates sandbox bases under ~/.agent-infra", async () =>
   const tools = sandboxTools.resolveTools({
     home: "/home/host-user",
     project: "demo",
-    tools: ["claude-code", "codex", "opencode", "gemini-cli", "agent-infra"]
+    tools: ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"]
   });
 
   assert.deepEqual(tools.map((tool) => ({
     id: tool.id,
     sandboxBase: tool.sandboxBase
   })), [
+    {
+      id: "agent-infra",
+      sandboxBase: "/home/host-user/.agent-infra/sandboxes/agent-infra"
+    },
     {
       id: "claude-code",
       sandboxBase: "/home/host-user/.agent-infra/sandboxes/claude-code"
@@ -707,16 +711,12 @@ test("resolveTools consolidates sandbox bases under ~/.agent-infra", async () =>
       sandboxBase: "/home/host-user/.agent-infra/sandboxes/codex"
     },
     {
-      id: "opencode",
-      sandboxBase: "/home/host-user/.agent-infra/sandboxes/opencode"
-    },
-    {
       id: "gemini-cli",
       sandboxBase: "/home/host-user/.agent-infra/sandboxes/gemini-cli"
     },
     {
-      id: "agent-infra",
-      sandboxBase: "/home/host-user/.agent-infra/sandboxes/agent-infra"
+      id: "opencode",
+      sandboxBase: "/home/host-user/.agent-infra/sandboxes/opencode"
     }
   ]);
 });

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -665,12 +665,33 @@ test("gemini-cli tool preseeds host settings for model and thinking config inher
   )));
 });
 
+test("agent-infra tool exposes the ai CLI without credentials or tmpfs state", async () => {
+  const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
+  const [maybeTool] = sandboxTools.resolveTools({
+    home: "/home/host-user",
+    project: "demo",
+    tools: ["agent-infra"]
+  });
+
+  const tool = required(maybeTool);
+  assert.equal(tool.id, "agent-infra");
+  assert.equal(tool.install.type, "npm");
+  assert.equal(tool.install.cmd, "@fitlab-ai/agent-infra@latest");
+  assert.equal(tool.sandboxBase, "/home/host-user/.agent-infra/sandboxes/agent-infra");
+  assert.equal(tool.containerMount, "/home/devuser/.agent-infra-cli");
+  assert.equal(tool.versionCmd, "ai version --raw");
+  assert.equal(tool.tmpfs, undefined);
+  assert.equal(tool.hostLiveMounts, undefined);
+  assert.equal(tool.hostPreSeedFiles, undefined);
+  assert.equal(tool.hostPreSeedDirs, undefined);
+});
+
 test("resolveTools consolidates sandbox bases under ~/.agent-infra", async () => {
   const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
   const tools = sandboxTools.resolveTools({
     home: "/home/host-user",
     project: "demo",
-    tools: ["claude-code", "codex", "opencode", "gemini-cli"]
+    tools: ["claude-code", "codex", "opencode", "gemini-cli", "agent-infra"]
   });
 
   assert.deepEqual(tools.map((tool) => ({
@@ -692,6 +713,10 @@ test("resolveTools consolidates sandbox bases under ~/.agent-infra", async () =>
     {
       id: "gemini-cli",
       sandboxBase: "/home/host-user/.agent-infra/sandboxes/gemini-cli"
+    },
+    {
+      id: "agent-infra",
+      sandboxBase: "/home/host-user/.agent-infra/sandboxes/agent-infra"
     }
   ]);
 });

--- a/tests/unit/cli/sync-templates.test.ts
+++ b/tests/unit/cli/sync-templates.test.ts
@@ -248,7 +248,7 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
   }
 });
 
-test("syncTemplates appends agent-infra to legacy default sandbox tools regardless of ordering", async () => {
+test("syncTemplates migrates legacy default sandbox tools to canonical order", async () => {
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-sandbox-tools-"));
 
@@ -284,7 +284,7 @@ test("syncTemplates appends agent-infra to legacy default sandbox tools regardle
     const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8"));
 
     assert.equal(report.configUpdated, true);
-    assert.deepEqual(cfg.sandbox.tools, ["claude-code", "opencode", "codex", "gemini-cli", "agent-infra"]);
+    assert.deepEqual(cfg.sandbox.tools, ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"]);
   } finally {
     childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/unit/cli/sync-templates.test.ts
+++ b/tests/unit/cli/sync-templates.test.ts
@@ -248,6 +248,91 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
   }
 });
 
+test("syncTemplates appends agent-infra to legacy default sandbox tools regardless of ordering", async () => {
+  const originalExecSync = childProcess.execSync;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-sandbox-tools-"));
+
+  try {
+    const projectRoot = path.join(tmpDir, "project");
+    const { templateRoot } = createTemplateInstall(tmpDir);
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    writeJson(projectRoot, ".agents/.airc.json", {
+      project: "demo",
+      org: "acme",
+      language: "en",
+      platform: { type: "github" },
+      sandbox: {
+        engine: null,
+        runtimes: ["node22"],
+        tools: ["claude-code", "opencode", "codex", "gemini-cli"],
+        dockerfile: null,
+        vm: { cpu: null, memory: null, disk: null }
+      },
+      files: { managed: [], merged: [], ejected: [] }
+    });
+
+    childProcess.execSync = (command) => {
+      if (command === "git remote get-url origin") {
+        throw new Error("not a git repo");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    };
+
+    const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
+    const report = syncTemplates(projectRoot, templateRoot);
+    const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8"));
+
+    assert.equal(report.configUpdated, true);
+    assert.deepEqual(cfg.sandbox.tools, ["claude-code", "opencode", "codex", "gemini-cli", "agent-infra"]);
+  } finally {
+    childProcess.execSync = originalExecSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncTemplates preserves customized sandbox tools", async () => {
+  const originalExecSync = childProcess.execSync;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-sandbox-custom-tools-"));
+
+  try {
+    const projectRoot = path.join(tmpDir, "project");
+    const { templateRoot } = createTemplateInstall(tmpDir);
+
+    fs.mkdirSync(projectRoot, { recursive: true });
+    writeJson(projectRoot, ".agents/.airc.json", {
+      project: "demo",
+      org: "acme",
+      language: "en",
+      platform: { type: "github" },
+      sandbox: {
+        engine: null,
+        runtimes: ["node22"],
+        tools: ["codex"],
+        dockerfile: null,
+        vm: { cpu: null, memory: null, disk: null }
+      },
+      files: { managed: [], merged: [], ejected: [] }
+    });
+
+    childProcess.execSync = (command) => {
+      if (command === "git remote get-url origin") {
+        throw new Error("not a git repo");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    };
+
+    const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
+    syncTemplates(projectRoot, templateRoot);
+    const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8"));
+
+    assert.deepEqual(cfg.sandbox.tools, ["codex"]);
+  } finally {
+    childProcess.execSync = originalExecSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("syncTemplates prefers platform-specific variants and composes with zh-CN localization", async () => {
   const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-platform-"));

--- a/tests/unit/core/airc.test.ts
+++ b/tests/unit/core/airc.test.ts
@@ -28,7 +28,7 @@ test(".agents/.airc.json declares default sandbox configuration", () => {
   assert.deepEqual(collaborator.sandbox, {
     engine: "orbstack",
     runtimes: ["node22"],
-    tools: ["claude-code", "codex", "gemini-cli", "opencode"],
+    tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
     dockerfile: null,
     vm: { cpu: null, memory: null, disk: null }
   });

--- a/tests/unit/core/airc.test.ts
+++ b/tests/unit/core/airc.test.ts
@@ -28,7 +28,7 @@ test(".agents/.airc.json declares default sandbox configuration", () => {
   assert.deepEqual(collaborator.sandbox, {
     engine: "orbstack",
     runtimes: ["node22"],
-    tools: ["claude-code", "codex", "gemini-cli", "opencode", "agent-infra"],
+    tools: ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"],
     dockerfile: null,
     vm: { cpu: null, memory: null, disk: null }
   });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #572 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

人工裁决提示会引导用户运行 `ai task decisions <task-ref>` 查看裁决详情，但默认任务沙箱此前不安装 agent-infra CLI，导致用户在沙箱中无法按提示执行 `ai` 命令。本次变更把 agent-infra CLI 纳入默认沙箱工具，使人工裁决查看命令在沙箱内直接可用。

## 📋 主要变更 / Brief Changelog

- 新增默认 sandbox tool `agent-infra`，通过 `@fitlab-ai/agent-infra@latest` 在沙箱镜像中提供 `ai` / `agent-infra` CLI。
- 更新默认 sandbox 配置，并为 `ai update` 与 `update-agent-infra` 增加旧默认 tools 的顺序无关迁移。
- 保持自定义 sandbox tools 不被自动改写，且 `agent-infra` 不进入 `tuis` 选择体系。
- 更新中英文 sandbox 文档和 README 模板，说明已有沙箱需要刷新重建。
- 补充配置、安装参数、show 输出、迁移和工具字段测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`
2. Commit hook: `npm run typecheck`
3. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #572 milestone `0.8.2`.
- 旧默认 sandbox tools 会迁移为追加 `agent-infra`；自定义 tools 组合保持不变。
- 待人工验证：执行 `ai sandbox rebuild --refresh`、`ai sandbox create #04`，并在容器内确认 `command -v ai && ai version --raw && ai task decisions #04` 可用。

---

**审查者注意事项 / Reviewer Notes:**

重点关注 `agent-infra` 作为 sandbox tool 而非 TUI 的边界、旧默认 tools 迁移是否只命中默认集合，以及新增 `containerMount` 是否不会与现有工具目录或 `~/.agent-infra` 运行目录冲突。

Generated with AI assistance
