### PR TITLE
fix(workflow): 修复补审后审查基线未推进的问题

### DIFF
--- a/.agents/rules/review-handshake.md
+++ b/.agents/rules/review-handshake.md
@@ -85,8 +85,8 @@
 
 ## post-review commit 门禁（仅 code 阶段）
 
-- `review-code` 在最高轮报告中记录 `审查基线提交`（R，`git rev-parse HEAD`）和 `审查差异指纹`（F，完整工作区 diff fingerprint）。
-- `commit` 只读取最高轮 `review-code` 产物；当该产物 Approved、提交前 HEAD 等于 R、且 staged diff fingerprint 等于 F 时，在 task.md 写入 `last_reviewed_commit`（B，新提交 SHA）。
+- `review-code` 一次性捕获 `审查基线提交`（R，`git rev-parse HEAD`），以同一 R 计算 `审查差异指纹`（F，完整工作区 diff fingerprint）并写入最高轮报告；本轮 Approved 时同时在 task.md 写入 `last_reviewed_commit: R`（B），非 Approved 时保留既有 B。
+- `commit` 只读取最高轮 `review-code` 产物；当该产物 Approved、提交前 HEAD 等于 R、且 staged diff fingerprint 等于 F 时，把 task.md 的 B 推进为新提交 SHA。
 - `complete-task` 的 `post-review-commit` gate 优先使用 B；B 缺失或非法时回退最高轮 `review-code` 的 R。
 - 若 B / R 之后代码 / 规则路径出现新提交，gate 会拦截，要求重新 `review-code`。
 - **豁免**：在账本追加一行 `| PRC-1 | post-review-commit | - | - | human-decided | <裁定说明> |`，记录人工明确允许该批提交免复审。

--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 
 import {
   extractReviewBaseline,
+  extractReviewDiffFingerprint,
   findAuthoritativeReviewCodeArtifact,
+  parseReviewVerdict,
   resolvePostReviewGlobs
 } from "./lib/post-review-commit.js";
 
