### PR TITLE
fix(templates): 统一模板版本语义并移除自更新特判

### DIFF
--- a/.agents/skills/update-agent-infra/SKILL.md
+++ b/.agents/skills/update-agent-infra/SKILL.md
@@ -35,7 +35,7 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 
 **关键字段**：
 - `error`：错误信息（如非空则停止并报告）
-- `templateVersion`：模板源当前版本
+- `templateVersion`：模板源包的精确 `v` 前缀 SemVer（可包含 prerelease 或 build metadata）
 - `templateRoot`：模板文件根目录绝对路径
 - `templateSources.conflicts`：外部模板源冲突列表；报告中必须显式展示，说明哪些文件因内置模板或后续外部源获胜而被忽略
 - `managed.written` / `managed.created`：已更新/新建的 managed 文件
@@ -47,7 +47,6 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 - `merged.pending`：需要 AI 处理的 merged 文件列表
   - 每项包含 `target`（项目中的目标路径）和 `template`（模板根目录下的相对路径）
 - `registryAdded`：新增的文件注册条目
-- `selfUpdate`：是否为自更新模式
 - `configUpdated`：`.agents/.airc.json` 是否已更新
 
 如果 `managed.conflicts` 非空，输出全部冲突并立即停止，不进入阶段 B；禁止覆盖冲突文件或推进其 `files.managedBaselines`。

--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -13,7 +13,6 @@
  * Output: JSON report to stdout.
  */
 
-import childProcess from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -871,14 +870,6 @@ function isBinary(fp) {
   return false;
 }
 
