### PR TITLE
feat(meta): 引入通用工作流告警机制

### DIFF
--- a/.agents/rules/create-issue.md
+++ b/.agents/rules/create-issue.md
@@ -188,4 +188,4 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 - 认证失败 / 命令不可用：返回结构化错误 `{code: "AUTH_FAILED", message}` 给 `create-task`，不修改 task.md
 - 网络超时 / DNS 失败：`{code: "NETWORK", message}`
 - 模板解析失败、Issue 编号解析失败、其它异常：`{code: "VALIDATION", message}`
-- 任意失败均不回滚 task.md；`create-task` 走"场景 C 失败兜底"输出，提示用户手动重试或在事后写入 `issue_number`
+- 任意失败均不回滚 task.md；`create-task` 必须把结构化错误写入 `## 工作流告警`（`severity=ACTION_REQUIRED`，`code=ISSUE_CREATE_FAILED`，`target=issue`），再走"场景 C 失败兜底"输出，提示用户手动重试或在事后写入 `issue_number`

--- a/.agents/rules/issue-sync.md
+++ b/.agents/rules/issue-sync.md
@@ -66,6 +66,17 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 - 权限不足只影响直接写 Issue 元数据的步骤，不中断整个技能
 - 现有 `2>/dev/null || true` 容错模式保持不变
 
+当调用方存在 `{task-id}` / task 目录时，权限降级或关键同步失败必须写入 `## 工作流告警`：
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step issue-sync --severity IMPORTANT --code PERMISSION_DEGRADED \
+  --target "{operation}" --message "{reason}" \
+  --action "等待 bot/维护者补位，或在具备权限后重跑对应 workflow 步骤"
+```
+
+评论创建 / 更新失败、网络重试耗尽等影响后续 reviewer 可见性的失败使用 `severity=ACTION_REQUIRED` 和 `code=COMMENT_SYNC_FAILED` 或 `NETWORK_RETRY_EXHAUSTED`。
+
 ## 外部开发者锁定机制
 
 维护者（`has_triage=true`）不受限制。外部开发者（`has_triage=false`）在开始任务前，必须先检查 Issue 上是否已有当前任务的 `task` 留言作者。
@@ -209,6 +220,8 @@ EOF
 ```
 
 评论发布不受 `has_triage` / `has_push` 限制，认证用户可正常执行。
+
+若评论查询、创建或更新失败且调用方有关联任务目录，记录 Workflow Warning（`step=issue-sync`、`severity=ACTION_REQUIRED`、`code=COMMENT_SYNC_FAILED`、`target={file-stem}`），并在最终输出的 Workflow Warnings 块提示人工处理。
 
 ## task.md 评论同步
 

--- a/.agents/rules/next-step-output.md
+++ b/.agents/rules/next-step-output.md
@@ -1,10 +1,11 @@
 # 下一步输出规则
 
-本文件定义 skill「告知用户 / 下一步」输出的三类**相互独立**的规则（第 3 类仅 review-* 适用）；渲染最终输出前先读取本文件并落实其中适用的规则：
+本文件定义 skill「告知用户 / 下一步」输出的四类**相互独立**的规则（第 3 类仅 review-* 适用）；渲染最终输出前先读取本文件并落实其中适用的规则：
 
 1. **下一步输出结构**：「下一步」命令与「任务信息」段如何呈现任务 ID 形态（占位符 / 取短号 / 回退）。
 2. **Agent 输出收尾行（Completed at）**：面向用户输出的**绝对最后一行**，**独立于「下一步」块**，正常 / 错误 / 早退路径都适用。
 3. **人工裁决待办前置块**：仅 `review-analysis` / `review-plan` / `review-code`，且本阶段存在待裁决项（`{h} > 0`）时适用——在「下一步」命令前展开待裁决项并提示先完成裁决。
+4. **Workflow Warnings 输出块**：当前 task.md 存在 `status=open` 的 `## 工作流告警` 行时适用——在所有常规信息和「下一步」命令之后、`Completed at` 之前输出告警摘要。
 
 ## 占位符语义
 
@@ -61,6 +62,19 @@ Completed at: YYYY-MM-DD HH:mm:ss
 - 取值命令（本地时区、不带偏移）：`date "+%Y-%m-%d %H:%M:%S"`
 - 位置：必须是整段面向用户输出的最后一行，排在所有「下一步」命令之后。若某场景在命令之后还有条件性提醒行（如 manual-validation 提醒），收尾行排在该提醒行之后。
 - 该行只用于终端扫视，不写入任何产物文件或 Issue/PR 评论；完成时刻的单一事实源仍是 task.md 的 Activity Log。
+
+## Workflow Warnings 输出块
+
+若当前任务的 `## 工作流告警` / `## Workflow Warnings` 表中存在 `status=open` 行，skill 最终输出必须在所有常规信息和「下一步」命令之后、`Completed at` 之前追加摘要块；无 open 告警时不输出本块。
+
+格式：
+
+```text
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N {code} ({target}): {action}
+```
+
+`severity=ACTION_REQUIRED` 的行使用 `[ACTION REQUIRED]`；只有 `IMPORTANT` 行时使用 `[IMPORTANT]`。`{code}`、`{target}`、`{action}` 直接来自告警表对应列。
 
 ## 人工裁决待办前置块（review-* 专用，{h} > 0 时）
 

--- a/.agents/rules/pr-sync.md
+++ b/.agents/rules/pr-sync.md
@@ -117,6 +117,15 @@ EOF
 | `gh api` GET/PATCH/POST 失败 | 输出警告并继续；是否阻塞当前 skill 由调用方决定 |
 | `pr_number` 指向的 PR 不存在 | 输出 `PR #{pr-number} not found` 警告并继续 |
 
