### PR TITLE
fix(sandbox): Windows WSL2 沙箱回退宿主机 gh token

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -629,6 +629,7 @@ export function buildContainerEnvFile(
     chmodFn?: typeof fs.chmodSync;
     rmFn?: typeof fs.rmSync;
     tmpDir?: string;
+    runSafeFn?: DirectRunSafeFn;
   } = {}
 ): { dockerArgs: string[]; cleanup: () => void } {
   const {
@@ -636,11 +637,15 @@ export function buildContainerEnvFile(
     writeFileFn = fs.writeFileSync,
     chmodFn = fs.chmodSync,
     rmFn = fs.rmSync,
-    tmpDir = os.tmpdir()
+    tmpDir = os.tmpdir(),
+    runSafeFn = runSafe
   } = options;
 
   const entries: Array<[string, string]> = resolvedTools.flatMap(({ tool }) => Object.entries(tool.envVars ?? {}));
-  const ghToken = runSafeEngineFn(engine, 'gh', ['auth', 'token']);
+  let ghToken = runSafeEngineFn(engine, 'gh', ['auth', 'token']);
+  if (!ghToken && engine === 'wsl2') {
+    ghToken = runSafeFn('gh', ['auth', 'token']);
+  }
   if (ghToken) {
     entries.push(['GH_TOKEN', ghToken]);
   }

--- a/tests/integration/cli/sandbox-dotfiles.test.ts
+++ b/tests/integration/cli/sandbox-dotfiles.test.ts
@@ -166,6 +166,74 @@ test("buildContainerEnvFile stores GH_TOKEN in the env file but not docker argv"
   }
 });
 
