### PR TITLE
refactor(server): 解耦 IM 通道显示架构

### DIFF
--- a/lib/server/adapters/_contract.ts
+++ b/lib/server/adapters/_contract.ts
@@ -1,4 +1,5 @@
 import type { ServerConfig } from '../config.ts';
+import type { OutboundMessage } from '../display.ts';
 import type { Logger } from '../logger.ts';
 
 // Adapter contract for agent-infra-server.
@@ -19,6 +20,7 @@ export type InboundMessage = {
   messageId: string;
   raw: unknown;
   reply: (text: string) => Promise<void>;
+  replyDisplay?: (message: OutboundMessage) => Promise<void>;
 };
 
 // Runtime context passed to every adapter's start(). dispatch() is registered
@@ -36,6 +38,7 @@ export type Adapter = {
   start: (ctx: AdapterCtx) => Promise<void>;
   stop: () => Promise<void>;
   sendMessage: (target: { chatId: string }, text: string) => Promise<void>;
+  sendDisplayMessage?: (target: { chatId: string }, message: OutboundMessage) => Promise<void>;
 };
 
 // The shape of an adapter module's default export (a factory).

--- a/lib/server/adapters/feishu/index.ts
+++ b/lib/server/adapters/feishu/index.ts
@@ -1,5 +1,7 @@
 import type { Adapter, AdapterCtx, AdapterFactory, InboundMessage } from '../_contract.ts';
-import { cardMessage, createFeishuTransport, normalizeMessage } from './transport.ts';
+import type { OutboundMessage } from '../../display.ts';
+import { renderFeishuMessage } from './renderer.ts';
+import { createFeishuTransport, normalizeMessage } from './transport.ts';
 import type { FeishuTransport } from './transport.ts';
 
 // Assemble the feishu adapter. The transport is injectable so unit tests can
@@ -26,7 +28,10 @@ export function createFeishuAdapter(
             messageId: normalized.messageId,
             raw: normalized.raw,
             reply: async (text) => {
-              await transport.send(normalized.chatId, cardMessage(text));
+              await transport.send(normalized.chatId, renderFeishuMessage(text));
+            },
+            replyDisplay: async (message: OutboundMessage) => {
+              await transport.send(normalized.chatId, renderFeishuMessage(message));
             }
           };
           await adapterCtx.dispatch(message);
@@ -39,7 +44,10 @@ export function createFeishuAdapter(
       await transport.stop();
     },
     async sendMessage(target, text) {
-      await transport.send(target.chatId, cardMessage(text));
+      await transport.send(target.chatId, renderFeishuMessage(text));
+    },
+    async sendDisplayMessage(target, message) {
+      await transport.send(target.chatId, renderFeishuMessage(message));
     }
   };
 }

--- a/lib/server/adapters/feishu/renderer.ts
+++ b/lib/server/adapters/feishu/renderer.ts
@@ -1,0 +1,99 @@
+import { stripVTControlCharacters } from 'node:util';
+import { normalizeOutbound, outboundToText, type DisplayMessage, type OutboundMessage } from '../../display.ts';
+import type { FeishuMessagePayload } from './transport.ts';
+
+const FEISHU_LARK_MD_MAX_LENGTH = 20_000;
+
+type FeishuElement =
+  | { tag: 'div'; text: { tag: 'lark_md'; content: string } }
+  | { tag: 'div'; fields: Array<{ is_short: boolean; text: { tag: 'lark_md'; content: string } }> };
+
+function templateForTone(tone: 'info' | 'success' | 'warning' | 'danger' | 'running'): string {
+  if (tone === 'success') return 'green';
+  if (tone === 'warning') return 'yellow';
+  if (tone === 'danger') return 'red';
+  return 'blue';
+}
+
+function templateForResult(exitCode: number | null): string {
+  return exitCode === 0 ? 'green' : 'red';
+}
+
+export function cleanFeishuText(text: string): string {
+  return stripVTControlCharacters(text).replace(/\r\n/g, '\n');
+}
+
+function clampLarkMarkdown(text: string): string {
+  const clean = cleanFeishuText(text);
+  if (clean.length <= FEISHU_LARK_MD_MAX_LENGTH) return clean;
+  return `${clean.slice(0, FEISHU_LARK_MD_MAX_LENGTH - 18)}\n\n...(truncated)`;
+}
+
+function div(content: string): FeishuElement {
+  return { tag: 'div', text: { tag: 'lark_md', content: clampLarkMarkdown(content) } };
+}
+
+function fields(rows: [string, string][]): FeishuElement {
+  return {
+    tag: 'div',
+    fields: rows.map(([label, value]) => ({
+      is_short: true,
+      text: { tag: 'lark_md', content: clampLarkMarkdown(`**${label}**\n${value}`) }
+    }))
+  };
+}
+
+function card(title: string, template: string, elements: FeishuElement[]): FeishuMessagePayload {
+  return {
+    msg_type: 'interactive',
+    content: JSON.stringify({
+      config: { wide_screen_mode: true },
+      header: { title: { tag: 'plain_text', content: cleanFeishuText(title) }, template },
+      elements
+    })
+  };
+}
+
+function tableMarkdown(message: Extract<DisplayMessage, { kind: 'table' }>): string {
+  return outboundToText(message);
+}
+
+function renderStatus(message: Extract<DisplayMessage, { kind: 'status-card' }>): FeishuMessagePayload {
+  const elements: FeishuElement[] = [];
+  if (message.fields && message.fields.length > 0) elements.push(fields(message.fields));
+  if (message.body) elements.push(div(message.body));
+  if (elements.length === 0) elements.push(div(message.title));
+  return card(message.title, templateForTone(message.tone), elements);
+}
+
+function renderStream(message: Extract<DisplayMessage, { kind: 'stream-event' }>): FeishuMessagePayload {
+  const template = message.phase === 'finished' ? templateForResult(message.exitCode ?? null) : 'blue';
+  return card(message.title, template, [div(outboundToText(message))]);
+}
+
+function renderCommandResult(message: Extract<DisplayMessage, { kind: 'command-result' }>): FeishuMessagePayload {
+  return card(message.title, templateForResult(message.exitCode), [div(outboundToText(message))]);
+}
+
+function renderUnknownDisplayKind(message: never): FeishuMessagePayload {
+  return card('agent-infra', 'blue', [div(`[unknown display kind: ${String((message as { kind?: unknown }).kind)}]`)]);
+}
+
+export function renderFeishuMessage(message: OutboundMessage): FeishuMessagePayload {
+  const normalized = normalizeOutbound(message);
+  switch (normalized.kind) {
+    case 'text':
+      return card('agent-infra', 'blue', [div(normalized.text)]);
+    case 'markdown':
+      return card('agent-infra', 'blue', [div(normalized.markdown)]);
+    case 'table':
+      return card(normalized.title ?? 'agent-infra', 'blue', [div(tableMarkdown(normalized))]);
+    case 'status-card':
+      return renderStatus(normalized);
+    case 'stream-event':
+      return renderStream(normalized);
+    case 'command-result':
+      return renderCommandResult(normalized);
+  }
+  return renderUnknownDisplayKind(normalized);
+}

