### PR TITLE
fix(sandbox): Windows WSL2 (Ubuntu 22.04+) 沙箱镜像构建时 uid=1000/gid=1000 冲突导致失败

### DIFF
--- a/lib/sandbox/runtimes/base.dockerfile
+++ b/lib/sandbox/runtimes/base.dockerfile
@@ -12,6 +12,9 @@ RUN if [ "${HOST_UID}" = "0" ]; then \
         (groupadd -o -g ${HOST_GID} devuser || true) && \
         useradd -o -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser; \
     else \
+        if ubuntu_uid="$(id -u ubuntu 2>/dev/null)" && [ "${ubuntu_uid}" = "${HOST_UID}" ]; then \
+            userdel -r ubuntu || exit 1; \
+        fi; \
         (groupadd -g ${HOST_GID} devuser || true) && \
         useradd -u ${HOST_UID} -g ${HOST_GID} -m -s /bin/bash devuser; \
     fi

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -578,6 +578,138 @@ test("base.dockerfile guards root host uid with useradd -o", () => {
   assert.match(content, /useradd -o -u \$\{HOST_UID\}/);
 });
 
+test("base.dockerfile handles the preinstalled ubuntu UID conflict", onPlatforms("linux", "darwin"), async (t) => {
+  const content = fs.readFileSync(filePath("lib/sandbox/runtimes/base.dockerfile"), "utf8");
+  const runBlock = content
+    .split(/^(?=FROM |USER |ENV |ARG |RUN |WORKDIR |CMD |COPY |ADD )/m)
+    .find((block) => block.startsWith("RUN ") && block.includes("useradd"));
+  assert.ok(runBlock, "expected a RUN block creating devuser");
+
+  const shellBody = runBlock.replace(/^RUN\s+/, "").replace(/\\\n\s*/g, " ").trim();
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-user-stubs-"));
+  const logFile = path.join(stubDir, "invocations.log");
+  const stubs = {
+    id: [
+      "#!/bin/sh",
+      "printf 'id %s\\n' \"$*\" >> \"$INVOCATIONS_LOG\"",
+      "[ \"$*\" = \"-u ubuntu\" ] && [ -n \"$STUB_UBUNTU_UID\" ] || exit 1",
+      "printf '%s\\n' \"$STUB_UBUNTU_UID\""
+    ],
+    userdel: [
+      "#!/bin/sh",
+      "printf 'userdel %s\\n' \"$*\" >> \"$INVOCATIONS_LOG\"",
+      'exit "${STUB_USERDEL_STATUS:-0}"'
+    ],
+    groupadd: [
+      "#!/bin/sh",
+      "printf 'groupadd %s\\n' \"$*\" >> \"$INVOCATIONS_LOG\""
+    ],
+    useradd: [
+      "#!/bin/sh",
+      "printf 'useradd %s\\n' \"$*\" >> \"$INVOCATIONS_LOG\""
+    ]
+  };
+
+  try {
+    for (const [name, lines] of Object.entries(stubs)) {
+      fs.writeFileSync(path.join(stubDir, name), `${lines.join("\n")}\n`, { mode: 0o755 });
+    }
+
+    const cases = [
+      {
+        name: "removes a matching ubuntu account before creating devuser",
+        uid: "1000",
+        gid: "1000",
+        ubuntuUid: "1000",
+        userdelStatus: "0",
+        status: 0,
+        invocations: [
+          "id -u ubuntu",
+          "userdel -r ubuntu",
+          "groupadd -g 1000 devuser",
+          "useradd -u 1000 -g 1000 -m -s /bin/bash devuser"
+        ]
+      },
+      {
+        name: "preserves the macOS 501 mapping when ubuntu has UID 1000",
+        uid: "501",
+        gid: "20",
+        ubuntuUid: "1000",
+        userdelStatus: "0",
+        status: 0,
+        invocations: [
+          "id -u ubuntu",
+          "groupadd -g 20 devuser",
+          "useradd -u 501 -g 20 -m -s /bin/bash devuser"
+        ]
+      },
+      {
+        name: "creates devuser when the ubuntu account is absent",
+        uid: "1000",
+        gid: "1000",
+        ubuntuUid: "",
+        userdelStatus: "0",
+        status: 0,
+        invocations: [
+          "id -u ubuntu",
+          "groupadd -g 1000 devuser",
+          "useradd -u 1000 -g 1000 -m -s /bin/bash devuser"
+        ]
+      },
+      {
+        name: "keeps the root mapping branch unchanged",
+        uid: "0",
+        gid: "0",
+        ubuntuUid: "1000",
+        userdelStatus: "0",
+        status: 0,
+        invocations: [
+          "groupadd -o -g 0 devuser",
+          "useradd -o -u 0 -g 0 -m -s /bin/bash devuser"
+        ]
+      },
+      {
+        name: "stops before group creation when ubuntu cleanup fails",
+        uid: "1000",
+        gid: "1000",
+        ubuntuUid: "1000",
+        userdelStatus: "1",
+        status: 1,
+        invocations: [
+          "id -u ubuntu",
+          "userdel -r ubuntu"
+        ]
+      }
+    ];
+
+    for (const scenario of cases) {
+      await t.test(scenario.name, () => {
+        fs.rmSync(logFile, { force: true });
+        const result = spawnSync("/bin/sh", ["-c", shellBody], {
+          env: {
+            ...process.env,
+            PATH: `${stubDir}:${process.env.PATH}`,
+            HOST_UID: scenario.uid,
+            HOST_GID: scenario.gid,
+            INVOCATIONS_LOG: logFile,
+            STUB_UBUNTU_UID: scenario.ubuntuUid,
+            STUB_USERDEL_STATUS: scenario.userdelStatus
+          },
+          encoding: "utf8"
+        });
+        const invocations = fs.existsSync(logFile)
+          ? fs.readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean)
+          : [];
+
+        assert.equal(result.status, scenario.status, result.stderr);
+        assert.deepEqual(invocations, scenario.invocations);
+      });
+    }
+  } finally {
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  }
+});
+
 test("composeDockerfile rejects unknown runtimes", async () => {
   const sandboxDockerfile = await loadFreshEsm<typeof import("../../../lib/sandbox/dockerfile.ts")>("lib/sandbox/dockerfile.js");
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #589

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #589

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 Windows 11 + WSL2（Ubuntu 22.04/24.04）环境下，沙箱基础镜像在创建 `devuser` 时与预置的 `ubuntu` 账户发生 UID=1000 冲突，导致 `ai sandbox create` 在 Docker 构建阶段失败的问题。

## 📋 主要变更 / Brief Changelog

- 在 `lib/sandbox/runtimes/base.dockerfile` 中，仅当预置 `ubuntu` 账户的 UID 与 `HOST_UID` 一致时才删除该账户，并在清理失败时立即终止构建。
- 在 `tests/integration/cli/sandbox-dockerfile.test.ts` 中补齐五个场景的行为测试，覆盖冲突成功、非冲突 UID/GID、账户缺失、root 分支和清理失败传播。
- 保持非 `1000/1000` 映射行为不变，避免引入 UID/GID 回归。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm test` 完成构建、类型检查和全量测试。
2. 运行 `node .agents/scripts/review-diff-fingerprint.js staged 8fb592b1fd8316fbcc2ad7c23f8c502bb58944c2` 验证 staged diff 指纹与审查基线一致。
3. 以真实 Docker + Windows 11 + WSL2 环境执行 `ai sandbox create <branch>`，确认完整沙箱链路成功。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

自动化结果：`npm test` 1394 通过、1 跳过、0 失败；`test:core` 1136 通过、1 跳过、0 失败；`typecheck` 通过。

## 📸 截图 / Screenshots

不适用：本次改动为 Dockerfile 与行为测试修复，无 UI 变更。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更（微小变更除外）
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更
- [x] PR 中的每个 commit 都有有意义的主题行和描述
- [x] 我的代码遵循项目的代码规范
- [x] 我已经进行了自我代码审查
- [x] 我已经为复杂的代码添加了必要的注释
- [x] 我已经编写了必要的单元测试来验证逻辑正确性
- [x] 当存在跨模块依赖时，我尽量使用了 mock
- [x] 代码检查通过
- [x] 单元测试通过
- [ ] 我已经更新了相应的文档
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明
- [x] 我已经考虑了向后兼容性

## 📋 附加信息 / Additional Notes

当前实现严格采用“精确匹配预置 `ubuntu` 账户 + UID 一致时删除”的方案，避免 `useradd -o` 带来的重复 UID 语义歧义。真实 Docker 镜像与 Windows WSL2 端到端验证仍需维护者在目标环境执行。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 `userdel -r ubuntu || exit 1` 的失败传播、macOS 501/20 分支不受影响，以及测试对五个场景的完整覆盖。

Generated with AI assistance