+当调用方存在 `{task-id}` / task 目录且 GET/PATCH/POST 失败时，记录 Workflow Warning：
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step pr-sync --severity ACTION_REQUIRED --code COMMENT_SYNC_FAILED \
+  --target "pr-summary" --message "{reason}" \
+  --action "修复 GitHub API / 网络问题后重跑触发 PR 摘要同步的 workflow 步骤"
+```
+
 ## 结果回传
 
 统一回传以下结果之一，供调用方在 Activity Log 或用户输出中复用：

--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -61,6 +61,10 @@ const LEDGER_TERMINAL_OK = new Set(["confirmed", "closed", "human-decided"]);
 const DEFAULT_MAX_HANDSHAKE_ROUNDS = 3;
 const POST_REVIEW_COMMIT_STAGE = "post-review-commit";
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+const WORKFLOW_WARNING_SECTION_NAMES = ["工作流告警", "Workflow Warnings"];
+const WORKFLOW_WARNING_STATUSES = new Set(["open", "resolved", "ignored"]);
+const WORKFLOW_WARNING_SEVERITIES = new Set(["IMPORTANT", "ACTION_REQUIRED"]);
+const WORKFLOW_WARNING_ID_PATTERN = /^WW-\d+$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
@@ -282,6 +286,11 @@ function checkTaskMeta({ taskDir, config }) {
   const branchValidationError = validateTaskBranch(metadata);
   if (branchValidationError) {
     return failResult("task-meta", branchValidationError);
+  }
+
+  const warningValidationErrors = validateWorkflowWarnings(task.content);
+  if (warningValidationErrors.length > 0) {
+    return failResult("task-meta", `Invalid Workflow Warnings: ${warningValidationErrors.join("; ")}`);
   }
 
   const expectedStep = config.expected_step;
@@ -559,6 +568,117 @@ function parseLedgerRows(section) {
     rows.push(cells);
   }
   return rows;
+}
+
+function splitMarkdownTableRow(line) {
+  let value = String(line || "").trim();
+  if (!value.startsWith("|")) {
+    return [];
+  }
+  value = value.replace(/^\|/, "").replace(/\|$/, "");
+
+  const cells = [];
+  let cell = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "|" && !isEscapedAt(value, index)) {
+      cells.push(unescapeMarkdownTableCell(cell.trim()));
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+  cells.push(unescapeMarkdownTableCell(cell.trim()));
+  return cells;
+}
+
+function unescapeMarkdownTableCell(value) {
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const next = value[index + 1];
+    if (char === "\\" && (next === "\\" || next === "|")) {
+      output += next;
+      index += 1;
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function isEscapedAt(value, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function parseWorkflowWarningRows(section) {
+  const rows = [];
+  for (const rawLine of String(section || "").split(/\r?\n/)) {
+    const cells = splitMarkdownTableRow(rawLine);
+    if (cells.length === 0) {
+      continue;
+    }
+    if ((cells[0] || "").toLowerCase() === "id") {
+      continue;
+    }
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) {
+      continue;
+    }
+    rows.push(cells);
+  }
+  return rows;
+}
+
+function validateWorkflowWarnings(content) {
+  const section = getSectionContent(content, WORKFLOW_WARNING_SECTION_NAMES);
+  if (!section.trim()) {
+    return [];
+  }
+
+  const rows = parseWorkflowWarningRows(section);
+  const errors = [];
+  for (const cells of rows) {
+    if (cells.length < 11) {
+      errors.push(`malformed row (expected 11 columns): ${cells.join(" | ")}`);
+      continue;
+    }
+    const [id, time, step, severity, code, status, target, message, action, resolvedAt, resolution] = cells;
+    if (!WORKFLOW_WARNING_ID_PATTERN.test(id)) {
+      errors.push(`${id || "(empty id)"}: invalid id`);
+    }
+    if (!DATE_TIME_PATTERN.test(time)) {
+      errors.push(`${id}: invalid time '${time}'`);
+    }
+    if (isBlank(step)) {
+      errors.push(`${id}: step is required`);
+    }
+    if (!WORKFLOW_WARNING_SEVERITIES.has(severity)) {
+      errors.push(`${id}: illegal severity '${severity}'`);
+    }
+    if (isBlank(code)) {
+      errors.push(`${id}: code is required`);
+    }
+    if (!WORKFLOW_WARNING_STATUSES.has(status)) {
+      errors.push(`${id}: illegal status '${status}'`);
+    }
+    if (isBlank(target)) {
+      errors.push(`${id}: target is required`);
+    }
+    if (isBlank(message)) {
+      errors.push(`${id}: message is required`);
+    }
+    if (status === "open" && isBlank(action)) {
+      errors.push(`${id}: open warning requires action`);
+    }
+    if ((status === "resolved" || status === "ignored") && (isBlank(resolvedAt) || isBlank(resolution))) {
+      errors.push(`${id}: ${status} warning requires resolved_at and resolution`);
+    }
+  }
+  return errors;
 }
 
 function resolveReviewSetting(config, key, fallback) {

--- a/.agents/scripts/workflow-warnings.js
+++ b/.agents/scripts/workflow-warnings.js
@@ -1,0 +1,290 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SECTION_ZH = "工作流告警";
+const SECTION_EN = "Workflow Warnings";
+const ACTIVITY_ZH = "活动日志";
+const ACTIVITY_EN = "Activity Log";
+const HEADER = "| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |";
+const SEPARATOR = "|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|";
+const VALID_SEVERITIES = new Set(["IMPORTANT", "ACTION_REQUIRED"]);
+const VALID_STATUSES = new Set(["open", "resolved", "ignored"]);
+
+function usage() {
+  process.stderr.write([
+    "Usage:",
+    "  node .agents/scripts/workflow-warnings.js add <task-dir> --step <step> --severity <IMPORTANT|ACTION_REQUIRED> --code <code> --target <target> --message <message> --action <action>",
+    "  node .agents/scripts/workflow-warnings.js set-status <task-dir> --id <WW-N> --status <resolved|ignored> --resolution <reason>",
+    "  node .agents/scripts/workflow-warnings.js list <task-dir> [--status <status>] [--format json|text]",
+    ""
+  ].join("\n"));
+  process.exit(2);
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const key = args[index];
+    if (!key?.startsWith("--")) usage();
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) usage();
+    options[key.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function timestamp() {
+  const date = new Date();
+  const pad = (value) => String(value).padStart(2, "0");
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absolute = Math.abs(offsetMinutes);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${sign}${pad(Math.floor(absolute / 60))}:${pad(absolute % 60)}`;
+}
+
+function escapeCell(value) {
+  return String(value ?? "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function unescapeCell(value) {
+  const text = String(value ?? "");
+  let output = "";
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (char === "\\" && (next === "\\" || next === "|")) {
+      output += next;
+      index += 1;
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function isEscapedAt(value, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function splitRow(line) {
+  let value = String(line || "").trim();
+  if (!value.startsWith("|")) return [];
+  value = value.replace(/^\|/, "").replace(/\|$/, "");
+  const cells = [];
+  let cell = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "|" && !isEscapedAt(value, index)) {
+      cells.push(unescapeCell(cell.trim()));
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+  cells.push(unescapeCell(cell.trim()));
+  return cells;
+}
+
+function rowToWarning(cells, lineIndex) {
+  return {
+    lineIndex,
+    id: cells[0] || "",
+    time: cells[1] || "",
+    step: cells[2] || "",
+    severity: cells[3] || "",
+    code: cells[4] || "",
+    status: cells[5] || "",
+    target: cells[6] || "",
+    message: cells[7] || "",
+    action: cells[8] || "",
+    resolved_at: cells[9] || "",
+    resolution: cells[10] || ""
+  };
+}
+
+function warningToLine(warning) {
+  return [
+    warning.id,
+    warning.time,
+    warning.step,
+    warning.severity,
+    warning.code,
+    warning.status,
+    warning.target,
+    warning.message,
+    warning.action,
+    warning.resolved_at,
+    warning.resolution
+  ].map(escapeCell).join(" | ").replace(/^/, "| ").replace(/$/, " |");
+}
+
+function findSection(lines) {
+  let start = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (new RegExp(`^##\\s+(${SECTION_ZH}|${SECTION_EN})\\s*$`).test(lines[index].trim())) {
+      start = index;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^##\s+/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+function insertSection(content) {
+  const lines = content.split(/\r?\n/);
+  const existing = findSection(lines);
+  if (existing) return { content, section: existing };
+
+  const activityIndex = lines.findIndex((line) => {
+    const trimmed = line.trim();
+    return trimmed === `## ${ACTIVITY_ZH}` || trimmed === `## ${ACTIVITY_EN}`;
+  });
+  const heading = content.includes(`## ${ACTIVITY_EN}`) ? SECTION_EN : SECTION_ZH;
+  const block = [`## ${heading}`, "", "<!-- Workflow degradation, platform sync failures, permission gaps, and related events. Keep the header when empty. -->", "", HEADER, SEPARATOR, ""];
+  const insertAt = activityIndex >= 0 ? activityIndex : lines.length;
+  lines.splice(insertAt, 0, ...block);
+  const updated = lines.join("\n");
+  return { content: updated, section: findSection(updated.split(/\r?\n/)) };
+}
+
+function readTask(taskDir) {
+  const taskPath = path.join(taskDir, "task.md");
+  if (!fs.existsSync(taskPath)) {
+    throw new Error(`Task file not found: ${taskPath}`);
+  }
+  return { taskPath, content: fs.readFileSync(taskPath, "utf8") };
+}
+
+function parseWarnings(content) {
+  const lines = content.split(/\r?\n/);
+  const section = findSection(lines);
+  if (!section) return [];
+  const warnings = [];
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const cells = splitRow(lines[index]);
+    if (cells.length === 0) continue;
+    if ((cells[0] || "").toLowerCase() === "id") continue;
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) continue;
+    if (cells.length < 11) continue;
+    warnings.push(rowToWarning(cells, index));
+  }
+  return warnings;
+}
+
+function nextId(warnings) {
+  const max = warnings.reduce((current, warning) => {
+    const match = /^WW-(\d+)$/.exec(warning.id);
+    return match ? Math.max(current, Number.parseInt(match[1], 10)) : current;
+  }, 0);
+  return `WW-${max + 1}`;
+}
+
+function requireOption(options, key) {
+  const value = options[key];
+  if (!value) usage();
+  return value;
+}
+
+function add(taskDir, options) {
+  const severity = requireOption(options, "severity");
+  if (!VALID_SEVERITIES.has(severity)) throw new Error(`Invalid severity: ${severity}`);
+  const step = requireOption(options, "step");
+  const code = requireOption(options, "code");
+  const target = requireOption(options, "target");
+  const message = requireOption(options, "message");
+  const action = requireOption(options, "action");
+
+  const task = readTask(taskDir);
+  const inserted = insertSection(task.content);
+  const lines = inserted.content.split(/\r?\n/);
+  const warnings = parseWarnings(inserted.content);
+  const duplicate = warnings.find((warning) =>
+    warning.status === "open" &&
+    warning.step === step &&
+    warning.code === code &&
+    warning.target === target
+  );
+  if (duplicate) {
+    process.stdout.write(`${JSON.stringify({ created: false, warning: duplicate }, null, 2)}\n`);
+    if (inserted.content !== task.content) fs.writeFileSync(task.taskPath, inserted.content, "utf8");
+    return;
+  }
+
+  const warning = {
+    id: nextId(warnings),
+    time: timestamp(),
+    step,
+    severity,
+    code,
+    status: "open",
+    target,
+    message,
+    action,
+    resolved_at: "",
+    resolution: ""
+  };
+  lines.splice(inserted.section.end - 1, 0, warningToLine(warning));
+  fs.writeFileSync(task.taskPath, lines.join("\n"), "utf8");
+  process.stdout.write(`${JSON.stringify({ created: true, warning }, null, 2)}\n`);
+}
+
+function setStatus(taskDir, options) {
+  const id = requireOption(options, "id");
+  const status = requireOption(options, "status");
+  if (!["resolved", "ignored"].includes(status)) throw new Error(`Invalid status for set-status: ${status}`);
+  const resolution = requireOption(options, "resolution");
+  const task = readTask(taskDir);
+  const lines = task.content.split(/\r?\n/);
+  const warnings = parseWarnings(task.content);
+  const warning = warnings.find((candidate) => candidate.id === id);
+  if (!warning) throw new Error(`Warning not found: ${id}`);
+  warning.status = status;
+  warning.resolved_at = timestamp();
+  warning.resolution = resolution;
+  lines[warning.lineIndex] = warningToLine(warning);
+  fs.writeFileSync(task.taskPath, lines.join("\n"), "utf8");
+  process.stdout.write(`${JSON.stringify({ updated: true, warning }, null, 2)}\n`);
+}
+
+function list(taskDir, options) {
+  const format = options.format || "text";
+  const status = options.status || "";
+  if (format !== "json" && format !== "text") usage();
+  const warnings = parseWarnings(readTask(taskDir).content)
+    .filter((warning) => !status || warning.status === status)
+    .map(({ lineIndex: _lineIndex, ...warning }) => warning);
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify({ warnings }, null, 2)}\n`);
+    return;
+  }
+  for (const warning of warnings) {
+    process.stdout.write(`${warning.id} [${warning.severity}] ${warning.code} ${warning.target} - ${warning.action}\n`);
+  }
+}
+
+try {
+  const [command, taskDirArg, ...rest] = process.argv.slice(2);
+  if (!command || !taskDirArg) usage();
+  const taskDir = path.resolve(taskDirArg);
+  const options = parseOptions(rest);
+  if (command === "add") add(taskDir, options);
+  else if (command === "set-status") setStatus(taskDir, options);
+  else if (command === "list") list(taskDir, options);
+  else usage();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -165,3 +165,5 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
 - 推送被拒绝：建议执行 `git pull --rebase`
 - 已存在 PR：直接输出当前 PR URL 并结束
 - 无法访问 Issue 元数据：跳过继承并继续
+- PR 创建失败且已关联 `{task-id}`：调用 `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-pr --severity ACTION_REQUIRED --code PR_CREATE_FAILED --target pr --message "{reason}" --action "修复推送、权限或平台问题后重跑 create-pr"`，不写 `pr_number`
+- PR 摘要评论失败且已关联 `{task-id}`：按 `.agents/rules/pr-sync.md` 记录 `COMMENT_SYNC_FAILED` 告警，不回滚已创建 PR

--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -134,7 +134,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 处理结果：
 - 规则成功创建 Issue：`issue_number` 已按规则回写到 task.md；继续读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并按规则设置 `status: waiting-for-triage`
-- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`，让用户决定后续是否手动重试或写入 `issue_number`
+- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；先调用 `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-task --severity ACTION_REQUIRED --code ISSUE_CREATE_FAILED --target issue --message "{error_code}: {error_message}" --action "修复认证/网络/模板问题后手动重试 Issue 创建，或手动创建/找到 Issue 后写入 issue_number"` 记录通用告警；再按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`
 - 规则为 no-op（自定义或空平台）：不创建评论，不阻塞后续工作流，不写 Activity Log
 - task.md 已存在 `issue_number`：规则中的前置检查会跳过；`create-task` 直接进入步骤 5
 
@@ -230,6 +230,9 @@ Issue 创建失败：
   - Codex CLI：$analyze-task {task-ref}
 
 后续如需平台同步：修复认证/网络/模板问题后，可按 `.agents/rules/create-issue.md` 对当前任务手动执行一次 Issue 创建；或手动创建/查找 Issue，并把 `issue_number` 写入 task.md，后续技能会接管级联同步。
+
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N ISSUE_CREATE_FAILED (issue): 修复认证/网络/模板问题后手动重试 Issue 创建，或手动创建/找到 Issue 后写入 issue_number
 ```
 
 

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -64,6 +64,13 @@ pr_status: pending             # PR 状态：pending（默认）| created（已�
 
 <!-- 人类在此记录对 needs-human-decision 决策的裁定，并把 ## 审查分歧账本 对应 HD- 行翻为 human-decided。 -->
 
+## 工作流告警
+
+<!-- 工作流降级、平台同步失败、权限不足等需要后续注意的事件写入此段。无告警时保留表头即可。 -->
+
+| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |
+|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|
+
 ## 活动日志
 
 <!-- 每个工作流步骤追加一条新记录，不要覆盖之前的记录。 -->

--- a/lib/task/commands/status.ts
+++ b/lib/task/commands/status.ts
@@ -6,6 +6,7 @@ import { resolveTaskRef } from '../resolve-ref.ts';
 import { enumerateArtifacts, type Artifact } from '../artifacts.ts';
 import { parseTaskFrontmatter, extractTitle, type Frontmatter } from '../frontmatter.ts';
 import { loadShortIdByTaskId } from '../short-id.ts';
+import { getOpenWorkflowWarnings, formatWorkflowWarningSummary, type WorkflowWarning } from '../workflow-warnings.ts';
 import { parseActivityLog, pairEntries } from './log.ts';
 import { statusCard, type DisplayMessage } from '../../server/display.ts';
 
@@ -323,6 +324,7 @@ type StatusModel = {
   shortId: string;
   title: string;
   metadata: [string, string][];
+  workflowWarnings: WorkflowWarning[];
   artifacts: { count: number; groups: { stage: string; files: string[] }[] };
   workflow: WorkflowInfo;
   runtime: RuntimeInfo;
@@ -358,6 +360,14 @@ function renderStatus(model: StatusModel): string[] {
   if (model.title) lines.push(model.title);
 
   lines.push('', 'Metadata', ...renderPairs(model.metadata));
+
+  if (model.workflowWarnings.length > 0) {
+    lines.push(
+      '',
+      `Workflow Warnings (${model.workflowWarnings.length} open)`,
+      ...formatWorkflowWarningSummary(model.workflowWarnings).map((line) => `  ${line}`)
+    );
+  }
 
   lines.push('', `Artifacts (${model.artifacts.count})`);
   if (model.artifacts.groups.length === 0) {
@@ -431,6 +441,7 @@ function buildFromResolved(input: BuildStatusModelInput): StatusModel {
     shortId: input.shortId ?? loadShortIdByTaskId(input.repoRoot).get(input.taskId) ?? DASH,
     title: extractTitle(content),
     metadata: collectMetadata(fm),
+    workflowWarnings: getOpenWorkflowWarnings(content),
     artifacts: { count: artifacts.length, groups: groupArtifacts(artifacts) },
     workflow,
     runtime: collectRuntime(input.taskDir, workflow, run),

--- a/lib/task/workflow-warnings.ts
+++ b/lib/task/workflow-warnings.ts
@@ -1,0 +1,121 @@
+import { extractSection } from './sections.ts';
+
+const WORKFLOW_WARNING_HEADINGS = ['工作流告警', 'Workflow Warnings'];
+const WORKFLOW_WARNING_STATUSES = new Set(['open', 'resolved', 'ignored']);
+const WORKFLOW_WARNING_SEVERITIES = new Set(['IMPORTANT', 'ACTION_REQUIRED']);
+
+type WorkflowWarning = {
+  id: string;
+  time: string;
+  step: string;
+  severity: string;
+  code: string;
+  status: string;
+  target: string;
+  message: string;
+  action: string;
+  resolvedAt: string;
+  resolution: string;
+};
+
+function splitTableRow(line: string): string[] {
+  let value = line.trim();
+  if (!value.startsWith('|')) return [];
+  value = value.replace(/^\|/, '').replace(/\|$/, '');
+
+  const cells: string[] = [];
+  let cell = '';
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    if (char === '|' && !isEscapedAt(value, index)) {
+      cells.push(unescapeTableCell(cell.trim()));
+      cell = '';
+      continue;
+    }
+    cell += char;
+  }
+  cells.push(unescapeTableCell(cell.trim()));
+  return cells;
+}
+
+function unescapeTableCell(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    const next = value[index + 1];
+    if (char === '\\' && (next === '\\' || next === '|')) {
+      output += next;
+      index += 1;
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function isEscapedAt(value: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function isSeparatorRow(cells: string[]): boolean {
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+/**
+ * Parses well-formed workflow warning rows. Malformed rows are intentionally
+ * ignored here; validate-artifact is responsible for reporting structure errors.
+ */
+function parseWorkflowWarnings(content: string): WorkflowWarning[] {
+  const section = extractSection(content, WORKFLOW_WARNING_HEADINGS);
+  if (!section) return [];
+
+  const rows: WorkflowWarning[] = [];
+  for (const rawLine of section.split(/\r?\n/)) {
+    const cells = splitTableRow(rawLine);
+    if (cells.length === 0) continue;
+    if ((cells[0] ?? '').toLowerCase() === 'id') continue;
+    if (isSeparatorRow(cells)) continue;
+    if (cells.length < 11) continue;
+
+    rows.push({
+      id: cells[0] ?? '',
+      time: cells[1] ?? '',
+      step: cells[2] ?? '',
+      severity: cells[3] ?? '',
+      code: cells[4] ?? '',
+      status: cells[5] ?? '',
+      target: cells[6] ?? '',
+      message: cells[7] ?? '',
+      action: cells[8] ?? '',
+      resolvedAt: cells[9] ?? '',
+      resolution: cells[10] ?? ''
+    });
+  }
+  return rows;
+}
+
+function getOpenWorkflowWarnings(content: string): WorkflowWarning[] {
+  return parseWorkflowWarnings(content).filter((warning) => warning.status === 'open');
+}
+
+function formatWorkflowWarningSummary(warnings: readonly WorkflowWarning[]): string[] {
+  return warnings.map((warning) => {
+    const target = warning.target ? ` ${warning.target}` : '';
+    const action = warning.action ? ` - ${warning.action}` : '';
+    return `${warning.id} [${warning.severity}] ${warning.code}${target}${action}`;
+  });
+}
+
+export {
+  WORKFLOW_WARNING_HEADINGS,
+  WORKFLOW_WARNING_STATUSES,
+  WORKFLOW_WARNING_SEVERITIES,
+  parseWorkflowWarnings,
+  getOpenWorkflowWarnings,
+  formatWorkflowWarningSummary
+};
+export type { WorkflowWarning };

--- a/templates/.agents/rules/create-issue.github.en.md
+++ b/templates/.agents/rules/create-issue.github.en.md
@@ -188,4 +188,4 @@ Hand the following back to the caller `create-task`:
 - Auth failure / command unavailable: return a structured `{code: "AUTH_FAILED", message}` to `create-task`; do not modify task.md
 - Network timeout / DNS failure: `{code: "NETWORK", message}`
 - Template parsing failure, Issue number parsing failure, other anomalies: `{code: "VALIDATION", message}`
-- All failures keep task.md untouched; `create-task` takes the "Scenario C: failure fallback" output branch and prompts the user to retry manually or fill `issue_number` later
+- All failures keep task.md untouched; `create-task` must record the structured error in `## Workflow Warnings` (`severity=ACTION_REQUIRED`, `code=ISSUE_CREATE_FAILED`, `target=issue`) before taking the "Scenario C: failure fallback" output branch and prompting the user to retry manually or fill `issue_number` later

--- a/templates/.agents/rules/create-issue.github.zh-CN.md
+++ b/templates/.agents/rules/create-issue.github.zh-CN.md
@@ -188,4 +188,4 @@ gh api "repos/$upstream_repo/issues/{issue-number}" -X PATCH \
 - 认证失败 / 命令不可用：返回结构化错误 `{code: "AUTH_FAILED", message}` 给 `create-task`，不修改 task.md
 - 网络超时 / DNS 失败：`{code: "NETWORK", message}`
 - 模板解析失败、Issue 编号解析失败、其它异常：`{code: "VALIDATION", message}`
-- 任意失败均不回滚 task.md；`create-task` 走"场景 C 失败兜底"输出，提示用户手动重试或在事后写入 `issue_number`
+- 任意失败均不回滚 task.md；`create-task` 必须把结构化错误写入 `## 工作流告警`（`severity=ACTION_REQUIRED`，`code=ISSUE_CREATE_FAILED`，`target=issue`），再走"场景 C 失败兜底"输出，提示用户手动重试或在事后写入 `issue_number`

--- a/templates/.agents/rules/issue-sync.github.en.md
+++ b/templates/.agents/rules/issue-sync.github.en.md
@@ -66,6 +66,17 @@ Key rules:
 - insufficient permission only affects direct Issue metadata writes and must not stop the skill
 - keep the existing `2>/dev/null || true` error-tolerance pattern
 
+When the caller has a `{task-id}` / task directory, permission degradation or critical sync failure must be recorded in `## Workflow Warnings`:
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step issue-sync --severity IMPORTANT --code PERMISSION_DEGRADED \
+  --target "{operation}" --message "{reason}" \
+  --action "Wait for the bot/maintainer to backfill, or rerun the workflow step after permissions are available"
+```
+
+Comment create/update failures and exhausted network retries that affect reviewer visibility use `severity=ACTION_REQUIRED` with `code=COMMENT_SYNC_FAILED` or `NETWORK_RETRY_EXHAUSTED`.
+
 ## External Contributor Locking
 
 Maintainers (`has_triage=true`) are never blocked. External contributors (`has_triage=false`) must check whether the current task already has a `task` comment author on the Issue before they start.
@@ -209,6 +220,8 @@ EOF
 ```
 
 Comment publishing is not gated by `has_triage` or `has_push`.
+
+If comment lookup, creation, or update fails and the caller has a task directory, record a Workflow Warning (`step=issue-sync`, `severity=ACTION_REQUIRED`, `code=COMMENT_SYNC_FAILED`, `target={file-stem}`) and surface it in the final Workflow Warnings output block.
 
 ## task.md Comment Sync
 

--- a/templates/.agents/rules/issue-sync.github.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.github.zh-CN.md
@@ -66,6 +66,17 @@ has_push=$(printf '%s' "$repo_perms" | grep -q '"push":true' 2>/dev/null && echo
 - 权限不足只影响直接写 Issue 元数据的步骤，不中断整个技能
 - 现有 `2>/dev/null || true` 容错模式保持不变
 
+当调用方存在 `{task-id}` / task 目录时，权限降级或关键同步失败必须写入 `## 工作流告警`：
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step issue-sync --severity IMPORTANT --code PERMISSION_DEGRADED \
+  --target "{operation}" --message "{reason}" \
+  --action "等待 bot/维护者补位，或在具备权限后重跑对应 workflow 步骤"
+```
+
+评论创建 / 更新失败、网络重试耗尽等影响后续 reviewer 可见性的失败使用 `severity=ACTION_REQUIRED` 和 `code=COMMENT_SYNC_FAILED` 或 `NETWORK_RETRY_EXHAUSTED`。
+
 ## 外部开发者锁定机制
 
 维护者（`has_triage=true`）不受限制。外部开发者（`has_triage=false`）在开始任务前，必须先检查 Issue 上是否已有当前任务的 `task` 留言作者。
@@ -209,6 +220,8 @@ EOF
 ```
 
 评论发布不受 `has_triage` / `has_push` 限制，认证用户可正常执行。
+
+若评论查询、创建或更新失败且调用方有关联任务目录，记录 Workflow Warning（`step=issue-sync`、`severity=ACTION_REQUIRED`、`code=COMMENT_SYNC_FAILED`、`target={file-stem}`），并在最终输出的 Workflow Warnings 块提示人工处理。
 
 ## task.md 评论同步
 

--- a/templates/.agents/rules/next-step-output.en.md
+++ b/templates/.agents/rules/next-step-output.en.md
@@ -1,10 +1,11 @@
 # Next-Step Output Rule
 
-This file defines three **independent** rules for a skill's "notify-user / Next steps" output (the 3rd applies to review-* only); read this file before rendering the final output and apply whichever rules apply:
+This file defines four **independent** rules for a skill's "notify-user / Next steps" output (the 3rd applies to review-* only); read this file before rendering the final output and apply whichever rules apply:
 
 1. **Next-step output structure**: how "Next steps" commands and the "Task info" block present the task ID (placeholders / short-id lookup / fallback).
 2. **Agent output trailing line (Completed at)**: the **very last line** of user-facing output, **independent of the "Next steps" block**, applying to normal / error / early-return paths alike.
 3. **Pending human-decision pre-block**: applies only to `review-analysis` / `review-plan` / `review-code` when this stage has pending rulings (`{h} > 0`) — expand the pending items before the "Next steps" commands and prompt to resolve them first.
+4. **Workflow Warnings output block**: applies when task.md has `status=open` rows in `## Workflow Warnings` — print the warning summary after all normal information and "Next steps" commands, and before `Completed at`.
 
 ## Placeholder semantics
 
@@ -61,6 +62,19 @@ Completed at: YYYY-MM-DD HH:mm:ss
 - Value command (local timezone, no offset): `date "+%Y-%m-%d %H:%M:%S"`
 - Position: it must be the last line of the entire user-facing output, after all "Next steps" commands. If a scenario has a conditional reminder line after the commands (e.g. the manual-validation reminder), the completion line goes after that reminder.
 - This line is for terminal scanning only; it is never written to any artifact file or Issue/PR comment. The single source of truth for completion time remains the Activity Log in task.md.
+
+## Workflow Warnings Output Block
+
+If the current task's `## Workflow Warnings` / `## 工作流告警` table has any `status=open` row, the skill's final user output must append a summary block after all normal information and "Next steps" commands, and before `Completed at`. When no open warning exists, do not render this block.
+
+Format:
+
+```text
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N {code} ({target}): {action}
+```
+
+Use `[ACTION REQUIRED]` when any open row has `severity=ACTION_REQUIRED`; otherwise use `[IMPORTANT]`. `{code}`, `{target}`, and `{action}` come directly from the warning table columns.
 
 ## Pending human-decision pre-block (review-* only, when {h} > 0)
 

--- a/templates/.agents/rules/next-step-output.zh-CN.md
+++ b/templates/.agents/rules/next-step-output.zh-CN.md
@@ -1,10 +1,11 @@
 # 下一步输出规则
 
-本文件定义 skill「告知用户 / 下一步」输出的三类**相互独立**的规则（第 3 类仅 review-* 适用）；渲染最终输出前先读取本文件并落实其中适用的规则：
+本文件定义 skill「告知用户 / 下一步」输出的四类**相互独立**的规则（第 3 类仅 review-* 适用）；渲染最终输出前先读取本文件并落实其中适用的规则：
 
 1. **下一步输出结构**：「下一步」命令与「任务信息」段如何呈现任务 ID 形态（占位符 / 取短号 / 回退）。
 2. **Agent 输出收尾行（Completed at）**：面向用户输出的**绝对最后一行**，**独立于「下一步」块**，正常 / 错误 / 早退路径都适用。
 3. **人工裁决待办前置块**：仅 `review-analysis` / `review-plan` / `review-code`，且本阶段存在待裁决项（`{h} > 0`）时适用——在「下一步」命令前展开待裁决项并提示先完成裁决。
+4. **Workflow Warnings 输出块**：当前 task.md 存在 `status=open` 的 `## 工作流告警` 行时适用——在所有常规信息和「下一步」命令之后、`Completed at` 之前输出告警摘要。
 
 ## 占位符语义
 
@@ -61,6 +62,19 @@ Completed at: YYYY-MM-DD HH:mm:ss
 - 取值命令（本地时区、不带偏移）：`date "+%Y-%m-%d %H:%M:%S"`
 - 位置：必须是整段面向用户输出的最后一行，排在所有「下一步」命令之后。若某场景在命令之后还有条件性提醒行（如 manual-validation 提醒），收尾行排在该提醒行之后。
 - 该行只用于终端扫视，不写入任何产物文件或 Issue/PR 评论；完成时刻的单一事实源仍是 task.md 的 Activity Log。
+
+## Workflow Warnings 输出块
+
+若当前任务的 `## 工作流告警` / `## Workflow Warnings` 表中存在 `status=open` 行，skill 最终输出必须在所有常规信息和「下一步」命令之后、`Completed at` 之前追加摘要块；无 open 告警时不输出本块。
+
+格式：
+
+```text
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N {code} ({target}): {action}
+```
+
+`severity=ACTION_REQUIRED` 的行使用 `[ACTION REQUIRED]`；只有 `IMPORTANT` 行时使用 `[IMPORTANT]`。`{code}`、`{target}`、`{action}` 直接来自告警表对应列。
 
 ## 人工裁决待办前置块（review-* 专用，{h} > 0 时）
 

--- a/templates/.agents/rules/pr-sync.github.en.md
+++ b/templates/.agents/rules/pr-sync.github.en.md
@@ -117,6 +117,15 @@ EOF
 | `gh api` GET/PATCH/POST fails | warn and continue; whether the current skill should block is decided by the caller |
 | `pr_number` points to a missing PR | warn with `PR #{pr-number} not found` and continue |
 
+When the caller has a `{task-id}` / task directory and GET/PATCH/POST fails, record a Workflow Warning:
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step pr-sync --severity ACTION_REQUIRED --code COMMENT_SYNC_FAILED \
+  --target "pr-summary" --message "{reason}" \
+  --action "Fix GitHub API / network issues and rerun the workflow step that triggers PR summary sync"
+```
+
 ## Result Reporting
 
 Return one of these normalized results so callers can reuse it in Activity Log entries or user output:

--- a/templates/.agents/rules/pr-sync.github.zh-CN.md
+++ b/templates/.agents/rules/pr-sync.github.zh-CN.md
@@ -117,6 +117,15 @@ EOF
 | `gh api` GET/PATCH/POST 失败 | 输出警告并继续；是否阻塞当前 skill 由调用方决定 |
 | `pr_number` 指向的 PR 不存在 | 输出 `PR #{pr-number} not found` 警告并继续 |
 
+当调用方存在 `{task-id}` / task 目录且 GET/PATCH/POST 失败时，记录 Workflow Warning：
+
+```bash
+node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} \
+  --step pr-sync --severity ACTION_REQUIRED --code COMMENT_SYNC_FAILED \
+  --target "pr-summary" --message "{reason}" \
+  --action "修复 GitHub API / 网络问题后重跑触发 PR 摘要同步的 workflow 步骤"
+```
+
 ## 结果回传
 
 统一回传以下结果之一，供调用方在 Activity Log 或用户输出中复用：

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -61,6 +61,10 @@ const LEDGER_TERMINAL_OK = new Set(["confirmed", "closed", "human-decided"]);
 const DEFAULT_MAX_HANDSHAKE_ROUNDS = 3;
 const POST_REVIEW_COMMIT_STAGE = "post-review-commit";
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+const WORKFLOW_WARNING_SECTION_NAMES = ["工作流告警", "Workflow Warnings"];
+const WORKFLOW_WARNING_STATUSES = new Set(["open", "resolved", "ignored"]);
+const WORKFLOW_WARNING_SEVERITIES = new Set(["IMPORTANT", "ACTION_REQUIRED"]);
+const WORKFLOW_WARNING_ID_PATTERN = /^WW-\d+$/;
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..", "..");
@@ -282,6 +286,11 @@ function checkTaskMeta({ taskDir, config }) {
   const branchValidationError = validateTaskBranch(metadata);
   if (branchValidationError) {
     return failResult("task-meta", branchValidationError);
+  }
+
+  const warningValidationErrors = validateWorkflowWarnings(task.content);
+  if (warningValidationErrors.length > 0) {
+    return failResult("task-meta", `Invalid Workflow Warnings: ${warningValidationErrors.join("; ")}`);
   }
 
   const expectedStep = config.expected_step;
@@ -559,6 +568,117 @@ function parseLedgerRows(section) {
     rows.push(cells);
   }
   return rows;
+}
+
+function splitMarkdownTableRow(line) {
+  let value = String(line || "").trim();
+  if (!value.startsWith("|")) {
+    return [];
+  }
+  value = value.replace(/^\|/, "").replace(/\|$/, "");
+
+  const cells = [];
+  let cell = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "|" && !isEscapedAt(value, index)) {
+      cells.push(unescapeMarkdownTableCell(cell.trim()));
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+  cells.push(unescapeMarkdownTableCell(cell.trim()));
+  return cells;
+}
+
+function unescapeMarkdownTableCell(value) {
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const next = value[index + 1];
+    if (char === "\\" && (next === "\\" || next === "|")) {
+      output += next;
+      index += 1;
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function isEscapedAt(value, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function parseWorkflowWarningRows(section) {
+  const rows = [];
+  for (const rawLine of String(section || "").split(/\r?\n/)) {
+    const cells = splitMarkdownTableRow(rawLine);
+    if (cells.length === 0) {
+      continue;
+    }
+    if ((cells[0] || "").toLowerCase() === "id") {
+      continue;
+    }
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) {
+      continue;
+    }
+    rows.push(cells);
+  }
+  return rows;
+}
+
+function validateWorkflowWarnings(content) {
+  const section = getSectionContent(content, WORKFLOW_WARNING_SECTION_NAMES);
+  if (!section.trim()) {
+    return [];
+  }
+
+  const rows = parseWorkflowWarningRows(section);
+  const errors = [];
+  for (const cells of rows) {
+    if (cells.length < 11) {
+      errors.push(`malformed row (expected 11 columns): ${cells.join(" | ")}`);
+      continue;
+    }
+    const [id, time, step, severity, code, status, target, message, action, resolvedAt, resolution] = cells;
+    if (!WORKFLOW_WARNING_ID_PATTERN.test(id)) {
+      errors.push(`${id || "(empty id)"}: invalid id`);
+    }
+    if (!DATE_TIME_PATTERN.test(time)) {
+      errors.push(`${id}: invalid time '${time}'`);
+    }
+    if (isBlank(step)) {
+      errors.push(`${id}: step is required`);
+    }
+    if (!WORKFLOW_WARNING_SEVERITIES.has(severity)) {
+      errors.push(`${id}: illegal severity '${severity}'`);
+    }
+    if (isBlank(code)) {
+      errors.push(`${id}: code is required`);
+    }
+    if (!WORKFLOW_WARNING_STATUSES.has(status)) {
+      errors.push(`${id}: illegal status '${status}'`);
+    }
+    if (isBlank(target)) {
+      errors.push(`${id}: target is required`);
+    }
+    if (isBlank(message)) {
+      errors.push(`${id}: message is required`);
+    }
+    if (status === "open" && isBlank(action)) {
+      errors.push(`${id}: open warning requires action`);
+    }
+    if ((status === "resolved" || status === "ignored") && (isBlank(resolvedAt) || isBlank(resolution))) {
+      errors.push(`${id}: ${status} warning requires resolved_at and resolution`);
+    }
+  }
+  return errors;
 }
 
 function resolveReviewSetting(config, key, fallback) {

--- a/templates/.agents/scripts/workflow-warnings.js
+++ b/templates/.agents/scripts/workflow-warnings.js
@@ -1,0 +1,290 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SECTION_ZH = "工作流告警";
+const SECTION_EN = "Workflow Warnings";
+const ACTIVITY_ZH = "活动日志";
+const ACTIVITY_EN = "Activity Log";
+const HEADER = "| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |";
+const SEPARATOR = "|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|";
+const VALID_SEVERITIES = new Set(["IMPORTANT", "ACTION_REQUIRED"]);
+const VALID_STATUSES = new Set(["open", "resolved", "ignored"]);
+
+function usage() {
+  process.stderr.write([
+    "Usage:",
+    "  node .agents/scripts/workflow-warnings.js add <task-dir> --step <step> --severity <IMPORTANT|ACTION_REQUIRED> --code <code> --target <target> --message <message> --action <action>",
+    "  node .agents/scripts/workflow-warnings.js set-status <task-dir> --id <WW-N> --status <resolved|ignored> --resolution <reason>",
+    "  node .agents/scripts/workflow-warnings.js list <task-dir> [--status <status>] [--format json|text]",
+    ""
+  ].join("\n"));
+  process.exit(2);
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const key = args[index];
+    if (!key?.startsWith("--")) usage();
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) usage();
+    options[key.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function timestamp() {
+  const date = new Date();
+  const pad = (value) => String(value).padStart(2, "0");
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absolute = Math.abs(offsetMinutes);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${sign}${pad(Math.floor(absolute / 60))}:${pad(absolute % 60)}`;
+}
+
+function escapeCell(value) {
+  return String(value ?? "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function unescapeCell(value) {
+  const text = String(value ?? "");
+  let output = "";
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (char === "\\" && (next === "\\" || next === "|")) {
+      output += next;
+      index += 1;
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function isEscapedAt(value, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function splitRow(line) {
+  let value = String(line || "").trim();
+  if (!value.startsWith("|")) return [];
+  value = value.replace(/^\|/, "").replace(/\|$/, "");
+  const cells = [];
+  let cell = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "|" && !isEscapedAt(value, index)) {
+      cells.push(unescapeCell(cell.trim()));
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+  cells.push(unescapeCell(cell.trim()));
+  return cells;
+}
+
+function rowToWarning(cells, lineIndex) {
+  return {
+    lineIndex,
+    id: cells[0] || "",
+    time: cells[1] || "",
+    step: cells[2] || "",
+    severity: cells[3] || "",
+    code: cells[4] || "",
+    status: cells[5] || "",
+    target: cells[6] || "",
+    message: cells[7] || "",
+    action: cells[8] || "",
+    resolved_at: cells[9] || "",
+    resolution: cells[10] || ""
+  };
+}
+
+function warningToLine(warning) {
+  return [
+    warning.id,
+    warning.time,
+    warning.step,
+    warning.severity,
+    warning.code,
+    warning.status,
+    warning.target,
+    warning.message,
+    warning.action,
+    warning.resolved_at,
+    warning.resolution
+  ].map(escapeCell).join(" | ").replace(/^/, "| ").replace(/$/, " |");
+}
+
+function findSection(lines) {
+  let start = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (new RegExp(`^##\\s+(${SECTION_ZH}|${SECTION_EN})\\s*$`).test(lines[index].trim())) {
+      start = index;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^##\s+/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+function insertSection(content) {
+  const lines = content.split(/\r?\n/);
+  const existing = findSection(lines);
+  if (existing) return { content, section: existing };
+
+  const activityIndex = lines.findIndex((line) => {
+    const trimmed = line.trim();
+    return trimmed === `## ${ACTIVITY_ZH}` || trimmed === `## ${ACTIVITY_EN}`;
+  });
+  const heading = content.includes(`## ${ACTIVITY_EN}`) ? SECTION_EN : SECTION_ZH;
+  const block = [`## ${heading}`, "", "<!-- Workflow degradation, platform sync failures, permission gaps, and related events. Keep the header when empty. -->", "", HEADER, SEPARATOR, ""];
+  const insertAt = activityIndex >= 0 ? activityIndex : lines.length;
+  lines.splice(insertAt, 0, ...block);
+  const updated = lines.join("\n");
+  return { content: updated, section: findSection(updated.split(/\r?\n/)) };
+}
+
+function readTask(taskDir) {
+  const taskPath = path.join(taskDir, "task.md");
+  if (!fs.existsSync(taskPath)) {
+    throw new Error(`Task file not found: ${taskPath}`);
+  }
+  return { taskPath, content: fs.readFileSync(taskPath, "utf8") };
+}
+
+function parseWarnings(content) {
+  const lines = content.split(/\r?\n/);
+  const section = findSection(lines);
+  if (!section) return [];
+  const warnings = [];
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const cells = splitRow(lines[index]);
+    if (cells.length === 0) continue;
+    if ((cells[0] || "").toLowerCase() === "id") continue;
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) continue;
+    if (cells.length < 11) continue;
+    warnings.push(rowToWarning(cells, index));
+  }
+  return warnings;
+}
+
+function nextId(warnings) {
+  const max = warnings.reduce((current, warning) => {
+    const match = /^WW-(\d+)$/.exec(warning.id);
+    return match ? Math.max(current, Number.parseInt(match[1], 10)) : current;
+  }, 0);
+  return `WW-${max + 1}`;
+}
+
+function requireOption(options, key) {
+  const value = options[key];
+  if (!value) usage();
+  return value;
+}
+
+function add(taskDir, options) {
+  const severity = requireOption(options, "severity");
+  if (!VALID_SEVERITIES.has(severity)) throw new Error(`Invalid severity: ${severity}`);
+  const step = requireOption(options, "step");
+  const code = requireOption(options, "code");
+  const target = requireOption(options, "target");
+  const message = requireOption(options, "message");
+  const action = requireOption(options, "action");
+
+  const task = readTask(taskDir);
+  const inserted = insertSection(task.content);
+  const lines = inserted.content.split(/\r?\n/);
+  const warnings = parseWarnings(inserted.content);
+  const duplicate = warnings.find((warning) =>
+    warning.status === "open" &&
+    warning.step === step &&
+    warning.code === code &&
+    warning.target === target
+  );
+  if (duplicate) {
+    process.stdout.write(`${JSON.stringify({ created: false, warning: duplicate }, null, 2)}\n`);
+    if (inserted.content !== task.content) fs.writeFileSync(task.taskPath, inserted.content, "utf8");
+    return;
+  }
+
+  const warning = {
+    id: nextId(warnings),
+    time: timestamp(),
+    step,
+    severity,
+    code,
+    status: "open",
+    target,
+    message,
+    action,
+    resolved_at: "",
+    resolution: ""
+  };
+  lines.splice(inserted.section.end - 1, 0, warningToLine(warning));
+  fs.writeFileSync(task.taskPath, lines.join("\n"), "utf8");
+  process.stdout.write(`${JSON.stringify({ created: true, warning }, null, 2)}\n`);
+}
+
+function setStatus(taskDir, options) {
+  const id = requireOption(options, "id");
+  const status = requireOption(options, "status");
+  if (!["resolved", "ignored"].includes(status)) throw new Error(`Invalid status for set-status: ${status}`);
+  const resolution = requireOption(options, "resolution");
+  const task = readTask(taskDir);
+  const lines = task.content.split(/\r?\n/);
+  const warnings = parseWarnings(task.content);
+  const warning = warnings.find((candidate) => candidate.id === id);
+  if (!warning) throw new Error(`Warning not found: ${id}`);
+  warning.status = status;
+  warning.resolved_at = timestamp();
+  warning.resolution = resolution;
+  lines[warning.lineIndex] = warningToLine(warning);
+  fs.writeFileSync(task.taskPath, lines.join("\n"), "utf8");
+  process.stdout.write(`${JSON.stringify({ updated: true, warning }, null, 2)}\n`);
+}
+
+function list(taskDir, options) {
+  const format = options.format || "text";
+  const status = options.status || "";
+  if (format !== "json" && format !== "text") usage();
+  const warnings = parseWarnings(readTask(taskDir).content)
+    .filter((warning) => !status || warning.status === status)
+    .map(({ lineIndex: _lineIndex, ...warning }) => warning);
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify({ warnings }, null, 2)}\n`);
+    return;
+  }
+  for (const warning of warnings) {
+    process.stdout.write(`${warning.id} [${warning.severity}] ${warning.code} ${warning.target} - ${warning.action}\n`);
+  }
+}
+
+try {
+  const [command, taskDirArg, ...rest] = process.argv.slice(2);
+  if (!command || !taskDirArg) usage();
+  const taskDir = path.resolve(taskDirArg);
+  const options = parseOptions(rest);
+  if (command === "add") add(taskDir, options);
+  else if (command === "set-status") setStatus(taskDir, options);
+  else if (command === "list") list(taskDir, options);
+  else usage();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -165,3 +165,5 @@ Next step (alternative) - Skip monitoring and archive the task directly:
 - Push rejected: suggest `git pull --rebase`
 - Existing PR found: show the current PR URL and stop
 - Inaccessible Issue metadata: skip inheritance and continue
+- PR creation failed with an associated `{task-id}`: run `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-pr --severity ACTION_REQUIRED --code PR_CREATE_FAILED --target pr --message "{reason}" --action "Fix push, permission, or platform issues and rerun create-pr"` and do not write `pr_number`
+- PR summary comment failed with an associated `{task-id}`: record a `COMMENT_SYNC_FAILED` warning per `.agents/rules/pr-sync.md`, without rolling back an already-created PR

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -165,3 +165,5 @@ node .agents/scripts/validate-artifact.js gate create-pr .agents/workspace/activ
 - 推送被拒绝：建议执行 `git pull --rebase`
 - 已存在 PR：直接输出当前 PR URL 并结束
 - 无法访问 Issue 元数据：跳过继承并继续
+- PR 创建失败且已关联 `{task-id}`：调用 `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-pr --severity ACTION_REQUIRED --code PR_CREATE_FAILED --target pr --message "{reason}" --action "修复推送、权限或平台问题后重跑 create-pr"`，不写 `pr_number`
+- PR 摘要评论失败且已关联 `{task-id}`：按 `.agents/rules/pr-sync.md` 记录 `COMMENT_SYNC_FAILED` 告警，不回滚已创建 PR

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -135,7 +135,7 @@ The rule's content is determined by the configured code platform:
 
 Handle the result:
 - Rule successfully created the Issue: `issue_number` has been written back to task.md per the rule; continue by reading `.agents/rules/issue-sync.md`, completing upstream repository and permission detection, then sync the task comment and set `status: waiting-for-triage` by rule
-- Rule failed (auth / network / template parse / etc.): do not roll back task.md; do NOT append an extra Activity Log entry; follow "Scenario C: Issue creation failed" output to surface `error_code` and `error_message` to the user so they can decide whether to retry manually or write `issue_number` later
+- Rule failed (auth / network / template parse / etc.): do not roll back task.md; do NOT append an extra Activity Log entry; first run `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-task --severity ACTION_REQUIRED --code ISSUE_CREATE_FAILED --target issue --message "{error_code}: {error_message}" --action "Fix auth/network/template issues and manually retry Issue creation, or create/find an Issue and write issue_number"` to record a generic warning; then follow "Scenario C: Issue creation failed" output to surface `error_code` and `error_message`
 - Rule was a no-op (custom or empty platform): do not create comments, do not block the workflow, and do not write an Activity Log entry
 - task.md already has `issue_number`: the rule's prerequisite check skips creation; `create-task` proceeds directly to step 5
 
@@ -231,6 +231,9 @@ Next step - run requirements analysis:
   - Codex CLI: $analyze-task {task-ref}
 
 For later platform sync: after fixing auth / network / template issues, manually run the Issue creation flow in `.agents/rules/create-issue.md` for this task; or manually create/find an Issue and write `issue_number` into task.md so later skills can take over cascade sync.
+
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N ISSUE_CREATE_FAILED (issue): Fix auth/network/template issues and manually retry Issue creation, or create/find an Issue and write issue_number
 ```
 
 

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -134,7 +134,7 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 
 处理结果：
 - 规则成功创建 Issue：`issue_number` 已按规则回写到 task.md；继续读取 `.agents/rules/issue-sync.md`，完成 upstream 仓库检测和权限检测，然后同步 task 评论并按规则设置 `status: waiting-for-triage`
-- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`，让用户决定后续是否手动重试或写入 `issue_number`
+- 规则失败（认证 / 网络 / 模板解析等）：不回滚 task.md；不追加额外 Activity Log；先调用 `node .agents/scripts/workflow-warnings.js add .agents/workspace/active/{task-id} --step create-task --severity ACTION_REQUIRED --code ISSUE_CREATE_FAILED --target issue --message "{error_code}: {error_message}" --action "修复认证/网络/模板问题后手动重试 Issue 创建，或手动创建/找到 Issue 后写入 issue_number"` 记录通用告警；再按"场景 C：Issue 创建失败"输出向用户透出 `error_code` 与 `error_message`
 - 规则为 no-op（自定义或空平台）：不创建评论，不阻塞后续工作流，不写 Activity Log
 - task.md 已存在 `issue_number`：规则中的前置检查会跳过；`create-task` 直接进入步骤 5
 
@@ -230,6 +230,9 @@ Issue 创建失败：
   - Codex CLI：$analyze-task {task-ref}
 
 后续如需平台同步：修复认证/网络/模板问题后，可按 `.agents/rules/create-issue.md` 对当前任务手动执行一次 Issue 创建；或手动创建/查找 Issue，并把 `issue_number` 写入 task.md，后续技能会接管级联同步。
+
+[ACTION REQUIRED] Workflow warnings are open:
+  - WW-N ISSUE_CREATE_FAILED (issue): 修复认证/网络/模板问题后手动重试 Issue 创建，或手动创建/找到 Issue 后写入 issue_number
 ```
 
 

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -64,6 +64,13 @@ pr_status: pending             # PR status: pending (default) | created (PR crea
 
 <!-- Humans record rulings for needs-human-decision decisions here and flip matching HD- rows in the Review Disagreement Ledger to human-decided. -->
 
+## Workflow Warnings
+
+<!-- Workflow degradation, platform sync failures, permission gaps, and related events. Keep the header when empty. -->
+
+| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |
+|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|
+
 ## Activity Log
 
 <!-- Append a new entry for each workflow step. Do NOT overwrite previous entries. -->

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -64,6 +64,13 @@ pr_status: pending             # PR 状态：pending（默认）| created（已�
 
 <!-- 人类在此记录对 needs-human-decision 决策的裁定，并把 ## 审查分歧账本 对应 HD- 行翻为 human-decided。 -->
 
+## 工作流告警
+
+<!-- 工作流降级、平台同步失败、权限不足等需要后续注意的事件写入此段。无告警时保留表头即可。 -->
+
+| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |
+|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|
+
 ## 活动日志
 
 <!-- 每个工作流步骤追加一条新记录，不要覆盖之前的记录。 -->

--- a/tests/e2e/core/validate-artifact.test.ts
+++ b/tests/e2e/core/validate-artifact.test.ts
@@ -446,6 +446,47 @@ test("validate-artifact completion-checklist fails when a complete-task item is 
   })
 ));
 
+test("validate-artifact task-meta accepts a valid workflow warning with escaped pipes", () => (
+  withTempRoot("agent-infra-workflow-warning-pass-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    write(path.join(taskDir, "task.md"), [
+      buildTaskContent(),
+      "",
+      "## 工作流告警",
+      "",
+      "| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |",
+      "|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|",
+      String.raw`| WW-1 | 2026-07-09 12:00:00+08:00 | issue-sync | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | task-comment | failed a\\\|b | retry a\\\|b |  |  |`
+    ].join("\n"));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "code-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "task-meta", status: "pass" });
+  })
+));
+
+test("validate-artifact task-meta rejects invalid workflow warning lifecycle fields", () => (
+  withTempRoot("agent-infra-workflow-warning-fail-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    write(path.join(taskDir, "task.md"), [
+      buildTaskContent(),
+      "",
+      "## Workflow Warnings",
+      "",
+      "| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |",
+      "|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|",
+      "| WW-1 | 2026-07-09 12:00:00+08:00 | issue-sync | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | task-comment | failed |  |  |  |",
+      "| WW-2 | 2026-07-09 12:01:00+08:00 | issue-sync | INFO | METADATA_SYNC_SKIPPED | resolved | label | skipped | none |  |  |"
+    ].join("\n"));
+
+    const result = runValidator(["check", "task-meta", taskDir, "--skill", "code-task"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /open warning requires action/);
+    assert.match(result.stdout, /illegal severity 'INFO'/);
+    assert.match(result.stdout, /resolved warning requires resolved_at and resolution/);
+  })
+));
+
 test("PR summary callers reference the shared pr-sync rule", () => {
   assertPointsToPrSyncRule(".agents/skills/commit/reference/pr-summary-sync.md");
   assertPointsToPrSyncRule(".agents/skills/create-pr/reference/comment-publish.md");

--- a/tests/e2e/core/workflow-warnings-script.test.ts
+++ b/tests/e2e/core/workflow-warnings-script.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { buildTaskContent, parseValidatorPayload, runValidator, withTempRoot, write } from "./validate-artifact-helpers.ts";
+import { filePath } from "../../helpers.ts";
+
+const scriptPath = filePath(".agents/scripts/workflow-warnings.js");
+
+function runWarningScript(args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+    cwd: filePath(".")
+  });
+}
+
+test("workflow-warnings script inserts, deduplicates, lists, and closes warnings", () => (
+  withTempRoot("agent-infra-workflow-warnings-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    write(path.join(taskDir, "task.md"), buildTaskContent());
+
+    const addArgs = [
+      "add",
+      taskDir,
+      "--step",
+      "issue-sync",
+      "--severity",
+      "ACTION_REQUIRED",
+      "--code",
+      "COMMENT_SYNC_FAILED",
+      "--target",
+      "task-comment",
+      "--message",
+      "failed a\\|b",
+      "--action",
+      "retry a\\|b"
+    ];
+
+    const added = runWarningScript(addArgs);
+    assert.equal(added.status, 0, added.stderr);
+    assert.equal(JSON.parse(added.stdout).created, true);
+
+    const duplicate = runWarningScript(addArgs);
+    assert.equal(duplicate.status, 0, duplicate.stderr);
+    assert.equal(JSON.parse(duplicate.stdout).created, false);
+
+    const listed = runWarningScript(["list", taskDir, "--status", "open", "--format", "json"]);
+    assert.equal(listed.status, 0, listed.stderr);
+    const warnings = JSON.parse(listed.stdout).warnings;
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0].message, "failed a\\|b");
+    assert.equal(warnings[0].action, "retry a\\|b");
+
+    const gateBeforeClose = runValidator(["check", "task-meta", taskDir, "--skill", "code-task"]);
+    assert.equal(gateBeforeClose.status, 0, gateBeforeClose.stderr);
+
+    const closed = runWarningScript([
+      "set-status",
+      taskDir,
+      "--id",
+      "WW-1",
+      "--status",
+      "resolved",
+      "--resolution",
+      "manual sync completed"
+    ]);
+    assert.equal(closed.status, 0, closed.stderr);
+    assert.equal(JSON.parse(closed.stdout).warning.status, "resolved");
+
+    const payload = parseValidatorPayload(runValidator(["check", "task-meta", taskDir, "--skill", "code-task"]).stdout);
+    assert.equal(payload.status, "pass");
+  })
+));

--- a/tests/unit/cli/server-daemon.test.ts
+++ b/tests/unit/cli/server-daemon.test.ts
@@ -51,6 +51,7 @@ const statusModel: StatusModel = {
   shortId: '#01',
   title: 'demo title',
   metadata: [['current_step', 'code']],
+  workflowWarnings: [],
   artifacts: { count: 1, groups: [{ stage: 'plan', files: ['plan.md'] }] },
   workflow: {
     state: 'in-progress',

--- a/tests/unit/cli/task-status.test.ts
+++ b/tests/unit/cli/task-status.test.ts
@@ -263,6 +263,7 @@ const baseModel: StatusModel = {
     ['type', 'feature'],
     ['status', 'active']
   ],
+  workflowWarnings: [],
   artifacts: {
     count: 2,
     groups: [
@@ -311,6 +312,27 @@ test('renderStatus emits workflow and runtime before git', () => {
   assert.match(out, /^Git$/m);
   // Stage group renders its files joined, in order.
   assert.match(out, /^  plan +plan\.md, plan-r2\.md$/m);
+});
+
+test('renderStatus shows open workflow warnings after metadata', () => {
+  const out = renderStatus({
+    ...baseModel,
+    workflowWarnings: [{
+      id: 'WW-1',
+      time: '2026-07-09 12:00:00+08:00',
+      step: 'create-task',
+      severity: 'ACTION_REQUIRED',
+      code: 'ISSUE_CREATE_FAILED',
+      status: 'open',
+      target: 'issue',
+      message: 'Issue creation failed',
+      action: 'Authenticate gh and rerun create-task',
+      resolvedAt: '',
+      resolution: ''
+    }]
+  }).join('\n');
+  assert.match(out, /^Metadata[\s\S]*^Workflow Warnings \(1 open\)$/m);
+  assert.match(out, /^  WW-1 \[ACTION_REQUIRED\] ISSUE_CREATE_FAILED issue - Authenticate gh and rerun create-task$/m);
 });
 
 test('renderStatus shows (none) when a task has no artifacts', () => {

--- a/tests/unit/task/workflow-warnings.test.ts
+++ b/tests/unit/task/workflow-warnings.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getOpenWorkflowWarnings,
+  parseWorkflowWarnings,
+  formatWorkflowWarningSummary
+} from '../../../lib/task/workflow-warnings.ts';
+
+test('parseWorkflowWarnings reads Chinese and English warning sections', () => {
+  const zh = [
+    '# 任务',
+    '',
+    '## 工作流告警',
+    '',
+    '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+    '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+    '| WW-1 | 2026-07-09 12:00:00+08:00 | create-task | ACTION_REQUIRED | ISSUE_CREATE_FAILED | open | issue | message | retry auth |  |  |'
+  ].join('\n');
+  const en = zh.replace('## 工作流告警', '## Workflow Warnings');
+
+  assert.equal(parseWorkflowWarnings(zh).length, 1);
+  assert.equal(parseWorkflowWarnings(en).length, 1);
+});
+
+test('parseWorkflowWarnings restores escaped pipes and filters open warnings', () => {
+  const content = [
+    '## Workflow Warnings',
+    '',
+    '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+    '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+    '| WW-1 | 2026-07-09 12:00:00+08:00 | issue-sync | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | task-comment | failed a\\|b | rerun a\\|b |  |  |',
+    '| WW-2 | 2026-07-09 12:01:00+08:00 | issue-sync | IMPORTANT | METADATA_SYNC_SKIPPED | ignored | label | skipped | none | 2026-07-09 12:02:00+08:00 | not needed |'
+  ].join('\n');
+
+  const warnings = parseWorkflowWarnings(content);
+  assert.equal(warnings[0]!.message, 'failed a|b');
+  assert.equal(warnings[0]!.action, 'rerun a|b');
+  assert.deepEqual(getOpenWorkflowWarnings(content).map((warning) => warning.id), ['WW-1']);
+});
+
+test('parseWorkflowWarnings restores escaped backslashes before pipes', () => {
+  const content = String.raw`## Workflow Warnings
+
+| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |
+|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|
+| WW-1 | 2026-07-09 12:00:00+08:00 | issue-sync | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | task-comment | failed a\\\|b | rerun a\\\|b |  |  |`;
+
+  const [warning] = parseWorkflowWarnings(content);
+  assert.equal(warning!.message, 'failed a\\|b');
+  assert.equal(warning!.action, 'rerun a\\|b');
+});
+
+test('parseWorkflowWarnings accepts CRLF line endings', () => {
+  const content = [
+    '## Workflow Warnings',
+    '',
+    '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+    '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+    '| WW-1 | 2026-07-09 12:00:00+08:00 | create-task | IMPORTANT | PERMISSION_DEGRADED | open | label | skipped | wait for maintainer |  |  |'
+  ].join('\r\n');
+
+  assert.equal(parseWorkflowWarnings(content).length, 1);
+});
+
+test('formatWorkflowWarningSummary includes actionable fields', () => {
+  const warnings = parseWorkflowWarnings([
+    '## Workflow Warnings',
+    '',
+    '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+    '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+    '| WW-1 | 2026-07-09 12:00:00+08:00 | create-pr | ACTION_REQUIRED | PR_CREATE_FAILED | open | pr | failed | retry create-pr |  |  |'
+  ].join('\n'));
+
+  assert.deepEqual(formatWorkflowWarningSummary(warnings), [
+    'WW-1 [ACTION_REQUIRED] PR_CREATE_FAILED pr - retry create-pr'
+  ]);
+});

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -89,6 +89,7 @@ test("required template files were migrated into templates/", () => {
     "templates/.agents/workspace/README.en.md",
     "templates/.agents/workspace/README.zh-CN.md",
     "templates/.agents/scripts/validate-artifact.js",
+    "templates/.agents/scripts/workflow-warnings.js",
     "templates/.agents/scripts/lib/review-artifacts.js",
     "templates/.git-hooks/check-version-format.sh",
     "templates/.git-hooks/pre-commit",
@@ -174,6 +175,18 @@ test("task templates include human ruling sections", () => {
   }
 });
 
+test("task templates include workflow warning sections", () => {
+  for (const [relativePath, heading] of [
+    [".agents/templates/task.md", "## 工作流告警"],
+    ["templates/.agents/templates/task.en.md", "## Workflow Warnings"],
+    ["templates/.agents/templates/task.zh-CN.md", "## 工作流告警"]
+  ] as Array<[string, string]>) {
+    const content = read(relativePath);
+    assert.match(content, new RegExp(`^${escapeRegExp(heading)}$`, "m"));
+    assert.match(content, /^\| id \| time \| step \| severity \| code \| status \| target \| message \| action \| resolved_at \| resolution \|$/m);
+  }
+});
+
 test("update-agent-infra template copies stay in sync with working files", () => {
   const collaborator = JSON.parse(read(".agents/.airc.json"));
   const project = collaborator.project;
@@ -204,6 +217,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/skills/import-issue/SKILL.md", "templates/.agents/skills/import-issue/SKILL.en.md"],
     [".agents/skills/import-issue/config/verify.json", "templates/.agents/skills/import-issue/config/verify.json"],
     [".agents/scripts/find-existing-task.js", "templates/.agents/scripts/find-existing-task.js"],
+    [".agents/scripts/workflow-warnings.js", "templates/.agents/scripts/workflow-warnings.js"],
     [".agents/skills/init-labels/SKILL.md", "templates/.agents/skills/init-labels/SKILL.en.md"],
     [".agents/skills/plan-task/SKILL.md", "templates/.agents/skills/plan-task/SKILL.en.md"],
     [".agents/skills/review-code/SKILL.md", "templates/.agents/skills/review-code/SKILL.en.md"],


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** Closes #587 👈👈

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created a related Issue and discussed the changes
- [ ] 这是一个微小的修改，不需要 Issue / This is a minor change that doesn't require an Issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 配置变更 / Configuration change
- [ ] ⚡ 性能改进 / Performance improvement
- [ ] 📦 依赖更新 / Dependency update
- [x] 🚀 功能增强 / Enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

当前工作流在 Issue、PR、评论、label、milestone 等平台级联动作失败或降级时，后续从 task.md 和 ai task status 难以看到同步缺口。本次引入通用 Workflow Warnings 机制，用同一套表格、helper、校验和输出规则记录这些降级事件，并在状态展示和最终输出中提示后续动作。

## 📋 主要变更 / Brief Changelog

- Add a Workflow Warnings section to task templates with lifecycle fields for open, resolved, and ignored warnings.
- Add `workflow-warnings.js` helpers plus parser/status rendering for open warning summaries.
- Extend artifact validation to check warning structure, lifecycle fields, and escaped table cells.
- Update create-task, create-pr, issue-sync, pr-sync, and next-step-output rules/templates to record and surface warning events.
- Add unit, e2e, and template coverage for warning parsing, helper lifecycle operations, status output, and validation gates.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. `npm test`
2. Commit hook: `npm run typecheck`
3. Commit hook: `npm run test:core`
4. `node .agents/scripts/validate-artifact.js gate commit .agents/workspace/active/TASK-20260708-194833 --format text`

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

N/A

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 我的代码遵循项目的代码风格 / My code follows the project's coding standards
- [x] 我已经进行了自我审查 / I have performed a self-review
- [x] 我已经添加了必要的注释 / I have added necessary comments
- [x] 我已经更新了相关文档 / I have updated relevant documentation
- [x] 我的更改没有引入新的警告 / My changes generate no new warnings
- [x] 我已经添加了测试来证明修复或功能有效 / I have added tests proving the fix or feature works
- [x] 新旧单元测试都通过 / New and existing unit tests pass locally
- [x] 任何依赖变更都已记录 / Any dependency changes have been documented
- [ ] 我已经更新了 CHANGELOG / I have updated the CHANGELOG
- [ ] 这是一个破坏性变更 / This is a breaking change

## 📋 附加信息 / Additional Notes

- PR milestone reuses Issue #587 milestone `0.8.3`.
- `review-code-r2.md` approved the implementation with 0 blockers, 0 major, 0 minor, and 0 manual-validation items.
- `last_reviewed_commit` points to `13ffddf664fdd7c473ae9800b8b5694b88153a6d`.
- Workflow warning compensation remains manual by HD-1; this PR records warnings and suggested actions but does not add a user-facing retry command.

---

**审查者注意事项 / Reviewer Notes:**
重点关注 workflow warning 表格解析/转义在 helper、TypeScript parser、validator 三处是否保持一致，以及 create-task/create-pr/issue/pr sync 规则是否只记录通用告警、不引入场景专用字段。

Generated with AI assistance