--- a/lib/server/adapters/feishu/transport.ts
+++ b/lib/server/adapters/feishu/transport.ts
@@ -1,5 +1,4 @@
 import * as lark from '@larksuiteoapi/node-sdk';
-import { stripVTControlCharacters } from 'node:util';
 
 // Transport layer for the feishu adapter. All @larksuiteoapi/node-sdk surface is
 // confined here so the adapter body (index.ts) depends only on this narrow
@@ -11,10 +10,10 @@ export type FeishuTransport = {
   // each inbound im.message.receive_v1.
   start: (onMessage: (raw: unknown) => Promise<void>) => Promise<void>;
   stop: () => Promise<void>;
-  send: (chatId: string, message: FeishuOutgoingMessage) => Promise<void>;
+  send: (chatId: string, message: FeishuMessagePayload) => Promise<void>;
 };
 
-export type FeishuOutgoingMessage = { kind: 'interactive'; title: string; text: string };
+export type FeishuMessagePayload = { msg_type: 'interactive'; content: string };
 
 type FeishuCreateData = {
   receive_id: string;
@@ -78,23 +77,11 @@ function resolveDomain(value: unknown): number {
   return value === 'lark' || value === 'Lark' ? lark.Domain.Lark : lark.Domain.Feishu;
 }
 
-export function cleanFeishuText(text: string): string {
-  return stripVTControlCharacters(text).replace(/\r\n/g, '\n');
-}
-
-export function cardMessage(text: string): FeishuOutgoingMessage {
-  return { kind: 'interactive', title: 'agent-infra', text: cleanFeishuText(text) };
-}
-
-export function toFeishuCreateData(chatId: string, message: FeishuOutgoingMessage): FeishuCreateData {
+export function toFeishuCreateData(chatId: string, message: FeishuMessagePayload): FeishuCreateData {
   return {
     receive_id: chatId,
-    msg_type: 'interactive',
-    content: JSON.stringify({
-      config: { wide_screen_mode: true },
-      header: { title: { tag: 'plain_text', content: message.title }, template: 'blue' },
-      elements: [{ tag: 'div', text: { tag: 'lark_md', content: message.text } }]
-    })
+    msg_type: message.msg_type,
+    content: message.content
   };
 }
 

--- a/lib/server/daemon.ts
+++ b/lib/server/daemon.ts
@@ -1,15 +1,92 @@
 import { VERSION } from '../version.ts';
 import { loadServerConfig } from './config.ts';
+import type { ServerConfig } from './config.ts';
 import { createLogger } from './logger.ts';
+import type { Logger } from './logger.ts';
 import { loadAdapters, unloadAdapters } from './plugin-loader.ts';
 import type { InboundMessage } from './adapters/_contract.ts';
 import { authorize } from './auth.ts';
 import { commandHelp, parseCommand } from './protocol.ts';
 import { runAi } from './runner.ts';
+import type { RunnerOptions, RunnerResult } from './runner.ts';
 import { streamCommand } from './streamer.ts';
+import { markdownMessage, replyOutbound, textMessage } from './display.ts';
+import { buildStatusModel, statusModelToDisplay, type StatusModel } from '../task/commands/status.ts';
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+type MessageDispatcherOptions = {
+  config: ServerConfig;
+  logger: Pick<Logger, 'info'>;
+  runAi?: (args: string[], options?: RunnerOptions) => Promise<RunnerResult>;
+  buildStatusModel?: (ref: string) => StatusModel;
+  statusModelToDisplay?: (model: StatusModel) => ReturnType<typeof statusModelToDisplay>;
+};
+
+function isTaskStatus(argv: string[]): boolean {
+  return argv[0] === 'task' && argv[1] === 'status' && typeof argv[2] === 'string';
+}
+
+export function createMessageDispatcher(options: MessageDispatcherOptions): (message: InboundMessage) => Promise<void> {
+  const runAiImpl = options.runAi ?? runAi;
+  const buildStatusModelImpl = options.buildStatusModel ?? buildStatusModel;
+  const statusModelToDisplayImpl = options.statusModelToDisplay ?? statusModelToDisplay;
+
+  return async (message: InboundMessage): Promise<void> => {
+    const plan = parseCommand(message.text);
+    if (plan.kind === 'ignore') return;
+    if (plan.kind === 'error') {
+      await replyOutbound(message, textMessage(plan.message));
+      options.logger.info(`command rejected from ${message.adapter}:${message.userId}: ${plan.message}`);
+      return;
+    }
+    if (plan.kind === 'builtin' && plan.name === 'ping') {
+      await replyOutbound(message, textMessage(`pong ${VERSION}`));
+      return;
+    }
+    if (plan.kind === 'builtin' && plan.name === 'help') {
+      await replyOutbound(message, markdownMessage(commandHelp()));
+      return;
+    }
+    if (plan.kind === 'builtin' && plan.name === 'version') {
+      await replyOutbound(message, textMessage(`agent-infra ${VERSION}`));
+      return;
+    }
+    if (plan.kind === 'ai') {
+      const allowed = authorize(
+        { adapter: message.adapter, userId: message.userId },
+        plan.role,
+        options.config.auth
+      );
+      if (!allowed.ok) {
+        await replyOutbound(message, textMessage(allowed.message));
+        options.logger.info(`unauthorized command from ${message.adapter}:${message.userId}: ${allowed.message}`);
+        return;
+      }
+
+      if (isTaskStatus(plan.argv)) {
+        try {
+          await replyOutbound(message, statusModelToDisplayImpl(buildStatusModelImpl(plan.argv[2]!)));
+          return;
+        } catch {
+          // Fall back to the existing CLI streaming path. This preserves the
+          // old behavior for invalid refs and any status-model collection error.
+        }
+      }
+
+      await streamCommand(
+        {
+          title: `ai ${plan.argv.join(' ')}`,
+          chunkChars: typeof options.config.stream?.chunkChars === 'number' ? options.config.stream.chunkChars : 4000,
+          throttleMs: typeof options.config.stream?.throttleMs === 'number' ? options.config.stream.throttleMs : 1500
+        },
+        (emit) => runAiImpl(plan.argv, { onChunk: emit }),
+        (outbound) => replyOutbound(message, outbound)
+      );
+    }
+  };
 }
 
 // The daemon main loop. Runs in the detached child spawned by
@@ -40,48 +117,7 @@ export async function runDaemon(): Promise<void> {
     resolveShutdown = resolve;
   });
 
-  const dispatch = async (message: InboundMessage): Promise<void> => {
-    const plan = parseCommand(message.text);
-    if (plan.kind === 'ignore') return;
-    if (plan.kind === 'error') {
-      await message.reply(plan.message);
-      logger.info(`command rejected from ${message.adapter}:${message.userId}: ${plan.message}`);
-      return;
-    }
-    if (plan.kind === 'builtin' && plan.name === 'ping') {
-      await message.reply(`pong ${VERSION}`);
-      return;
-    }
-    if (plan.kind === 'builtin' && plan.name === 'help') {
-      await message.reply(commandHelp());
-      return;
-    }
-    if (plan.kind === 'builtin' && plan.name === 'version') {
-      await message.reply(`agent-infra ${VERSION}`);
-      return;
-    }
-    if (plan.kind === 'ai') {
-      const allowed = authorize(
-        { adapter: message.adapter, userId: message.userId },
-        plan.role,
-        config.auth
-      );
-      if (!allowed.ok) {
-        await message.reply(allowed.message);
-        logger.info(`unauthorized command from ${message.adapter}:${message.userId}: ${allowed.message}`);
-        return;
-      }
-      await streamCommand(
-        {
-          title: `ai ${plan.argv.join(' ')}`,
-          chunkChars: typeof config.stream?.chunkChars === 'number' ? config.stream.chunkChars : 4000,
-          throttleMs: typeof config.stream?.throttleMs === 'number' ? config.stream.throttleMs : 1500
-        },
-        (emit) => runAi(plan.argv, { onChunk: emit }),
-        (text) => message.reply(text)
-      );
-    }
-  };
+  const dispatch = createMessageDispatcher({ config, logger });
 
   const ctx = { config, logger, dispatch, signal: abortController.signal };
   const adapters = await loadAdapters(config, ctx);

--- a/lib/server/display.ts
+++ b/lib/server/display.ts
@@ -1,0 +1,136 @@
+export type OutboundMessage = string | DisplayMessage;
+
+export type DisplayTone = 'info' | 'success' | 'warning' | 'danger' | 'running';
+
+export type DisplayMessage =
+  | { kind: 'text'; text: string }
+  | { kind: 'markdown'; markdown: string }
+  | { kind: 'table'; title?: string; columns: string[]; rows: string[][] }
+  | { kind: 'status-card'; title: string; tone: DisplayTone; fields?: [string, string][]; body?: string }
+  | {
+      kind: 'stream-event';
+      title: string;
+      phase: 'started' | 'chunk' | 'finished';
+      text?: string;
+      exitCode?: number | null;
+      signal?: NodeJS.Signals | null;
+    }
+  | {
+      kind: 'command-result';
+      title: string;
+      exitCode: number | null;
+      signal: NodeJS.Signals | null;
+      stdout?: string;
+      stderr?: string;
+    };
+
+export function textMessage(text: string): DisplayMessage {
+  return { kind: 'text', text };
+}
+
+export function markdownMessage(markdown: string): DisplayMessage {
+  return { kind: 'markdown', markdown };
+}
+
+export function tableMessage(columns: string[], rows: string[][], title?: string): DisplayMessage {
+  return { kind: 'table', title, columns, rows };
+}
+
+export function statusCard(
+  title: string,
+  tone: DisplayTone,
+  fields?: [string, string][],
+  body?: string
+): DisplayMessage {
+  return { kind: 'status-card', title, tone, fields, body };
+}
+
+export function streamEvent(
+  title: string,
+  phase: 'started' | 'chunk' | 'finished',
+  text?: string,
+  exitCode?: number | null,
+  signal?: NodeJS.Signals | null
+): DisplayMessage {
+  const message: Extract<DisplayMessage, { kind: 'stream-event' }> = { kind: 'stream-event', title, phase };
+  if (text !== undefined) message.text = text;
+  if (exitCode !== undefined) message.exitCode = exitCode;
+  if (signal !== undefined) message.signal = signal;
+  return message;
+}
+
+export function commandResult(
+  title: string,
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+  stdout?: string,
+  stderr?: string
+): DisplayMessage {
+  return { kind: 'command-result', title, exitCode, signal, stdout, stderr };
+}
+
+export function normalizeOutbound(message: OutboundMessage): DisplayMessage {
+  return typeof message === 'string' ? textMessage(message) : message;
+}
+
+function tableToText(message: Extract<DisplayMessage, { kind: 'table' }>): string {
+  const lines: string[] = [];
+  if (message.title) lines.push(message.title);
+  lines.push(message.columns.join(' | '));
+  lines.push(message.columns.map(() => '---').join(' | '));
+  for (const row of message.rows) {
+    lines.push(row.join(' | '));
+  }
+  return lines.join('\n');
+}
+
+function compact(lines: Array<string | undefined>): string {
+  return lines.filter((line): line is string => typeof line === 'string' && line !== '').join('\n');
+}
+
+function unknownDisplayKind(message: never): string {
+  return `[unknown: ${String((message as { kind?: unknown }).kind)}]`;
+}
+
+export function outboundToText(message: OutboundMessage): string {
+  const normalized = normalizeOutbound(message);
+  switch (normalized.kind) {
+    case 'text':
+      return normalized.text;
+    case 'markdown':
+      return normalized.markdown;
+    case 'table':
+      return tableToText(normalized);
+    case 'status-card':
+      return compact([
+        normalized.title,
+        ...(normalized.fields ?? []).map(([label, value]) => `${label}: ${value}`),
+        normalized.body
+      ]);
+    case 'stream-event':
+      if (normalized.phase === 'started') return `started ${normalized.title}`;
+      if (normalized.phase === 'chunk') return normalized.text ?? '';
+      return `finished ${normalized.title} exitCode=${normalized.exitCode ?? 'null'} signal=${normalized.signal ?? 'null'}`;
+    case 'command-result':
+      return compact([
+        `finished ${normalized.title} exitCode=${normalized.exitCode ?? 'null'} signal=${normalized.signal ?? 'null'}`,
+        normalized.stdout,
+        normalized.stderr
+      ]);
+  }
+  return unknownDisplayKind(normalized);
+}
+
+export async function replyOutbound(
+  inbound: {
+    reply: (text: string) => Promise<void>;
+    replyDisplay?: (message: OutboundMessage) => Promise<void>;
+  },
+  message: OutboundMessage
+): Promise<void> {
+  if (inbound.replyDisplay) {
+    await inbound.replyDisplay(message);
+    return;
+  }
+  await inbound.reply(outboundToText(message));
+}

--- a/lib/server/streamer.ts
+++ b/lib/server/streamer.ts
@@ -1,3 +1,4 @@
+import { streamEvent, type OutboundMessage } from './display.ts';
 import { redactSecrets } from './redact.ts';
 import type { RunnerResult } from './runner.ts';
 
@@ -19,9 +20,9 @@ function chunks(text: string, size: number): string[] {
 export async function streamCommand(
   options: StreamOptions,
   run: (emit?: (chunk: string) => Promise<void>) => Promise<RunnerResult>,
-  send: (text: string) => Promise<void>
+  send: (message: OutboundMessage) => Promise<void>
 ): Promise<RunnerResult> {
-  await send(`started ${options.title}`);
+  await send(streamEvent(options.title, 'started'));
   const size = options.chunkChars ?? 4000;
   const throttleMs = options.throttleMs ?? 0;
   let streamed = false;
@@ -34,7 +35,7 @@ export async function streamCommand(
     buffer = '';
     lastFlush = Date.now();
     for (const chunk of chunks(text, size)) {
-      await send(chunk);
+      await send(streamEvent(options.title, 'chunk', chunk));
     }
   };
 
@@ -52,6 +53,6 @@ export async function streamCommand(
     buffer += [result.stdout, result.stderr].filter(Boolean).join('\n');
   }
   await flush();
-  await send(`finished ${options.title} exitCode=${result.exitCode} signal=${result.signal ?? 'null'}`);
+  await send(streamEvent(options.title, 'finished', undefined, result.exitCode, result.signal));
   return result;
 }

--- a/lib/task/commands/status.ts
+++ b/lib/task/commands/status.ts
@@ -7,6 +7,7 @@ import { enumerateArtifacts, type Artifact } from '../artifacts.ts';
 import { parseTaskFrontmatter, extractTitle, type Frontmatter } from '../frontmatter.ts';
 import { loadShortIdByTaskId } from '../short-id.ts';
 import { parseActivityLog, pairEntries } from './log.ts';
+import { statusCard, type DisplayMessage } from '../../server/display.ts';
 
 const USAGE = `Usage: ai task status <N | #N | TASK-id>
 
@@ -328,6 +329,21 @@ type StatusModel = {
   git: GitInfo;
 };
 
+type BuildStatusModelInput = {
+  taskId: string;
+  taskDir: string;
+  taskMdPath: string;
+  repoRoot: string;
+  shortId?: string;
+  run?: Runner;
+  now?: Date;
+};
+
+type BuildStatusModelOptions = {
+  run?: Runner;
+  now?: Date;
+};
+
 // Indent each label/value pair by two spaces and pad labels to a common width so
 // every section reads as an aligned "key   value" block.
 function renderPairs(rows: [string, string][]): string[] {
@@ -394,6 +410,73 @@ function renderStatus(model: StatusModel): string[] {
   return lines;
 }
 
+function modelTone(model: StatusModel): 'info' | 'success' | 'warning' | 'danger' | 'running' {
+  if (model.workflow.state === 'in-progress') return model.workflow.stale === 'yes' ? 'warning' : 'running';
+  if (model.metadata.some(([key, value]) => key === 'status' && value === 'completed')) return 'success';
+  if (model.metadata.some(([key, value]) => key === 'status' && (value === 'blocked' || value === 'cancelled'))) {
+    return 'danger';
+  }
+  return 'info';
+}
+
+function buildFromResolved(input: BuildStatusModelInput): StatusModel {
+  const content = fs.readFileSync(input.taskMdPath, 'utf8');
+  const fm = parseTaskFrontmatter(content);
+  const run = input.run ?? makeRunner(input.repoRoot);
+  const artifacts = enumerateArtifacts(input.taskDir);
+  const workflow = collectWorkflow(content, input.now);
+
+  return {
+    taskId: input.taskId,
+    shortId: input.shortId ?? loadShortIdByTaskId(input.repoRoot).get(input.taskId) ?? DASH,
+    title: extractTitle(content),
+    metadata: collectMetadata(fm),
+    artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
+    workflow,
+    runtime: collectRuntime(input.taskDir, workflow, run),
+    git: collectGit(fm.branch ?? '', run)
+  };
+}
+
+function buildStatusModel(ref: string, options?: BuildStatusModelOptions): StatusModel;
+function buildStatusModel(input: BuildStatusModelInput): StatusModel;
+function buildStatusModel(
+  refOrInput: string | BuildStatusModelInput,
+  options: BuildStatusModelOptions = {}
+): StatusModel {
+  if (typeof refOrInput !== 'string') {
+    return buildFromResolved(refOrInput);
+  }
+
+  const resolved = resolveTaskRef(refOrInput);
+  if (!resolved.ok) {
+    throw new Error(resolved.message);
+  }
+
+  return buildFromResolved({
+    taskId: resolved.taskId,
+    taskDir: resolved.taskDir,
+    taskMdPath: resolved.taskMdPath,
+    repoRoot: resolved.repoRoot,
+    run: options.run,
+    now: options.now
+  });
+}
+
+function statusModelToDisplay(model: StatusModel): DisplayMessage {
+  return statusCard(
+    `Task ${model.taskId} (${model.shortId})`,
+    modelTone(model),
+    [
+      ['workflow', model.workflow.state],
+      ['step', model.workflow.step],
+      ['runtime', model.runtime.status],
+      ['git', model.git.uncommitted]
+    ],
+    renderStatus(model).join('\n')
+  );
+}
+
 function status(args: string[] = []): void {
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(USAGE);
@@ -401,29 +484,14 @@ function status(args: string[] = []): void {
     return;
   }
 
-  const resolved = resolveTaskRef(args[0]!);
-  if (!resolved.ok) {
-    process.stderr.write(`ai task status: ${resolved.message}\n`);
+  let model: StatusModel;
+  try {
+    model = buildStatusModel(args[0]!);
+  } catch (error) {
+    process.stderr.write(`ai task status: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
     return;
   }
-
-  const content = fs.readFileSync(resolved.taskMdPath, 'utf8');
-  const fm = parseTaskFrontmatter(content);
-  const run = makeRunner(resolved.repoRoot);
-  const artifacts = enumerateArtifacts(resolved.taskDir);
-  const workflow = collectWorkflow(content);
-
-  const model: StatusModel = {
-    taskId: resolved.taskId,
-    shortId: loadShortIdByTaskId(resolved.repoRoot).get(resolved.taskId) ?? DASH,
-    title: extractTitle(content),
-    metadata: collectMetadata(fm),
-    artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
-    workflow,
-    runtime: collectRuntime(resolved.taskDir, workflow, run),
-    git: collectGit(fm.branch ?? '', run)
-  };
 
   for (const line of renderStatus(model)) {
     process.stdout.write(`${line}\n`);
@@ -433,12 +501,14 @@ function status(args: string[] = []): void {
 export {
   status,
   makeRunner,
+  buildStatusModel,
   collectMetadata,
   groupArtifacts,
   collectGit,
   collectWorkflow,
   collectRuntime,
   renderStatus,
+  statusModelToDisplay,
   METADATA_KEYS
 };
-export type { Runner, GitInfo, WorkflowInfo, RuntimeInfo, StatusModel };
+export type { Runner, GitInfo, WorkflowInfo, RuntimeInfo, StatusModel, BuildStatusModelInput };

--- a/tests/unit/cli/server-adapter-contract.test.ts
+++ b/tests/unit/cli/server-adapter-contract.test.ts
@@ -1,12 +1,34 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { ADAPTER_CONTRACT_VERSION } from '../../../lib/server/adapters/_contract.ts';
+import { ADAPTER_CONTRACT_VERSION, type Adapter, type InboundMessage } from '../../../lib/server/adapters/_contract.ts';
 
 // Structural tripwire: bumping the contract version is a deliberate, breaking
 // change for subtasks B/C, so it must be an intentional test update too.
 test('adapter contract exposes a stable integer version constant', () => {
   assert.equal(typeof ADAPTER_CONTRACT_VERSION, 'number');
   assert.equal(Number.isInteger(ADAPTER_CONTRACT_VERSION), true);
+  assert.equal(ADAPTER_CONTRACT_VERSION, 1);
+});
+
+test('display methods are optional and do not require a contract version bump', () => {
+  const inbound: InboundMessage = {
+    adapter: 'test',
+    userId: 'u1',
+    chatId: 'c1',
+    text: '/ping',
+    messageId: 'm1',
+    raw: {},
+    reply: async () => {}
+  };
+  const adapter: Adapter = {
+    name: 'test',
+    start: async () => {},
+    stop: async () => {},
+    sendMessage: async () => {}
+  };
+
+  assert.equal(inbound.replyDisplay, undefined);
+  assert.equal(adapter.sendDisplayMessage, undefined);
   assert.equal(ADAPTER_CONTRACT_VERSION, 1);
 });

--- a/tests/unit/cli/server-daemon.test.ts
+++ b/tests/unit/cli/server-daemon.test.ts
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMessageDispatcher } from '../../../lib/server/daemon.ts';
+import { outboundToText, type DisplayMessage, type OutboundMessage } from '../../../lib/server/display.ts';
+import type { InboundMessage } from '../../../lib/server/adapters/_contract.ts';
+import type { ServerConfig } from '../../../lib/server/config.ts';
+import type { RunnerResult } from '../../../lib/server/runner.ts';
+import type { StatusModel } from '../../../lib/task/commands/status.ts';
+
+const config: ServerConfig = {
+  repoRoot: '/tmp/repo',
+  pidFile: '/tmp/server.pid',
+  log: { path: '/tmp/server.log', rotateAtBytes: 1024 },
+  heartbeatMs: 30_000,
+  adapters: {},
+  auth: { users: { 'test:u1': { role: 'read' }, 'test:exec': { role: 'exec' } } },
+  stream: { chunkChars: 100, throttleMs: 0 }
+};
+
+function inbound(text: string, userId = 'u1'): { message: InboundMessage; textReplies: string[]; displayReplies: OutboundMessage[] } {
+  const textReplies: string[] = [];
+  const displayReplies: OutboundMessage[] = [];
+  return {
+    textReplies,
+    displayReplies,
+    message: {
+      adapter: 'test',
+      userId,
+      chatId: 'c1',
+      text,
+      messageId: 'm1',
+      raw: {},
+      reply: async (replyText) => {
+        textReplies.push(replyText);
+      },
+      replyDisplay: async (display) => {
+        displayReplies.push(display);
+      }
+    }
+  };
+}
+
+function displayKind(message: OutboundMessage): DisplayMessage['kind'] {
+  if (typeof message === 'string') throw new Error(`expected display message, got ${message}`);
+  return message.kind;
+}
+
+const statusModel: StatusModel = {
+  taskId: 'TASK-20260101-000001',
+  shortId: '#01',
+  title: 'demo title',
+  metadata: [['current_step', 'code']],
+  artifacts: { count: 1, groups: [{ stage: 'plan', files: ['plan.md'] }] },
+  workflow: {
+    state: 'in-progress',
+    step: 'Code Task (Round 1)',
+    agent: 'codex',
+    startedAt: '2026-07-02 20:00:00+08:00',
+    doneAt: '-',
+    stale: 'no'
+  },
+  runtime: {
+    mode: 'none',
+    status: '-',
+    run: '-',
+    tmux: '-',
+    startedAt: '-',
+    finishedAt: '-',
+    exitCode: '-',
+    log: '-'
+  },
+  git: {
+    current: 'feat',
+    frontmatter: 'feat',
+    match: 'yes',
+    exists: 'yes',
+    uncommitted: 'clean',
+    aheadBehind: '-'
+  }
+};
+
+test('dispatcher sends builtin replies through text fallback when structured reply is unavailable', async () => {
+  const replies: string[] = [];
+  const message: InboundMessage = {
+    ...inbound('/ping').message,
+    reply: async (text) => {
+      replies.push(text);
+    },
+    replyDisplay: undefined
+  };
+  const dispatch = createMessageDispatcher({ config, logger: { info: () => {} } });
+
+  await dispatch(message);
+
+  assert.equal(replies.length, 1);
+  assert.match(replies[0] ?? '', /^pong /);
+});
+
+test('dispatcher sends ai command streams as structured messages', async () => {
+  const { message, displayReplies } = inbound('/task ls');
+  const dispatch = createMessageDispatcher({
+    config,
+    logger: { info: () => {} },
+    runAi: async (_argv, options): Promise<RunnerResult> => {
+      await options?.onChunk?.('tasks');
+      return { exitCode: 0, signal: null, stdout: 'tasks', stderr: '' };
+    }
+  });
+
+  await dispatch(message);
+
+  assert.deepEqual(displayReplies.map(displayKind), ['stream-event', 'stream-event', 'stream-event']);
+  assert.deepEqual(displayReplies.map(outboundToText), [
+    'started ai task ls',
+    'tasks',
+    'finished ai task ls exitCode=0 signal=null'
+  ]);
+});
+
+test('dispatcher renders /task status directly from StatusModel', async () => {
+  const { message, displayReplies } = inbound('/task status #01');
+  const dispatch = createMessageDispatcher({
+    config,
+    logger: { info: () => {} },
+    buildStatusModel: () => statusModel
+  });
+
+  await dispatch(message);
+
+  assert.equal(displayReplies.length, 1);
+  assert.equal(displayKind(displayReplies[0] ?? ''), 'status-card');
+  assert.match(outboundToText(displayReplies[0] ?? ''), /Task TASK-20260101-000001/);
+});
+
+test('dispatcher falls back to streaming text path when /task status direct model fails', async () => {
+  const { message, displayReplies } = inbound('/task status #missing');
+  const dispatch = createMessageDispatcher({
+    config,
+    logger: { info: () => {} },
+    buildStatusModel: () => {
+      throw new Error('not found');
+    },
+    runAi: async (): Promise<RunnerResult> => ({ exitCode: 1, signal: null, stdout: '', stderr: 'not found' })
+  });
+
+  await dispatch(message);
+
+  assert.deepEqual(displayReplies.map(outboundToText), [
+    'started ai task status #missing',
+    'not found',
+    'finished ai task status #missing exitCode=1 signal=null'
+  ]);
+});

--- a/tests/unit/cli/server-display.test.ts
+++ b/tests/unit/cli/server-display.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  commandResult,
+  normalizeOutbound,
+  outboundToText,
+  replyOutbound,
+  statusCard,
+  streamEvent,
+	  tableMessage
+	} from '../../../lib/server/display.ts';
+import type { OutboundMessage } from '../../../lib/server/display.ts';
+
+test('normalizeOutbound preserves display messages and wraps plain text', () => {
+  assert.deepEqual(normalizeOutbound('hello'), { kind: 'text', text: 'hello' });
+  const message = statusCard('Build', 'running', [['step', 'test']]);
+  assert.equal(normalizeOutbound(message), message);
+});
+
+test('outboundToText renders table, status, stream, and command result fallbacks', () => {
+  assert.equal(
+    outboundToText(tableMessage(['name', 'state'], [['task', 'active']], 'Tasks')),
+    'Tasks\nname | state\n--- | ---\ntask | active'
+  );
+  assert.equal(outboundToText(statusCard('Deploy', 'success', [['env', 'prod']], 'done')), 'Deploy\nenv: prod\ndone');
+  assert.equal(outboundToText(streamEvent('ai task ls', 'started')), 'started ai task ls');
+  assert.equal(outboundToText(streamEvent('ai task ls', 'chunk', 'payload')), 'payload');
+  assert.equal(
+    outboundToText(streamEvent('ai task ls', 'finished', undefined, 0, null)),
+    'finished ai task ls exitCode=0 signal=null'
+  );
+  assert.equal(
+    outboundToText(commandResult('ai task ls', 1, null, 'out', 'err')),
+    'finished ai task ls exitCode=1 signal=null\nout\nerr'
+	  );
+	});
+
+test('outboundToText returns a visible fallback for unknown display kinds', () => {
+  const unknown = { kind: 'future-kind' } as unknown as OutboundMessage;
+  assert.equal(outboundToText(unknown), '[unknown: future-kind]');
+});
+
+test('replyOutbound prefers structured replies and falls back to text replies', async () => {
+  const structured: unknown[] = [];
+  await replyOutbound(
+    {
+      reply: async () => {
+        throw new Error('text fallback should not be used');
+      },
+      replyDisplay: async (message) => {
+        structured.push(message);
+      }
+    },
+    streamEvent('ai task ls', 'started')
+  );
+  assert.deepEqual(structured, [{ kind: 'stream-event', title: 'ai task ls', phase: 'started' }]);
+
+  const text: string[] = [];
+  await replyOutbound(
+    {
+      reply: async (message) => {
+        text.push(message);
+      }
+    },
+    streamEvent('ai task ls', 'finished', undefined, 0, null)
+  );
+  assert.deepEqual(text, ['finished ai task ls exitCode=0 signal=null']);
+});

--- a/tests/unit/cli/server-feishu-adapter.test.ts
+++ b/tests/unit/cli/server-feishu-adapter.test.ts
@@ -3,14 +3,17 @@ import assert from 'node:assert/strict';
 
 import feishuFactory, { createFeishuAdapter } from '../../../lib/server/adapters/feishu/index.ts';
 import {
-  cardMessage,
-  cleanFeishuText,
   createFeishuTransport,
   normalizeMessage,
   toFeishuCreateData
 } from '../../../lib/server/adapters/feishu/transport.ts';
-import type { FeishuOutgoingMessage, FeishuTransport } from '../../../lib/server/adapters/feishu/transport.ts';
+import {
+  cleanFeishuText,
+  renderFeishuMessage
+} from '../../../lib/server/adapters/feishu/renderer.ts';
+import type { FeishuMessagePayload, FeishuTransport } from '../../../lib/server/adapters/feishu/transport.ts';
 import type { AdapterCtx, InboundMessage } from '../../../lib/server/adapters/_contract.ts';
+import type { OutboundMessage } from '../../../lib/server/display.ts';
 
 // Build an im.message.receive_v1 event the way the SDK delivers it: content is a
 // JSON string, mentions are injected as "@_user_N" placeholders in the text.
@@ -55,11 +58,11 @@ test('normalizeMessage throws when content is not JSON', () => {
 // without the SDK.
 function fakeTransport(): {
   transport: FeishuTransport;
-  sends: Array<{ chatId: string; message: FeishuOutgoingMessage }>;
+  sends: Array<{ chatId: string; message: FeishuMessagePayload }>;
   fire: (raw: unknown) => Promise<void>;
   stopped: () => boolean;
 } {
-  const sends: Array<{ chatId: string; message: FeishuOutgoingMessage }> = [];
+  const sends: Array<{ chatId: string; message: FeishuMessagePayload }> = [];
   let onMessage: ((raw: unknown) => Promise<void>) | null = null;
   let stopped = false;
   return {
@@ -113,9 +116,11 @@ test('an inbound /ping dispatches a normalized message and reply routes a card t
   assert.equal(dispatched[0]?.adapter, 'feishu');
 
   await dispatched[0]?.reply('pong v9.9.9');
-  assert.deepEqual(fake.sends, [
-    { chatId: 'oc_chat', message: { kind: 'interactive', title: 'agent-infra', text: 'pong v9.9.9' } }
-  ]);
+  assert.equal(fake.sends[0]?.chatId, 'oc_chat');
+  assert.equal(fake.sends[0]?.message.msg_type, 'interactive');
+  const content = JSON.parse(fake.sends[0]?.message.content ?? '{}');
+  assert.equal(content.header.title.content, 'agent-infra');
+  assert.equal(content.elements[0].text.content, 'pong v9.9.9');
 });
 
 test('a non-ping inbound reply also routes a card to send', async () => {
@@ -130,9 +135,22 @@ test('a non-ping inbound reply also routes a card to send', async () => {
   assert.equal(dispatched[0]?.text, '/version');
 
   await dispatched[0]?.reply('agent-infra v9.9.9');
-  assert.deepEqual(fake.sends, [
-    { chatId: 'oc_chat', message: { kind: 'interactive', title: 'agent-infra', text: 'agent-infra v9.9.9' } }
-  ]);
+  assert.equal(JSON.parse(fake.sends[0]?.message.content ?? '{}').elements[0].text.content, 'agent-infra v9.9.9');
+});
+
+test('inbound messages expose structured replyDisplay for feishu rendering', async () => {
+  const fake = fakeTransport();
+  const dispatched: InboundMessage[] = [];
+  const adapter = createFeishuAdapter({ appId: 'x' }, fake.transport);
+
+  await adapter.start(makeCtx(dispatched));
+  await fake.fire(receiveEvent('/version'));
+  await dispatched[0]?.replyDisplay?.({ kind: 'status-card', title: 'Status', tone: 'success', fields: [['state', 'ok']] });
+
+  const content = JSON.parse(fake.sends[0]?.message.content ?? '{}');
+  assert.equal(content.header.title.content, 'Status');
+  assert.equal(content.header.template, 'green');
+  assert.equal(content.elements[0].fields[0].text.content, '**state**\nok');
 });
 
 test('a malformed inbound message is dropped (logged) without dispatching', async () => {
@@ -157,26 +175,63 @@ test('sendMessage and stop delegate to the transport', async () => {
 
   await adapter.start(makeCtx([]));
   await adapter.sendMessage({ chatId: 'oc_target' }, 'hello');
-  assert.deepEqual(fake.sends, [
-    { chatId: 'oc_target', message: { kind: 'interactive', title: 'agent-infra', text: 'hello' } }
-  ]);
+  await adapter.sendDisplayMessage?.({ chatId: 'oc_target' }, { kind: 'markdown', markdown: '**hello**' });
+  assert.equal(fake.sends[0]?.chatId, 'oc_target');
+  assert.equal(JSON.parse(fake.sends[0]?.message.content ?? '{}').elements[0].text.content, 'hello');
+  assert.equal(JSON.parse(fake.sends[1]?.message.content ?? '{}').elements[0].text.content, '**hello**');
 
   await adapter.stop();
   assert.equal(fake.stopped(), true);
 });
 
-test('feishu message helpers strip ANSI and map payloads to create data', () => {
+test('feishu renderer strips ANSI and maps payloads to create data', () => {
   assert.equal(cleanFeishuText('\u001b[31mred\u001b[0m\nnext'), 'red\nnext');
-  assert.deepEqual(cardMessage('\u001b[32mok\u001b[0m'), { kind: 'interactive', title: 'agent-infra', text: 'ok' });
 
-  const cardData = toFeishuCreateData('oc_chat', { kind: 'interactive', title: 'Card', text: 'hello' });
+  const rendered = renderFeishuMessage({
+    kind: 'table',
+    title: 'Tasks',
+    columns: ['name', 'state'],
+    rows: [['task', 'active']]
+  });
+  const cardData = toFeishuCreateData('oc_chat', rendered);
   assert.equal(cardData.receive_id, 'oc_chat');
   assert.equal(cardData.msg_type, 'interactive');
-  assert.deepEqual(JSON.parse(cardData.content), {
-    config: { wide_screen_mode: true },
-    header: { title: { tag: 'plain_text', content: 'Card' }, template: 'blue' },
-    elements: [{ tag: 'div', text: { tag: 'lark_md', content: 'hello' } }]
-  });
+  assert.equal(cardData.content, rendered.content);
+  const content = JSON.parse(rendered.content);
+  assert.equal(content.header.title.content, 'Tasks');
+  assert.match(content.elements[0].text.content, /name \\| state/);
+});
+
+test('feishu renderer maps stream events and command results to interactive cards', () => {
+  const stream = JSON.parse(renderFeishuMessage({
+    kind: 'stream-event',
+    title: 'ai task ls',
+    phase: 'finished',
+    exitCode: 0,
+    signal: null
+  }).content);
+  assert.equal(stream.header.template, 'green');
+  assert.match(stream.elements[0].text.content, /exitCode=0/);
+
+  const result = JSON.parse(renderFeishuMessage({
+    kind: 'command-result',
+    title: 'ai task ls',
+    exitCode: 1,
+    signal: null,
+    stdout: 'out',
+    stderr: 'err'
+  }).content);
+  assert.equal(result.header.template, 'red');
+  assert.match(result.elements[0].text.content, /err/);
+});
+
+test('feishu renderer returns an interactive fallback for unknown display kinds', () => {
+  const unknown = { kind: 'future-kind' } as unknown as OutboundMessage;
+  const rendered = renderFeishuMessage(unknown);
+  const content = JSON.parse(rendered.content);
+  assert.equal(rendered.msg_type, 'interactive');
+  assert.equal(content.header.title.content, 'agent-infra');
+  assert.match(content.elements[0].text.content, /unknown display kind/);
 });
 
 // CD-1: an enabled-but-misconfigured feishu adapter must fail loudly rather than

--- a/tests/unit/cli/server-streamer.test.ts
+++ b/tests/unit/cli/server-streamer.test.ts
@@ -7,10 +7,18 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 import { streamCommand } from '../../../lib/server/streamer.ts';
 import { runAi } from '../../../lib/server/runner.ts';
+import { outboundToText, type DisplayMessage, type OutboundMessage } from '../../../lib/server/display.ts';
 import { envWithPrependedPath, writeNodeCommandShim } from '../../helpers.ts';
 
+function isDisplayKind<K extends DisplayMessage['kind']>(
+  message: OutboundMessage,
+  kind: K
+): message is Extract<DisplayMessage, { kind: K }> {
+  return typeof message !== 'string' && message.kind === kind;
+}
+
 test('streamCommand chunks output, redacts secrets, and always sends exit status', async () => {
-  const messages: string[] = [];
+  const messages: OutboundMessage[] = [];
   await streamCommand(
     { title: '/run code-task #7', chunkChars: 10 },
     async () => ({
@@ -19,30 +27,36 @@ test('streamCommand chunks output, redacts secrets, and always sends exit status
       stdout: 'abcdefghijklmnop token=secret-value',
       stderr: ''
     }),
-    async (text) => {
-      messages.push(text);
+    async (message) => {
+      messages.push(message);
     }
   );
-  assert.match(messages[0] ?? '', /started/);
-  assert.ok(messages.some((message) => message.includes('abcdefghij')));
-  assert.ok(messages.every((message) => !message.includes('secret-value')));
-  assert.match(messages.at(-1) ?? '', /exitCode=1/);
+  assert.deepEqual(messages[0], { kind: 'stream-event', title: '/run code-task #7', phase: 'started' });
+  assert.ok(messages.some((message) => isDisplayKind(message, 'stream-event') && message.text?.includes('abcdefghij')));
+  assert.ok(messages.every((message) => !outboundToText(message).includes('secret-value')));
+  assert.deepEqual(messages.at(-1), {
+    kind: 'stream-event',
+    title: '/run code-task #7',
+    phase: 'finished',
+    exitCode: 1,
+    signal: null
+  });
 });
 
 test('streamCommand can forward output before process completion', async () => {
-  const messages: string[] = [];
+  const messages: OutboundMessage[] = [];
   await streamCommand(
     { title: '/task ls', chunkChars: 100 },
     async (emit) => {
       await emit?.('early output');
-      assert.deepEqual(messages, ['started /task ls', 'early output']);
+      assert.deepEqual(messages.map(outboundToText), ['started /task ls', 'early output']);
       return { exitCode: 0, signal: null, stdout: 'early output', stderr: '' };
     },
-    async (text) => {
-      messages.push(text);
+    async (message) => {
+      messages.push(message);
     }
   );
-  assert.match(messages.at(-1) ?? '', /exitCode=0/);
+  assert.equal(outboundToText(messages.at(-1) ?? ''), 'finished /task ls exitCode=0 signal=null');
 });
 
 test('streamCommand sends streamed payload before finished when reply is slow', async () => {
@@ -55,20 +69,40 @@ test('streamCommand sends streamed payload before finished when reply is slow', 
 
   const originalEnv: NodeJS.ProcessEnv = { ...process.env };
   Object.assign(process.env, envWithPrependedPath(process.env, binDir));
-  const messages: string[] = [];
+  const messages: OutboundMessage[] = [];
 
   try {
     await streamCommand(
       { title: 'ai task ls', chunkChars: 100, throttleMs: 0 },
       (emit) => runAi(['task', 'ls'], { onChunk: emit }),
-      async (text) => {
-        if (text === 'payload') await delay(30);
-        messages.push(text);
+      async (message) => {
+        if (outboundToText(message) === 'payload') await delay(30);
+        messages.push(message);
       }
     );
 
-    assert.deepEqual(messages, ['started ai task ls', 'payload', 'finished ai task ls exitCode=0 signal=null']);
+    assert.deepEqual(messages.map(outboundToText), [
+      'started ai task ls',
+      'payload',
+      'finished ai task ls exitCode=0 signal=null'
+    ]);
   } finally {
     process.env = originalEnv;
   }
+});
+
+test('streamCommand keeps old adapter text fallback stable through outboundToText', async () => {
+  const textFallback: string[] = [];
+  await streamCommand(
+    { title: 'ai task ls', chunkChars: 100 },
+    async (emit) => {
+      await emit?.('payload');
+      return { exitCode: 0, signal: null, stdout: 'payload', stderr: '' };
+    },
+    async (message) => {
+      textFallback.push(outboundToText(message));
+    }
+  );
+
+  assert.deepEqual(textFallback, ['started ai task ls', 'payload', 'finished ai task ls exitCode=0 signal=null']);
 });

--- a/tests/unit/cli/task-status.test.ts
+++ b/tests/unit/cli/task-status.test.ts
@@ -5,12 +5,14 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+  buildStatusModel,
   collectMetadata,
   groupArtifacts,
   collectGit,
   collectWorkflow,
   collectRuntime,
   renderStatus,
+  statusModelToDisplay,
   type Runner,
   type StatusModel
 } from '../../../lib/task/commands/status.ts';
@@ -314,4 +316,72 @@ test('renderStatus emits workflow and runtime before git', () => {
 test('renderStatus shows (none) when a task has no artifacts', () => {
   const out = renderStatus({ ...baseModel, artifacts: { count: 0, groups: [] } }).join('\n');
   assert.match(out, /^Artifacts \(0\)\n {2}\(none\)$/m);
+});
+
+test('statusModelToDisplay maps status model to a structured status card', () => {
+  const display = statusModelToDisplay(baseModel);
+  assert.equal(display.kind, 'status-card');
+  assert.equal(display.title, 'Task TASK-20260101-000001 (#01)');
+  assert.equal(display.tone, 'running');
+  assert.deepEqual(display.fields?.slice(0, 4), [
+    ['workflow', 'in-progress'],
+    ['step', 'Code Task (Round 2)'],
+    ['runtime', 'running'],
+    ['git', 'clean']
+  ]);
+  assert.match(display.body ?? '', /Artifacts \(2\)/);
+});
+
+test('buildStatusModel constructs the model without parsing rendered stdout', () => {
+  const taskDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-status-build-'));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-status-repo-'));
+  const taskId = 'TASK-20260101-000001';
+  const taskMdPath = path.join(taskDir, 'task.md');
+  fs.writeFileSync(path.join(taskDir, 'analysis.md'), '# analysis\n', 'utf8');
+  fs.writeFileSync(
+    taskMdPath,
+    [
+      '---',
+      `id: ${taskId}`,
+      'type: feature',
+      'status: active',
+      'current_step: code',
+      'branch: feat',
+      '---',
+      '',
+      '# 任务：demo title',
+      '',
+      '## 活动日志',
+      '',
+      '- 2026-07-02 20:00:00+08:00 — **Code Task (Round 1) [started]** by codex — started',
+      '',
+      '## 完成检查清单'
+    ].join('\n'),
+    'utf8'
+  );
+  const run: Runner = (_file, args) => {
+    if (args.includes('--abbrev-ref')) return 'feat\n';
+    if (args.includes('--verify')) return 'deadbeef\n';
+    if (args[0] === 'status') return '';
+    throw new Error(`unexpected command ${args.join(' ')}`);
+  };
+
+  const model = buildStatusModel({
+    taskId,
+    taskDir,
+    taskMdPath,
+    repoRoot,
+    shortId: '#01',
+    run,
+    now: new Date('2026-07-02T12:30:00Z')
+  });
+
+  assert.equal(model.taskId, taskId);
+  assert.equal(model.title, 'demo title');
+  assert.equal(model.workflow.state, 'in-progress');
+  assert.equal(model.git.match, 'yes');
+  assert.deepEqual(model.artifacts.groups, [
+    { stage: 'analysis', files: ['analysis.md'] },
+    { stage: 'task', files: ['task.md'] }
+  ]);
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #584 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

当前飞书 bridge 的入站消息已经归一化，但出站回复仍以纯文本为核心，飞书 adapter 在末端统一包装 interactive card，导致显示语义、飞书展示能力和传输层职责耦合。本次变更引入通用出站显示模型，让 daemon、streamer、内置命令和任务状态视图表达结构化显示意图，再由通道 renderer 负责映射到平台载体。

## 📋 主要变更 / Brief Changelog

- Add a generic outbound display model with text, markdown, table, status-card, stream-event, and command-result variants.
- Keep `reply(text)` and `sendMessage(text)` compatibility while adding optional structured display methods to the adapter contract.
- Move Feishu interactive card construction into a dedicated renderer and leave transport focused on SDK/API payload delivery.
- Emit structured stream progress and reuse `StatusModel` for `/task status` display instead of parsing stdout.
- Add daemon, display, streamer, Feishu renderer, adapter contract, and task status tests.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm run typecheck`
2. `node --test tests/unit/cli/server-daemon.test.ts tests/unit/cli/server-streamer.test.ts`
3. `npm test`
4. Commit hook: `npm run typecheck`
5. Commit hook: `npm run test:core`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #584 milestone `0.8.3`.
- `review-code-r2.md` approved the implementation with 0 blockers, 0 major, 0 minor, and 0 manual-validation items.
- `last_reviewed_commit` was not set because the staged fingerprint differed from the reviewed fingerprint after test typecheck fixes; completion should rely on current PR checks and any required follow-up review.

---

**审查者注意事项 / Reviewer Notes:**

重点关注通用 `OutboundMessage` 模型是否保持旧 adapter fallback 兼容、飞书 renderer 是否独占平台展示策略，以及 daemon/streamer/status 是否没有引入 Feishu 平台分支。

Generated with AI assistance