### PR TITLE
fix(ci): skip issue-type gate for personal repositories

### DIFF
--- a/.agents/rules/create-issue.md
+++ b/.agents/rules/create-issue.md
@@ -101,7 +101,7 @@ ai task issue-body {task-id} > "{body-file}"
 | `feature`, `enhancement` | `Feature` |
 | `task`, `documentation`, `dependency-upgrade`, `chore`, `docs`, `refactor`, `refactoring` 及其它 | `Task` |
 
-实际设置时按 `.agents/rules/issue-pr-commands.md` 的 "设置 Issue Type" 命令；先调 `gh api orgs/{owner}/issue-types` 列出 org 实际可用的 Type，仅当推断值在列表中时才设置；设置失败不阻断流程。
+实际设置时按 `.agents/rules/issue-pr-commands.md` 的 "设置 Issue Type" 命令；仅当 owner type 为 `Organization` 时，先调 `gh api orgs/{owner}/issue-types` 列出 org 实际可用的 Type，并且仅当推断值在列表中时才设置；个人仓库、owner type 探测失败或设置失败都不阻断流程。
 
 #### milestone
 
@@ -149,7 +149,7 @@ gh issue create -R "$upstream_repo" \
 
 ### 6. 设置 Issue Type（可选）
 
-仅当 `has_push=true` 且 §4 推断的 Issue Type 在 org 实际可用列表中时执行：
+仅当 `has_push=true`、owner type 为 `Organization`，且 §4 推断的 Issue Type 在 org 实际可用列表中时执行：
 
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \

--- a/.agents/rules/issue-pr-commands.md
+++ b/.agents/rules/issue-pr-commands.md
@@ -83,11 +83,16 @@ gh issue create -R "$upstream_repo" --title "{title}" --body "{body}" --assignee
 设置 Issue Type：
 
 ```bash
-gh api "orgs/{owner}/issue-types" --jq '.[].name'
-gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+owner_type=$(gh api "repos/$upstream_repo" --jq '.owner.type // empty' 2>/dev/null || true)
+if [ "$owner_type" = "Organization" ]; then
+  owner=${upstream_repo%%/*}
+  gh api "orgs/$owner/issue-types" --jq '.[].name'
+  gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+fi
 ```
 
 - 仅当 `has_push=true` 时执行 Issue Type 设置；否则跳过并继续
+- 仅当 owner type 为 `Organization` 时查询和设置 Issue Type；个人仓库或 owner type 探测失败时跳过并继续
 - 变更现有 Issue Type 时，先读取 `.agents/rules/issue-fields.md` 并使用流程 B，确保同名 pinned fields 迁移，且新 type 不包含的字段被清空
 
 ## Issue 更新

--- a/.agents/scripts/platform-adapters/platform-sync.js
+++ b/.agents/scripts/platform-adapters/platform-sync.js
@@ -159,6 +159,7 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
   }
   const permissions = detectPermissions(upstreamRepo.value, taskDir);
