### PR TITLE
fix(server): 修复过期 PID 文件并验证进程身份

### DIFF
--- a/lib/server/daemon.ts
+++ b/lib/server/daemon.ts
@@ -12,6 +12,7 @@ import type { RunnerOptions, RunnerResult } from './runner.ts';
 import { streamCommand } from './streamer.ts';
 import { markdownMessage, replyOutbound, textMessage } from './display.ts';
 import { buildStatusModel, statusModelToDisplay, type StatusModel } from '../task/commands/status.ts';
+import { getProcessStartTime, removePidRecordIfMatches } from './process-state.ts';
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -110,6 +111,7 @@ export async function runDaemon(): Promise<void> {
 
   const logger = createLogger(config.log);
   logger.info(`daemon starting agent-infra ${VERSION} pid=${process.pid}`);
+  const ownStartTime = getProcessStartTime(process.pid);
 
   const abortController = new AbortController();
   let resolveShutdown: () => void = () => {};
@@ -135,6 +137,13 @@ export async function runDaemon(): Promise<void> {
       await unloadAdapters(adapters);
       clearInterval(heartbeat);
       logger.close();
+      if (ownStartTime !== null) {
+        removePidRecordIfMatches(config.pidFile, {
+          version: 1,
+          pid: process.pid,
+          startTime: ownStartTime
+        });
+      }
       resolveShutdown();
     })();
   };

--- a/lib/server/process-control.ts
+++ b/lib/server/process-control.ts
@@ -1,9 +1,19 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { spawn, execFileSync } from 'node:child_process';
 import { loadServerConfig } from './config.ts';
 import type { ServerConfig } from './config.ts';
 import { runDaemon } from './daemon.ts';
+import {
+  getProcessStartTime,
+  isProcessAlive,
+  processIdentityMatches,
+  readProcessState,
+  removePidFileIfMatches,
+  writePidRecord
+} from './process-state.ts';
+import type { PidRecord } from './process-state.ts';
+
+export { isProcessAlive } from './process-state.ts';
 
 export type StartOptions = { foreground?: boolean };
 export type LogsOptions = { follow?: boolean };
@@ -20,57 +30,31 @@ export function buildStopCommand(pid: number, platform: NodeJS.Platform): StopCo
   }
   return { kind: 'signal', signal: 'SIGTERM' };
 }