-function gitUrl(dir) {
-  try {
-    return childProcess.execSync('git remote get-url origin', {
-      cwd: dir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-  } catch { return null; }
-}
-
 function langSelect(rels, lang, allSet, project) {
   const sel = new Map();
 
@@ -1021,8 +1012,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     },
     ejected: { created: [], skipped: [] },
     merged:  { pending: [] },
-    configUpdated: false,
-    selfUpdate: false
+    configUpdated: false
   };
   const customTUIs = validateCustomTUIs(projectRoot, customTUIsConfig, report);
   const customTUICommandTargets = buildCustomTUICommandTargets(
@@ -1365,9 +1355,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
   report.merged.pending = [...mergedMap].map(
     ([target, template]) => ({ target, template })
   );
-
-  const projUrl = gitUrl(projectRoot);
-  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/.git-hooks/check-version-format.sh
+++ b/.git-hooks/check-version-format.sh
@@ -21,7 +21,11 @@ template_version=$(
   exit 1
 }
 
-if ! printf '%s\n' "$template_version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+if ! node -e '
+  const version = process.argv[1];
+  const semver = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+  process.exit(semver.test(version) ? 0 : 1);
+' "$template_version"; then
   echo "Error: .agents/.airc.json templateVersion must use v-prefixed semver (found: $template_version)."
   exit 1
 fi

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -56,7 +56,7 @@ The generated `.agents/.airc.json` file is the central contract between the boot
 | `project` | Project name used when rendering commands, paths, and templates. |
 | `org` | GitHub organization or owner used by generated metadata and links. |
 | `language` | Primary project language or locale used by rendered templates. |
-| `templateVersion` | Installed template version for future upgrades and drift tracking. |
+| `templateVersion` | Exact `v`-prefixed SemVer of the installed template package, including prerelease or build metadata, for future upgrades and drift tracking. |
 | `templates` | Optional external template overlay configuration. |
 | `templates.sources` | Optional ordered list of external template sources. Only `type: "local"` is supported today. |
 | `skills` | Optional custom skill sync configuration. |
@@ -91,4 +91,4 @@ External template files and skill scripts can include executable JavaScript or s
 
 ## Version Management
 
-agent-infra uses semantic versioning through Git tags and GitHub releases. The installed template version is recorded in `.agents/.airc.json` as `templateVersion`, which gives both humans and AI tools a stable reference point for upgrades.
+agent-infra uses semantic versioning through Git tags and GitHub releases. The installed template package's exact `v`-prefixed SemVer is recorded in `.agents/.airc.json` as `templateVersion`, including any prerelease or build metadata. This gives both humans and AI tools a stable reference point for upgrades.

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -56,7 +56,7 @@
 | `project` | 用于渲染命令、路径和模板内容的项目名。 |
 | `org` | 生成元数据和链接时使用的 GitHub 组织或拥有者。 |
 | `language` | 渲染模板时采用的项目主语言或区域设置。 |
-| `templateVersion` | 当前安装的模板版本，用于升级和差异追踪。 |
+| `templateVersion` | 当前安装模板包的精确 `v` 前缀 SemVer（可包含 prerelease 或 build metadata），用于升级和差异追踪。 |
 | `templates` | 可选的外部模板叠加配置。 |
 | `templates.sources` | 可选的外部模板源列表，按顺序应用。当前仅支持 `type: "local"`。 |
 | `skills` | 可选的自定义 skill 同步配置。 |
@@ -91,4 +91,4 @@
 
 ## 版本管理
 
-agent-infra 通过 Git tag 和 GitHub release 使用语义化版本号。当前安装的模板版本记录在 `.agents/.airc.json` 的 `templateVersion` 字段中，方便人和 AI 工具在升级时都能基于同一个版本基线工作。
+agent-infra 通过 Git tag 和 GitHub release 使用语义化版本号。当前安装模板包的精确 `v` 前缀 SemVer 会记录在 `.agents/.airc.json` 的 `templateVersion` 字段中，包括 prerelease 或 build metadata，方便人和 AI 工具在升级时都能基于同一个版本基线工作。

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -13,7 +13,6 @@
  * Output: JSON report to stdout.
  */
 
-import childProcess from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -797,14 +796,6 @@ function isBinary(fp) {
   return false;
 }
 
-function gitUrl(dir) {
-  try {
-    return childProcess.execSync('git remote get-url origin', {
-      cwd: dir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-  } catch { return null; }
-}
-
 function langSelect(rels, lang, allSet, project) {
   const sel = new Map();
 
@@ -947,8 +938,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     },
     ejected: { created: [], skipped: [] },
     merged:  { pending: [] },
-    configUpdated: false,
-    selfUpdate: false
+    configUpdated: false
   };
   const customTUIs = validateCustomTUIs(projectRoot, customTUIsConfig, report);
   const customTUICommandTargets = buildCustomTUICommandTargets(
@@ -1291,9 +1281,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
   report.merged.pending = [...mergedMap].map(
     ([target, template]) => ({ target, template })
   );
-
-  const projUrl = gitUrl(projectRoot);
-  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/templates/.agents/skills/update-agent-infra/SKILL.en.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.en.md
@@ -41,7 +41,7 @@ The script outputs JSON to stdout. Parse and record the report.
 
 **Key fields**:
 - `error`: error message (if non-empty, stop and report)
-- `templateVersion`: current template source version
+- `templateVersion`: exact `v`-prefixed SemVer of the template source package (including prerelease or build metadata)
 - `templateRoot`: absolute path to the template file root directory
 - `templateSources.conflicts`: external template source conflicts; explicitly
   list these in the report so users know which files were ignored because a
@@ -55,7 +55,6 @@ The script outputs JSON to stdout. Parse and record the report.
 - `merged.pending`: list of merged files for AI to process
   - Each item has `target` (project-relative path) and `template` (template-root-relative path)
 - `registryAdded`: newly added file registry entries
-- `selfUpdate`: whether this is a self-update scenario
 - `configUpdated`: whether `.agents/.airc.json` was updated
 
 If `managed.conflicts` is non-empty, output every conflict and stop immediately before Phase B. Do not overwrite a conflicting file or advance its `files.managedBaselines` entry.

--- a/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
+++ b/templates/.agents/skills/update-agent-infra/SKILL.zh-CN.md
@@ -35,7 +35,7 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 
 **关键字段**：
 - `error`：错误信息（如非空则停止并报告）
-- `templateVersion`：模板源当前版本
+- `templateVersion`：模板源包的精确 `v` 前缀 SemVer（可包含 prerelease 或 build metadata）
 - `templateRoot`：模板文件根目录绝对路径
 - `templateSources.conflicts`：外部模板源冲突列表；报告中必须显式展示，说明哪些文件因内置模板或后续外部源获胜而被忽略
 - `managed.written` / `managed.created`：已更新/新建的 managed 文件
@@ -47,7 +47,6 @@ node .agents/skills/update-agent-infra/scripts/sync-templates.js
 - `merged.pending`：需要 AI 处理的 merged 文件列表
   - 每项包含 `target`（项目中的目标路径）和 `template`（模板根目录下的相对路径）
 - `registryAdded`：新增的文件注册条目
-- `selfUpdate`：是否为自更新模式
 - `configUpdated`：`.agents/.airc.json` 是否已更新
 
 如果 `managed.conflicts` 非空，输出全部冲突并立即停止，不进入阶段 B；禁止覆盖冲突文件或推进其 `files.managedBaselines`。

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -13,7 +13,6 @@
  * Output: JSON report to stdout.
  */
 
-import childProcess from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -871,14 +870,6 @@ function isBinary(fp) {
   return false;
 }
 
-function gitUrl(dir) {
-  try {
-    return childProcess.execSync('git remote get-url origin', {
-      cwd: dir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-  } catch { return null; }
-}
-
 function langSelect(rels, lang, allSet, project) {
   const sel = new Map();
 
@@ -1021,8 +1012,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     },
     ejected: { created: [], skipped: [] },
     merged:  { pending: [] },
-    configUpdated: false,
-    selfUpdate: false
+    configUpdated: false
   };
   const customTUIs = validateCustomTUIs(projectRoot, customTUIsConfig, report);
   const customTUICommandTargets = buildCustomTUICommandTargets(
@@ -1365,9 +1355,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
   report.merged.pending = [...mergedMap].map(
     ([target, template]) => ({ target, template })
   );
-
-  const projUrl = gitUrl(projectRoot);
-  report.selfUpdate = !!(projUrl && /fitlab-ai\/agent-infra/.test(projUrl));
 
   const hasChanges = (
     report.managed.written.length +

--- a/templates/.git-hooks/check-version-format.sh
+++ b/templates/.git-hooks/check-version-format.sh
@@ -21,7 +21,11 @@ template_version=$(
   exit 1
 }
 
-if ! printf '%s\n' "$template_version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+if ! node -e '
+  const version = process.argv[1];
+  const semver = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:(?:0|[1-9]\d*)|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+  process.exit(semver.test(version) ? 0 : 1);
+' "$template_version"; then
   echo "Error: .agents/.airc.json templateVersion must use v-prefixed semver (found: $template_version)."
   exit 1
 fi

--- a/tests/unit/cli/sync-templates.test.ts
+++ b/tests/unit/cli/sync-templates.test.ts
@@ -91,9 +91,6 @@ test("syncTemplates resolves template roots via PATH lookup and removes legacy t
         assert.equal(options.encoding, "utf8");
         return path.join(installRoot, "bin", "cli.js");
       }
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
       throw new Error(`Unexpected command: ${command}`);
     }) as typeof childProcess.execSync;
 
@@ -195,9 +192,6 @@ test("syncTemplates resolves Windows npm wrappers via .cmd launchers", async () 
     childProcess.execSync = ((command) => {
       if (command === "where ai") {
         return wrapperPath;
-      }
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
       }
       throw new Error(`Unexpected command: ${command}`);
     }) as typeof childProcess.execSync;
@@ -326,13 +320,12 @@ test("agent-infra package lookup failure is diagnostic and does not install into
   }
 });
 
-test("syncTemplates reports the bundled installer version with a v prefix", async () => {
-  const originalExecSync = childProcess.execSync;
+test("syncTemplates persists the exact prerelease template version idempotently", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-installer-version-"));
 
   try {
     const projectRoot = path.join(tmpDir, "project");
-    const { templateRoot } = createTemplateInstall(tmpDir);
+    const { templateRoot } = createTemplateInstall(tmpDir, "0.8.6-alpha.0");
 
     fs.mkdirSync(projectRoot, { recursive: true });
 
@@ -342,6 +335,7 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
       org: "acme",
       language: "en",
       platform: { type: "github" },
+      templateVersion: "v0.8.5",
       files: {
         managed: ["README.md"],
         merged: [],
@@ -349,25 +343,21 @@ test("syncTemplates reports the bundled installer version with a v prefix", asyn
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
-    const report = syncTemplates(projectRoot, templateRoot);
+    const firstReport = syncTemplates(projectRoot, templateRoot);
+    const config = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents/.airc.json"), "utf8"));
+    const secondReport = syncTemplates(projectRoot, templateRoot);
 
-    assert.equal(report.templateVersion, "v0.0.0-test");
+    assert.equal(firstReport.templateVersion, "v0.8.6-alpha.0");
+    assert.equal(config.templateVersion, "v0.8.6-alpha.0");
+    assert.equal(firstReport.configUpdated, true);
+    assert.equal(secondReport.configUpdated, false);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates migrates legacy default sandbox tools to canonical order", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-sandbox-tools-"));
 
   try {
@@ -390,13 +380,6 @@ test("syncTemplates migrates legacy default sandbox tools to canonical order", a
       files: { managed: [], merged: [], ejected: [] }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
     const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8"));
@@ -404,13 +387,11 @@ test("syncTemplates migrates legacy default sandbox tools to canonical order", a
     assert.equal(report.configUpdated, true);
     assert.deepEqual(cfg.sandbox.tools, ["agent-infra", "claude-code", "codex", "gemini-cli", "opencode"]);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates preserves customized sandbox tools", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-sandbox-custom-tools-"));
 
   try {
@@ -433,26 +414,17 @@ test("syncTemplates preserves customized sandbox tools", async () => {
       files: { managed: [], merged: [], ejected: [] }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     syncTemplates(projectRoot, templateRoot);
     const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, ".agents", ".airc.json"), "utf8"));
 
     assert.deepEqual(cfg.sandbox.tools, ["codex"]);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates prefers platform-specific variants and composes with zh-CN localization", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-platform-"));
 
   try {
@@ -477,26 +449,17 @@ test("syncTemplates prefers platform-specific variants and composes with zh-CN l
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
     assert.deepEqual(report.managed.created.sort(), ["docs/rule.md"]);
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/rule.md"), "utf8"), "github-zh\n");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates selects JSON language variants for managed config files", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-json-lang-"));
 
   try {
@@ -534,13 +497,6 @@ test("syncTemplates selects JSON language variants for managed config files", as
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
 
     syncTemplates(projectRoot, templateRoot);
@@ -569,13 +525,11 @@ test("syncTemplates selects JSON language variants for managed config files", as
       zhVerify
     );
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates includes external-only files for managed directories", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-template-source-dir-"));
 
   try {
@@ -603,13 +557,6 @@ test("syncTemplates includes external-only files for managed directories", async
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -626,13 +573,11 @@ test("syncTemplates includes external-only files for managed directories", async
       "Custom demo\n"
     );
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates keeps built-ins authoritative and lets later external template sources override earlier sources", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-template-source-priority-"));
 
   try {
@@ -669,13 +614,6 @@ test("syncTemplates keeps built-ins authoritative and lets later external templa
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -703,13 +641,11 @@ test("syncTemplates keeps built-ins authoritative and lets later external templa
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/rule.md"), "utf8"), "builtin\n");
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/external.md"), "utf8"), "external-two\n");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates ignores external platform variants when a built-in variant already exists", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-template-source-builtin-variant-"));
 
   try {
@@ -739,13 +675,6 @@ test("syncTemplates ignores external platform variants when a built-in variant a
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -758,13 +687,11 @@ test("syncTemplates ignores external platform variants when a built-in variant a
     ]);
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/rule.md"), "utf8"), "builtin-gitea-zh\n");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates selects platform and language variants from external template sources", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-template-source-variant-"));
 
   try {
@@ -793,26 +720,17 @@ test("syncTemplates selects platform and language variants from external templat
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
     assert.equal(report.templateSources.loaded, 1);
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/rule.md"), "utf8"), "external-gitea-zh\n");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates reports invalid external template sources and keeps built-in behavior", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-template-source-invalid-"));
 
   try {
@@ -842,13 +760,6 @@ test("syncTemplates reports invalid external template sources and keeps built-in
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -862,13 +773,11 @@ test("syncTemplates reports invalid external template sources and keeps built-in
     assert.deepEqual(report.templateSources.conflicts, []);
     assert.equal(fs.readFileSync(path.join(projectRoot, "README.md"), "utf8"), "Hello demo\n");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates removes stale managed files but preserves merged and ejected files", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-cleanup-"));
 
   try {
@@ -902,13 +811,6 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
     writeFile(projectRoot, ".agents/keep.md", "AI enabled\n");
     writeFile(projectRoot, ".github/workflows/release.yml", "name: custom\n");
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
 
     const firstReport = syncTemplates(projectRoot, templateRoot);
@@ -926,13 +828,11 @@ test("syncTemplates removes stale managed files but preserves merged and ejected
     assert.ok(secondReport.managed.unchanged.includes(".agents/keep.md"));
     assert.deepEqual(secondReport.managed.skippedMerged, [".github/workflows/release.yml"]);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates keeps an ejected entry that has no template source under a managed directory wildcard", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-project-only-ejected-"));
 
   try {
@@ -958,13 +858,6 @@ test("syncTemplates keeps an ejected entry that has no template source under a m
     writeFile(projectRoot, "docs/template.md", "Template\n");
     writeFile(projectRoot, "docs/project-only.md", "Project only\n");
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -972,13 +865,11 @@ test("syncTemplates keeps an ejected entry that has no template source under a m
     assert.equal(fs.readFileSync(path.join(projectRoot, "docs/project-only.md"), "utf8"), "Project only\n");
     assert.deepEqual(report.ejected.skipped, ["docs/project-only.md"]);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates preserves custom skills when the template has only an empty same-name directory", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-empty-skill-dir-"));
 
   try {
@@ -1004,13 +895,6 @@ test("syncTemplates preserves custom skills when the template has only an empty 
     writeFile(projectRoot, ".agents/skills/local-check/SKILL.md", "---\nname: local-check\ndescription: Local\n---\n");
     writeFile(projectRoot, ".agents/skills/local-check/reference/checklist.md", "keep local\n");
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -1026,13 +910,11 @@ test("syncTemplates preserves custom skills when the template has only an empty 
     assert.ok(!report.managed.removed.includes(".agents/skills/local-check/SKILL.md"));
     assert.ok(!report.managed.removed.includes(".agents/skills/local-check/reference/checklist.md"));
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates preserves stale files that match merged glob patterns", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-glob-"));
 
   try {
@@ -1058,13 +940,6 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
     writeFile(projectRoot, "docs/stale/note.md", "keep merged glob\n");
     writeFile(projectRoot, "docs/stale/extra.txt", "remove non-md\n");
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -1072,13 +947,11 @@ test("syncTemplates preserves stale files that match merged glob patterns", asyn
     assert.ok(!fs.existsSync(path.join(projectRoot, "docs/stale/extra.txt")));
     assert.deepEqual(report.managed.removed, ["docs/stale/extra.txt"]);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates syncs the managed shared hook as a single file", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-github-hook-"));
 
   try {
@@ -1124,13 +997,6 @@ test("syncTemplates syncs the managed shared hook as a single file", async () =>
 
     writeFile(projectRoot, ".git-hooks/custom.sh", "#!/bin/sh\necho keep me\n");
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -1164,13 +1030,11 @@ test("syncTemplates syncs the managed shared hook as a single file", async () =>
       "#!/bin/sh\necho keep me\n"
     );
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates reports shared pre-commit as a merged pending file", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-github-pre-commit-"));
 
   try {
@@ -1193,13 +1057,6 @@ test("syncTemplates reports shared pre-commit as a merged pending file", async (
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
 
@@ -1213,13 +1070,11 @@ test("syncTemplates reports shared pre-commit as a merged pending file", async (
       [{ target: ".git-hooks/pre-commit", template: ".git-hooks/pre-commit" }]
     );
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates preserves project testing discipline as a merged file", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-testing-discipline-"));
 
   try {
@@ -1244,13 +1099,6 @@ test("syncTemplates preserves project testing discipline as a merged file", asyn
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const firstReport = syncTemplates(projectRoot, templateRoot);
     const secondReport = syncTemplates(projectRoot, templateRoot);
@@ -1270,13 +1118,11 @@ test("syncTemplates preserves project testing discipline as a merged file", asyn
     assert.deepEqual(firstReport.managed.written, []);
     assert.deepEqual(secondReport.managed.written, []);
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("syncTemplates deploys a loadable GitHub platform adapter without downstream dependencies", async () => {
-  const originalExecSync = childProcess.execSync;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-sync-platform-adapter-"));
 
   try {
@@ -1305,13 +1151,6 @@ test("syncTemplates deploys a loadable GitHub platform adapter without downstrea
       }
     });
 
-    childProcess.execSync = (command) => {
-      if (command === "git remote get-url origin") {
-        throw new Error("not a git repo");
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    };
-
     const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(".agents/skills/update-agent-infra/scripts/sync-templates.js");
     const report = syncTemplates(projectRoot, templateRoot);
     const deployedPath = path.join(projectRoot, target);
@@ -1328,7 +1167,6 @@ test("syncTemplates deploys a loadable GitHub platform adapter without downstrea
     assert.equal(getDefaults().statusLabels.inProgress, "status: in-progress");
     assert.equal(getDefaults().markers.task, "<!-- sync-issue:{task-id}:task -->");
   } finally {
-    childProcess.execSync = originalExecSync;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import * as semver from "semver";
 
 import {
   buildCommandSyncFiles,
@@ -355,12 +356,13 @@ test("version format validation hooks are wired into templates and local config"
     "package.json should install the managed hooks path during prepare"
   );
 
-  assert.match(
-    collaborator.templateVersion,
-    /^v\d+\.\d+\.\d+$/,
-    ".agents/.airc.json templateVersion should be a v-prefixed released semver"
+  assert.equal(
+    semver.valid(collaborator.templateVersion.slice(1)),
+    collaborator.templateVersion.slice(1),
+    ".agents/.airc.json templateVersion should be an exact v-prefixed semver"
   );
 
+  assert.equal(templateCheckScript, localCheckScript);
   assert.equal(templateLargeFileCheck, localLargeFileCheck);
   assert.match(localLargeFileCheck, /1024 \* 1024/, "the large-file limit should be 1 MiB");
   assert.match(localLargeFileCheck, /diff.*--cached/s, "the large-file check should inspect staged changes");
@@ -480,18 +482,27 @@ test("version format validation hooks are wired into templates and local config"
   });
 });
 
-test("version format validation hook only blocks git commit in PreToolUse mode", () => {
+test("version format validation hooks enforce exact v-prefixed semver", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-version-hook-"));
   const hooksDir = path.join(tempRoot, ".git-hooks");
   const aiHooksDir = path.join(tempRoot, ".agents", "hooks");
   const configDir = path.join(tempRoot, ".agents");
+  const configPath = path.join(configDir, ".airc.json");
 
   fs.mkdirSync(hooksDir, { recursive: true });
   fs.mkdirSync(aiHooksDir, { recursive: true });
   fs.mkdirSync(configDir, { recursive: true });
   fs.copyFileSync(".git-hooks/check-version-format.sh", path.join(hooksDir, "check-version-format.sh"));
   fs.copyFileSync(".agents/hooks/check-version-format.sh", path.join(aiHooksDir, "check-version-format.sh"));
-  fs.writeFileSync(path.join(configDir, ".airc.json"), JSON.stringify({ templateVersion: "v1.2.3" }));
+  const writeTemplateVersion = (templateVersion: string) => {
+    fs.writeFileSync(configPath, JSON.stringify({ templateVersion }));
+  };
+
+  const runGitHook = () => spawnSync(
+    "sh",
+    [path.join(hooksDir, "check-version-format.sh")],
+    { cwd: tempRoot, encoding: "utf8", input: "" }
+  );
 
   const runAiHook = (input: string) => spawnSync(
     "sh",
@@ -504,31 +515,53 @@ test("version format validation hook only blocks git commit in PreToolUse mode",
   );
 
   try {
+    const validVersions = [
+      "v0.0.0",
+      "v1.2.3",
+      "v1.2.3-alpha-beta",
+      "v1.2.3-rc.1",
+      "v1.2.3+build-x.5",
+      "v1.2.3-alpha.0+build-x.5"
+    ];
+    const invalidVersions = [
+      "1.2.3",
+      "v1.2",
+      "v01.2.3",
+      "v1.2.3-01",
+      "v1.2.3-alpha..1",
+      "v1.2.3+build..1",
+      "v1.2.3-alpha_1"
+    ];
+
+    for (const version of validVersions) {
+      writeTemplateVersion(version);
+      const result = runGitHook();
+      assert.equal(result.status, 0, `${version} should be accepted: ${result.stderr}`);
+      assert.match(result.stdout, /Version format check passed\./);
+    }
+
+    for (const version of invalidVersions) {
+      writeTemplateVersion(version);
+      const result = runGitHook();
+      assert.equal(result.status, 1, `${version} should be rejected`);
+      assert.match(result.stdout, /templateVersion must use v-prefixed semver/);
+    }
+
     const nonCommit = runAiHook(JSON.stringify({ tool_input: { command: "git status" } }));
     assert.equal(nonCommit.status, 0, "PreToolUse should skip non-git-commit commands");
     assert.equal(nonCommit.stdout, "", "PreToolUse should stay silent when skipping non-git-commit commands");
 
+    writeTemplateVersion("v1.2.3-alpha.0+build-x.5");
     const commit = runAiHook(JSON.stringify({ tool_input: { command: "git commit -m test" } }));
     assert.equal(commit.status, 0, "PreToolUse should validate git commit commands");
     assert.match(commit.stdout, /Version format check passed\./, "PreToolUse should log successful validation");
     assert.match(commit.stdout, /AI hook: version check passed\./, "PreToolUse should log successful AI-hook delegation");
 
-    fs.writeFileSync(path.join(configDir, ".airc.json"), JSON.stringify({ templateVersion: "1.2.3" }));
+    writeTemplateVersion("1.2.3");
 
     const blockedCommit = runAiHook(JSON.stringify({ tool_input: { command: "git commit -m broken" } }));
     assert.equal(blockedCommit.status, 2, "PreToolUse should block invalid git commit commands with exit 2");
     assert.match(blockedCommit.stderr, /AI hook: blocking git commit \(version format error\)\./, "PreToolUse should log blocked AI-hook delegation");
-
-    const preCommit = spawnSync(
-      "sh",
-      [path.join(hooksDir, "check-version-format.sh")],
-      {
-        cwd: tempRoot,
-        encoding: "utf8",
-        input: ""
-      }
-    );
-    assert.equal(preCommit.status, 1, "git pre-commit should fail with exit 1 on invalid versions");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #642

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #642

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [x] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

统一 `templateVersion` 的生命周期语义，使初始化、模板同步和提交前 Hook 都接受并保留实际安装模板包的精确 `v` 前缀 SemVer，包括 prerelease 与 build metadata。同时移除依赖仓库 origin 身份的 `selfUpdate` 报告特判，避免开发期 prerelease 版本直到提交阶段才暴露契约冲突。

## 📋 主要变更 / Brief Changelog

- 将模板同步报告和 `.agents/.airc.json` 的 `templateVersion` 统一为精确 `v` 前缀 SemVer，并覆盖 prerelease 幂等落盘。
- 更新根目录与模板目录的版本格式 Hook，严格校验 SemVer 核心版本、prerelease 和 build metadata。
- 删除 `selfUpdate` 报告字段、Git origin 查询和仅服务于该查询的测试桩，保留基于技能文件实际 diff 的二次运行提醒。
- 同步规范源生成脚本、运行时与中英文 Skill、双语配置文档和模板镜像。
- 增加同步落盘、Hook 正反边界矩阵和生成物一致性自动化覆盖。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `node scripts/build-inline.js --check`。
3. 运行 `npm test`。
4. 验证根目录与模板目录的版本 Hook 内容一致，并覆盖 prerelease/build metadata 正反用例。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 已完成独立代码审查 / Independent code review completed
- [x] 已同步英文主文档与中文翻译 / English and Chinese docs updated

自动化结果：实现阶段完整测试共 1465 项，1463 通过、2 项按平台条件跳过、0 失败；提交钩子再次完成类型检查、构建与 core 测试，共 1185 项，1184 通过、1 项按平台条件跳过、0 失败；inline build 与 `git diff --check` 通过。

## 📸 截图 / Screenshots

不适用：本次改动为模板同步、版本校验 Hook、技能说明与自动化测试，无图形 UI。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 Issue，且本 PR 仅解决 Issue #642。
- [x] 每个 commit 均有有意义的主题行和描述。
- [x] 代码遵循项目规范并已完成独立代码审查。
- [x] 已编写必要的单元测试，类型检查、构建与完整测试通过。
- [x] 已同步英文主文档与中文翻译。
- [x] 已考虑正式版、prerelease、build metadata、幂等同步和既有自身更新提醒的兼容边界。

## 📋 附加信息 / Additional Notes

本次仅移除基于仓库身份的 `selfUpdate` 报告特判；`update-agent-infra` 对技能文件实际变更后的二次运行提醒保持不变。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 `templateVersion` 是否在同步器、Hook、测试和文档中遵循同一精确 SemVer 契约，以及删除 Git origin 查询后是否仍保留基于实际技能 diff 的自身更新提醒。

Generated with AI assistance