+test("buildContainerEnvFile falls back to the host GH token on WSL2", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-wsl2-token-"));
+  const calls: string[] = [];
+
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([], "wsl2", (engine, cmd, args) => {
+      calls.push(`${engine}:${cmd}:${args.join(" ")}`);
+      return "";
+    }, {
+      tmpDir,
+      runSafeFn: (cmd: string, args: string[]) => {
+        calls.push(`host:${cmd}:${args.join(" ")}`);
+        return "ghp_host_token";
+      }
+    });
+    const envPath = required(envFile.dockerArgs[1]);
+
+    assert.deepEqual(calls, ["wsl2:gh:auth token", "host:gh:auth token"]);
+    assert.equal(fs.readFileSync(envPath, "utf8"), "GH_TOKEN=ghp_host_token\n");
+    assert.ok(!envFile.dockerArgs.some((arg) => arg.includes("ghp_host_token")));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvFile keeps the WSL2 engine token as the preferred result", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-wsl2-preferred-"));
+
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([], "wsl2", () => "ghp_engine_token", {
+      tmpDir,
+      runSafeFn: () => {
+        throw new Error("host fallback must not run");
+      }
+    });
+    const envPath = required(envFile.dockerArgs[1]);
+
+    assert.equal(fs.readFileSync(envPath, "utf8"), "GH_TOKEN=ghp_engine_token\n");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvFile does not use the host fallback outside WSL2", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+
+  const envFile = sandboxCreate.buildContainerEnvFile([], "native", () => "", {
+    runSafeFn: () => {
+      throw new Error("host fallback must not run");
+    }
+  });
+
+  assert.deepEqual(envFile.dockerArgs, []);
+});
+
+test("buildContainerEnvFile remains best-effort when both WSL2 token lookups fail", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+
+  const envFile = sandboxCreate.buildContainerEnvFile([], "wsl2", () => "", {
+    runSafeFn: () => ""
+  });
+
+  assert.deepEqual(envFile.dockerArgs, []);
+  assert.doesNotThrow(() => envFile.cleanup());
+});
+
 test("buildContainerEnvFile returns empty docker args when there are no env vars", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
 
@@ -216,6 +284,7 @@ test("buildContainerEnvFile uses engine-aware env-file paths for WSL2", async ()
     { tool: { envVars: { FOO: "bar" } } }
   ], "wsl2", () => "", {
     tmpDir: "F:\\tmp",
+    runSafeFn: () => "",
     mkdtempFn: () => "F:\\tmp\\agent-infra-env-fixed",
     writeFileFn: () => {},
     chmodFn: () => {},

--- a/tests/integration/cli/sandbox-dotfiles.test.ts
+++ b/tests/integration/cli/sandbox-dotfiles.test.ts
@@ -170,6 +170,7 @@ test("buildContainerEnvFile falls back to the host GH token on WSL2", async () =
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-wsl2-token-"));
   const calls: string[] = [];
+  let hostEnvDir = "";
 
   try {
     const envFile = sandboxCreate.buildContainerEnvFile([], "wsl2", (engine, cmd, args) => {
@@ -177,15 +178,18 @@ test("buildContainerEnvFile falls back to the host GH token on WSL2", async () =
       return "";
     }, {
       tmpDir,
+      mkdtempFn: (prefix: string) => {
+        hostEnvDir = fs.mkdtempSync(prefix);
+        return hostEnvDir;
+      },
       runSafeFn: (cmd: string, args: string[]) => {
         calls.push(`host:${cmd}:${args.join(" ")}`);
         return "ghp_host_token";
       }
     });
-    const envPath = required(envFile.dockerArgs[1]);
 
     assert.deepEqual(calls, ["wsl2:gh:auth token", "host:gh:auth token"]);
-    assert.equal(fs.readFileSync(envPath, "utf8"), "GH_TOKEN=ghp_host_token\n");
+    assert.equal(fs.readFileSync(path.join(hostEnvDir, "env"), "utf8"), "GH_TOKEN=ghp_host_token\n");
     assert.ok(!envFile.dockerArgs.some((arg) => arg.includes("ghp_host_token")));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -195,17 +199,21 @@ test("buildContainerEnvFile falls back to the host GH token on WSL2", async () =
 test("buildContainerEnvFile keeps the WSL2 engine token as the preferred result", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-env-file-wsl2-preferred-"));
+  let hostEnvDir = "";
 
   try {
     const envFile = sandboxCreate.buildContainerEnvFile([], "wsl2", () => "ghp_engine_token", {
       tmpDir,
+      mkdtempFn: (prefix: string) => {
+        hostEnvDir = fs.mkdtempSync(prefix);
+        return hostEnvDir;
+      },
       runSafeFn: () => {
         throw new Error("host fallback must not run");
       }
     });
-    const envPath = required(envFile.dockerArgs[1]);
 
-    assert.equal(fs.readFileSync(envPath, "utf8"), "GH_TOKEN=ghp_engine_token\n");
+    assert.equal(fs.readFileSync(path.join(hostEnvDir, "env"), "utf8"), "GH_TOKEN=ghp_engine_token\n");
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #588

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #588

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

修复 Windows 11 使用 WSL2 引擎创建沙箱时，因 `gh` 仅安装并登录于 Windows 宿主机而无法向容器传入 `GH_TOKEN` 的问题。

## 📋 主要变更 / Brief Changelog

- 保留 WSL2 内 `gh auth token` 为首选凭据来源，仅在其返回空结果时回退到 Windows 宿主机。
- 复用现有私有 env file 管道传递回退 token，避免 token 出现在 Docker argv 中。
- 新增 4 组集成测试，覆盖回退成功、首选短路、非 WSL2 边界和双路径失败。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm test`。
3. 在 Windows 11 + WSL2 环境中，使宿主机已登录 `gh`、WSL2 内 `gh auth token` 不可用，创建沙箱并在容器内运行 `gh auth status`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了集成测试 / I have added integration tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

自动化结果：`npm test` 1411 通过、1 项按平台条件跳过、0 失败；`test:core` 1149 通过、1 跳过、0 失败；typecheck 通过。

## 📸 截图 / Screenshots

不适用：本次改动为 CLI 凭据发现与测试，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #588。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要测试，构建、类型检查和全量测试通过。
- [x] 已考虑向后兼容性；非 WSL2 行为保持不变。
- [ ] 已完成 Windows 11 + WSL2 真实环境人工验证。

## 📋 附加信息 / Additional Notes

两条 token 查询路径均失败时继续保持 best-effort 行为，不阻断沙箱创建。真实 Windows PATH 中 `gh.exe` 的解析与完整容器认证链路需维护者在目标环境验证。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 WSL2 条件门禁、引擎 token 的优先级、宿主回退的 best-effort 语义，以及 token 不进入 Docker argv 的安全边界。

Generated with AI assistance