-
-
-// Liveness check that treats an exited-but-unreaped daemon as dead.
-//
-// The daemon is spawned detached and re-parented to init when `ai server start`
-// exits. After it terminates, `process.kill(pid, 0)` still succeeds until init
-// reaps the zombie. On Linux we therefore also check /proc state so status/stop
-// /start don't treat an already-exited daemon as running. macOS reaps orphans
-// via launchd and Windows has no zombies, so the kill(pid, 0) result is enough.
-export function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-  } catch (error) {
-    // EPERM means the process exists but we may not signal it → still alive.
-    return (error as NodeJS.ErrnoException).code === 'EPERM';
-  }
-  if (process.platform === 'linux') {
-    try {
-      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
-      // The process state is the first token after the parenthesised comm.
-      const state = stat.slice(stat.lastIndexOf(')') + 1).trim().charAt(0);
-      if (state === 'Z') return false;
-    } catch {
-      return false; // /proc entry vanished → not alive
-    }
-  }
-  return true;
-}
-
-function readPid(pidFile: string): number | null {
-  try {
-    const raw = fs.readFileSync(pidFile, 'utf8').trim();
-    const pid = Number.parseInt(raw, 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
-  } catch {
-    return null;
-  }
-}
-
-function removePidFile(pidFile: string): void {
-  try {
-    fs.unlinkSync(pidFile);
-  } catch {
-    // Already gone.
-  }
-}
-
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function waitForProcessIdentity(pid: number, timeoutMs = 2000): Promise<PidRecord | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const startTime = getProcessStartTime(pid);
+    if (startTime !== null) return { version: 1, pid, startTime };
+    await delay(25);
+  }
+  return null;
+}
+
+function terminateIfMatching(record: PidRecord): void {
+  if (!processIdentityMatches(record)) return;
+  const command = buildStopCommand(record.pid, process.platform);
+  try {
+    if (command.kind === 'exec') execFileSync(command.command, command.args);
+    else process.kill(record.pid, command.signal);
+  } catch {
+    // Best effort cleanup for a daemon whose PID record could not be published.
+  }
 }
 
 function enabledAdapterNames(config: ServerConfig): string[] {
@@ -83,15 +67,13 @@ export async function start({ foreground = false }: StartOptions = {}): Promise<
   const config = loadServerConfig();
   const pidPath = config.pidFile;
 
-  // Zombie PID cleanup: a stale PID file from a crashed daemon must not block a
-  // fresh start.
-  const existing = readPid(pidPath);
-  if (existing !== null && isProcessAlive(existing)) {
-    process.stdout.write(`server already running (pid ${existing})\n`);
+  const existing = readProcessState(pidPath);
+  if (existing.kind === 'running') {
+    process.stdout.write(`server already running (pid ${existing.record.pid})\n`);
     return;
   }
-  if (existing !== null) {
-    removePidFile(pidPath);
+  if (existing.kind !== 'missing') {
+    removePidFileIfMatches(pidPath, existing.snapshot);
   }
 
   if (foreground) {
@@ -116,52 +98,69 @@ export async function start({ foreground = false }: StartOptions = {}): Promise<
   if (typeof child.pid !== 'number') {
     throw new Error('server: failed to spawn daemon process');
   }
-  fs.mkdirSync(path.dirname(pidPath), { recursive: true });
-  fs.writeFileSync(pidPath, `${child.pid}\n`);
-  process.stdout.write(`server started (pid ${child.pid})\n`);
+
+  // The initial check, spawn, and record publication are not a mutually
+  // exclusive transaction. Atomic publication keeps the record complete, but
+  // a separate locking design is required to serialize concurrent starts.
+  const record = await waitForProcessIdentity(child.pid);
+  if (record === null || !processIdentityMatches(record)) {
+    throw new Error('server: unable to verify spawned daemon process identity');
+  }
+  try {
+    writePidRecord(pidPath, record);
+  } catch (error) {
+    terminateIfMatching(record);
+    throw error;
+  }
+  process.stdout.write(`server started (pid ${record.pid})\n`);
 }
 
 export async function stop(): Promise<void> {
   const config = loadServerConfig();
-  const pid = readPid(config.pidFile);
+  const state = readProcessState(config.pidFile);
 
-  if (pid === null) {
+  if (state.kind === 'missing') {
     process.stdout.write('server is not running (no pid file)\n');
     return;
   }
-  if (!isProcessAlive(pid)) {
-    removePidFile(config.pidFile);
+  if (state.kind !== 'running') {
+    removePidFileIfMatches(config.pidFile, state.snapshot);
     process.stdout.write('server is not running (removed stale pid file)\n');
     return;
   }
 
-  const command = buildStopCommand(pid, process.platform);
+  const { record } = state;
+  if (!processIdentityMatches(record)) {
+    removePidFileIfMatches(config.pidFile, state.snapshot);
+    process.stdout.write('server is not running (removed stale pid file)\n');
+    return;
+  }
+
+  const command = buildStopCommand(record.pid, process.platform);
   if (command.kind === 'exec') {
     execFileSync(command.command, command.args);
   } else {
-    process.kill(pid, command.signal);
+    process.kill(record.pid, command.signal);
     const deadline = Date.now() + 5000;
-    while (isProcessAlive(pid) && Date.now() < deadline) {
+    while (isProcessAlive(record.pid) && Date.now() < deadline) {
       await delay(100);
     }
-    if (isProcessAlive(pid)) {
-      process.kill(pid, 'SIGKILL');
+    if (isProcessAlive(record.pid) && processIdentityMatches(record)) {
+      process.kill(record.pid, 'SIGKILL');
     }
   }
 
-  removePidFile(config.pidFile);
-  process.stdout.write(`server stopped (pid ${pid})\n`);
+  removePidFileIfMatches(config.pidFile, state.snapshot);
+  process.stdout.write(`server stopped (pid ${record.pid})\n`);
 }
 
 export function status(): void {
   const config = loadServerConfig();
-  const pid = readPid(config.pidFile);
+  const state = readProcessState(config.pidFile);
 
-  if (pid === null || !isProcessAlive(pid)) {
+  if (state.kind !== 'running') {
+    if (state.kind !== 'missing') removePidFileIfMatches(config.pidFile, state.snapshot);
     process.stdout.write('server: stopped\n');
-    if (pid !== null) {
-      process.stdout.write(`  (stale pid file references pid ${pid})\n`);
-    }
     return;
   }
 
@@ -174,7 +173,7 @@ export function status(): void {
   const adapters = enabledAdapterNames(config);
   process.stdout.write(
     `server: running\n` +
-      `  pid: ${pid}\n` +
+      `  pid: ${state.record.pid}\n` +
       `  started: ${startedAt}\n` +
       `  adapters: ${adapters.length > 0 ? adapters.join(', ') : '(none)'}\n` +
       `  pid file: ${config.pidFile}\n` +

--- a/lib/server/process-state.ts
+++ b/lib/server/process-state.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+export type PidRecord = {
+  version: 1;
+  pid: number;
+  startTime: string;
+};
+
+export type ProcessStartTimeQuery = { command: string; args: string[] };
+
+export type ProcessState =
+  | { kind: 'missing'; snapshot: null }
+  | { kind: 'invalid'; snapshot: string }
+  | { kind: 'legacy'; snapshot: string; pid: number }
+  | { kind: 'stale'; snapshot: string; record: PidRecord }
+  | { kind: 'running'; snapshot: string; record: PidRecord };
+
+export type LinuxProcessStat = { state: string; startTime: string };
+
+export function parseLinuxProcessStat(raw: string): LinuxProcessStat | null {
+  const closeParen = raw.lastIndexOf(')');
+  if (closeParen < 0) return null;
+  const fields = raw.slice(closeParen + 1).trim().split(/\s+/);
+  const state = fields[0];
+  const startTime = fields[19];
+  if (typeof state !== 'string' || state.length !== 1 || !/^\d+$/.test(startTime ?? '')) {
+    return null;
+  }
+  return { state, startTime: startTime! };
+}
+
+export function buildProcessStartTimeQuery(
+  pid: number,
+  platform: NodeJS.Platform
+): ProcessStartTimeQuery | null {
+  if (platform === 'darwin') {
+    return { command: 'ps', args: ['-p', String(pid), '-o', 'lstart='] };
+  }
+  if (platform === 'win32') {
+    const script =
+      `$process = Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}'; ` +
+      `if ($null -ne $process) { $process.CreationDate.ToUniversalTime().ToString('o') }`;
+    return {
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-NonInteractive', '-Command', script]
+    };
+  }
+  return null;
+}
+
+export function isProcessAlive(pid: number, platform: NodeJS.Platform = process.platform): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (platform === 'linux') {
+    try {
+      const stat = parseLinuxProcessStat(fs.readFileSync(`/proc/${pid}/stat`, 'utf8'));
+      return stat !== null && stat.state !== 'Z';
+    } catch {
+      return false;
+    }
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export function getProcessStartTime(
+  pid: number,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (platform === 'linux') {
+    try {
+      const stat = parseLinuxProcessStat(fs.readFileSync(`/proc/${pid}/stat`, 'utf8'));
+      return stat !== null && stat.state !== 'Z' ? stat.startTime : null;
+    } catch {
+      return null;
+    }
+  }
+  if (!isProcessAlive(pid, platform)) return null;
+  const query = buildProcessStartTimeQuery(pid, platform);
+  if (query === null) return null;
+  try {
+    const output = execFileSync(query.command, query.args, { encoding: 'utf8' }).trim();
+    if (output.length === 0) return null;
+    if (platform === 'win32') {
+      const timestamp = new Date(output);
+      return Number.isNaN(timestamp.getTime()) ? null : timestamp.toISOString();
+    }
+    return output;
+  } catch {
+    return null;
+  }
+}
+
+function parsePidRecord(raw: string): { kind: 'invalid' } | { kind: 'legacy'; pid: number } | { kind: 'record'; record: PidRecord } {
+  const trimmed = raw.trim();
+  if (/^[1-9]\d*$/.test(trimmed)) {
+    const pid = Number(trimmed);
+    return Number.isSafeInteger(pid) ? { kind: 'legacy', pid } : { kind: 'invalid' };
+  }
+  try {
+    const value = JSON.parse(trimmed) as Partial<PidRecord> | null;
+    if (
+      value !== null &&
+      value.version === 1 &&
+      Number.isSafeInteger(value.pid) &&
+      (value.pid ?? 0) > 0 &&
+      typeof value.startTime === 'string' &&
+      value.startTime.length > 0
+    ) {
+      return {
+        kind: 'record',
+        record: { version: 1, pid: value.pid!, startTime: value.startTime }
+      };
+    }
+  } catch {
+    // Invalid JSON is an invalid PID record.
+  }
+  return { kind: 'invalid' };
+}
+
+export function readProcessState(pidFile: string): ProcessState {
+  let snapshot: string;
+  try {
+    snapshot = fs.readFileSync(pidFile, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { kind: 'missing', snapshot: null };
+    return { kind: 'invalid', snapshot: '' };
+  }
+
+  const parsed = parsePidRecord(snapshot);
+  if (parsed.kind === 'invalid') return { kind: 'invalid', snapshot };
+  if (parsed.kind === 'legacy') return { kind: 'legacy', snapshot, pid: parsed.pid };
+
+  const currentStartTime = getProcessStartTime(parsed.record.pid);
+  if (currentStartTime === null || currentStartTime !== parsed.record.startTime) {
+    return { kind: 'stale', snapshot, record: parsed.record };
+  }
+  return { kind: 'running', snapshot, record: parsed.record };
+}
+
+export function writePidRecord(pidFile: string, record: PidRecord): void {
+  fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+  const temporary = `${pidFile}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(record)}\n`);
+    fs.renameSync(temporary, pidFile);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      // The temporary file was never created or was already renamed.
+    }
+    throw error;
+  }
+}
+
+export function removePidFileIfMatches(pidFile: string, expectedSnapshot: string | null): boolean {
+  if (expectedSnapshot === null) return false;
+  try {
+    if (fs.readFileSync(pidFile, 'utf8') !== expectedSnapshot) return false;
+    fs.unlinkSync(pidFile);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removePidRecordIfMatches(pidFile: string, expected: PidRecord): boolean {
+  const state = readProcessState(pidFile);
+  if (state.kind !== 'running') return false;
+  if (state.record.pid !== expected.pid || state.record.startTime !== expected.startTime) return false;
+  return removePidFileIfMatches(pidFile, state.snapshot);
+}
+
+export function processIdentityMatches(record: PidRecord): boolean {
+  return getProcessStartTime(record.pid) === record.startTime;
+}

--- a/tests/integration/cli/server-lifecycle.test.ts
+++ b/tests/integration/cli/server-lifecycle.test.ts
@@ -3,10 +3,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 import { CLI_PATH, onPlatforms, gitSafeEnv, initIsolatedGitRepo, escapeRegExp } from '../../helpers.ts';
 import { buildStopCommand, isProcessAlive } from '../../../lib/server/process-control.ts';
+import { getProcessStartTime } from '../../../lib/server/process-state.ts';
 
 // buildStopCommand is pure, so both platform branches are asserted on every OS.
 // This is the win32 `taskkill` coverage that the platform-guarded lifecycle
@@ -82,8 +83,9 @@ function readPid(dir: string): number | null {
   const pidPath = pidPathOf(dir);
   if (pidPath === null) return null;
   try {
-    const pid = Number.parseInt(fs.readFileSync(pidPath, 'utf8').trim(), 10);
-    return Number.isInteger(pid) ? pid : null;
+    const record = JSON.parse(fs.readFileSync(pidPath, 'utf8')) as { pid?: unknown };
+    const pid = record.pid;
+    return typeof pid === 'number' && Number.isInteger(pid) ? pid : null;
   } catch {
     return null;
   }
@@ -164,7 +166,12 @@ test(
       assert.ok(await waitFor(() => !isProcessAlive(crashedPid)), 'crashed daemon should be gone');
       assert.ok(pidPathOf(dir) !== null, 'stale pid file should remain after a crash');
 
-      // Starting again must detect the stale pid, clean it, and spawn a fresh daemon.
+      const staleStatus = runServer(dir, 'status');
+      assert.equal(staleStatus.status, 0, staleStatus.stderr);
+      assert.match(staleStatus.stdout, /server: stopped/);
+      assert.equal(pidPathOf(dir), null, 'status should remove the stale pid file');
+
+      // Starting again after status cleanup must spawn a fresh daemon.
       assert.equal(runServer(dir, 'start').status, 0);
       pid = readPid(dir);
       assert.ok(pid !== null && pid !== crashedPid, 'stale pid should be replaced by a fresh daemon pid');
@@ -173,6 +180,90 @@ test(
       if (pid !== null && isProcessAlive(pid)) {
         runServer(dir, 'stop');
       }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  'server status and stop reclaim invalid, legacy, and reused pid records without signaling unrelated processes',
+  onPlatforms('linux', 'darwin'),
+  async () => {
+    const dir = makeRepo();
+    const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore'
+    });
+    try {
+      assert.equal(runServer(dir, 'start').status, 0);
+      const pidPath = pidPathOf(dir);
+      assert.ok(pidPath !== null, 'server start should create a pid record');
+      assert.equal(runServer(dir, 'stop').status, 0);
+
+      fs.writeFileSync(pidPath, 'invalid pid record\n');
+      assert.match(runServer(dir, 'status').stdout, /server: stopped/);
+      assert.equal(fs.existsSync(pidPath), false, 'status should reclaim an invalid record');
+
+      assert.ok(typeof unrelated.pid === 'number');
+      const unrelatedPid = unrelated.pid;
+      assert.ok(await waitFor(() => isProcessAlive(unrelatedPid)), 'unrelated child should be alive');
+
+      fs.writeFileSync(pidPath, `${unrelatedPid}\n`);
+      assert.match(runServer(dir, 'stop').stdout, /server is not running/);
+      assert.ok(isProcessAlive(unrelatedPid), 'stop must not trust or signal a legacy pid record');
+      assert.equal(fs.existsSync(pidPath), false, 'stop should reclaim the legacy record');
+
+      const startTime = getProcessStartTime(unrelatedPid);
+      assert.ok(startTime !== null, 'unrelated child identity should be queryable');
+      const mismatchedRecord = `${JSON.stringify({
+        version: 1,
+        pid: unrelatedPid,
+        startTime: `${startTime}-from-previous-process`
+      })}\n`;
+
+      fs.writeFileSync(pidPath, mismatchedRecord);
+      assert.match(runServer(dir, 'status').stdout, /server: stopped/);
+      assert.ok(isProcessAlive(unrelatedPid), 'status must not signal an unrelated process');
+      assert.equal(fs.existsSync(pidPath), false, 'status should reclaim the mismatched record');
+
+      fs.writeFileSync(pidPath, mismatchedRecord);
+      assert.match(runServer(dir, 'stop').stdout, /server is not running/);
+      assert.ok(isProcessAlive(unrelatedPid), 'stop must not signal an unrelated process');
+      assert.equal(fs.existsSync(pidPath), false, 'stop should reclaim the mismatched record');
+    } finally {
+      if (typeof unrelated.pid === 'number' && isProcessAlive(unrelated.pid)) {
+        process.kill(unrelated.pid, 'SIGKILL');
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  'daemon removes its own pid record on direct graceful termination and repeated stop is idempotent',
+  onPlatforms('linux', 'darwin'),
+  async () => {
+    const dir = makeRepo();
+    let pid: number | null = null;
+    try {
+      assert.equal(runServer(dir, 'start').status, 0);
+      pid = readPid(dir);
+      assert.ok(pid !== null, 'daemon should publish a pid record');
+      const ready = await waitFor(() => {
+        const logPath = logPathOf(dir);
+        return logPath !== null && /\[INFO\] heartbeat/.test(fs.readFileSync(logPath, 'utf8'));
+      });
+      assert.ok(ready, 'daemon signal handlers should be installed before direct SIGTERM');
+      process.kill(pid, 'SIGTERM');
+      assert.ok(await waitFor(() => !isProcessAlive(pid as number)), 'daemon should exit after SIGTERM');
+      assert.ok(await waitFor(() => pidPathOf(dir) === null), 'daemon should remove its own pid record');
+      pid = null;
+
+      const firstStop = runServer(dir, 'stop');
+      const secondStop = runServer(dir, 'stop');
+      assert.match(firstStop.stdout, /server is not running/);
+      assert.match(secondStop.stdout, /server is not running/);
+    } finally {
+      if (pid !== null && isProcessAlive(pid)) process.kill(pid, 'SIGKILL');
       fs.rmSync(dir, { recursive: true, force: true });
     }
   }

--- a/tests/unit/cli/server-process-state.test.ts
+++ b/tests/unit/cli/server-process-state.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildProcessStartTimeQuery,
+  getProcessStartTime,
+  parseLinuxProcessStat,
+  readProcessState,
+  removePidFileIfMatches,
+  writePidRecord
+} from '../../../lib/server/process-state.ts';
+
+test('parseLinuxProcessStat handles spaces and closing parentheses in comm', () => {
+  const fields = ['S', ...Array.from({ length: 18 }, (_, index) => String(index + 1)), '987654', '0'];
+  assert.deepEqual(parseLinuxProcessStat(`42 (worker ) name) ${fields.join(' ')}`), {
+    state: 'S',
+    startTime: '987654'
+  });
+  assert.equal(parseLinuxProcessStat(`42 (worker) ${['Z', ...fields.slice(1)].join(' ')}`)?.state, 'Z');
+  assert.equal(parseLinuxProcessStat('not a proc stat line'), null);
+});
+
+test('buildProcessStartTimeQuery uses argv without a shell on macOS and Windows', () => {
+  assert.deepEqual(buildProcessStartTimeQuery(4321, 'darwin'), {
+    command: 'ps',
+    args: ['-p', '4321', '-o', 'lstart=']
+  });
+
+  const windows = buildProcessStartTimeQuery(4321, 'win32');
+  assert.equal(windows?.command, 'powershell.exe');
+  assert.deepEqual(windows?.args.slice(0, 3), ['-NoProfile', '-NonInteractive', '-Command']);
+  assert.match(windows?.args[3] ?? '', /ProcessId = 4321/);
+  assert.equal(buildProcessStartTimeQuery(4321, 'linux'), null);
+});
+
+test('readProcessState classifies missing, invalid, legacy, mismatch, and matching records', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-process-state-'));
+  const pidFile = path.join(dir, 'server.pid');
+  try {
+    assert.equal(readProcessState(pidFile).kind, 'missing');
+
+    fs.writeFileSync(pidFile, 'not-a-pid\n');
+    const invalid = readProcessState(pidFile);
+    assert.equal(invalid.kind, 'invalid');
+    assert.equal(removePidFileIfMatches(pidFile, invalid.snapshot), true);
+    assert.equal(fs.existsSync(pidFile), false);
+
+    fs.writeFileSync(pidFile, `${process.pid}\n`);
+    const legacy = readProcessState(pidFile);
+    assert.equal(legacy.kind, 'legacy');
+    assert.equal(legacy.pid, process.pid);
+
+    const startTime = getProcessStartTime(process.pid);
+    assert.ok(startTime !== null, 'the current process start time should be queryable');
+    writePidRecord(pidFile, { version: 1, pid: process.pid, startTime: `${startTime}-mismatch` });
+    assert.equal(readProcessState(pidFile).kind, 'stale');
+
+    writePidRecord(pidFile, { version: 1, pid: process.pid, startTime });
+    const running = readProcessState(pidFile);
+    assert.equal(running.kind, 'running');
+    assert.equal(running.record.pid, process.pid);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('conditional cleanup preserves a replaced pid record', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-process-state-race-'));
+  const pidFile = path.join(dir, 'server.pid');
+  try {
+    fs.writeFileSync(pidFile, '123\n');
+    const oldState = readProcessState(pidFile);
+    fs.writeFileSync(pidFile, '456\n');
+
+    assert.equal(removePidFileIfMatches(pidFile, oldState.snapshot), false);
+    assert.equal(fs.readFileSync(pidFile, 'utf8'), '456\n');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #612

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #612

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 server 正常退出、异常退出或 PID 被复用后残留状态误导生命周期命令的问题。PID 文件现在记录 PID 与操作系统进程启动时间，只有两者同时匹配时才把目标视为当前 server；无法验证的状态会 fail closed、自愈清理，并且不会向无关进程发送停止信号。

## 📋 主要变更 / Brief Changelog

- 新增共享进程状态模块，统一解析 missing、invalid、legacy、stale 与 running 状态，并以临时文件加 rename 原子发布版本化 PID 记录。
- 让 `start`、`stop`、`status` 统一验证 PID 与 OS 启动时间，在初始停止和超时升级信号前重新核对进程身份。
- 让 daemon 在可捕获的 `SIGINT` / `SIGTERM` 优雅退出路径中条件删除仍属于自身的 PID 记录。
- 增加跨平台查询构造、状态分类、替换竞态、stale 自愈、PID 复用不误杀、优雅退出与重复停止测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run test:core`。
3. 运行 `npm test`。
4. 在 Windows PowerShell 5.1+ 实机验证 CreationDate UTC ISO、mismatch record 不触发 `taskkill`，以及正常 stop 可终止 daemon。
5. 在 macOS 实机运行完整测试，确认 `ps -p <pid> -o lstart=` 与生命周期集成行为稳定。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 我已经添加了集成测试 / I have added integration tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经完成 Windows PowerShell 5.1+ 实机验证 / I have completed real Windows validation
- [ ] 我已经完成 macOS 实机验证 / I have completed real macOS validation

自动化结果：针对性测试 9 项全部通过；core 测试 1158 项通过、1 项按平台条件跳过、0 失败；typecheck、完整 `npm test` 与 `git diff --check` 均通过。

## 📸 截图 / Screenshots

不适用：本次改动为 server 生命周期与进程身份校验，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #612。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要的单元和集成测试，类型检查、core 与完整测试通过。
- [x] 已考虑旧整数 PID 文件、崩溃恢复、PID 复用和条件删除的向后兼容与安全边界。
- [ ] 已完成 Windows 与 macOS 真实环境人工验证。

## 📋 附加信息 / Additional Notes

旧整数 PID 文件因缺少进程身份凭据，不再授权停止信号，而是按 unverified stale 状态安全回收。原子发布只保证 PID 记录完整，不序列化两个并发 `start`；完整启动互斥明确不在本任务范围。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 Linux `/proc/<pid>/stat` 解析、macOS/Windows 启动时间查询的 fail-closed 语义、停止前的身份复核，以及 PID 文件按快照条件删除是否避免误杀和覆盖新记录。合入前仍需完成上列 Windows 与 macOS 两项人工验证。

Generated with AI assistance