@@ -223,6 +225,8 @@ function runCheck(type, context) {
       return checkCompletionChecklist(context);
     case "review-ledger":
       return checkReviewLedger(context);
+    case "review-fact":
+      return checkReviewFact(context);
     case "post-review-commit":
       return checkPostReviewCommit(context);
     default: {
@@ -815,6 +819,95 @@ function checkPostReviewCommit({ taskDir, config }) {
   return failResult(
     "post-review-commit",
     `${commits.length} commit(s) to code/rule paths after review baseline ${sha.slice(0, 8)}; re-run review-code or record a human-decided exemption`
+  );
+}
+
+function checkReviewFact({ taskDir, artifactFile }) {
+  const resolvedArtifact = resolveArtifactPath(
+    taskDir,
+    "review-code.md|review-code-r{N}.md",
+    artifactFile
+  );
+  if (!resolvedArtifact.ok) {
+    return failResult("review-fact", resolvedArtifact.message);
+  }
+
+  const task = loadTask(taskDir);
+  if (!task.ok) {
+    return failResult("review-fact", task.message);
+  }
+
+  const content = fs.readFileSync(resolvedArtifact.path, "utf8");
+  const verdict = parseReviewVerdict(content);
+  const reviewBaseline = extractReviewBaseline(content);
+  const reviewedFingerprint = extractReviewDiffFingerprint(content);
+
+  if (!["通过", "需要修改", "拒绝", "Approved", "Changes Requested", "Rejected"].includes(verdict)) {
+    return failResult("review-fact", `Unsupported review verdict '${verdict}'`);
+  }
+
+  let gitRoot;
+  let head;
+  let baseline;
+  try {
+    gitRoot = execFileSync("git", ["-C", taskDir, "rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+    head = execFileSync("git", ["-C", gitRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    baseline = execFileSync("git", ["-C", gitRoot, "rev-parse", `${reviewBaseline}^{commit}`], { encoding: "utf8" }).trim();
+  } catch {
+    return blockedResult(
+      "review-fact",
+      `Unable to resolve review baseline '${reviewBaseline}' in the task repository; re-run review-code`
+    );
+  }
+
+  if (baseline !== head) {
+    return failResult(
+      "review-fact",
+      `Review baseline ${baseline.slice(0, 8)} does not match current HEAD ${head.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  let actualFingerprint;
+  try {
+    actualFingerprint = execFileSync(
+      process.execPath,
+      [path.join(repoRoot, ".agents", "scripts", "review-diff-fingerprint.js"), "worktree", baseline],
+      { cwd: gitRoot, encoding: "utf8" }
+    ).trim();
+  } catch {
+    return blockedResult(
+      "review-fact",
+      `Unable to recompute reviewed diff fingerprint from baseline ${baseline.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  if (actualFingerprint !== reviewedFingerprint) {
+    return failResult(
+      "review-fact",
+      `Reviewed diff fingerprint does not match the current worktree for baseline ${baseline.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  if (["通过", "Approved"].includes(verdict)) {
+    const lastReviewedCommit = String(task.metadata.last_reviewed_commit || "").trim();
+    let reviewedCommit = "";
+    try {
+      reviewedCommit = execFileSync("git", ["-C", gitRoot, "rev-parse", `${lastReviewedCommit}^{commit}`], { encoding: "utf8" }).trim();
+    } catch {
+      // The failure below names the missing or invalid task review fact.
+    }
+
+    if (reviewedCommit !== baseline) {
+      return failResult(
+        "review-fact",
+        `Approved review must set task last_reviewed_commit to baseline ${baseline.slice(0, 8)}`
+      );
+    }
+  }
+
+  return passResult(
+    "review-fact",
+    `Review fact valid for ${path.basename(resolvedArtifact.path)} at ${baseline.slice(0, 8)}`
   );
 }
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -73,9 +73,10 @@ tail .agents/workspace/active/{task-id}/task.md
 ### 4. 执行审查
 
 遵循 `.agents/workflows/feature-development.yaml`，并同时检查完整变更上下文：
-- `git diff --binary HEAD -- <post-review-globs>` 覆盖已跟踪变更
+- 一次性记录 `R=$(git rev-parse HEAD)`；本轮报告、指纹和任务审查事实都复用该 R，禁止稍后重新读取 HEAD 代替
+- `git diff --binary "$R" -- <post-review-globs>` 覆盖已跟踪变更
 - `git ls-files -o --exclude-standard -z -- <post-review-globs>` 覆盖未跟踪新文件
-- `node .agents/scripts/review-diff-fingerprint.js worktree HEAD` 生成审查差异指纹，并写入报告
+- `node .agents/scripts/review-diff-fingerprint.js worktree "$R"` 生成审查差异指纹，并写入报告
 
 > 详细审查标准、严重程度划分和 reviewer 关注点见 `reference/review-criteria.md`。执行此步骤前先读取 `reference/review-criteria.md`。
 > 测试审查硬门禁：当 `git diff` 触及测试文件时，必须先读取 `.agents/rules/testing-discipline.md` 并逐条核对（尤其"正向已覆盖时不应再加反向断言"）。
@@ -98,6 +99,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
+- 若本轮 `总体结论` / `Overall Verdict` 为 `通过` / `Approved`，写入 `last_reviewed_commit: {R}`；是否存在工作区 diff 不影响写入，重复写同一 R 幂等
+- 若本轮结论不是 Approved，保留既有 `last_reviewed_commit`，不得推进或清空
 - 追加：
 `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}, Manual-validation: {n} → {artifact-filename}`
 

--- a/.agents/skills/review-code/config/verify.json
+++ b/.agents/skills/review-code/config/verify.json
@@ -36,6 +36,7 @@
       ],
       "freshness_minutes": 30
     },
+    "review-fact": {},
     "activity-log": {
       "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30

--- a/.agents/skills/review-code/reference/report-template.md
+++ b/.agents/skills/review-code/reference/report-template.md
@@ -21,8 +21,8 @@
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
-- **审查基线提交**：{git rev-parse HEAD 原文}（complete-task 的 post-review commit 门禁基线；详见 `.agents/rules/review-handshake.md`）
-- **审查差异指纹**：{node .agents/scripts/review-diff-fingerprint.js worktree HEAD 原文}
+- **审查基线提交**：{本轮一次性捕获的 R 原文}（complete-task 的 post-review commit 门禁基线；详见 `.agents/rules/review-handshake.md`）
+- **审查差异指纹**：{node .agents/scripts/review-diff-fingerprint.js worktree "$R" 原文}
 - **总体结论**：{通过 / 需要修改 / 拒绝}（恰取一个；禁止写组合短语，否则 verify gate 失败）
 - **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
 

--- a/templates/.agents/rules/review-handshake.en.md
+++ b/templates/.agents/rules/review-handshake.en.md
@@ -85,8 +85,8 @@ When an executor judges an item to be a key design decision that needs human rul
 
 ## post-review commit gate (code stage only)
 
-- The highest-round `review-code` report records `Review Baseline Commit` (R, `git rev-parse HEAD`) and `Reviewed Diff Fingerprint` (F, full worktree diff fingerprint).
-- `commit` reads only the highest-round `review-code` artifact. When that artifact is Approved, the pre-commit HEAD equals R, and the staged diff fingerprint equals F, task.md receives `last_reviewed_commit` (B, the new commit SHA).
+- `review-code` captures `Review Baseline Commit` (R, `git rev-parse HEAD`) once, computes `Reviewed Diff Fingerprint` (F, the full worktree diff fingerprint) from that same R, and records both in the highest-round report. When the round is Approved it also writes `last_reviewed_commit: R` (B) to task.md; a non-Approved round preserves the existing B.
+- `commit` reads only the highest-round `review-code` artifact. When that artifact is Approved, the pre-commit HEAD equals R, and the staged diff fingerprint equals F, it advances task.md B to the new commit SHA.
 - The `complete-task` `post-review-commit` gate prefers B; when B is absent or invalid, it falls back to R from the highest-round `review-code` artifact.
 - If new commits touch code / rule paths after B / R, the gate blocks and requires a fresh `review-code`.
 - **Exemption**: append a ledger row `| PRC-1 | post-review-commit | - | - | human-decided | <ruling note> |` recording that a human explicitly allowed those commits without re-review.

--- a/templates/.agents/rules/review-handshake.zh-CN.md
+++ b/templates/.agents/rules/review-handshake.zh-CN.md
@@ -85,8 +85,8 @@
 
 ## post-review commit 门禁（仅 code 阶段）
 
-- `review-code` 在最高轮报告中记录 `审查基线提交`（R，`git rev-parse HEAD`）和 `审查差异指纹`（F，完整工作区 diff fingerprint）。
-- `commit` 只读取最高轮 `review-code` 产物；当该产物 Approved、提交前 HEAD 等于 R、且 staged diff fingerprint 等于 F 时，在 task.md 写入 `last_reviewed_commit`（B，新提交 SHA）。
+- `review-code` 一次性捕获 `审查基线提交`（R，`git rev-parse HEAD`），以同一 R 计算 `审查差异指纹`（F，完整工作区 diff fingerprint）并写入最高轮报告；本轮 Approved 时同时在 task.md 写入 `last_reviewed_commit: R`（B），非 Approved 时保留既有 B。
+- `commit` 只读取最高轮 `review-code` 产物；当该产物 Approved、提交前 HEAD 等于 R、且 staged diff fingerprint 等于 F 时，把 task.md 的 B 推进为新提交 SHA。
 - `complete-task` 的 `post-review-commit` gate 优先使用 B；B 缺失或非法时回退最高轮 `review-code` 的 R。
 - 若 B / R 之后代码 / 规则路径出现新提交，gate 会拦截，要求重新 `review-code`。
 - **豁免**：在账本追加一行 `| PRC-1 | post-review-commit | - | - | human-decided | <裁定说明> |`，记录人工明确允许该批提交免复审。

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 
 import {
   extractReviewBaseline,
+  extractReviewDiffFingerprint,
   findAuthoritativeReviewCodeArtifact,
+  parseReviewVerdict,
   resolvePostReviewGlobs
 } from "./lib/post-review-commit.js";
 
@@ -223,6 +225,8 @@ function runCheck(type, context) {
       return checkCompletionChecklist(context);
     case "review-ledger":
       return checkReviewLedger(context);
+    case "review-fact":
+      return checkReviewFact(context);
     case "post-review-commit":
       return checkPostReviewCommit(context);
     default: {
@@ -815,6 +819,95 @@ function checkPostReviewCommit({ taskDir, config }) {
   return failResult(
     "post-review-commit",
     `${commits.length} commit(s) to code/rule paths after review baseline ${sha.slice(0, 8)}; re-run review-code or record a human-decided exemption`
+  );
+}
+
+function checkReviewFact({ taskDir, artifactFile }) {
+  const resolvedArtifact = resolveArtifactPath(
+    taskDir,
+    "review-code.md|review-code-r{N}.md",
+    artifactFile
+  );
+  if (!resolvedArtifact.ok) {
+    return failResult("review-fact", resolvedArtifact.message);
+  }
+
+  const task = loadTask(taskDir);
+  if (!task.ok) {
+    return failResult("review-fact", task.message);
+  }
+
+  const content = fs.readFileSync(resolvedArtifact.path, "utf8");
+  const verdict = parseReviewVerdict(content);
+  const reviewBaseline = extractReviewBaseline(content);
+  const reviewedFingerprint = extractReviewDiffFingerprint(content);
+
+  if (!["通过", "需要修改", "拒绝", "Approved", "Changes Requested", "Rejected"].includes(verdict)) {
+    return failResult("review-fact", `Unsupported review verdict '${verdict}'`);
+  }
+
+  let gitRoot;
+  let head;
+  let baseline;
+  try {
+    gitRoot = execFileSync("git", ["-C", taskDir, "rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+    head = execFileSync("git", ["-C", gitRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    baseline = execFileSync("git", ["-C", gitRoot, "rev-parse", `${reviewBaseline}^{commit}`], { encoding: "utf8" }).trim();
+  } catch {
+    return blockedResult(
+      "review-fact",
+      `Unable to resolve review baseline '${reviewBaseline}' in the task repository; re-run review-code`
+    );
+  }
+
+  if (baseline !== head) {
+    return failResult(
+      "review-fact",
+      `Review baseline ${baseline.slice(0, 8)} does not match current HEAD ${head.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  let actualFingerprint;
+  try {
+    actualFingerprint = execFileSync(
+      process.execPath,
+      [path.join(repoRoot, ".agents", "scripts", "review-diff-fingerprint.js"), "worktree", baseline],
+      { cwd: gitRoot, encoding: "utf8" }
+    ).trim();
+  } catch {
+    return blockedResult(
+      "review-fact",
+      `Unable to recompute reviewed diff fingerprint from baseline ${baseline.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  if (actualFingerprint !== reviewedFingerprint) {
+    return failResult(
+      "review-fact",
+      `Reviewed diff fingerprint does not match the current worktree for baseline ${baseline.slice(0, 8)}; re-run review-code`
+    );
+  }
+
+  if (["通过", "Approved"].includes(verdict)) {
+    const lastReviewedCommit = String(task.metadata.last_reviewed_commit || "").trim();
+    let reviewedCommit = "";
+    try {
+      reviewedCommit = execFileSync("git", ["-C", gitRoot, "rev-parse", `${lastReviewedCommit}^{commit}`], { encoding: "utf8" }).trim();
+    } catch {
+      // The failure below names the missing or invalid task review fact.
+    }
+
+    if (reviewedCommit !== baseline) {
+      return failResult(
+        "review-fact",
+        `Approved review must set task last_reviewed_commit to baseline ${baseline.slice(0, 8)}`
+      );
+    }
+  }
+
+  return passResult(
+    "review-fact",
+    `Review fact valid for ${path.basename(resolvedArtifact.path)} at ${baseline.slice(0, 8)}`
   );
 }
 

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -74,9 +74,10 @@ Read the highest-round code artifact and, if present, the highest-round fix arti
 ### 4. Perform the Review
 
 Follow `.agents/workflows/feature-development.yaml` and inspect the full change context:
-- `git diff --binary HEAD -- <post-review-globs>` for tracked changes
+- Capture `R=$(git rev-parse HEAD)` exactly once; reuse that R for this round's report, fingerprint, and task review fact, and do not re-read HEAD later as a substitute
+- `git diff --binary "$R" -- <post-review-globs>` for tracked changes
 - `git ls-files -o --exclude-standard -z -- <post-review-globs>` for untracked new files
-- `node .agents/scripts/review-diff-fingerprint.js worktree HEAD` for the reviewed diff fingerprint; write it into the report
+- `node .agents/scripts/review-diff-fingerprint.js worktree "$R"` for the reviewed diff fingerprint; write it into the report
 
 > Detailed review criteria, severity rules, and reviewer expectations live in `reference/review-criteria.md`. Read `reference/review-criteria.md` before reviewing.
 > Test review gate: when `git diff` touches test files, read `.agents/rules/testing-discipline.md` first and check it item by item, especially "do not add negative assertions when a positive assertion already covers the behavior".
@@ -95,7 +96,10 @@ Get the current time:
 date "+%Y-%m-%d %H:%M:%S%:z"
 ```
 
-Update task.md and append:
+Update task.md:
+- When this round's `Overall Verdict` / `总体结论` is `Approved` / `通过`, write `last_reviewed_commit: {R}`; the presence of a worktree diff does not affect this write, and repeating the same R is idempotent
+- When this round is not Approved, preserve the existing `last_reviewed_commit`; do not advance or clear it
+- Append:
 `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}, Manual-validation: {n} → {artifact-filename}`
 
 Always include the `Manual-validation: {n}` field in the done log, including when it is 0.

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -73,9 +73,10 @@ tail .agents/workspace/active/{task-id}/task.md
 ### 4. 执行审查
 
 遵循 `.agents/workflows/feature-development.yaml`，并同时检查完整变更上下文：
-- `git diff --binary HEAD -- <post-review-globs>` 覆盖已跟踪变更
+- 一次性记录 `R=$(git rev-parse HEAD)`；本轮报告、指纹和任务审查事实都复用该 R，禁止稍后重新读取 HEAD 代替
+- `git diff --binary "$R" -- <post-review-globs>` 覆盖已跟踪变更
 - `git ls-files -o --exclude-standard -z -- <post-review-globs>` 覆盖未跟踪新文件
-- `node .agents/scripts/review-diff-fingerprint.js worktree HEAD` 生成审查差异指纹，并写入报告
+- `node .agents/scripts/review-diff-fingerprint.js worktree "$R"` 生成审查差异指纹，并写入报告
 
 > 详细审查标准、严重程度划分和 reviewer 关注点见 `reference/review-criteria.md`。执行此步骤前先读取 `reference/review-criteria.md`。
 > 测试审查硬门禁：当 `git diff` 触及测试文件时，必须先读取 `.agents/rules/testing-discipline.md` 并逐条核对（尤其"正向已覆盖时不应再加反向断言"）。
@@ -98,6 +99,8 @@ date "+%Y-%m-%d %H:%M:%S%:z"
 - `assigned_to`：{当前代理}
 - `updated_at`：{当前时间}
 - `agent_infra_version`：按 `.agents/rules/version-stamp.md` 取值
+- 若本轮 `总体结论` / `Overall Verdict` 为 `通过` / `Approved`，写入 `last_reviewed_commit: {R}`；是否存在工作区 diff 不影响写入，重复写同一 R 幂等
+- 若本轮结论不是 Approved，保留既有 `last_reviewed_commit`，不得推进或清空
 - 追加：
 `- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Review Code (Round {N})** by {agent} — Verdict: {Approved/Changes Requested/Rejected}, blockers: {n}, major: {n}, minor: {n}, Manual-validation: {n} → {artifact-filename}`
 

--- a/templates/.agents/skills/review-code/config/verify.en.json
+++ b/templates/.agents/skills/review-code/config/verify.en.json
@@ -36,6 +36,7 @@
       ],
       "freshness_minutes": 30
     },
+    "review-fact": {},
     "activity-log": {
       "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30

--- a/templates/.agents/skills/review-code/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-code/config/verify.zh-CN.json
@@ -36,6 +36,7 @@
       ],
       "freshness_minutes": 30
     },
+    "review-fact": {},
     "activity-log": {
       "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
       "freshness_minutes": 30

--- a/templates/.agents/skills/review-code/reference/report-template.en.md
+++ b/templates/.agents/skills/review-code/reference/report-template.en.md
@@ -21,8 +21,8 @@ Use this template when writing `review-code.md` or `review-code-r{N}.md`.
 - **Reviewer**: {reviewer-name}
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}
-- **Review Baseline Commit**: {raw git rev-parse HEAD} (baseline for the complete-task post-review commit gate; see `.agents/rules/review-handshake.md`)
-- **Reviewed Diff Fingerprint**: {raw node .agents/scripts/review-diff-fingerprint.js worktree HEAD}
+- **Review Baseline Commit**: {raw R captured once for this round} (baseline for the complete-task post-review commit gate; see `.agents/rules/review-handshake.md`)
+- **Reviewed Diff Fingerprint**: {raw node .agents/scripts/review-diff-fingerprint.js worktree "$R"}
 - **Overall Verdict**: {Approved / Changes Requested / Rejected} (pick exactly one; combined phrases will fail the verify gate)
 - **Findings (AI-actionable)**: 0 blockers, 0 majors, 0 minors / **Manual validation**: 0
 

--- a/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
@@ -21,8 +21,8 @@
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
-- **审查基线提交**：{git rev-parse HEAD 原文}（complete-task 的 post-review commit 门禁基线；详见 `.agents/rules/review-handshake.md`）
-- **审查差异指纹**：{node .agents/scripts/review-diff-fingerprint.js worktree HEAD 原文}
+- **审查基线提交**：{本轮一次性捕获的 R 原文}（complete-task 的 post-review commit 门禁基线；详见 `.agents/rules/review-handshake.md`）
+- **审查差异指纹**：{node .agents/scripts/review-diff-fingerprint.js worktree "$R" 原文}
 - **总体结论**：{通过 / 需要修改 / 拒绝}（恰取一个；禁止写组合短语，否则 verify gate 失败）
 - **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
 

--- a/tests/e2e/core/validate-artifact-post-review-commit.test.ts
+++ b/tests/e2e/core/validate-artifact-post-review-commit.test.ts
@@ -123,6 +123,33 @@ test("post-review-commit fails when a code-path commit lands after last_reviewed
   });
 });
 
+test("post-review-commit passes after a supplemental approved review advances last_reviewed_commit to HEAD", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-prc-supplemental-review-", (tempRoot) => {
+    const { taskDir } = setupRepo(tempRoot);
+    const oldReviewedCommit = commitCodePath(tempRoot, ".agents/skills/x.md", "base\n", "old reviewed change");
+    const supplementalBaseline = commitCodePath(tempRoot, ".agents/skills/x.md", "base\ncommitted\n", "committed before supplemental review");
+    write(path.join(taskDir, "task.md"), buildTask([], { last_reviewed_commit: supplementalBaseline }));
+    write(path.join(taskDir, "review-code.md"), buildReviewCode(oldReviewedCommit, "通过"));
+    write(path.join(taskDir, "review-code-r2.md"), buildReviewCode(supplementalBaseline, "通过"));
+
+    const { payload } = runCheck(taskDir);
+    assert.equal(payload.status, "pass");
+  });
+});
+
+test("post-review-commit still fails when a commit lands after the supplemental review fact", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-prc-after-supplemental-review-", (tempRoot) => {
+    const { taskDir } = setupRepo(tempRoot);
+    const supplementalBaseline = commitCodePath(tempRoot, ".agents/skills/x.md", "base\nreviewed\n", "supplementally reviewed change");
+    write(path.join(taskDir, "task.md"), buildTask([], { last_reviewed_commit: supplementalBaseline }));
+    write(path.join(taskDir, "review-code-r2.md"), buildReviewCode(supplementalBaseline, "通过"));
+    commitCodePath(tempRoot, ".agents/skills/x.md", "base\nreviewed\nunreviewed\n", "unreviewed follow-up");
+
+    const { payload } = runCheck(taskDir);
+    assert.equal(payload.status, "fail");
+  });
+});
+
 test("post-review-commit falls back to the review baseline when last_reviewed_commit is invalid", onPlatforms("linux", "darwin", "win32"), async () => {
   await withTempRoot("agent-infra-prc-invalid-last-reviewed-", (tempRoot) => {
     const { taskDir } = setupRepo(tempRoot);

--- a/tests/e2e/core/validate-artifact-review-code-verdict.test.ts
+++ b/tests/e2e/core/validate-artifact-review-code-verdict.test.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
+import { filePath, gitSafeEnv, initIsolatedGitRepo } from "../../helpers.ts";
 import {
   buildTaskContent,
   buildTaskFrontmatter,
@@ -14,7 +16,33 @@ import {
 
 const TASK_ID = "TASK-20260328-000001";
 
-function buildReviewArtifact(verdictLine: string) {
+const fingerprintScript = filePath(".agents/scripts/review-diff-fingerprint.js");
+
+function git(repoRoot: string, args: string[]) {
+  const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8", env: gitSafeEnv() });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+function setupReviewRepo(tempRoot: string) {
+  initIsolatedGitRepo(tempRoot);
+  git(tempRoot, ["config", "user.email", "codex@example.com"]);
+  git(tempRoot, ["config", "user.name", "Codex"]);
+  write(path.join(tempRoot, ".gitignore"), `${TASK_ID}/\n`);
+  write(path.join(tempRoot, ".agents/skills/x.md"), "reviewed\n");
+  git(tempRoot, ["add", "-A"]);
+  git(tempRoot, ["commit", "-qm", "reviewed"]);
+  const baseline = git(tempRoot, ["rev-parse", "HEAD"]);
+  const result = spawnSync(process.execPath, [fingerprintScript, "worktree", baseline], {
+    cwd: tempRoot,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return { taskDir: path.join(tempRoot, TASK_ID), baseline, reviewedFingerprint: result.stdout.trim() };
+}
+
+function buildReviewArtifact(verdictLine: string, baseline: string, reviewedFingerprint: string) {
   return [
     "# 代码审查报告",
     "",
@@ -27,8 +55,8 @@ function buildReviewArtifact(verdictLine: string) {
     "## 审查摘要",
     "",
     "- **审查者**：codex",
-    "- **审查基线提交**：0123456789abcdef0123456789abcdef01234567",
-    "- **审查差异指纹**：sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    `- **审查基线提交**：${baseline}`,
+    `- **审查差异指纹**：${reviewedFingerprint}`,
     `- ${verdictLine}`,
     "- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0",
     "",
@@ -63,13 +91,14 @@ function buildReviewArtifact(verdictLine: string) {
   ].join("\n");
 }
 
-function buildReviewTask(overrides: Record<string, string | number> = {}) {
+function buildReviewTask(baseline: string, overrides: Record<string, string | number> = {}) {
   return buildTaskContent(
     {
       id: TASK_ID,
       issue_number: "N/A",
       current_step: "code-review",
       agent_infra_version: "v0.0.0-test",
+      last_reviewed_commit: baseline,
       ...overrides
     },
     {
@@ -83,11 +112,11 @@ function buildReviewTask(overrides: Record<string, string | number> = {}) {
 
 test("review-code gate rejects combined zh-CN verdict phrase (A-a-zh)", async () => {
   await withTempRoot("agent-infra-rcv-bad-", (tempRoot) => {
-    const taskDir = path.join(tempRoot, TASK_ID);
-    write(path.join(taskDir, "task.md"), buildReviewTask());
+    const { taskDir, baseline, reviewedFingerprint } = setupReviewRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), buildReviewTask(baseline));
     write(
       path.join(taskDir, "review-code.md"),
-      buildReviewArtifact("**总体结论**：通过但有问题")
+      buildReviewArtifact("**总体结论**：通过但有问题", baseline, reviewedFingerprint)
     );
 
     const result = runValidator(["gate", "review-code", taskDir, "review-code.md"]);
@@ -113,11 +142,11 @@ test("review-code gate rejects combined zh-CN verdict phrase (A-a-zh)", async ()
 
 test("review-code gate accepts canonical zh-CN verdict (A-b-zh)", async () => {
   await withTempRoot("agent-infra-rcv-good-", (tempRoot) => {
-    const taskDir = path.join(tempRoot, TASK_ID);
-    write(path.join(taskDir, "task.md"), buildReviewTask());
+    const { taskDir, baseline, reviewedFingerprint } = setupReviewRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), buildReviewTask(baseline));
     write(
       path.join(taskDir, "review-code.md"),
-      buildReviewArtifact("**总体结论**：通过")
+      buildReviewArtifact("**总体结论**：通过", baseline, reviewedFingerprint)
     );
 
     const result = runValidator(["gate", "review-code", taskDir, "review-code.md"]);
@@ -132,9 +161,9 @@ test("review-code gate accepts canonical zh-CN verdict (A-b-zh)", async () => {
 
 test("review-code gate fails when the baseline commit field is absent", async () => {
   await withTempRoot("agent-infra-rcv-nobaseline-", (tempRoot) => {
-    const taskDir = path.join(tempRoot, TASK_ID);
-    write(path.join(taskDir, "task.md"), buildReviewTask());
-    const artifact = buildReviewArtifact("**总体结论**：通过")
+    const { taskDir, baseline, reviewedFingerprint } = setupReviewRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), buildReviewTask(baseline));
+    const artifact = buildReviewArtifact("**总体结论**：通过", baseline, reviewedFingerprint)
       .split("\n")
       .filter((line) => !line.startsWith("- **审查基线提交**"))
       .join("\n");
@@ -151,9 +180,9 @@ test("review-code gate fails when the baseline commit field is absent", async ()
 
 test("review-code gate fails when the ledger writeback section is absent", async () => {
   await withTempRoot("agent-infra-rcv-noledger-", (tempRoot) => {
-    const taskDir = path.join(tempRoot, TASK_ID);
-    write(path.join(taskDir, "task.md"), buildReviewTask());
-    const lines = buildReviewArtifact("**总体结论**：通过").split("\n");
+    const { taskDir, baseline, reviewedFingerprint } = setupReviewRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), buildReviewTask(baseline));
+    const lines = buildReviewArtifact("**总体结论**：通过", baseline, reviewedFingerprint).split("\n");
     const index = lines.indexOf("## 审查分歧账本回写");
     lines.splice(index, 3); // heading, blank line, body line
     write(path.join(taskDir, "review-code.md"), lines.join("\n"));

--- a/tests/e2e/core/validate-artifact-review-fact.test.ts
+++ b/tests/e2e/core/validate-artifact-review-fact.test.ts
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { filePath, gitSafeEnv, initIsolatedGitRepo, onPlatforms } from "../../helpers.ts";
+import {
+  buildTaskFrontmatter,
+  parseValidatorPayload,
+  runValidator,
+  withTempRoot,
+  write
+} from "./validate-artifact-helpers.ts";
+
+const TASK_ID = "TASK-20260328-000001";
+const fingerprintScript = filePath(".agents/scripts/review-diff-fingerprint.js");
+
+function git(repoRoot: string, args: string[]) {
+  const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8", env: gitSafeEnv() });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+function fingerprint(repoRoot: string, baseline: string) {
+  const result = spawnSync(process.execPath, [fingerprintScript, "worktree", baseline], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: gitSafeEnv()
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+function setupRepo(tempRoot: string) {
+  initIsolatedGitRepo(tempRoot);
+  git(tempRoot, ["config", "user.email", "codex@example.com"]);
+  git(tempRoot, ["config", "user.name", "Codex"]);
+  write(path.join(tempRoot, ".gitignore"), "task/\n");
+  write(path.join(tempRoot, ".agents/skills/x.md"), "base\n");
+  git(tempRoot, ["add", "-A"]);
+  git(tempRoot, ["commit", "-qm", "base"]);
+  const previous = git(tempRoot, ["rev-parse", "HEAD"]);
+  write(path.join(tempRoot, ".agents/skills/x.md"), "base\nreviewed\n");
+  git(tempRoot, ["add", "-A"]);
+  git(tempRoot, ["commit", "-qm", "reviewed"]);
+  return {
+    taskDir: path.join(tempRoot, "task", TASK_ID),
+    previous,
+    baseline: git(tempRoot, ["rev-parse", "HEAD"])
+  };
+}
+
+function taskContent(lastReviewedCommit?: string) {
+  return [
+    buildTaskFrontmatter({
+      id: TASK_ID,
+      current_step: "code-review",
+      ...(lastReviewedCommit ? { last_reviewed_commit: lastReviewedCommit } : {})
+    }),
+    "",
+    "# 任务：review fact",
+    "",
+    "## 活动日志",
+    "",
+    "- 2026-03-28 00:00:00+00:00 — **Review Code (Round 1)** by codex — done"
+  ].join("\n");
+}
+
+function artifactContent(baseline: string, reviewedFingerprint: string, verdict = "通过") {
+  return [
+    "# 代码审查报告",
+    "",
+    "## 审查摘要",
+    "",
+    `- **审查基线提交**：${baseline}`,
+    `- **审查差异指纹**：${reviewedFingerprint}`,
+    `- **总体结论**：${verdict}`
+  ].join("\n");
+}
+
+function runCheck(taskDir: string) {
+  const result = runValidator(["check", "review-fact", taskDir, "review-code.md", "--skill", "review-code"]);
+  return { result, payload: parseValidatorPayload(result.stdout) };
+}
+
+test("review-fact accepts an approved report whose HEAD, baseline, fingerprint, and task fact agree", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-ok-", (tempRoot) => {
+    const { taskDir, baseline } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent(baseline));
+    write(path.join(taskDir, "review-code.md"), artifactContent(baseline, fingerprint(tempRoot, baseline)));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(payload.status, "pass");
+  });
+});
+
+test("review-fact rejects an approved report when last_reviewed_commit is stale", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-stale-", (tempRoot) => {
+    const { taskDir, previous, baseline } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent(previous));
+    write(path.join(taskDir, "review-code.md"), artifactContent(baseline, fingerprint(tempRoot, baseline)));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(payload.status, "fail");
+    assert.match(payload.message, /last_reviewed_commit/);
+  });
+});
+
+test("review-fact rejects an approved report when last_reviewed_commit is missing", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-missing-", (tempRoot) => {
+    const { taskDir, baseline } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent());
+    write(path.join(taskDir, "review-code.md"), artifactContent(baseline, fingerprint(tempRoot, baseline)));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(payload.status, "fail");
+    assert.match(payload.message, /last_reviewed_commit/);
+  });
+});
+
+test("review-fact rejects a report whose baseline does not match HEAD", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-head-", (tempRoot) => {
+    const { taskDir, previous } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent(previous));
+    write(path.join(taskDir, "review-code.md"), artifactContent(previous, fingerprint(tempRoot, previous)));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(payload.status, "fail");
+    assert.match(payload.message, /HEAD|baseline/i);
+  });
+});
+
+test("review-fact rejects a report whose fingerprint does not match the reviewed worktree", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-fingerprint-", (tempRoot) => {
+    const { taskDir, baseline } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent(baseline));
+    write(path.join(taskDir, "review-code.md"), artifactContent(baseline, `sha256:${"0".repeat(64)}`));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(payload.status, "fail");
+    assert.match(payload.message, /fingerprint/i);
+  });
+});
+
+test("review-fact does not require a task review commit for a non-approved report", onPlatforms("linux", "darwin", "win32"), async () => {
+  await withTempRoot("agent-infra-review-fact-changes-", (tempRoot) => {
+    const { taskDir, baseline } = setupRepo(tempRoot);
+    write(path.join(taskDir, "task.md"), taskContent());
+    write(path.join(taskDir, "review-code.md"), artifactContent(baseline, fingerprint(tempRoot, baseline), "需要修改"));
+
+    const { result, payload } = runCheck(taskDir);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(payload.status, "pass");
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #607

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #607

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复已提交变更经后续 `review-code` 补审通过后，`last_reviewed_commit` 未推进，导致 `complete-task` 把已补审提交误判为 post-review commit 的问题。让通过审查的报告基线、差异指纹与任务审查事实形成可机械校验的一致状态。

## 📋 主要变更 / Brief Changelog

- `review-code` 一次性捕获审查基线 R，并在 Approved 时把 `last_reviewed_commit` 推进到同一 R；非 Approved 保留既有事实。
- 新增 `review-fact` gate，校验规范结论、当前 HEAD、报告基线 R、工作区指纹 F 与任务 B 的一致性。
- 同步更新 R/F/B 协议、部署 SKILL、英文/中文模板和报告模板。
- 增加专项与完成门禁回归，覆盖旧/缺失 B、R/F 漂移、补审后放行及真实后续提交拦截。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run build`。
3. 运行 `npm test`。
4. 运行 `node .agents/scripts/validate-artifact.js check review-fact <task-dir> <review-code-artifact> --skill review-code` 验证一致与漂移场景。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了端到端测试 / I have added end-to-end tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 已完成独立代码审查 / Independent code review completed

自动化结果：完整测试 1421 项，1420 通过、1 项按平台条件跳过、0 失败；提交钩子 core 测试 1151 项，1150 通过、1 跳过、0 失败；typecheck 和 build 通过。

## 📸 截图 / Screenshots

不适用：本次改动为工作流协议、校验器和测试，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #607。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要测试，构建、类型检查、core 和全量测试通过。
- [x] 已同步部署文件及英文/中文模板，并保持 legacy 报告与人工豁免兼容。
- [x] 已确认补审后无新提交放行、补审后真实新提交继续拦截。

## 📋 附加信息 / Additional Notes

`commit` 现有的先审后提交路径保持不变：只有 `pre_head == R` 且 staged fingerprint 等于 F 时，才把 B 推进到新提交。post-review pathspec 和 legacy fallback 未扩大或重构。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 `review-fact` 的 fail/blocked 边界、Approved 与非 Approved 的 B 更新语义、报告与模板镜像同步，以及补审完成门禁的正反两条回归路径。

Generated with AI assistance