+  const repoOwnerType = detectRepoOwnerType(upstreamRepo.value, taskDir);
   const expectedValues = resolveExpectedValues(config);
   if (!expectedValues.ok) {
     return { earlyReturn: failResult(CHECK_TYPE, expectedValues.message, "check_failed") };
@@ -181,6 +182,7 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     issueNumber,
     prNumber,
     upstreamRepo: upstreamRepo.value,
+    repoOwnerType,
     hasTriage: permissions.hasTriage,
     hasPush: permissions.hasPush,
     expectedStatusLabel: expectedValues.statusLabel,
@@ -758,6 +760,10 @@ function checkIssueType(context, remoteData) {
   }
 
   if (!remoteData.issueType) {
+    if (context.repoOwnerType === "User") {
+      return null;
+    }
+
     return failResult(CHECK_TYPE,
       `Issue #${context.issueNumber} has no Issue Type set`,
       "check_failed"
@@ -1262,6 +1268,21 @@ function detectPermissions(upstreamRepo, taskDir) {
     hasTriage: permissions.triage === true,
     hasPush: permissions.push === true
   };
+}
+
+function detectRepoOwnerType(upstreamRepo, taskDir) {
+  const ownerTypeResult = withRetry(() => ghText([
+    "api",
+    `repos/${upstreamRepo}`,
+    "--jq",
+    ".owner.type // empty"
+  ], taskDir));
+
+  if (!ownerTypeResult.ok) {
+    return "unknown";
+  }
+
+  return ownerTypeResult.value || "unknown";
 }
 
 function ghJson(args, cwd) {

--- a/.github/workflows/metadata-sync.yml
+++ b/.github/workflows/metadata-sync.yml
@@ -87,6 +87,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           TYPE: ${{ steps.metadata.outputs.type }}
         run: |
+          OWNER_TYPE=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.owner.type // empty' 2>/dev/null || true)
+          if [ "$OWNER_TYPE" != "Organization" ]; then
+            exit 0
+          fi
+
           case "$TYPE" in
             bug|bugfix)          ISSUE_TYPE="Bug" ;;
             feature|enhancement) ISSUE_TYPE="Feature" ;;

--- a/templates/.agents/rules/create-issue.github.en.md
+++ b/templates/.agents/rules/create-issue.github.en.md
@@ -101,7 +101,7 @@ If the final label set is empty, omit the `--label` argument.
 | `feature`, `enhancement` | `Feature` |
 | `task`, `documentation`, `dependency-upgrade`, `chore`, `docs`, `refactor`, `refactoring`, others | `Task` |
 
-When applying the Issue Type, follow the "Set Issue Type" command in `.agents/rules/issue-pr-commands.md`; first call `gh api orgs/{owner}/issue-types` to list the org's actually available Types, and only set the inferred value when it is present in that list. Failure to set is non-blocking.
+When applying the Issue Type, follow the "Set Issue Type" command in `.agents/rules/issue-pr-commands.md`; only when the owner type is `Organization`, first call `gh api orgs/{owner}/issue-types` to list the org's actually available Types, and only set the inferred value when it is present in that list. User repositories, failed owner type probes, and failed writes are non-blocking.
 
 #### milestone
 
@@ -149,7 +149,7 @@ After success, parse the Issue number from the output (match only the `https://.
 
 ### 6. Set Issue Type (Optional)
 
-Execute only when `has_push=true` and the Issue Type inferred in §4 is in the org's actually available list:
+Execute only when `has_push=true`, the owner type is `Organization`, and the Issue Type inferred in §4 is in the org's actually available list:
 
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \

--- a/templates/.agents/rules/create-issue.github.zh-CN.md
+++ b/templates/.agents/rules/create-issue.github.zh-CN.md
@@ -101,7 +101,7 @@ ai task issue-body {task-id} > "{body-file}"
 | `feature`, `enhancement` | `Feature` |
 | `task`, `documentation`, `dependency-upgrade`, `chore`, `docs`, `refactor`, `refactoring` 及其它 | `Task` |
 
-实际设置时按 `.agents/rules/issue-pr-commands.md` 的 "设置 Issue Type" 命令；先调 `gh api orgs/{owner}/issue-types` 列出 org 实际可用的 Type，仅当推断值在列表中时才设置；设置失败不阻断流程。
+实际设置时按 `.agents/rules/issue-pr-commands.md` 的 "设置 Issue Type" 命令；仅当 owner type 为 `Organization` 时，先调 `gh api orgs/{owner}/issue-types` 列出 org 实际可用的 Type，并且仅当推断值在列表中时才设置；个人仓库、owner type 探测失败或设置失败都不阻断流程。
 
 #### milestone
 
@@ -149,7 +149,7 @@ gh issue create -R "$upstream_repo" \
 
 ### 6. 设置 Issue Type（可选）
 
-仅当 `has_push=true` 且 §4 推断的 Issue Type 在 org 实际可用列表中时执行：
+仅当 `has_push=true`、owner type 为 `Organization`，且 §4 推断的 Issue Type 在 org 实际可用列表中时执行：
 
 ```bash
 gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \

--- a/templates/.agents/rules/issue-pr-commands.github.en.md
+++ b/templates/.agents/rules/issue-pr-commands.github.en.md
@@ -83,11 +83,16 @@ gh issue create -R "$upstream_repo" --title "{title}" --body "{body}" --assignee
 Set the Issue Type:
 
 ```bash
-gh api "orgs/{owner}/issue-types" --jq '.[].name'
-gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+owner_type=$(gh api "repos/$upstream_repo" --jq '.owner.type // empty' 2>/dev/null || true)
+if [ "$owner_type" = "Organization" ]; then
+  owner=${upstream_repo%%/*}
+  gh api "orgs/$owner/issue-types" --jq '.[].name'
+  gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+fi
 ```
 
 - set the Issue Type only when `has_push=true`; otherwise skip and continue
+- query and set Issue Type only when the owner type is `Organization`; skip and continue for user repositories or failed owner type probes
 - when changing an existing Issue Type, read `.agents/rules/issue-fields.md` and use Flow B so same-name pinned fields are migrated and fields absent from the new type are cleared
 
 ## Update Issues

--- a/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
+++ b/templates/.agents/rules/issue-pr-commands.github.zh-CN.md
@@ -83,11 +83,16 @@ gh issue create -R "$upstream_repo" --title "{title}" --body "{body}" --assignee
 设置 Issue Type：
 
 ```bash
-gh api "orgs/{owner}/issue-types" --jq '.[].name'
-gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+owner_type=$(gh api "repos/$upstream_repo" --jq '.owner.type // empty' 2>/dev/null || true)
+if [ "$owner_type" = "Organization" ]; then
+  owner=${upstream_repo%%/*}
+  gh api "orgs/$owner/issue-types" --jq '.[].name'
+  gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH -f type="{issue-type}" --silent
+fi
 ```
 
 - 仅当 `has_push=true` 时执行 Issue Type 设置；否则跳过并继续
+- 仅当 owner type 为 `Organization` 时查询和设置 Issue Type；个人仓库或 owner type 探测失败时跳过并继续
 - 变更现有 Issue Type 时，先读取 `.agents/rules/issue-fields.md` 并使用流程 B，确保同名 pinned fields 迁移，且新 type 不包含的字段被清空
 
 ## Issue 更新

--- a/templates/.agents/scripts/platform-adapters/platform-sync.github.js
+++ b/templates/.agents/scripts/platform-adapters/platform-sync.github.js
@@ -159,6 +159,7 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     return { earlyReturn: blockedResult(CHECK_TYPE, upstreamRepo.message, "network_error") };
   }
   const permissions = detectPermissions(upstreamRepo.value, taskDir);
+  const repoOwnerType = detectRepoOwnerType(upstreamRepo.value, taskDir);
   const expectedValues = resolveExpectedValues(config);
   if (!expectedValues.ok) {
     return { earlyReturn: failResult(CHECK_TYPE, expectedValues.message, "check_failed") };
@@ -181,6 +182,7 @@ function buildSyncContext({ taskDir, config, artifactFile }) {
     issueNumber,
     prNumber,
     upstreamRepo: upstreamRepo.value,
+    repoOwnerType,
     hasTriage: permissions.hasTriage,
     hasPush: permissions.hasPush,
     expectedStatusLabel: expectedValues.statusLabel,
@@ -758,6 +760,10 @@ function checkIssueType(context, remoteData) {
   }
 
   if (!remoteData.issueType) {
+    if (context.repoOwnerType === "User") {
+      return null;
+    }
+
     return failResult(CHECK_TYPE,
       `Issue #${context.issueNumber} has no Issue Type set`,
       "check_failed"
@@ -1262,6 +1268,21 @@ function detectPermissions(upstreamRepo, taskDir) {
     hasTriage: permissions.triage === true,
     hasPush: permissions.push === true
   };
+}
+
+function detectRepoOwnerType(upstreamRepo, taskDir) {
+  const ownerTypeResult = withRetry(() => ghText([
+    "api",
+    `repos/${upstreamRepo}`,
+    "--jq",
+    ".owner.type // empty"
+  ], taskDir));
+
+  if (!ownerTypeResult.ok) {
+    return "unknown";
+  }
+
+  return ownerTypeResult.value || "unknown";
 }
 
 function ghJson(args, cwd) {

--- a/templates/.github/workflows/metadata-sync.yml
+++ b/templates/.github/workflows/metadata-sync.yml
@@ -87,6 +87,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           TYPE: ${{ steps.metadata.outputs.type }}
         run: |
+          OWNER_TYPE=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.owner.type // empty' 2>/dev/null || true)
+          if [ "$OWNER_TYPE" != "Organization" ]; then
+            exit 0
+          fi
+
           case "$TYPE" in
             bug|bugfix)          ISSUE_TYPE="Bug" ;;
             feature|enhancement) ISSUE_TYPE="Feature" ;;

--- a/tests/e2e/core/validate-artifact-helpers.ts
+++ b/tests/e2e/core/validate-artifact-helpers.ts
@@ -278,6 +278,7 @@ function buildIssueType(name: string = "Task") {
 }
 
 function buildIssueFieldsPayload({
+  issueType = buildIssueType("Feature"),
   pinnedFields = [
     { typename: "IssueFieldSingleSelect", name: "Priority" },
     { typename: "IssueFieldSingleSelect", name: "Effort" }
@@ -287,21 +288,26 @@ function buildIssueFieldsPayload({
     { typename: "IssueFieldSingleSelectValue", fieldName: "Effort", value: "Medium" }
   ]
 }: {
+  issueType?: ReturnType<typeof buildIssueType> | null;
   pinnedFields?: Array<{ typename: string; name: string }>;
   values?: Array<{ typename: string; fieldName: string; value: string }>;
 } = {}) {
+  const normalizedIssueType = issueType
+    ? {
+        name: issueType.name,
+        pinnedFields: pinnedFields.map((field) => ({
+          __typename: field.typename,
+          id: `field-${field.name}`,
+          name: field.name
+        }))
+      }
+    : null;
+
   return {
     data: {
       repository: {
         issue: {
-          issueType: {
-            name: "Feature",
-            pinnedFields: pinnedFields.map((field) => ({
-              __typename: field.typename,
-              id: `field-${field.name}`,
-              name: field.name
-            }))
-          },
+          issueType: normalizedIssueType,
           issueFieldValues: {
             nodes: values.map((value) => value.typename === "IssueFieldDateValue"
               ? {

--- a/tests/e2e/core/validate-artifact-platform-sync.test.ts
+++ b/tests/e2e/core/validate-artifact-platform-sync.test.ts
@@ -120,6 +120,41 @@ const implementSyncCases = [
     }
   },
   {
+    name: "validate-artifact platform-sync fails for organization repos when the Issue Type is missing",
+    skill: "code-task",
+    issuePayload: buildIssuePayload({ type: null }),
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 1);
+      assertPayloadStatus(result, {
+        type: "platform-sync",
+        status: "fail",
+        message: /has no Issue Type set/
+      });
+    }
+  },
+  {
+    name: "validate-artifact platform-sync passes for user repos when the Issue Type is missing",
+    skill: "code-task",
+    issuePayload: buildIssuePayload({ type: null }),
+    extraEnv: { GH_FAKE_REPO_OWNER_TYPE: "User" },
+    comments(taskContent: string, artifactContent: string) {
+      return [
+        { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+        { body: buildTaskComment(taskId, taskContent) }
+      ];
+    },
+    assertResult(result: ReturnType<typeof runValidator>) {
+      assert.equal(result.status, 0, result.stderr);
+      assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+    }
+  },
+  {
     name: "validate-artifact platform-sync skips Issue Type verification when the REST query is unavailable",
     skill: "code-task",
     extraEnv: {
@@ -404,6 +439,19 @@ test("validate-artifact platform-sync skips Issue field verification when fields
       VALIDATE_ARTIFACT_RETRY_DELAYS_MS: "0,0"
     });
     assert.equal(unavailableResult.status, "pass");
+
+    writeJson(ctx.issueFieldsPath, buildIssueFieldsPayload({ issueType: null }));
+    const missingTypeFieldsResult = await runPlatformSyncAdapter(ctx.taskDir, {
+      when: "issue_number_exists",
+      verify_issue_fields: true
+    }, {
+      PATH: pathWithPrependedBin(ctx.binDir),
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([ctx.ghPath]),
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_ISSUE_FIELDS_PATH: ctx.issueFieldsPath
+    });
+    assert.equal(missingTypeFieldsResult.status, "pass");
   })
 ));
 

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -31,6 +31,7 @@ function buildRepoPayload() {
 
   return {
     full_name: fullName,
+    owner: { type: process.env.GH_FAKE_REPO_OWNER_TYPE || "Organization" },
     fork: process.env.GH_FAKE_REPO_FORK === "true",
     parent: { full_name: parentFullName },
     permissions
@@ -72,6 +73,11 @@ if (args[0] === "api" && args[1] && /^repos\/[^/]+\/[^/]+$/.test(args[1])) {
 
     if (query === ".permissions") {
       process.stdout.write(JSON.stringify(repoPayload.permissions));
+      process.exit(0);
+    }
+
+    if (query === ".owner.type // empty") {
+      process.stdout.write(repoPayload.owner.type);
       process.exit(0);
     }
   }

--- a/tests/unit/core/metadata-sync-workflow.test.ts
+++ b/tests/unit/core/metadata-sync-workflow.test.ts
@@ -24,7 +24,7 @@ test("metadata-sync workflow listens to task comment create and edit events and 
   });
 });
 
-test("metadata-sync workflow syncs type labels and fallback issue types", () => {
+test("metadata-sync workflow syncs type labels and organization issue types", () => {
   workflowTargets.forEach((relativePath) => {
     const content = read(relativePath);
 
@@ -33,8 +33,11 @@ test("metadata-sync workflow syncs type labels and fallback issue types", () => 
     assert.match(content, /--prefix "type:"/, `${relativePath} should scope type label syncs to the type: prefix`);
     assert.match(content, /--target "\$TYPE_LABEL"/, `${relativePath} should pass the mapped type label as the target set`);
     assert.match(content, /dependency-upgrade\) +TYPE_LABEL="type: dependency-upgrade"/, `${relativePath} should map dependency-upgrade to the matching label`);
+    assert.match(content, /OWNER_TYPE=\$\(gh api "repos\/\$GITHUB_REPOSITORY" --jq '\.owner\.type \/\/ empty'/, `${relativePath} should detect the repository owner type`);
+    assert.match(content, /if \[ "\$OWNER_TYPE" != "Organization" \]; then[\s\S]*exit 0[\s\S]*fi/, `${relativePath} should skip Issue Type sync outside organization repositories`);
     assert.match(content, /feature\|enhancement\) ISSUE_TYPE="Feature"/, `${relativePath} should map feature-like task types to the Feature issue type`);
     assert.match(content, /\*\) +ISSUE_TYPE="Task"/, `${relativePath} should fall back to the Task issue type`);
+    assert.match(content, /gh api "repos\/\$GITHUB_REPOSITORY\/issues\/\$ISSUE_NUMBER"[\s\S]*-f type="\$ISSUE_TYPE"/, `${relativePath} should patch the mapped Issue Type when supported`);
   });
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #582 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

个人账号仓库不支持 GitHub 组织级 Issue Type 能力，现有 metadata-sync 和 platform-sync gate 会把该平台能力差异误判为门禁失败。本次变更让 Issue Type 读写和校验基于 repository owner type 自动降级：组织仓库继续保持严格校验，个人仓库跳过缺失 Issue Type 的阻断逻辑。

## 📋 主要变更 / Brief Changelog

- 在 `platform-sync` 中检测 `repo.owner.type`，仅对 User owner 跳过缺失 Issue Type 校验。
- 在 metadata-sync workflow 中只对 Organization owner 执行 Issue Type PATCH。
- 更新 create-issue / issue-pr 命令规则及模板，明确个人仓库或 owner type 探测失败时跳过 Issue Type 设置。
- 扩展 fake-gh、platform-sync e2e 和 metadata-sync unit tests，覆盖 Organization/User owner 行为差异与 `issueType: null` fields 降级。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run build`
2. `node --experimental-strip-types --no-warnings --test tests/unit/core/metadata-sync-workflow.test.ts`
3. `node --experimental-strip-types --no-warnings --test tests/e2e/core/validate-artifact-platform-sync.test.ts`
4. `node --experimental-strip-types --no-warnings --test tests/integration/scripts/platform-adapter-defaults.test.ts`
5. `npm test`
6. Commit hook: `npm run typecheck`
7. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #582 milestone `0.8.3`.
- `review-code.md` approved the implementation with 0 blockers, 0 major, 0 minor, and 0 manual-validation items.
- `last_reviewed_commit` points to `5b73b54e27e3379942316f8d160858376c1e4923`.

---

**审查者注意事项 / Reviewer Notes:**

重点关注 `repoOwnerType === "User"` 是否是唯一跳过缺失 Issue Type 的路径，以及 Organization/unknown owner 是否仍保留严格校验。另请关注 metadata-sync workflow 的 non-Organization early exit 是否符合个人仓库的 non-blocking 目标。

Generated with AI assistance