### PR TITLE
fix(cli): 修复 Codex 沙箱配置文件的 tmpfs 种子方式

### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -98,6 +98,11 @@ Host aliases:
 type SandboxCreateConfig = ReturnType<typeof loadConfig>;
 type PreparedDockerfile = ReturnType<typeof prepareDockerfile>;
 type ResolvedTool = { tool: SandboxTool; dir: string };
+type TmpfsSeedPlanEntry = {
+  stagingPath: string;
+  targetPath: string;
+  volumeArgs: string[];
+};
 type RuntimeCheck = { name: string; cmd: string[] };
 type JsonObject = Record<string, unknown>;
 type GpgCache = { pub: Buffer; sec: Buffer } | null;
@@ -1493,6 +1498,7 @@ export async function create(args: string[]): Promise<void> {
             : null;
           const envFile = buildContainerEnvFile(effectiveResolvedTools, engine);
           let hostShellConfig: HostShellConfig;
+          let tmpfsSeedPlan: TmpfsSeedPlanEntry[] = [];
           try {
             const claudeCodeEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'claude-code');
             if (claudeCodeEntry) {
@@ -1533,22 +1539,24 @@ export async function create(args: string[]): Promise<void> {
               '-v',
               volumeArg(engine, hostPath, containerPath, ':ro')
             ]);
-            // A tmpfs containerMount starts empty, so the config seeded into the
-            // host dir before launch would be invisible in-container. Bind only
-            // the explicitly declared seed entries (config.toml, model-catalogs)
-            // back over the tmpfs as nested mounts — the same proven mechanism as
-            // hostLiveMounts/auth.json, established at `docker run` time (no
-            // post-start `docker cp`, which can land under a freshly-mounted
-            // tmpfs instead of inside it). The allowlist is deliberate: any
-            // runtime files left in the host dir (e.g. a stale logs_2.sqlite or
-            // sessions/ from a previous bind-mount era) must NOT be re-mounted,
-            // or the high-churn writes would land on the host SSD again.
-            const tmpfsSeedVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) =>
-              (tool.tmpfs?.seed ?? []).flatMap((entry) => {
+            // Mount each declared seed read-only at an isolated staging path.
+            // After docker run mounts the empty tmpfs, the container's default
+            // user copies these entries into it so the runtime targets are normal,
+            // writable files rather than nested mount points. The allowlist keeps
+            // stale runtime files (logs_2.sqlite, sessions, etc.) on the host from
+            // being exposed or written through.
+            tmpfsSeedPlan = effectiveResolvedTools.flatMap(({ tool, dir }) =>
+              (tool.tmpfs?.seed ?? []).flatMap((entry, index) => {
                 const hostPath = path.join(dir, entry);
-                return fs.existsSync(hostPath)
-                  ? ['-v', volumeArg(engine, hostPath, path.posix.join(tool.containerMount, entry))]
-                  : [];
+                if (!fs.existsSync(hostPath)) {
+                  return [];
+                }
+                const stagingPath = path.posix.join('/run/agent-infra/tmpfs-seeds', tool.id, String(index));
+                return [{
+                  stagingPath,
+                  targetPath: path.posix.join(tool.containerMount, entry),
+                  volumeArgs: ['-v', volumeArg(engine, hostPath, stagingPath, ':ro')]
+                }];
               })
             );
             const liveMountVolumes = effectiveResolvedTools.flatMap(({ tool }) =>
@@ -1604,7 +1612,7 @@ export async function create(args: string[]): Promise<void> {
               ...dotfilesMount,
               ...toolVolumes,
               ...tmpfsArgs,
-              ...tmpfsSeedVolumes,
+              ...tmpfsSeedPlan.flatMap(({ volumeArgs }) => volumeArgs),
               ...liveMountVolumes,
               ...shellConfigVolumes,
               ...envFile.dockerArgs,
@@ -1615,6 +1623,15 @@ export async function create(args: string[]): Promise<void> {
             ]);
           } finally {
             envFile.cleanup();
+          }
+
+          for (const { stagingPath, targetPath } of tmpfsSeedPlan) {
+            runEngineTaskCommand(engine, 'docker', [
+              'exec', container, 'mkdir', '-p', path.posix.dirname(targetPath)
+            ]);
+            runEngineTaskCommand(engine, 'docker', [
+              'exec', container, 'cp', '-R', '--', stagingPath, targetPath
+            ]);
           }
 
           // Belt-and-suspenders: re-create the four shell-config symlinks at

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -327,12 +327,14 @@ export function writeSanitizedGitconfig({
 const SHELL_CONFIG_SYMLINKS = ['.gitconfig', '.gitignore_global', '.stCommitMsg', '.bash_aliases'];
 
 export function ensureShellConfigSymlinks(engine: string, container: string, execFn: EngineExecFn = execEngine): void {
-  // Idempotent symlink setup. Runs against a started container so it also
-  // covers custom Dockerfiles that don't bake the symlinks into the image.
-  const script = SHELL_CONFIG_SYMLINKS
-    .map((file) => `ln -sf .host-shell-config/${file} ${CONTAINER_HOME}/${file}`)
-    .join(' && ');
-  execFn(engine, 'docker', ['exec', container, 'bash', '-lc', script], { stdio: 'ignore' });
+  // Idempotent symlink setup. Avoid a shell command here because Windows .cmd
+  // engine shims would interpret metacharacters in a `bash -lc` script before
+  // forwarding it to Docker.
+  for (const file of SHELL_CONFIG_SYMLINKS) {
+    execFn(engine, 'docker', [
+      'exec', container, 'ln', '-sf', `.host-shell-config/${file}`, `${CONTAINER_HOME}/${file}`
+    ], { stdio: 'ignore' });
+  }
 }
 
 export function prepareHostShellConfig({

--- a/lib/sandbox/shell.ts
+++ b/lib/sandbox/shell.ts
@@ -52,7 +52,7 @@ function resolveCommand(cmd: string): string {
   return cmd;
 }
 
-function commandOptions<T extends CommandOptions>(cmd: string, opts: T): T | (T & { shell: true }) {
+function commandOptions<T extends object>(cmd: string, opts: T): T | (T & { shell: true }) {
   if (process.platform === 'win32' && /\.(?:bat|cmd)$/i.test(cmd)) {
     return { ...opts, shell: true };
   }
@@ -153,7 +153,8 @@ export function runEngine(engine: string, cmd: string, args: string[], opts: Com
 
 export function execEngine(engine: string, cmd: string, args: string[], opts: ExecFileSyncOptions = {}) {
   const command = commandForEngine(engine, cmd, args);
-  return execFileSync(command.cmd, command.args, opts);
+  const resolved = resolveCommand(command.cmd);
+  return execFileSync(resolved, command.args, commandOptions(resolved, opts));
 }
 
 export function runOkEngine(engine: string, cmd: string, args: string[], opts: CommandOptions = {}): boolean {

--- a/lib/sandbox/tools.ts
+++ b/lib/sandbox/tools.ts
@@ -22,9 +22,9 @@ export type SandboxTool = {
   // When set, containerMount is mounted as an in-container tmpfs (RAM) instead
   // of bind-mounting the host config dir, keeping high-churn tool logs off the
   // host disk. `seed` lists the host-dir entries (relative to the tool's config
-  // dir) to bind back over the tmpfs so seeded config stays visible — it is an
-  // explicit allowlist so runtime files (e.g. logs_2.sqlite, sessions) left in
-  // the host dir are NOT re-mounted, which would defeat the tmpfs.
+  // dir) to copy into the tmpfs when the container starts. It is an explicit
+  // allowlist so runtime files (e.g. logs_2.sqlite, sessions) left in the host
+  // dir stay out of the container and seeded config cannot write back.
   tmpfs?: { size?: string; seed?: string[] };
 };
 
@@ -80,8 +80,8 @@ function createBuiltinTools(home: string, project: string): Record<string, Sandb
       // codex churns ~/.codex/logs_2.sqlite heavily (upstream openai/codex#24275);
       // a bind-mount would write-amplify onto the host SSD via virtiofs. Mount the
       // codex home as tmpfs so those logs stay in RAM and die with the container.
-      // Only the seeded config (config.toml, model-catalogs) is bound back over
-      // the tmpfs; runtime files like logs_2.sqlite must stay in RAM.
+      // Seeded config (config.toml, model-catalogs) is copied into the tmpfs at
+      // startup; runtime files like logs_2.sqlite stay in RAM.
       tmpfs: { size: '512m', seed: ['config.toml', 'model-catalogs'] },
       hostLiveMounts: [
         { hostPath: hostJoin(home, '.codex', 'auth.json'), containerSubpath: 'auth.json' }

--- a/tests/integration/cli/sandbox-git-config.test.ts
+++ b/tests/integration/cli/sandbox-git-config.test.ts
@@ -79,7 +79,7 @@ test("hostHasGpgKeys reports whether the host keyring is available", async () =>
   }), false);
 });
 
-test("ensureShellConfigSymlinks runs a single docker exec wiring all four $HOME entries", async () => {
+test("ensureShellConfigSymlinks wires all four $HOME entries without a shell command", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const calls: Array<{ engine: string; cmd: string; args: string[] }> = [];
   const fakeExec = (engine: string, cmd: string, args: string[]) => {
@@ -89,24 +89,18 @@ test("ensureShellConfigSymlinks runs a single docker exec wiring all four $HOME 
 
   sandboxCreate.ensureShellConfigSymlinks("docker", "agent-infra-dev-demo", fakeExec);
 
-  assert.equal(calls.length, 1, "single docker exec");
-  const call = required(calls[0]);
-  assert.equal(call.engine, "docker");
-  assert.equal(call.cmd, "docker");
-  assert.deepEqual(call.args.slice(0, 4), [
-    "exec",
-    "agent-infra-dev-demo",
-    "bash",
-    "-lc"
-  ]);
-  const script = required(call.args[4]);
-  for (const file of [".gitconfig", ".gitignore_global", ".stCommitMsg", ".bash_aliases"]) {
-    assert.match(
-      script,
-      new RegExp(`ln -sf \\.host-shell-config/${file.replace(".", "\\.")} /home/devuser/${file.replace(".", "\\.")}`),
-      `script wires ${file}`
-    );
-  }
+  assert.deepEqual(calls, [".gitconfig", ".gitignore_global", ".stCommitMsg", ".bash_aliases"].map((file) => ({
+    engine: "docker",
+    cmd: "docker",
+    args: [
+      "exec",
+      "agent-infra-dev-demo",
+      "ln",
+      "-sf",
+      `.host-shell-config/${file}`,
+      `/home/devuser/${file}`
+    ]
+  })));
 });
 
 test("prepareHostShellConfig writes sanitized config files and returns read-only mount metadata", async () => {

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -45,14 +45,24 @@ function spawnSandboxCli(
 }
 
 // Treat an arg as a mount whose container target equals containerPath, ignoring
-// an optional SELinux relabel suffix (:z / :Z). Plain string ops, no RegExp from
-// the path.
+// read-only and SELinux mount options. Plain string ops, no RegExp from the path.
 function isMountFor(arg: string, containerPath: string): boolean {
-  const target = arg.replace(/:[zZ]$/, "");
+  const separator = arg.lastIndexOf(":");
+  const options = separator >= 0 ? arg.slice(separator + 1).split(",") : [];
+  const hasOnlyMountOptions = options.length > 0 && options.every((option) => ["ro", "rw", "z", "Z"].includes(option));
+  const target = hasOnlyMountOptions ? arg.slice(0, separator) : arg;
   return target.endsWith(`:${containerPath}`);
 }
 
-test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds config over it", onPlatforms("linux", "darwin", "win32"), () => {
+function isReadOnlyMountFor(arg: string, containerPath: string): boolean {
+  return isMountFor(arg, containerPath) && arg.slice(arg.lastIndexOf(":") + 1).split(",").includes("ro");
+}
+
+function hasArgs(call: string[], expected: string[]): boolean {
+  return call.length === expected.length && call.every((arg, index) => arg === expected[index]);
+}
+
+test("sandbox create copies codex seeds into tmpfs without binding their runtime targets", onPlatforms("linux", "darwin", "win32"), () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-run-"));
 
   try {
@@ -71,19 +81,22 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
     const codexSandboxDir = path.join(tmpDir, ".agent-infra", "sandboxes", "codex", "demo", "feature-x");
     fs.mkdirSync(path.join(codexSandboxDir, "mcp"), { recursive: true });
     fs.mkdirSync(path.join(codexSandboxDir, "sessions"), { recursive: true });
+    fs.mkdirSync(path.join(codexSandboxDir, "model-catalogs"), { recursive: true });
     fs.writeFileSync(path.join(codexSandboxDir, "logs_2.sqlite"), "stale\n", "utf8");
     fs.writeFileSync(path.join(codexSandboxDir, "mcp.json"), "{}\n", "utf8");
     fs.writeFileSync(path.join(codexSandboxDir, "mcp", "server.json"), "{}\n", "utf8");
     fs.writeFileSync(path.join(codexSandboxDir, "sessions", "session.jsonl"), "{}\n", "utf8");
+    fs.writeFileSync(path.join(codexSandboxDir, "model-catalogs", "models.json"), "{}\n", "utf8");
 
-    spawnSandboxCli(
+    const result = spawnSandboxCli(
       fixture,
       tmpDir,
-      ["create", "feature-x", "--cpu", "1", "--memory", "1"],
-      { DOCKER_EXIT_FOR_RUN: "1" }
+      ["create", "feature-x", "--cpu", "1", "--memory", "1"]
     );
+    assert.equal(result.status, 0, result.stderr);
 
-    const runCall = fixture.readDockerCalls().find((call) => call[0] === "run");
+    const dockerCalls = fixture.readDockerCalls();
+    const runCall = dockerCalls.find((call) => call[0] === "run");
     assert.ok(runCall, "expected sandbox create to call docker run");
 
     // codex home is a tmpfs, not a host bind mount.
@@ -97,11 +110,43 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
       `expected NO host bind for /home/devuser/.codex, got ${JSON.stringify(runCall)}`
     );
 
-    // Seeded config (ensureCodexWorkspaceTrust always writes config.toml) is
-    // bind-mounted over the tmpfs at run time, so it is present in-container.
-    assert.ok(
+    // Seed sources are mounted read-only outside codex home, then copied into
+    // tmpfs after the container starts. Their runtime targets are regular files
+    // and directories rather than mount points, so Codex can atomically replace
+    // config.toml without writing back to the host seed.
+    assert.equal(
       runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/config.toml")),
-      `expected config.toml to be seeded as a nested bind over the tmpfs, got ${JSON.stringify(runCall)}`
+      false,
+      `expected config.toml runtime target to NOT be bind-mounted, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/model-catalogs")),
+      false,
+      `expected model-catalogs runtime target to NOT be bind-mounted, got ${JSON.stringify(runCall)}`
+    );
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isReadOnlyMountFor(arg, "/run/agent-infra/tmpfs-seeds/codex/0")),
+      `expected config.toml to have a read-only staging mount, got ${JSON.stringify(runCall)}`
+    );
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isReadOnlyMountFor(arg, "/run/agent-infra/tmpfs-seeds/codex/1")),
+      `expected model-catalogs to have a read-only staging mount, got ${JSON.stringify(runCall)}`
+    );
+    const configCopyIndex = dockerCalls.findIndex((call) => hasArgs(
+      call.slice(2),
+      ["cp", "-R", "--", "/run/agent-infra/tmpfs-seeds/codex/0", "/home/devuser/.codex/config.toml"]
+    ));
+    const catalogCopyIndex = dockerCalls.findIndex((call) => hasArgs(
+      call.slice(2),
+      ["cp", "-R", "--", "/run/agent-infra/tmpfs-seeds/codex/1", "/home/devuser/.codex/model-catalogs"]
+    ));
+    assert.ok(
+      configCopyIndex > dockerCalls.indexOf(runCall),
+      `expected config.toml to be copied into tmpfs, got ${JSON.stringify(dockerCalls)}`
+    );
+    assert.ok(
+      catalogCopyIndex > configCopyIndex,
+      `expected model-catalogs to be copied into tmpfs, got ${JSON.stringify(dockerCalls)}`
     );
 
     // A stale logs_2.sqlite left in the host dir must NOT be re-mounted (CD-1):
@@ -142,6 +187,45 @@ test("sandbox create mounts codex home as tmpfs, drops its host bind, and seeds 
       runCall.some((arg, index) => arg === "--tmpfs" && String(runCall[index + 1]).startsWith("/home/devuser/.local/share/opencode")),
       false,
       `expected opencode to NOT be tmpfs, got ${JSON.stringify(runCall)}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox create skips missing tmpfs seed entries", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-tmpfs-missing-seed-"));
+
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, {
+      project: "demo",
+      sandbox: { tools: ["codex"] }
+    });
+    commitInitialFile(fixture.repoDir);
+
+    const result = spawnSandboxCli(
+      fixture,
+      tmpDir,
+      ["create", "feature-x", "--cpu", "1", "--memory", "1"]
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const dockerCalls = fixture.readDockerCalls();
+    const runCall = dockerCalls.find((call) => call[0] === "run");
+    assert.ok(runCall, "expected sandbox create to call docker run");
+    assert.ok(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isReadOnlyMountFor(arg, "/run/agent-infra/tmpfs-seeds/codex/0")),
+      `expected generated config.toml to have a staging mount, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) => runCall[index - 1] === "-v" && isMountFor(arg, "/run/agent-infra/tmpfs-seeds/codex/1")),
+      false,
+      `missing model-catalogs must not have a staging mount, got ${JSON.stringify(runCall)}`
+    );
+    assert.equal(
+      dockerCalls.some((call) => call.includes("/run/agent-infra/tmpfs-seeds/codex/1")),
+      false,
+      `missing model-catalogs must not have a copy command, got ${JSON.stringify(dockerCalls)}`
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #603

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #603

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 Codex Home 使用 tmpfs 时，`config.toml` 又作为嵌套单文件 bind mount 挂回目标路径，导致 Codex 无法通过原子 rename 替换配置并返回 `EPERM` 的问题。保留高频 SQLite 写入的内存隔离，同时让沙箱内配置成为生命周期内可写且不会回流宿主的快照。

## 📋 主要变更 / Brief Changelog

- 将声明的 tmpfs seed 分别只读挂载到 `/run/agent-infra/tmpfs-seeds/<tool>/<index>` staging 路径。
- 在容器启动且 tmpfs 生效后，以容器默认用户把文件和目录 seed 复制到运行时目标，再执行其他 sandbox setup。
- 保持 Codex Home 512 MiB tmpfs、`auth.json` live mount 和非 seed 运行时隔离不变。
- 增加跨平台集成测试，覆盖文件 seed、目录 seed、缺失 seed、只读 staging、目标无 bind 及既有边界。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run test:core`。
3. 运行 `npm test`。
4. 在真实 OrbStack 或 Docker Desktop 沙箱中切换 Codex 模型，确认原子替换 `config.toml` 不再返回 `EPERM`，并确认宿主配置与种子未被修改。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了集成测试 / I have added integration tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

自动化结果：`npm test` 1409 项，1408 通过、1 项按平台条件跳过、0 失败；`test:core` 1147 项，1146 通过、1 跳过、0 失败；typecheck 通过。

## 📸 截图 / Screenshots

不适用：本次改动为沙箱挂载、启动编排和集成测试，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #603。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要测试，构建、类型检查、core 和全量测试通过。
- [x] 已更新相关类型注释，并保持 `tmpfs.seed` 字段形状向后兼容。
- [ ] 已完成真实容器内原子 rename 与宿主配置隔离人工验证。

## 📋 附加信息 / Additional Notes

`tmpfs.seed` 字段形状保持 `{ size?: string; seed?: string[] }` 不变；需要持续绑定的凭证仍由 `hostLiveMounts` 处理。真实容器人工验证步骤见 reviewer 摘要评论。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 staging mount 的只读性、seed copy 在其他 setup 前的执行顺序、目标路径不再成为 mount point，以及 `auth.json` / stale runtime 的隔离边界。

Generated with AI assistance