### PR TITLE
feat(sandbox): 支持沙箱启动时传入代理参数

### DIFF
--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -12,6 +12,34 @@ The sandbox image also preinstalls `gh`. When `gh auth token` succeeds on the ho
 
 Host `~/.ssh` is not bind-mounted into the sandbox. GitHub access is expected to use the `gh` / HTTPS token path above; `git@github.com:*` SSH workflows need a separate, explicit setup outside the default sandbox boundary.
 
+## Runtime proxy inheritance
+
+`ai sandbox create <branch> --inherit-proxy` copies standard host proxy variables into the new container environment. `-P` is the short form of the same boolean switch. The default remains off: if you do not pass the switch, agent-infra does not read or inject host proxy variables.
+
+The copied allowlist is fixed:
+
+- `http_proxy` / `HTTP_PROXY`
+- `https_proxy` / `HTTPS_PROXY`
+- `all_proxy` / `ALL_PROXY`
+- `no_proxy` / `NO_PROXY`
+
+Only variables that exist and are not empty strings are copied. Values are passed through unchanged by key and value: agent-infra does not parse proxy URLs, infer missing uppercase or lowercase variants, merge conflicts, interpret `NO_PROXY`, or add WebSocket-specific variables. If both uppercase and lowercase variants are set, both are written and the client inside the container decides which one it uses; prefer keeping host values consistent.
+
+Proxy values are written through the same private Docker `--env-file` path used for tool environment variables and `GH_TOKEN`, so credentials do not appear in the Docker argv or project configuration. The values are still container environment variables after creation, so every process in that container can read them. Avoid placing real proxy credentials in shell history or committed files; if credentials are required, set them in the host environment only for the create command.
+
+Example without credentials:
+
+```bash
+HTTP_PROXY=http://proxy.internal:8080 \
+HTTPS_PROXY=http://proxy.internal:8080 \
+NO_PROXY=localhost,127.0.0.1 \
+ai sandbox create feature/proxy --inherit-proxy
+```
+
+The proxy environment is captured at container creation time. `ai sandbox start` and `ai sandbox exec` do not refresh it. If the proxy entrypoint address changes, or if you need to fully remove proxy variables from a sandbox, remove and recreate the container. If the entrypoint address stays stable, switching between PROXY and DIRECT mode should happen in the proxy layer behind that address; simply stopping the proxy while leaving container proxy variables set will usually break clients.
+
+This feature covers only container runtime environment variables. Docker daemon proxy settings, image pulls, BuildKit, and image build proxy forwarding are separate build-time concerns and are not handled by `--inherit-proxy`.
+
 `ai sandbox rebuild` keeps Docker's build cache by default, so it quickly retags the sandbox image without refreshing every package. Use `ai sandbox rebuild --refresh` when you want to upgrade the image: it passes `--no-cache --pull` to Docker, pulls the current Ubuntu base image, and reruns the apt, tmux build, and global npm install layers. Claude Code updates are disabled inside the container, and OpenCode startup update checks are disabled; `--refresh` is the routine upgrade path for sandbox-managed tools. Manual `opencode upgrade` remains outside this guard. The default `python3` provided by the Ubuntu 24.04 sandbox base is Python 3.12, so scripts that hard-code Python 3.10 paths may need adjustment.
 
 `ai sandbox exec` also forwards a small terminal-detection whitelist (`TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `LC_TERMINAL`, `LC_TERMINAL_VERSION`) into the container. This keeps interactive TUIs aligned with the host terminal for behaviors such as Claude Code's Shift+Enter newline support, without passing through the full host environment.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -12,6 +12,34 @@
 
 宿主机 `~/.ssh` 不会 bind mount 到沙箱中。GitHub 访问默认走上面的 `gh` / HTTPS token 路径；`git@github.com:*` 这类 SSH workflow 需要在默认沙箱边界之外另行显式配置。
 
+## 运行时代理继承
+
+`ai sandbox create <branch> --inherit-proxy` 会把宿主机上的标准代理变量复制进新容器环境。`-P` 是同一个布尔开关的短写法。默认仍然关闭：不传该开关时，agent-infra 不读取也不注入宿主代理变量。
+
+固定白名单如下：
+
+- `http_proxy` / `HTTP_PROXY`
+- `https_proxy` / `HTTPS_PROXY`
+- `all_proxy` / `ALL_PROXY`
+- `no_proxy` / `NO_PROXY`
+
+只有已存在且不是空字符串的变量会被复制。键和值都会原样传递：agent-infra 不解析代理 URL，不补齐缺失的大小写变体，不合并冲突，不解释 `NO_PROXY`，也不新增 WebSocket 专用变量。如果大小写变体同时存在，它们都会写入容器，最终由容器内客户端决定使用哪一个；建议在宿主机上保持这些值一致。
+
+代理值通过与工具环境变量和 `GH_TOKEN` 相同的私有 Docker `--env-file` 路径写入，因此凭据不会出现在 Docker argv 或项目配置中。但创建后它们仍是容器环境变量，容器内所有进程都可以读取。不要把真实代理凭据写进 shell history 或提交到仓库；如果必须使用凭据，只在执行 create 命令时通过宿主环境提供。
+
+无凭据示例：
+
+```bash
+HTTP_PROXY=http://proxy.internal:8080 \
+HTTPS_PROXY=http://proxy.internal:8080 \
+NO_PROXY=localhost,127.0.0.1 \
+ai sandbox create feature/proxy --inherit-proxy
+```
+
+代理环境只在容器创建时捕获。`ai sandbox start` 和 `ai sandbox exec` 不会刷新这些变量。代理入口地址变化，或需要彻底移除沙箱里的代理变量时，需要删除并重新创建容器。如果入口地址保持稳定，PROXY / DIRECT 模式切换应在该地址背后的代理层完成；仅停止代理进程但保留容器代理变量通常会导致客户端连接失败。
+
+本能力只覆盖容器运行时环境变量。Docker daemon 代理、镜像拉取、BuildKit 和镜像构建期代理传递属于独立的构建期问题，不由 `--inherit-proxy` 处理。
+
 `ai sandbox rebuild` 默认保留 Docker build cache，因此会快速重打沙箱镜像，不会刷新每个软件包。需要升级镜像时使用 `ai sandbox rebuild --refresh`：它会向 Docker 传入 `--no-cache --pull`，重新拉取当前 Ubuntu 基础镜像，并重跑 apt、tmux 编译和全局 npm 安装层。容器内 Claude Code 更新已关闭，OpenCode 启动时更新检查也已关闭；`--refresh` 是沙箱托管工具的常规升级入口。手动 `opencode upgrade` 不受该保护覆盖。Ubuntu 24.04 沙箱基础镜像提供的默认 `python3` 是 Python 3.12，因此硬编码 Python 3.10 路径的脚本可能需要调整。
 
 `ai sandbox exec` 也会向容器透传一小组终端检测白名单变量（`TERM_PROGRAM`、`TERM_PROGRAM_VERSION`、`LC_TERMINAL`、`LC_TERMINAL_VERSION`）。这样可以让交互式 TUI 保持与宿主终端一致的行为，例如 Claude Code 的 `Shift+Enter` 换行支持，同时避免把整个宿主环境灌入容器。

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -87,13 +87,27 @@ alias gy='gemini --yolo; tput ed'
 `;
 const CONTAINER_HOME = '/home/devuser';
 const CONTAINER_SHELL_CONFIG_MOUNT = `${CONTAINER_HOME}/.host-shell-config`;
-const USAGE = `Usage: ai sandbox create <branch> [base] [--cpu <n>] [--memory <n>] [--no-refresh]
+const USAGE = `Usage: ai sandbox create <branch> [base] [--cpu <n>] [--memory <n>] [--no-refresh] [--inherit-proxy|-P]
 
 Host aliases:
   ${'~'}/.agent-infra/aliases/sandbox.sh is auto-created on first run and exposed
   as ${CONTAINER_HOME}/.bash_aliases inside the sandbox container (the host
   shell-config directory is bind-mounted at ${CONTAINER_SHELL_CONFIG_MOUNT} and
-  symlinked into $HOME).`;
+  symlinked into $HOME).
+
+Proxy:
+  --inherit-proxy, -P  Copy non-empty standard host proxy variables into the
+                       container environment through the private env file.`;
+const HOST_PROXY_ENV_KEYS = [
+  'http_proxy',
+  'HTTP_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+  'no_proxy',
+  'NO_PROXY'
+] as const;
 
 type SandboxCreateConfig = ReturnType<typeof loadConfig>;
 type PreparedDockerfile = ReturnType<typeof prepareDockerfile>;
@@ -626,11 +640,19 @@ function formatEnvFileEntry(key: string, value: string): string {
   return `${key}=${value}`;
 }
 
+export function collectHostProxyEntries(env: NodeJS.ProcessEnv): Array<[string, string]> {
+  return HOST_PROXY_ENV_KEYS.flatMap((key) => {
+    const value = env[key];
+    return typeof value === 'string' && value !== '' ? [[key, value]] : [];
+  });
+}
+
 export function buildContainerEnvFile(
   resolvedTools: ResolvedTool[],
   engine: string,
   runSafeEngineFn: EngineRunSafeFn = runSafeEngine,
   options: {
+    additionalEntries?: Array<[string, string]>;
     mkdtempFn?: typeof fs.mkdtempSync;
     writeFileFn?: typeof fs.writeFileSync;
     chmodFn?: typeof fs.chmodSync;
@@ -640,6 +662,7 @@ export function buildContainerEnvFile(
   } = {}
 ): { dockerArgs: string[]; cleanup: () => void } {
   const {
+    additionalEntries = [],
     mkdtempFn = fs.mkdtempSync,
     writeFileFn = fs.writeFileSync,
     chmodFn = fs.chmodSync,
@@ -649,6 +672,7 @@ export function buildContainerEnvFile(
   } = options;
 
   const entries: Array<[string, string]> = resolvedTools.flatMap(({ tool }) => Object.entries(tool.envVars ?? {}));
+  entries.push(...additionalEntries);
   let ghToken = runSafeEngineFn(engine, 'gh', ['auth', 'token']);
   if (!ghToken && engine === 'wsl2') {
     ghToken = runSafeFn('gh', ['auth', 'token']);
@@ -1246,6 +1270,7 @@ export async function create(args: string[]): Promise<void> {
       cpu: { type: 'string' },
       memory: { type: 'string' },
       'no-refresh': { type: 'boolean' },
+      'inherit-proxy': { type: 'boolean', short: 'P' },
       help: { type: 'boolean', short: 'h' }
     }
   });
@@ -1503,7 +1528,10 @@ export async function create(args: string[]): Promise<void> {
               signingKey
             )
             : null;
-          const envFile = buildContainerEnvFile(effectiveResolvedTools, engine);
+          const proxyEntries = values['inherit-proxy'] ? collectHostProxyEntries(process.env) : [];
+          const envFile = buildContainerEnvFile(effectiveResolvedTools, engine, undefined, {
+            additionalEntries: proxyEntries
+          });
           let hostShellConfig: HostShellConfig;
           let tmpfsSeedPlan: TmpfsSeedPlanEntry[] = [];
           try {

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -641,8 +641,9 @@ function formatEnvFileEntry(key: string, value: string): string {
 }
 
 export function collectHostProxyEntries(env: NodeJS.ProcessEnv): Array<[string, string]> {
+  const entriesByExactKey = new Map(Object.entries(env));
   return HOST_PROXY_ENV_KEYS.flatMap((key) => {
-    const value = env[key];
+    const value = entriesByExactKey.get(key);
     return typeof value === 'string' && value !== '' ? [[key, value]] : [];
   });
 }

--- a/tests/helpers/sandbox.ts
+++ b/tests/helpers/sandbox.ts
@@ -13,8 +13,10 @@ type SandboxFixture = {
   repoDir: string;
   binDir: string;
   logPath: string;
+  envFileLogPath: string;
   readDockerCalls(): string[][];
   readRawDockerCalls(): string[][];
+  readCapturedEnvFiles(): string[];
 };
 
 function dockerCommandArgs(args: string[]): string[] {
@@ -54,6 +56,7 @@ function writeSandboxEngineFixture(
   const repoDir = path.join(tmpDir, "repo");
   const binDir = path.join(tmpDir, "bin");
   const logPath = path.join(tmpDir, "docker-log.jsonl");
+  const envFileLogPath = path.join(tmpDir, "docker-env-files.jsonl");
   const dockerJsPath = path.join(binDir, "docker.js");
   const idJsPath = path.join(binDir, "id.js");
   const whichJsPath = path.join(binDir, "which.js");
@@ -93,7 +96,17 @@ function writeSandboxEngineFixture(
       "function log() {",
       "  fs.appendFileSync(process.env.DOCKER_LOG_PATH, JSON.stringify(rawArgs) + '\\n');",
       "}",
+      "function captureEnvFile() {",
+      "  if (!process.env.DOCKER_ENV_FILE_LOG_PATH || args[0] !== 'run') return;",
+      "  const index = args.indexOf('--env-file');",
+      "  if (index < 0 || !args[index + 1]) return;",
+      "  const envPath = args[index + 1];",
+      "  let content = '';",
+      "  try { content = fs.readFileSync(envPath, 'utf8'); } catch (error) { content = `__READ_ERROR__:${error.message}`; }",
+      "  fs.appendFileSync(process.env.DOCKER_ENV_FILE_LOG_PATH, JSON.stringify({ path: envPath, content }) + '\\n');",
+      "}",
       "log();",
+      "captureEnvFile();",
       "if (args[0] === 'ps') {",
       "  if (dockerStdoutForPs) {",
       "    process.stdout.write(dockerStdoutForPs.endsWith('\\n') ? dockerStdoutForPs : `${dockerStdoutForPs}\\n`);",
@@ -183,6 +196,7 @@ function writeSandboxEngineFixture(
     repoDir,
     binDir,
     logPath,
+    envFileLogPath,
     readDockerCalls() {
       if (!fs.existsSync(logPath)) {
         return [];
@@ -202,6 +216,16 @@ function writeSandboxEngineFixture(
         .split("\n")
         .filter(Boolean)
         .map((line) => JSON.parse(line) as string[]);
+    },
+    readCapturedEnvFiles() {
+      if (!fs.existsSync(envFileLogPath)) {
+        return [];
+      }
+      return fs.readFileSync(envFileLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => (JSON.parse(line) as { content: string }).content);
     }
   };
 }

--- a/tests/integration/cli/sandbox-proxy.test.ts
+++ b/tests/integration/cli/sandbox-proxy.test.ts
@@ -1,0 +1,209 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  assertModeBits,
+  cliArgs,
+  envWithPrependedPath,
+  gitSafeEnv,
+  loadFreshEsm,
+  writeSandboxEngineFixture
+} from "../../helpers.ts";
+
+type CommandOptions = Record<string, unknown> & {
+  env?: NodeJS.ProcessEnv;
+  input?: Buffer | string;
+  encoding?: BufferEncoding;
+  stdio?: unknown;
+};
+type ResolvedToolFixture = {
+  tool: {
+    envVars?: Record<string, string>;
+    id?: string;
+  };
+};
+type EnvFileResult = {
+  dockerArgs: string[];
+  cleanup(): void;
+};
+type EngineRunSafeFn = (engine: string, cmd: string, args: string[]) => string;
+type SandboxCreateModule = {
+  collectHostProxyEntries(env: NodeJS.ProcessEnv): Array<[string, string]>;
+  buildContainerEnvFile(
+    tools: ResolvedToolFixture[],
+    engine: string,
+    runSafe?: EngineRunSafeFn,
+    options?: CommandOptions & { additionalEntries?: Array<[string, string]> }
+  ): EnvFileResult;
+};
+
+function required<T>(value: T | undefined, message = "expected value"): T {
+  if (value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function spawnSandboxCli(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {}
+) {
+  return spawnSync(process.execPath, cliArgs("sandbox", ...args), {
+    cwd: fixture.repoDir,
+    env: {
+      ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      DOCKER_LOG_PATH: fixture.logPath,
+      DOCKER_ENV_FILE_LOG_PATH: fixture.envFileLogPath,
+      ...extraEnv
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 15_000
+  });
+}
+
+function commitFixtureRepo(repoDir: string) {
+  fs.writeFileSync(path.join(repoDir, "README.md"), "fixture\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" });
+  spawnSync("git", [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "commit",
+    "-m",
+    "init"
+  ], { cwd: repoDir, env: gitSafeEnv(), stdio: "ignore" });
+}
+
+function proxyEnvLines(content: string): string[] {
+  return content
+    .split("\n")
+    .filter((line) => /^(?:http_proxy|HTTP_PROXY|https_proxy|HTTPS_PROXY|all_proxy|ALL_PROXY|no_proxy|NO_PROXY)=/.test(line));
+}
+
+test("collectHostProxyEntries returns only non-empty standard proxy variables in fixed order", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+
+  const entries = sandboxCreate.collectHostProxyEntries({
+    http_proxy: "http://lower-http.example:8080",
+    HTTP_PROXY: "http://upper-http.example:8080",
+    https_proxy: "",
+    HTTPS_PROXY: "https://upper-https.example:8443",
+    all_proxy: "socks5://lower-all.example:1080",
+    ALL_PROXY: "socks5://upper-all.example:1080",
+    no_proxy: "localhost,127.0.0.1",
+    NO_PROXY: "example.test",
+    npm_config_proxy: "http://not-forwarded.example:8080"
+  });
+
+  assert.deepEqual(entries, [
+    ["http_proxy", "http://lower-http.example:8080"],
+    ["HTTP_PROXY", "http://upper-http.example:8080"],
+    ["HTTPS_PROXY", "https://upper-https.example:8443"],
+    ["all_proxy", "socks5://lower-all.example:1080"],
+    ["ALL_PROXY", "socks5://upper-all.example:1080"],
+    ["no_proxy", "localhost,127.0.0.1"],
+    ["NO_PROXY", "example.test"]
+  ]);
+});
+
+test("buildContainerEnvFile appends proxy entries after tool env and before GH_TOKEN", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-proxy-env-file-"));
+
+  try {
+    const envFile = sandboxCreate.buildContainerEnvFile([
+      { tool: { envVars: { HTTP_PROXY: "http://tool.example:8080", FOO: "bar" } } }
+    ], "native", () => "ghp_123456789012345678901234567890123456", {
+      tmpDir,
+      additionalEntries: [
+        ["HTTP_PROXY", "http://host.example:8080"],
+        ["NO_PROXY", "localhost"]
+      ]
+    });
+    const envPath = required(envFile.dockerArgs[1]);
+
+    assert.equal(fs.readFileSync(envPath, "utf8"), [
+      "HTTP_PROXY=http://tool.example:8080",
+      "FOO=bar",
+      "HTTP_PROXY=http://host.example:8080",
+      "NO_PROXY=localhost",
+      "GH_TOKEN=ghp_123456789012345678901234567890123456",
+      ""
+    ].join("\n"));
+    assert.ok(!envFile.dockerArgs.some((arg) => arg.includes("host.example")));
+    assertModeBits(path.dirname(envPath), 0o700);
+    assertModeBits(envPath, 0o600);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("buildContainerEnvFile rejects newlines in additional proxy entries and cleans up", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-proxy-env-file-newline-"));
+
+  try {
+    assert.throws(() => sandboxCreate.buildContainerEnvFile([], "native", () => "", {
+      tmpDir,
+      additionalEntries: [["HTTP_PROXY", "http://proxy.example:8080\nSECRET"]]
+    }), /HTTP_PROXY must not contain newlines/);
+    assert.deepEqual(fs.readdirSync(tmpDir), []);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox create inherits host proxy variables only when explicitly requested", { timeout: 30_000 }, () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-proxy-cli-"));
+
+  try {
+    const defaultFixture = writeSandboxEngineFixture(path.join(tmpDir, "default"), { project: "demo" });
+    commitFixtureRepo(defaultFixture.repoDir);
+    const defaultResult = spawnSandboxCli(defaultFixture, tmpDir, ["create", "feature/default-proxy"], {
+      HTTP_PROXY: "http://proxy.example:8080",
+      HTTPS_PROXY: "https://secure-proxy.example:8443"
+    });
+    assert.equal(defaultResult.status, 0, defaultResult.stderr);
+    assert.deepEqual(defaultFixture.readCapturedEnvFiles().flatMap(proxyEnvLines), []);
+
+    const inheritFixture = writeSandboxEngineFixture(path.join(tmpDir, "inherit"), { project: "demo" });
+    commitFixtureRepo(inheritFixture.repoDir);
+    const inheritResult = spawnSandboxCli(inheritFixture, tmpDir, ["create", "feature/inherit-proxy", "--inherit-proxy"], {
+      HTTP_PROXY: "http://user:pass@proxy.example:8080",
+      HTTPS_PROXY: "https://secure-proxy.example:8443",
+      NO_PROXY: "localhost,127.0.0.1",
+      npm_config_proxy: "http://not-forwarded.example:8080"
+    });
+    assert.equal(inheritResult.status, 0, inheritResult.stderr);
+    assert.deepEqual(inheritFixture.readCapturedEnvFiles().flatMap(proxyEnvLines), [
+      "HTTP_PROXY=http://user:pass@proxy.example:8080",
+      "HTTPS_PROXY=https://secure-proxy.example:8443",
+      "NO_PROXY=localhost,127.0.0.1"
+    ]);
+    const runCall = inheritFixture.readDockerCalls().find((call) => call[0] === "run") ?? [];
+    assert.ok(!runCall.some((arg) => arg.includes("user:pass")));
+    assert.equal(runCall.includes("--env-file"), true);
+
+    const shortFixture = writeSandboxEngineFixture(path.join(tmpDir, "short"), { project: "demo" });
+    commitFixtureRepo(shortFixture.repoDir);
+    const shortResult = spawnSandboxCli(shortFixture, tmpDir, ["create", "feature/short-proxy", "-P"], {
+      http_proxy: "http://lower-proxy.example:8080"
+    });
+    assert.equal(shortResult.status, 0, shortResult.stderr);
+    assert.deepEqual(shortFixture.readCapturedEnvFiles().flatMap(proxyEnvLines), [
+      "http_proxy=http://lower-proxy.example:8080"
+    ]);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/cli/sandbox-proxy.test.ts
+++ b/tests/integration/cli/sandbox-proxy.test.ts
@@ -116,6 +116,27 @@ test("collectHostProxyEntries returns only non-empty standard proxy variables in
   ]);
 });
 
+test("collectHostProxyEntries does not duplicate case-insensitive environment keys", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const env = new Proxy<NodeJS.ProcessEnv>({
+    HTTP_PROXY: "http://proxy.example:8080",
+    NO_PROXY: "localhost"
+  }, {
+    get(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property);
+      }
+      const exactKey = Object.keys(target).find((key) => key.toLowerCase() === property.toLowerCase());
+      return exactKey === undefined ? undefined : target[exactKey];
+    }
+  });
+
+  assert.deepEqual(sandboxCreate.collectHostProxyEntries(env), [
+    ["HTTP_PROXY", "http://proxy.example:8080"],
+    ["NO_PROXY", "localhost"]
+  ]);
+});
+
 test("buildContainerEnvFile appends proxy entries after tool env and before GH_TOKEN", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-proxy-env-file-"));


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #627

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #627

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [x] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

支持 sandbox create 在显式传入 `--inherit-proxy` 或短别名 `-P` 时继承宿主标准代理环境变量，使关闭底层 TUN 模式后仍可为沙箱运行时提供代理通道。默认未启用时保持现有行为，不复制宿主代理变量。

## 📋 主要变更 / Brief Changelog

- 新增 `--inherit-proxy` / `-P` 布尔开关，并在 Docker 运行时 env-file 中注入标准代理变量白名单。
- 仅继承 `http_proxy` / `HTTP_PROXY`、`https_proxy` / `HTTPS_PROXY`、`all_proxy` / `ALL_PROXY`、`no_proxy` / `NO_PROXY`，避免复制宿主完整环境。
- 增加 sandbox create 集成测试，覆盖默认不继承、显式继承大小写变量、空白变量过滤和短别名路径。
- 同步英文与中文 sandbox 文档，说明代理继承开关、安全边界和运行时生命周期。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm test`。
2. 提交前钩子运行类型检查、构建和 core 测试。
3. 检查 PR diff，确认未配置开关时不继承宿主代理变量，配置 `--inherit-proxy` 或 `-P` 时仅注入代理白名单。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了集成测试 / I have added integration tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 已完成独立代码审查 / Independent code review completed
- [x] 已同步英文与中文文档 / English and Chinese docs updated

自动化结果：实现阶段完整测试 1427 项，1426 通过、1 项按平台条件跳过、0 失败；提交钩子再次完成类型检查、构建与 core 测试，1157 通过、1 跳过、0 失败。

## 📸 截图 / Screenshots

不适用：本次改动为 sandbox CLI 参数、运行时环境注入和文档更新，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #627。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要的集成测试，类型检查、构建与完整测试通过。
- [x] 已同步英文主文档与中文翻译。
- [x] 已考虑代理凭据泄露、环境变量污染、默认兼容性和运行时边界。

## 📋 附加信息 / Additional Notes

本 PR 只覆盖容器运行时代理继承；Docker image build/pull 的构建期代理传递已拆分到 Issue #637 / TASK-20260714-195748。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 `--inherit-proxy` / `-P` 的显式启用边界、代理变量白名单是否避免复制无关宿主环境、env-file 注入是否保持既有私有文件生命周期，以及默认未启用时是否完全保持原行为。

Generated with AI assistance