### PR TITLE
refactor(task): 建立任务写入内核

### DIFF
--- a/lib/task/frontmatter.ts
+++ b/lib/task/frontmatter.ts
@@ -1,4 +1,75 @@
+import { parse, stringify } from 'yaml';
+
 type Frontmatter = Record<string, string>;
+type FrontmatterScalar = string | number | boolean | null;
+type TypedFrontmatter = Record<string, FrontmatterScalar>;
+
+class FrontmatterError extends Error {
+  code: 'TASK_DOCUMENT_INVALID' | 'MUTATION_INVALID';
+
+  constructor(code: 'TASK_DOCUMENT_INVALID' | 'MUTATION_INVALID', message: string) {
+    super(message);
+    this.name = 'FrontmatterError';
+    this.code = code;
+  }
+}
+
+type FrontmatterBlock = {
+  eol: '\n' | '\r\n';
+  bodyStart: number;
+  bodyEnd: number;
+};
+
+function locateFrontmatter(content: string): FrontmatterBlock {
+  const opening = /^---(\r?\n)/.exec(content);
+  if (!opening) {
+    throw new FrontmatterError('TASK_DOCUMENT_INVALID', 'task.md frontmatter is missing');
+  }
+  const eol = opening[1] as '\n' | '\r\n';
+  const bodyStart = opening[0].length;
+  const closing = /^---\r?$/gm;
+  closing.lastIndex = bodyStart;
+  const match = closing.exec(content);
+  if (!match) {
+    throw new FrontmatterError('TASK_DOCUMENT_INVALID', 'task.md frontmatter is unclosed');
+  }
+  return { eol, bodyStart, bodyEnd: match.index };
+}
+
+function parseFrontmatterLines(content: string, block: FrontmatterBlock) {
+  const body = content.slice(block.bodyStart, block.bodyEnd);
+  const lines = body.split(block.eol);
+  return lines.map((raw, index) => {
+    if (!raw.trim() || raw.trimStart().startsWith('#')) {
+      return { raw, index, key: null as string | null, value: null as string | null };
+    }
+    const match = /^([^\s:#][^:]*):(?:[ \t]*(.*))?$/.exec(raw);
+    if (!match || !match[1]) {
+      throw new FrontmatterError(
+        'TASK_DOCUMENT_INVALID',
+        `unsupported frontmatter structure on line ${index + 2}`
+      );
+    }
+    return {
+      raw,
+      index,
+      key: match[1].trim(),
+      value: match[2] ?? ''
+    };
+  });
+}
+
+function serializeScalar(value: FrontmatterScalar): string {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new FrontmatterError('MUTATION_INVALID', 'frontmatter numbers must be finite');
+  }
+  if (value === '') return '';
+  const serialized = stringify(value).trimEnd();
+  if (serialized.includes('\n') || serialized.includes('\r')) {
+    throw new FrontmatterError('MUTATION_INVALID', 'frontmatter values must be scalar');
+  }
+  return serialized;
+}
 
 function parseTaskFrontmatter(content: string): Frontmatter {
   const result: Frontmatter = {};
@@ -18,6 +89,107 @@ function parseTaskFrontmatter(content: string): Frontmatter {
   return result;
 }
 
+function parseTypedTaskFrontmatter(content: string): TypedFrontmatter {
+  const block = locateFrontmatter(content);
+  const result: TypedFrontmatter = {};
+  for (const line of parseFrontmatterLines(content, block)) {
+    if (!line.key || line.value === null) continue;
+    if (Object.hasOwn(result, line.key)) {
+      throw new FrontmatterError(
+        'TASK_DOCUMENT_INVALID',
+        `duplicate frontmatter key '${line.key}'`
+      );
+    }
+    if (line.value === '') {
+      result[line.key] = '';
+      continue;
+    }
+    let value: unknown;
+    try {
+      value = parse(line.value);
+    } catch {
+      throw new FrontmatterError(
+        'TASK_DOCUMENT_INVALID',
+        `frontmatter key '${line.key}' is not a valid scalar`
+      );
+    }
+    if (
+      value !== null &&
+      typeof value !== 'string' &&
+      typeof value !== 'number' &&
+      typeof value !== 'boolean'
+    ) {
+      throw new FrontmatterError(
+        'TASK_DOCUMENT_INVALID',
+        `frontmatter key '${line.key}' is not a scalar`
+      );
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new FrontmatterError(
+        'TASK_DOCUMENT_INVALID',
+        `frontmatter key '${line.key}' is not a finite scalar`
+      );
+    }
+    result[line.key] = value;
+  }
+  return result;
+}
+
+function updateTaskFrontmatter(
+  content: string,
+  set: Readonly<Record<string, FrontmatterScalar>>
+): string {
+  if (!set || typeof set !== 'object' || Array.isArray(set)) {
+    throw new FrontmatterError('MUTATION_INVALID', 'frontmatter set must be an object');
+  }
+  const entries = Object.entries(set);
+  for (const [key, value] of entries) {
+    if (!key || /[\r\n:]/.test(key)) {
+      throw new FrontmatterError('MUTATION_INVALID', `invalid frontmatter key '${key}'`);
+    }
+    if (
+      value !== null &&
+      typeof value !== 'string' &&
+      typeof value !== 'number' &&
+      typeof value !== 'boolean'
+    ) {
+      throw new FrontmatterError('MUTATION_INVALID', `invalid scalar for '${key}'`);
+    }
+  }
+
+  const block = locateFrontmatter(content);
+  const lines = parseFrontmatterLines(content, block);
+  const indexes = new Map<string, number[]>();
+  for (const line of lines) {
+    if (!line.key) continue;
+    const positions = indexes.get(line.key) ?? [];
+    positions.push(line.index);
+    indexes.set(line.key, positions);
+  }
+
+  for (const [key] of entries) {
+    if ((indexes.get(key)?.length ?? 0) > 1) {
+      throw new FrontmatterError('TASK_DOCUMENT_INVALID', `duplicate frontmatter key '${key}'`);
+    }
+  }
+
+  const nextLines = lines.map((line) => line.raw);
+  const additions: string[] = [];
+  for (const [key, value] of entries) {
+    const serialized = serializeScalar(value);
+    const replacement = serialized === '' ? `${key}:` : `${key}: ${serialized}`;
+    const index = indexes.get(key)?.[0];
+    if (index === undefined) additions.push(replacement);
+    else nextLines[index] = replacement;
+  }
+  if (additions.length > 0) {
+    if (nextLines.at(-1) === '') nextLines.splice(-1, 0, ...additions);
+    else nextLines.push(...additions);
+  }
+  const body = nextLines.join(block.eol);
+  return content.slice(0, block.bodyStart) + body + content.slice(block.bodyEnd);
+}
+
 function extractTitle(content: string): string {
   for (const line of content.split('\n')) {
     const m = /^#\s+(?:任务[:：]?\s*)?(.+)$/.exec(line.trim());
@@ -26,5 +198,10 @@ function extractTitle(content: string): string {
   return '';
 }
 
-export { parseTaskFrontmatter, extractTitle };
-export type { Frontmatter };
+export {
+  parseTaskFrontmatter,
+  parseTypedTaskFrontmatter,
+  updateTaskFrontmatter,
+  extractTitle
+};
+export type { Frontmatter, FrontmatterScalar, TypedFrontmatter };

--- a/lib/task/resolve-ref.ts
+++ b/lib/task/resolve-ref.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { normalizeShortIdInput } from './short-id.ts';
+import { execFileSync } from 'node:child_process';
+import { normalizeShortIdInput, resolveShortIdReadOnly } from './short-id.ts';
 
 const TASK_ID_RE = /^TASK-\d{8}-\d{6}$/;
 // Flat-structured workspace dirs that hold tasks under `{dir}/{taskId}/task.md`.
@@ -15,8 +15,33 @@ type ResolveRefResult =
       taskId: string;
       taskDir: string;
       taskMdPath: string;
+      state: TaskWorkspaceState;
     }
-  | { ok: false; message: string };
+  | {
+      ok: false;
+      code: ResolveTaskRefErrorCode;
+      message: string;
+      repoRoot: string | null;
+      taskId: string | null;
+    };
+
+type TaskWorkspaceState = 'active' | 'blocked' | 'completed' | 'archive';
+
+type ResolveTaskRefErrorCode =
+  | 'REPO_ROOT_NOT_FOUND'
+  | 'INVALID_TASK_REF'
+  | 'SHORT_ID_RESERVED'
+  | 'SHORT_ID_CAPACITY_EXCEEDED'
+  | 'SHORT_ID_REGISTRY_NOT_FOUND'
+  | 'SHORT_ID_REGISTRY_READ_FAILED'
+  | 'SHORT_ID_REGISTRY_INVALID_JSON'
+  | 'SHORT_ID_REGISTRY_INVALID_SCHEMA'
+  | 'SHORT_ID_REGISTRY_DUPLICATE_TASK'
+  | 'SHORT_ID_NOT_FOUND'
+  | 'SHORT_ID_STALE'
+  | 'TASK_NOT_FOUND';
+
+type ResolveTaskRefOptions = { repoRoot?: string };
 
 function detectRepoRoot(): string {
   try {
@@ -38,21 +63,6 @@ function readShortIdLength(repoRoot: string): number {
     // fall through to default
   }
   return 2;
-}
-
-function resolveShortIdToTaskId(arg: string, repoRoot: string): string {
-  const scriptPath = path.join(repoRoot, '.agents', 'scripts', 'task-short-id.js');
-  if (!fs.existsSync(scriptPath)) {
-    throw new Error(`task-short-id.js not found at ${scriptPath}`);
-  }
-  const result = spawnSync('node', [scriptPath, 'resolve', arg], {
-    encoding: 'utf8',
-    cwd: repoRoot
-  });
-  if (result.status !== 0) {
-    throw new Error((result.stderr || '').trim() || `failed to resolve '${arg}'`);
-  }
-  return result.stdout.trim();
 }
 
 function listSortedNumeric(dir: string, width: number): string[] {
@@ -84,12 +94,16 @@ function findInArchive(repoRoot: string, taskId: string): string | null {
   return null;
 }
 
-function findTaskMd(repoRoot: string, taskId: string): string | null {
+function findTaskMd(
+  repoRoot: string,
+  taskId: string
+): { taskMdPath: string; state: TaskWorkspaceState } | null {
   for (const sub of FLAT_WORKSPACE_DIRS) {
     const candidate = path.join(repoRoot, '.agents', 'workspace', sub, taskId, 'task.md');
-    if (fs.existsSync(candidate)) return candidate;
+    if (fs.existsSync(candidate)) return { taskMdPath: candidate, state: sub };
   }
-  return findInArchive(repoRoot, taskId);
+  const archived = findInArchive(repoRoot, taskId);
+  return archived ? { taskMdPath: archived, state: 'archive' } : null;
 }
 
 /**
@@ -121,8 +135,19 @@ function enumerateTaskDirs(repoRoot: string): { taskId: string; taskDir: string 
  * prefix); callers prepend their own prefix so each command keeps its existing
  * stderr wording byte-for-byte.
  */
-function resolveTaskRef(arg: string): ResolveRefResult {
-  const repoRoot = detectRepoRoot();
+function resolveTaskRef(arg: string, options: ResolveTaskRefOptions = {}): ResolveRefResult {
+  let repoRoot: string;
+  try {
+    repoRoot = options.repoRoot ? path.resolve(options.repoRoot) : detectRepoRoot();
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'REPO_ROOT_NOT_FOUND',
+      message: error instanceof Error ? error.message : String(error),
+      repoRoot: null,
+      taskId: null
+    };
+  }
   let taskId: string;
   if (TASK_ID_RE.test(arg)) {
     taskId = arg;
@@ -130,31 +155,61 @@ function resolveTaskRef(arg: string): ResolveRefResult {
     const shortIdLength = readShortIdLength(repoRoot);
     const normalized = normalizeShortIdInput(arg, { shortIdLength });
     if (normalized.kind === 'error') {
-      return { ok: false, message: normalized.message };
+      return {
+        ok: false,
+        code: normalized.code,
+        message: normalized.message,
+        repoRoot,
+        taskId: null
+      };
     }
     if (normalized.kind === 'pass') {
       return {
         ok: false,
+        code: 'INVALID_TASK_REF',
         message:
           `'${arg}' is not a valid short id or TASK-id; ` +
-          `expected bare digits, '#N', or 'TASK-YYYYMMDD-HHMMSS'`
+          `expected bare digits, '#N', or 'TASK-YYYYMMDD-HHMMSS'`,
+        repoRoot,
+        taskId: null
       };
     }
-    try {
-      taskId = resolveShortIdToTaskId(normalized.value, repoRoot);
-    } catch (e) {
-      return { ok: false, message: (e as Error).message };
+    const shortResult = resolveShortIdReadOnly(normalized.value, repoRoot, { shortIdLength });
+    if (!shortResult.ok) {
+      return {
+        ok: false,
+        code: shortResult.code,
+        message: shortResult.message,
+        repoRoot,
+        taskId: shortResult.taskId
+      };
     }
+    taskId = shortResult.taskId;
   }
-  const taskMdPath = findTaskMd(repoRoot, taskId);
-  if (!taskMdPath) {
+  const located = findTaskMd(repoRoot, taskId);
+  if (!located) {
     return {
       ok: false,
-      message: `task ${taskId} not found in active / blocked / completed / archive`
+      code: 'TASK_NOT_FOUND',
+      message: `task ${taskId} not found in active / blocked / completed / archive`,
+      repoRoot,
+      taskId
     };
   }
-  return { ok: true, repoRoot, taskId, taskDir: path.dirname(taskMdPath), taskMdPath };
+  return {
+    ok: true,
+    repoRoot,
+    taskId,
+    taskDir: path.dirname(located.taskMdPath),
+    taskMdPath: located.taskMdPath,
+    state: located.state
+  };
 }
 
 export { resolveTaskRef, detectRepoRoot, enumerateTaskDirs, TASK_ID_RE };
-export type { ResolveRefResult };
+export type {
+  ResolveRefResult,
+  ResolveTaskRefErrorCode,
+  ResolveTaskRefOptions,
+  TaskWorkspaceState
+};

--- a/lib/task/sections.ts
+++ b/lib/task/sections.ts
@@ -1,5 +1,393 @@
+import type { FrontmatterScalar } from './frontmatter.ts';
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+type SectionMutationInput = {
+  aliases: readonly string[];
+  heading: string;
+  body: string;
+};
+
+type TableRowBase = {
+  kind: 'table-row';
+  sectionAliases: readonly string[];
+  columns: readonly string[];
+  keyColumn: string;
+  key: string;
+};
+
+type TableRowUpsertMutation = TableRowBase & {
+  action: 'upsert';
+  values: Readonly<Record<string, FrontmatterScalar>>;
+};
+
+type TableRowDeleteMutation = TableRowBase & { action: 'delete' };
+type TableRowMutation = TableRowUpsertMutation | TableRowDeleteMutation;
+
+type SectionMutationResult = {
+  content: string;
+  heading: string;
+  operation: 'create' | 'update';
+};
+
+type TableMutationResult = {
+  content: string;
+  section: string;
+  operation: 'insert' | 'update' | 'delete';
+};
+
+type DocumentMutationErrorCode =
+  | 'TASK_DOCUMENT_INVALID'
+  | 'MUTATION_INVALID'
+  | 'TABLE_NOT_FOUND'
+  | 'TABLE_AMBIGUOUS'
+  | 'TABLE_DUPLICATE_KEY'
+  | 'TABLE_UNKNOWN_COLUMN'
+  | 'TABLE_KEY_COLUMN_IN_VALUES'
+  | 'TABLE_KEY_CONFLICT'
+  | 'TABLE_MISSING_COLUMN'
+  | 'TABLE_DELETE_VALUES_FORBIDDEN'
+  | 'TABLE_CELL_INVALID';
+
+class DocumentMutationError extends Error {
+  code: DocumentMutationErrorCode;
+
+  constructor(code: DocumentMutationErrorCode, message: string) {
+    super(message);
+    this.name = 'DocumentMutationError';
+    this.code = code;
+  }
+}
+
+type Line = {
+  start: number;
+  contentEnd: number;
+  end: number;
+  text: string;
+  eol: string;
+};
+
+function linesOf(content: string): Line[] {
+  const lines: Line[] = [];
+  let start = 0;
+  while (start < content.length) {
+    const newline = content.indexOf('\n', start);
+    const end = newline === -1 ? content.length : newline + 1;
+    const hasCr = newline !== -1 && content[newline - 1] === '\r';
+    const contentEnd = newline === -1 ? content.length : newline - (hasCr ? 1 : 0);
+    lines.push({
+      start,
+      contentEnd,
+      end,
+      text: content.slice(start, contentEnd),
+      eol: newline === -1 ? '' : hasCr ? '\r\n' : '\n'
+    });
+    start = end;
+  }
+  return lines;
+}
+
+function documentEol(content: string): '\n' | '\r\n' {
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function matchingSections(content: string, aliases: readonly string[]) {
+  const allowed = new Set(aliases);
+  return linesOf(content)
+    .map((line, index, lines) => {
+      const match = /^##\s+(.+?)\s*$/.exec(line.text);
+      if (!match?.[1] || !allowed.has(match[1])) return null;
+      let end = content.length;
+      for (let i = index + 1; i < lines.length; i += 1) {
+        if (/^##\s+/.test(lines[i]!.text)) {
+          end = lines[i]!.start;
+          break;
+        }
+      }
+      return { heading: match[1], line, bodyStart: line.end, end };
+    })
+    .filter((match): match is NonNullable<typeof match> => match !== null);
+}
+
+function validateAliases(aliases: readonly string[], name: string): void {
+  if (!Array.isArray(aliases) || aliases.length === 0 || aliases.some((alias) => !alias || /[\r\n]/.test(alias))) {
+    throw new DocumentMutationError('MUTATION_INVALID', `${name} must contain headings`);
+  }
+  if (new Set(aliases).size !== aliases.length) {
+    throw new DocumentMutationError('MUTATION_INVALID', `${name} must be unique`);
+  }
+}
+
+function upsertSection(content: string, input: SectionMutationInput): SectionMutationResult {
+  validateAliases(input.aliases, 'section aliases');
+  if (!input.heading || /[\r\n]/.test(input.heading) || typeof input.body !== 'string') {
+    throw new DocumentMutationError('MUTATION_INVALID', 'section heading and body are invalid');
+  }
+  const matches = matchingSections(content, input.aliases);
+  if (matches.length > 1) {
+    throw new DocumentMutationError('TASK_DOCUMENT_INVALID', 'section aliases match more than once');
+  }
+  const eol = documentEol(content);
+  const normalizedBody = input.body.replace(/\r?\n/g, eol).replace(/(?:\r?\n)+$/, '');
+  if (matches.length === 0) {
+    const separator = content.length === 0
+      ? ''
+      : content.endsWith(`${eol}${eol}`)
+        ? ''
+        : content.endsWith(eol)
+          ? eol
+          : `${eol}${eol}`;
+    const body = normalizedBody ? `${eol}${eol}${normalizedBody}` : '';
+    return {
+      content: `${content}${separator}## ${input.heading}${body}${eol}`,
+      heading: input.heading,
+      operation: 'create'
+    };
+  }
+  const match = matches[0]!;
+  const existingBody = content
+    .slice(match.bodyStart, match.end)
+    .replace(/^(?:\r?\n)+/, '')
+    .replace(/(?:\r?\n)+$/, '')
+    .replace(/\r?\n/g, eol);
+  if (existingBody === normalizedBody) {
+    return { content, heading: match.heading, operation: 'update' };
+  }
+  const body = normalizedBody ? `${eol}${normalizedBody}${eol}${eol}` : eol;
+  return {
+    content: content.slice(0, match.bodyStart) + body + content.slice(match.end),
+    heading: match.heading,
+    operation: 'update'
+  };
+}
+
+function splitTableCells(line: string): { prefix: string; suffix: string; cells: string[] } | null {
+  const first = line.indexOf('|');
+  const last = line.lastIndexOf('|');
+  if (first === -1 || first === last || line.slice(0, first).trim() || line.slice(last + 1).trim()) {
+    return null;
+  }
+  const inner = line.slice(first + 1, last);
+  const cells: string[] = [];
+  let start = 0;
+  let backslashes = 0;
+  for (let i = 0; i < inner.length; i += 1) {
+    const char = inner[i]!;
+    if (char === '\\') {
+      backslashes += 1;
+      continue;
+    }
+    if (char === '|' && backslashes % 2 === 0) {
+      cells.push(inner.slice(start, i));
+      start = i + 1;
+    }
+    backslashes = 0;
+  }
+  if (backslashes % 2 === 1) {
+    throw new DocumentMutationError('TASK_DOCUMENT_INVALID', 'table cell has an unclosed escape');
+  }
+  cells.push(inner.slice(start));
+  return { prefix: line.slice(0, first), suffix: line.slice(last + 1), cells };
+}
+
+function decodeCell(raw: string): string {
+  let result = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    if (raw[i] === '\\' && (raw[i + 1] === '\\' || raw[i + 1] === '|')) {
+      result += raw[i + 1];
+      i += 1;
+    } else {
+      result += raw[i];
+    }
+  }
+  return result;
+}
+
+function scalarCell(value: FrontmatterScalar): string {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new DocumentMutationError('TABLE_CELL_INVALID', 'table numbers must be finite');
+  }
+  if (
+    value !== null &&
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    typeof value !== 'boolean'
+  ) {
+    throw new DocumentMutationError('TABLE_CELL_INVALID', 'table cells must be scalar');
+  }
+  const raw = value === null ? '' : String(value);
+  if (/[\r\n]/.test(raw)) {
+    throw new DocumentMutationError('TABLE_CELL_INVALID', 'table cells cannot contain newlines');
+  }
+  return raw.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+}
+
+function replaceCellToken(raw: string, value: string): string {
+  const firstContent = raw.search(/\S/);
+  if (firstContent === -1) {
+    const boundary = Math.floor(raw.length / 2);
+    return `${raw.slice(0, boundary)}${value}${raw.slice(boundary)}`;
+  }
+  let lastContent = raw.length - 1;
+  while (/\s/.test(raw[lastContent]!)) lastContent -= 1;
+  return `${raw.slice(0, firstContent)}${value}${raw.slice(lastContent + 1)}`;
+}
+
+function mutateTableRow(content: string, mutation: TableRowMutation): TableMutationResult {
+  validateAliases(mutation.sectionAliases, 'table section aliases');
+  if (
+    !Array.isArray(mutation.columns) ||
+    mutation.columns.length === 0 ||
+    mutation.columns.some((column) => !column || /[\r\n|]/.test(column)) ||
+    new Set(mutation.columns).size !== mutation.columns.length ||
+    !mutation.columns.includes(mutation.keyColumn) ||
+    typeof mutation.key !== 'string' ||
+    !mutation.key.trim() ||
+    /[\r\n]/.test(mutation.key)
+  ) {
+    throw new DocumentMutationError('MUTATION_INVALID', 'table mutation shape is invalid');
+  }
+  const normalizedKey = mutation.key.trim();
+  if (mutation.action !== 'upsert' && mutation.action !== 'delete') {
+    throw new DocumentMutationError('MUTATION_INVALID', 'table action is invalid');
+  }
+  if (mutation.action === 'delete' && 'values' in mutation) {
+    throw new DocumentMutationError('TABLE_DELETE_VALUES_FORBIDDEN', 'delete cannot include values');
+  }
+  if (
+    mutation.action === 'upsert' &&
+    (!mutation.values || typeof mutation.values !== 'object' || Array.isArray(mutation.values))
+  ) {
+    throw new DocumentMutationError('MUTATION_INVALID', 'upsert values must be an object');
+  }
+
+  const sections = matchingSections(content, mutation.sectionAliases);
+  if (sections.length !== 1) {
+    throw new DocumentMutationError(
+      sections.length === 0 ? 'TABLE_NOT_FOUND' : 'TASK_DOCUMENT_INVALID',
+      sections.length === 0 ? 'table section not found' : 'table section is ambiguous'
+    );
+  }
+  const section = sections[0]!;
+  const sectionLines = linesOf(content).filter(
+    (line) => line.start >= section.bodyStart && line.start < section.end
+  );
+  const tables: { headerIndex: number; cells: string[] }[] = [];
+  for (let i = 0; i + 1 < sectionLines.length; i += 1) {
+    const header = splitTableCells(sectionLines[i]!.text);
+    const separator = splitTableCells(sectionLines[i + 1]!.text);
+    if (!header || !separator || header.cells.length !== mutation.columns.length) continue;
+    const names = header.cells.map((cell) => decodeCell(cell).trim());
+    if (!names.every((name, index) => name === mutation.columns[index])) continue;
+    if (
+      separator.cells.length !== mutation.columns.length ||
+      !separator.cells.every((cell) => /^\s*:?-{3,}:?\s*$/.test(cell))
+    ) continue;
+    tables.push({ headerIndex: i, cells: header.cells });
+  }
+  if (tables.length === 0) {
+    throw new DocumentMutationError('TABLE_NOT_FOUND', 'matching table not found');
+  }
+  if (tables.length > 1) {
+    throw new DocumentMutationError('TABLE_AMBIGUOUS', 'matching table appears more than once');
+  }
+
+  const table = tables[0]!;
+  const keyIndex = mutation.columns.indexOf(mutation.keyColumn);
+  let rowIndex = table.headerIndex + 2;
+  const rows: { line: Line; parsed: NonNullable<ReturnType<typeof splitTableCells>> }[] = [];
+  while (rowIndex < sectionLines.length) {
+    const line = sectionLines[rowIndex]!;
+    const parsed = splitTableCells(line.text);
+    if (!parsed) break;
+    if (parsed.cells.length !== mutation.columns.length) {
+      throw new DocumentMutationError('TASK_DOCUMENT_INVALID', 'table row has the wrong column count');
+    }
+    rows.push({ line, parsed });
+    rowIndex += 1;
+  }
+  const matches = rows.filter(
+    (row) => decodeCell(row.parsed.cells[keyIndex]!).trim() === normalizedKey
+  );
+  if (matches.length > 1) {
+    throw new DocumentMutationError('TABLE_DUPLICATE_KEY', `duplicate table key '${normalizedKey}'`);
+  }
+
+  if (mutation.action === 'delete') {
+    if (matches.length === 0) return { content, section: section.heading, operation: 'delete' };
+    const line = matches[0]!.line;
+    return {
+      content: content.slice(0, line.start) + content.slice(line.end),
+      section: section.heading,
+      operation: 'delete'
+    };
+  }
+
+  const values = mutation.values;
+  for (const [column, value] of Object.entries(values)) {
+    if (!mutation.columns.includes(column)) {
+      throw new DocumentMutationError('TABLE_UNKNOWN_COLUMN', `unknown table column '${column}'`);
+    }
+    if (column === mutation.keyColumn) {
+      const serialized = scalarCell(value);
+      throw new DocumentMutationError(
+        decodeCell(serialized).trim() === normalizedKey
+          ? 'TABLE_KEY_COLUMN_IN_VALUES'
+          : 'TABLE_KEY_CONFLICT',
+        `key column '${column}' must not appear in values`
+      );
+    }
+    scalarCell(value);
+  }
+
+  if (matches.length === 1) {
+    const row = matches[0]!;
+    const cells = [...row.parsed.cells];
+    for (const [column, value] of Object.entries(values)) {
+      const index = mutation.columns.indexOf(column);
+      cells[index] = replaceCellToken(cells[index]!, scalarCell(value));
+    }
+    const rebuilt = `${row.parsed.prefix}|${cells.join('|')}|${row.parsed.suffix}`;
+    return {
+      content:
+        content.slice(0, row.line.start) +
+        rebuilt +
+        row.line.eol +
+        content.slice(row.line.end),
+      section: section.heading,
+      operation: 'update'
+    };
+  }
+
+  const missing = mutation.columns.filter(
+    (column) => column !== mutation.keyColumn && !Object.hasOwn(values, column)
+  );
+  if (missing.length > 0) {
+    throw new DocumentMutationError(
+      'TABLE_MISSING_COLUMN',
+      `new table row is missing columns: ${missing.join(', ')}`
+    );
+  }
+  const newCells = mutation.columns.map((column) =>
+    column === mutation.keyColumn ? scalarCell(normalizedKey) : scalarCell(values[column]!)
+  );
+  const newLine = `| ${newCells.join(' | ')} |`;
+  const separatorLine = sectionLines[table.headerIndex + 1]!;
+  const lastLine = rows.at(-1)?.line ?? separatorLine;
+  const eol = lastLine.eol || documentEol(content);
+  const needsLeadingEol = lastLine.eol === '';
+  return {
+    content:
+      content.slice(0, lastLine.end) +
+      (needsLeadingEol ? eol : '') +
+      newLine +
+      eol +
+      content.slice(lastLine.end),
+    section: section.heading,
+    operation: 'insert'
+  };
 }
 
 /**
@@ -70,4 +458,20 @@ function extractSubSection(content: string, headingPrefix: string): string {
   return lines.slice(start, end).join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
 }
 
-export { extractSection, findSectionHeading, extractSubSection };
+export {
+  extractSection,
+  findSectionHeading,
+  extractSubSection,
+  upsertSection,
+  mutateTableRow
+};
+export type {
+  SectionMutationInput,
+  SectionMutationResult,
+  TableRowBase,
+  TableRowUpsertMutation,
+  TableRowDeleteMutation,
+  TableRowMutation,
+  TableMutationResult,
+  DocumentMutationErrorCode
+};

--- a/lib/task/short-id.ts
+++ b/lib/task/short-id.ts
@@ -6,7 +6,11 @@ const REGISTRY_NAME = '.short-ids.json';
 type NormalizeResult =
   | { kind: 'shortId'; value: string }
   | { kind: 'pass'; value: string }
-  | { kind: 'error'; message: string };
+  | {
+      kind: 'error';
+      code: 'SHORT_ID_RESERVED' | 'SHORT_ID_CAPACITY_EXCEEDED';
+      message: string;
+    };
 
 type NormalizeOpts = { shortIdLength: number };
 
@@ -20,6 +24,7 @@ function normalizeShortIdInput(input: string, opts: NormalizeOpts): NormalizeRes
   if (n === 0) {
     return {
       kind: 'error',
+      code: 'SHORT_ID_RESERVED',
       message: `short id '${input}' is invalid (#${'0'.repeat(L)} is reserved)`
     };
   }
@@ -27,10 +32,163 @@ function normalizeShortIdInput(input: string, opts: NormalizeOpts): NormalizeRes
   if (n > max) {
     return {
       kind: 'error',
+      code: 'SHORT_ID_CAPACITY_EXCEEDED',
       message: `short id ${n} exceeds shortIdLength=${L} capacity (max=${max}); archive tasks or raise task.shortIdLength in .agents/.airc.json`
     };
   }
   return { kind: 'shortId', value: `#${String(n).padStart(L, '0')}` };
+}
+
+type ResolveShortIdErrorCode =
+  | 'SHORT_ID_RESERVED'
+  | 'SHORT_ID_CAPACITY_EXCEEDED'
+  | 'SHORT_ID_REGISTRY_NOT_FOUND'
+  | 'SHORT_ID_REGISTRY_READ_FAILED'
+  | 'SHORT_ID_REGISTRY_INVALID_JSON'
+  | 'SHORT_ID_REGISTRY_INVALID_SCHEMA'
+  | 'SHORT_ID_REGISTRY_DUPLICATE_TASK'
+  | 'SHORT_ID_NOT_FOUND'
+  | 'SHORT_ID_STALE';
+
+type ResolveShortIdResult =
+  | { ok: true; taskId: string }
+  | { ok: false; code: ResolveShortIdErrorCode; message: string; taskId: string | null };
+
+function shortIdFailure(
+  code: ResolveShortIdErrorCode,
+  message: string,
+  taskId: string | null = null
+): ResolveShortIdResult {
+  return { ok: false, code, message, taskId };
+}
+
+function resolveShortIdReadOnly(
+  input: string,
+  repoRoot: string,
+  opts: NormalizeOpts
+): ResolveShortIdResult {
+  const normalized = normalizeShortIdInput(input, opts);
+  if (normalized.kind === 'error') {
+    return shortIdFailure(normalized.code, normalized.message);
+  }
+  if (normalized.kind !== 'shortId') {
+    return shortIdFailure(
+      'SHORT_ID_NOT_FOUND',
+      `short id '${input}' not found in active task registry`
+    );
+  }
+
+  const key = normalized.value.slice(1);
+  const registryPath = path.join(repoRoot, '.agents', 'workspace', 'active', REGISTRY_NAME);
+  if (!fs.existsSync(registryPath)) {
+    return shortIdFailure(
+      'SHORT_ID_REGISTRY_NOT_FOUND',
+      `short id '#${key}' not found; active task registry is empty.`
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(registryPath, 'utf8');
+  } catch (error) {
+    return shortIdFailure(
+      'SHORT_ID_REGISTRY_READ_FAILED',
+      `cannot read registry ${registryPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (error) {
+    return shortIdFailure(
+      'SHORT_ID_REGISTRY_INVALID_JSON',
+      `registry ${registryPath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const max = Math.pow(10, opts.shortIdLength) - 1;
+  const validKey = new RegExp(`^\\d{${opts.shortIdLength}}$`);
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    Array.isArray(data) ||
+    (data as { version?: unknown }).version !== 1 ||
+    !(data as { ids?: unknown }).ids ||
+    typeof (data as { ids?: unknown }).ids !== 'object' ||
+    Array.isArray((data as { ids?: unknown }).ids)
+  ) {
+    return shortIdFailure(
+      'SHORT_ID_REGISTRY_INVALID_SCHEMA',
+      `registry ${registryPath} has invalid schema`
+    );
+  }
+
+  const ids = (data as RegistrySchema).ids;
+  const seen = new Map<string, string>();
+  for (const [registryKey, taskId] of Object.entries(ids)) {
+    const numericKey = Number(registryKey);
+    if (
+      !validKey.test(registryKey) ||
+      numericKey < 1 ||
+      numericKey > max ||
+      typeof taskId !== 'string' ||
+      !/^TASK-\d{8}-\d{6}$/.test(taskId)
+    ) {
+      return shortIdFailure(
+        'SHORT_ID_REGISTRY_INVALID_SCHEMA',
+        `registry ${registryPath} has invalid schema`
+      );
+    }
+    const existing = seen.get(taskId);
+    if (existing) {
+      return shortIdFailure(
+        'SHORT_ID_REGISTRY_DUPLICATE_TASK',
+        `duplicate registry entries for taskId ${taskId} at keys [#${existing}, #${registryKey}]; manual resolution required`,
+        taskId
+      );
+    }
+    seen.set(taskId, registryKey);
+  }
+
+  const taskId = ids[key];
+  if (!taskId) {
+    const message = Object.keys(ids).length === 0
+      ? `short id '#${key}' not found; active task registry is empty.`
+      : `short id '#${key}' not found in active task registry (it may have been cleaned up after archival; check 'task-short-id.js list').`;
+    return shortIdFailure('SHORT_ID_NOT_FOUND', message);
+  }
+  const taskMdPath = path.join(
+    repoRoot,
+    '.agents',
+    'workspace',
+    'active',
+    taskId,
+    'task.md'
+  );
+  if (!fs.existsSync(taskMdPath)) {
+    const remainingActiveEntries = Object.values(ids).filter((candidateTaskId) =>
+      fs.existsSync(
+        path.join(
+          repoRoot,
+          '.agents',
+          'workspace',
+          'active',
+          candidateTaskId,
+          'task.md'
+        )
+      )
+    );
+    const message = remainingActiveEntries.length === 0
+      ? `short id '#${key}' not found; active task registry is empty.`
+      : `short id '#${key}' not found in active task registry (it may have been cleaned up after archival; check 'task-short-id.js list').`;
+    return shortIdFailure(
+      'SHORT_ID_STALE',
+      message,
+      taskId
+    );
+  }
+  return { ok: true, taskId };
 }
 
 type RegistrySchema = {
@@ -103,5 +261,15 @@ function lookupShortIdByBranch(
   return matches[0]!;
 }
 
-export { normalizeShortIdInput, lookupShortIdByBranch, loadShortIdByTaskId };
-export type { NormalizeResult, NormalizeOpts };
+export {
+  normalizeShortIdInput,
+  resolveShortIdReadOnly,
+  lookupShortIdByBranch,
+  loadShortIdByTaskId
+};
+export type {
+  NormalizeResult,
+  NormalizeOpts,
+  ResolveShortIdErrorCode,
+  ResolveShortIdResult
+};

--- a/lib/task/write.ts
+++ b/lib/task/write.ts
@@ -1,0 +1,458 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { VERSION } from '../version.ts';
+import {
+  parseTypedTaskFrontmatter,
+  updateTaskFrontmatter
+} from './frontmatter.ts';
+import type { FrontmatterScalar } from './frontmatter.ts';
+import { resolveTaskRef } from './resolve-ref.ts';
+import type {
+  ResolveTaskRefErrorCode,
+  TaskWorkspaceState
+} from './resolve-ref.ts';
+import { mutateTableRow, upsertSection } from './sections.ts';
+import type {
+  TableRowDeleteMutation,
+  TableRowUpsertMutation
+} from './sections.ts';
+
+type FrontmatterMutation = {
+  kind: 'frontmatter';
+  set: Readonly<Record<string, FrontmatterScalar>>;
+};
+
+type SectionMutation = {
+  kind: 'section';
+  aliases: readonly string[];
+  heading: string;
+  body: string;
+};
+
+type TaskMutation =
+  | FrontmatterMutation
+  | SectionMutation
+  | TableRowUpsertMutation
+  | TableRowDeleteMutation;
+
+type TaskWriteRequest = {
+  taskRef: string;
+  expectedState: TaskWorkspaceState;
+  mutations: readonly TaskMutation[];
+  dryRun?: boolean;
+};
+
+type TaskOperationSummary =
+  | {
+      index: number;
+      kind: 'frontmatter';
+      fields: readonly string[];
+      wouldChange: boolean;
+    }
+  | {
+      index: number;
+      kind: 'section';
+      heading: string;
+      operation: 'create' | 'update';
+      wouldChange: boolean;
+    }
+  | {
+      index: number;
+      kind: 'table-row';
+      section: string;
+      keyColumn: string;
+      key: string;
+      operation: 'insert' | 'update' | 'delete';
+      wouldChange: boolean;
+    }
+  | {
+      index: -1;
+      kind: 'metadata';
+      fields: readonly ['updated_at', 'agent_infra_version'];
+      wouldChange: boolean;
+    };
+
+type TaskWriteMetadata = {
+  timestamp: string;
+  agentInfraVersion: string;
+};
+
+type TaskWriteErrorCode =
+  | ResolveTaskRefErrorCode
+  | 'TASK_STATE_MISMATCH'
+  | 'TASK_READ_FAILED'
+  | 'TASK_DOCUMENT_INVALID'
+  | 'MUTATION_INVALID'
+  | 'TABLE_NOT_FOUND'
+  | 'TABLE_AMBIGUOUS'
+  | 'TABLE_DUPLICATE_KEY'
+  | 'TABLE_UNKNOWN_COLUMN'
+  | 'TABLE_KEY_COLUMN_IN_VALUES'
+  | 'TABLE_KEY_CONFLICT'
+  | 'TABLE_MISSING_COLUMN'
+  | 'TABLE_DELETE_VALUES_FORBIDDEN'
+  | 'TABLE_CELL_INVALID'
+  | 'METADATA_CAPTURE_FAILED'
+  | 'TEMP_WRITE_FAILED'
+  | 'RENAME_FAILED'
+  | 'TEMP_CLEANUP_FAILED';
+
+type TaskWriteError = { code: TaskWriteErrorCode; message: string };
+
+type TaskWriteSuccessBase = {
+  requestRef: string;
+  expectedState: TaskWorkspaceState;
+  taskId: string;
+  taskMdPath: string;
+  actualState: TaskWorkspaceState;
+  operations: readonly TaskOperationSummary[];
+  timestamp: string;
+  agentInfraVersion: string;
+  error: null;
+};
+
+type TaskWritePlanned = TaskWriteSuccessBase & { status: 'planned'; changed: true };
+type TaskWriteApplied = TaskWriteSuccessBase & { status: 'applied'; changed: true };
+type TaskWriteNoOp = TaskWriteSuccessBase & { status: 'no-op'; changed: false };
+
+type TaskWriteFailed = {
+  status: 'failed';
+  requestRef: string;
+  expectedState: TaskWorkspaceState;
+  taskId: string | null;
+  taskMdPath: string | null;
+  actualState: TaskWorkspaceState | null;
+  changed: false;
+  operations: readonly TaskOperationSummary[];
+  timestamp: string | null;
+  agentInfraVersion: string | null;
+  error: TaskWriteError;
+};
+
+type TaskWriteResult =
+  | TaskWritePlanned
+  | TaskWriteApplied
+  | TaskWriteNoOp
+  | TaskWriteFailed;
+
+type TaskFileSystem = {
+  readFileSync: (file: string) => string;
+  statModeSync: (file: string) => number;
+  writeFileSync: (file: string, content: string, mode: number) => void;
+  renameSync: (from: string, to: string) => void;
+  unlinkSync: (file: string) => void;
+};
+
+type TaskWriteOptions = {
+  repoRoot?: string;
+  metadataProvider?: () => TaskWriteMetadata;
+  randomSuffix?: () => string;
+  fileSystem?: Partial<TaskFileSystem>;
+};
+
+const DEFAULT_FILE_SYSTEM: TaskFileSystem = {
+  readFileSync: (file) => fs.readFileSync(file, 'utf8'),
+  statModeSync: (file) => fs.statSync(file).mode,
+  writeFileSync: (file, content, mode) => {
+    fs.writeFileSync(file, content, { encoding: 'utf8', flag: 'wx', mode });
+  },
+  renameSync: (from, to) => fs.renameSync(from, to),
+  unlinkSync: (file) => fs.unlinkSync(file)
+};
+
+function canonicalTimestamp(): string {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZoneName: 'longOffset',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  })
+    .format(new Date())
+    .replace(' GMT', '');
+}
+
+function defaultMetadataProvider(): TaskWriteMetadata {
+  return { timestamp: canonicalTimestamp(), agentInfraVersion: VERSION };
+}
+
+function failure(
+  request: TaskWriteRequest,
+  identity: { taskId: string | null; taskMdPath: string | null; actualState: TaskWorkspaceState | null },
+  code: TaskWriteErrorCode,
+  message: string,
+  operations: readonly TaskOperationSummary[] = [],
+  metadata: TaskWriteMetadata | null = null
+): TaskWriteFailed {
+  return {
+    status: 'failed',
+    requestRef: request.taskRef,
+    expectedState: request.expectedState,
+    taskId: identity.taskId,
+    taskMdPath: identity.taskMdPath,
+    actualState: identity.actualState,
+    changed: false,
+    operations,
+    timestamp: metadata?.timestamp ?? null,
+    agentInfraVersion: metadata?.agentInfraVersion ?? null,
+    error: { code, message }
+  };
+}
+
+function errorDetails(error: unknown, fallback: TaskWriteErrorCode): TaskWriteError {
+  if (error && typeof error === 'object' && 'code' in error && typeof error.code === 'string') {
+    return {
+      code: error.code as TaskWriteErrorCode,
+      message: error instanceof Error ? error.message : String(error)
+    };
+  }
+  return {
+    code: fallback,
+    message: error instanceof Error ? error.message : String(error)
+  };
+}
+
+function writeTask(request: TaskWriteRequest, options: TaskWriteOptions = {}): TaskWriteResult {
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) {
+    return failure(
+      request,
+      { taskId: resolved.taskId, taskMdPath: null, actualState: null },
+      resolved.code,
+      resolved.message
+    );
+  }
+  const identity = {
+    taskId: resolved.taskId,
+    taskMdPath: resolved.taskMdPath,
+    actualState: resolved.state
+  };
+  if (resolved.state !== request.expectedState) {
+    return failure(
+      request,
+      identity,
+      'TASK_STATE_MISMATCH',
+      `task ${resolved.taskId} is ${resolved.state}, expected ${request.expectedState}`
+    );
+  }
+
+  const io: TaskFileSystem = { ...DEFAULT_FILE_SYSTEM, ...options.fileSystem };
+  let original: string;
+  let mode: number;
+  try {
+    original = io.readFileSync(resolved.taskMdPath);
+    mode = io.statModeSync(resolved.taskMdPath);
+  } catch (error) {
+    return failure(
+      request,
+      identity,
+      'TASK_READ_FAILED',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  let candidate = original;
+  const operations: TaskOperationSummary[] = [];
+  try {
+    parseTypedTaskFrontmatter(original);
+    if (!Array.isArray(request.mutations)) {
+      throw Object.assign(new Error('mutations must be an array'), { code: 'MUTATION_INVALID' });
+    }
+    for (const [index, mutation] of request.mutations.entries()) {
+      if (!mutation || typeof mutation !== 'object' || !('kind' in mutation)) {
+        throw Object.assign(new Error(`mutation ${index} is invalid`), { code: 'MUTATION_INVALID' });
+      }
+      const before = candidate;
+      if (mutation.kind === 'frontmatter') {
+        candidate = updateTaskFrontmatter(candidate, mutation.set);
+        operations.push({
+          index,
+          kind: 'frontmatter',
+          fields: Object.keys(mutation.set),
+          wouldChange: candidate !== before
+        });
+      } else if (mutation.kind === 'section') {
+        const result = upsertSection(candidate, mutation);
+        candidate = result.content;
+        operations.push({
+          index,
+          kind: 'section',
+          heading: result.heading,
+          operation: result.operation,
+          wouldChange: candidate !== before
+        });
+      } else if (mutation.kind === 'table-row') {
+        const result = mutateTableRow(candidate, mutation);
+        candidate = result.content;
+        operations.push({
+          index,
+          kind: 'table-row',
+          section: result.section,
+          keyColumn: mutation.keyColumn,
+          key: mutation.key.trim(),
+          operation: result.operation,
+          wouldChange: candidate !== before
+        });
+      } else {
+        throw Object.assign(new Error(`mutation ${index} has an unknown kind`), {
+          code: 'MUTATION_INVALID'
+        });
+      }
+    }
+  } catch (error) {
+    const details = errorDetails(error, 'MUTATION_INVALID');
+    return failure(request, identity, details.code, details.message);
+  }
+
+  let metadata: TaskWriteMetadata;
+  try {
+    metadata = (options.metadataProvider ?? defaultMetadataProvider)();
+    if (
+      !metadata ||
+      typeof metadata.timestamp !== 'string' ||
+      !metadata.timestamp ||
+      typeof metadata.agentInfraVersion !== 'string' ||
+      !metadata.agentInfraVersion
+    ) {
+      throw new Error('metadata provider returned invalid metadata');
+    }
+  } catch (error) {
+    return failure(
+      request,
+      identity,
+      'METADATA_CAPTURE_FAILED',
+      error instanceof Error ? error.message : String(error),
+      operations
+    );
+  }
+
+  if (candidate === original) {
+    return {
+      status: 'no-op',
+      requestRef: request.taskRef,
+      expectedState: request.expectedState,
+      taskId: resolved.taskId,
+      taskMdPath: resolved.taskMdPath,
+      actualState: resolved.state,
+      changed: false,
+      operations,
+      timestamp: metadata.timestamp,
+      agentInfraVersion: metadata.agentInfraVersion,
+      error: null
+    };
+  }
+
+  try {
+    const beforeMetadata = candidate;
+    candidate = updateTaskFrontmatter(candidate, {
+      updated_at: metadata.timestamp,
+      agent_infra_version: metadata.agentInfraVersion
+    });
+    operations.push({
+      index: -1,
+      kind: 'metadata',
+      fields: ['updated_at', 'agent_infra_version'],
+      wouldChange: candidate !== beforeMetadata
+    });
+  } catch (error) {
+    const details = errorDetails(error, 'TASK_DOCUMENT_INVALID');
+    return failure(request, identity, details.code, details.message, operations, metadata);
+  }
+
+  const successBase: TaskWriteSuccessBase = {
+    requestRef: request.taskRef,
+    expectedState: request.expectedState,
+    taskId: resolved.taskId,
+    taskMdPath: resolved.taskMdPath,
+    actualState: resolved.state,
+    operations,
+    timestamp: metadata.timestamp,
+    agentInfraVersion: metadata.agentInfraVersion,
+    error: null
+  };
+  if (request.dryRun) {
+    return { ...successBase, status: 'planned', changed: true };
+  }
+
+  const suffix = (options.randomSuffix ?? (() => Math.random().toString(36).slice(2)))();
+  const tempPath = path.join(
+    path.dirname(resolved.taskMdPath),
+    `.task.md.${process.pid}.${suffix}.tmp`
+  );
+  let primary: TaskWriteError | null = null;
+  let shouldCleanupTemp = false;
+  try {
+    io.writeFileSync(tempPath, candidate, mode);
+    shouldCleanupTemp = true;
+  } catch (error) {
+    shouldCleanupTemp = (error as NodeJS.ErrnoException).code !== 'EEXIST';
+    primary = errorDetails(error, 'TEMP_WRITE_FAILED');
+    primary.code = 'TEMP_WRITE_FAILED';
+  }
+  if (!primary) {
+    try {
+      io.renameSync(tempPath, resolved.taskMdPath);
+    } catch (error) {
+      primary = errorDetails(error, 'RENAME_FAILED');
+      primary.code = 'RENAME_FAILED';
+    }
+  }
+  if (primary && shouldCleanupTemp) {
+    try {
+      io.unlinkSync(tempPath);
+    } catch (cleanupError) {
+      const nodeError = cleanupError as NodeJS.ErrnoException;
+      if (nodeError.code !== 'ENOENT') {
+        return failure(
+          request,
+          identity,
+          'TEMP_CLEANUP_FAILED',
+          `${primary.code}: ${primary.message}; failed to clean ${tempPath}: ${nodeError.message}`,
+          operations,
+          metadata
+        );
+      }
+    }
+  }
+  if (primary) {
+    return failure(
+      request,
+      identity,
+      primary.code,
+      primary.message,
+      operations,
+      metadata
+    );
+  }
+  return { ...successBase, status: 'applied', changed: true };
+}
+
+export { writeTask };
+export type {
+  FrontmatterMutation,
+  SectionMutation,
+  TaskMutation,
+  TaskWriteRequest,
+  TaskOperationSummary,
+  TaskWriteMetadata,
+  TaskWriteErrorCode,
+  TaskWriteError,
+  TaskWritePlanned,
+  TaskWriteApplied,
+  TaskWriteNoOp,
+  TaskWriteFailed,
+  TaskWriteResult,
+  TaskFileSystem,
+  TaskWriteOptions
+};
+export type { FrontmatterScalar } from './frontmatter.ts';
+export type { ResolveTaskRefErrorCode, TaskWorkspaceState } from './resolve-ref.ts';
+export type {
+  TableRowBase,
+  TableRowUpsertMutation,
+  TableRowDeleteMutation
+} from './sections.ts';

--- a/tests/integration/cli/task-write.test.ts
+++ b/tests/integration/cli/task-write.test.ts
@@ -1,0 +1,469 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveTaskRef } from '../../../lib/task/resolve-ref.ts';
+import { writeTask } from '../../../lib/task/write.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+const METADATA = { timestamp: '2026-07-15 12:34:56+00:00', agentInfraVersion: 'v9.9.9' };
+
+type FixtureState = 'active' | 'blocked' | 'completed' | 'archive';
+
+function fixture(state: FixtureState = 'active') {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-write-'));
+  const taskDir = state === 'archive'
+    ? path.join(repoRoot, '.agents', 'workspace', 'archive', '2026', '07', '15', TASK_ID)
+    : path.join(repoRoot, '.agents', 'workspace', state, TASK_ID);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.mkdirSync(path.join(repoRoot, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, '.agents', '.airc.json'), '{"task":{"shortIdLength":2}}\n');
+  const taskMdPath = path.join(taskDir, 'task.md');
+  fs.writeFileSync(
+    taskMdPath,
+    `---\nid: ${TASK_ID}\nstatus: ${state}\nupdated_at: old\nagent_infra_version: v0.0.1\n---\n# Task\n\n## Notes\n\nold\n`
+  );
+  if (state === 'active') {
+    fs.writeFileSync(
+      path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json'),
+      JSON.stringify({ version: 1, ids: { '01': TASK_ID } })
+    );
+  }
+  return { repoRoot, taskDir, taskMdPath };
+}
+
+test('resolveTaskRef maps full and short refs without changing the registry', () => {
+  const { repoRoot, taskMdPath } = fixture();
+  const registry = path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json');
+  const before = fs.readFileSync(registry);
+  const beforeMtime = fs.statSync(registry).mtimeMs;
+  assert.deepEqual(resolveTaskRef('1', { repoRoot }), {
+    ok: true,
+    repoRoot,
+    taskId: TASK_ID,
+    taskDir: path.dirname(taskMdPath),
+    taskMdPath,
+    state: 'active'
+  });
+  assert.equal(resolveTaskRef('#01', { repoRoot }).ok, true);
+  assert.equal(resolveTaskRef(TASK_ID, { repoRoot }).ok, true);
+  assert.deepEqual(fs.readFileSync(registry), before);
+  assert.equal(fs.statSync(registry).mtimeMs, beforeMtime);
+});
+
+test('resolveTaskRef returns stable codes for invalid, missing, stale and duplicate refs', () => {
+  const { repoRoot } = fixture();
+  const invalid = resolveTaskRef('bad', { repoRoot });
+  assert.equal(invalid.ok ? null : invalid.code, 'INVALID_TASK_REF');
+  const reserved = resolveTaskRef('0', { repoRoot });
+  assert.equal(reserved.ok ? null : reserved.code, 'SHORT_ID_RESERVED');
+  const missing = resolveTaskRef('2', { repoRoot });
+  assert.equal(missing.ok ? null : missing.code, 'SHORT_ID_NOT_FOUND');
+
+  const registry = path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json');
+  fs.writeFileSync(registry, JSON.stringify({ version: 1, ids: { '01': TASK_ID, '02': TASK_ID } }));
+  const duplicate = resolveTaskRef('1', { repoRoot });
+  assert.equal(duplicate.ok ? null : duplicate.code, 'SHORT_ID_REGISTRY_DUPLICATE_TASK');
+  fs.writeFileSync(registry, JSON.stringify({ version: 1, ids: { '01': 'TASK-20260101-000002' } }));
+  const stale = resolveTaskRef('1', { repoRoot });
+  assert.equal(stale.ok ? null : stale.code, 'SHORT_ID_STALE');
+  assert.equal(stale.ok ? null : stale.taskId, 'TASK-20260101-000002');
+});
+
+test('resolveTaskRef distinguishes registry storage failures', () => {
+  const { repoRoot } = fixture();
+  const registry = path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json');
+  fs.rmSync(registry);
+  let result = resolveTaskRef('1', { repoRoot });
+  assert.equal(result.ok ? null : result.code, 'SHORT_ID_REGISTRY_NOT_FOUND');
+
+  fs.writeFileSync(registry, '{');
+  result = resolveTaskRef('1', { repoRoot });
+  assert.equal(result.ok ? null : result.code, 'SHORT_ID_REGISTRY_INVALID_JSON');
+
+  fs.writeFileSync(registry, JSON.stringify({ version: 2, ids: {} }));
+  result = resolveTaskRef('1', { repoRoot });
+  assert.equal(result.ok ? null : result.code, 'SHORT_ID_REGISTRY_INVALID_SCHEMA');
+
+  fs.rmSync(registry);
+  fs.mkdirSync(registry);
+  result = resolveTaskRef('1', { repoRoot });
+  assert.equal(result.ok ? null : result.code, 'SHORT_ID_REGISTRY_READ_FAILED');
+});
+
+test('resolveTaskRef reports all workspace states for full task ids', () => {
+  for (const state of ['active', 'blocked', 'completed', 'archive'] as const) {
+    const { repoRoot } = fixture(state);
+    const result = resolveTaskRef(TASK_ID, { repoRoot });
+    assert.equal(result.ok && result.state, state);
+  }
+});
+
+test('writeTask enforces the complete workspace state match and mismatch matrix', () => {
+  const states = ['active', 'blocked', 'completed', 'archive'] as const;
+  for (const [index, actualState] of states.entries()) {
+    const matched = fixture(actualState);
+    const applied = writeTask(
+      {
+        taskRef: TASK_ID,
+        expectedState: actualState,
+        mutations: [{ kind: 'frontmatter', set: { status: `matched-${actualState}` } }]
+      },
+      {
+        repoRoot: matched.repoRoot,
+        metadataProvider: () => METADATA,
+        randomSuffix: () => `matched-${actualState}`
+      }
+    );
+    assert.equal(applied.status, 'applied');
+    assert.equal(applied.actualState, actualState);
+    assert.match(fs.readFileSync(matched.taskMdPath, 'utf8'), new RegExp(`status: matched-${actualState}`));
+    assert.deepEqual(fs.readdirSync(matched.taskDir), ['task.md']);
+
+    const mismatched = fixture(actualState);
+    const before = fs.readFileSync(mismatched.taskMdPath);
+    const beforeMtime = fs.statSync(mismatched.taskMdPath).mtimeMs;
+    const beforeFiles = fs.readdirSync(mismatched.taskDir);
+    let metadataCalls = 0;
+    const expectedState = states[(index + 1) % states.length]!;
+    const rejected = writeTask(
+      {
+        taskRef: TASK_ID,
+        expectedState,
+        mutations: [{ kind: 'frontmatter', set: { status: 'must-not-write' } }]
+      },
+      {
+        repoRoot: mismatched.repoRoot,
+        metadataProvider: () => { metadataCalls += 1; return METADATA; }
+      }
+    );
+    assert.equal(rejected.status, 'failed');
+    assert.equal(rejected.error?.code, 'TASK_STATE_MISMATCH');
+    assert.equal(rejected.actualState, actualState);
+    assert.equal(metadataCalls, 0);
+    assert.deepEqual(fs.readFileSync(mismatched.taskMdPath), before);
+    assert.equal(fs.statSync(mismatched.taskMdPath).mtimeMs, beforeMtime);
+    assert.deepEqual(fs.readdirSync(mismatched.taskDir), beforeFiles);
+  }
+});
+
+test('writeTask returns a dry-run plan without changing bytes, mtime or directory', () => {
+  const { repoRoot, taskDir, taskMdPath } = fixture();
+  const before = fs.readFileSync(taskMdPath);
+  const beforeMtime = fs.statSync(taskMdPath).mtimeMs;
+  const beforeFiles = fs.readdirSync(taskDir);
+  const result = writeTask(
+    {
+      taskRef: '1',
+      expectedState: 'active',
+      dryRun: true,
+      mutations: [{ kind: 'section', aliases: ['Notes'], heading: 'Notes', body: 'new' }]
+    },
+    { repoRoot, metadataProvider: () => METADATA, randomSuffix: () => 'dry' }
+  );
+  assert.equal(result.status, 'planned');
+  assert.equal(result.changed, true);
+  assert.equal(result.timestamp, METADATA.timestamp);
+  assert.equal(result.agentInfraVersion, METADATA.agentInfraVersion);
+  assert.deepEqual(result.operations, [
+    {
+      index: 0,
+      kind: 'section',
+      heading: 'Notes',
+      operation: 'update',
+      wouldChange: true
+    },
+    {
+      index: -1,
+      kind: 'metadata',
+      fields: ['updated_at', 'agent_infra_version'],
+      wouldChange: true
+    }
+  ]);
+  assert.deepEqual(fs.readFileSync(taskMdPath), before);
+  assert.equal(fs.statSync(taskMdPath).mtimeMs, beforeMtime);
+  assert.deepEqual(fs.readdirSync(taskDir), beforeFiles);
+});
+
+test('writeTask reports cancellation as no-op while retaining operation facts', () => {
+  const { repoRoot, taskDir, taskMdPath } = fixture();
+  const before = fs.readFileSync(taskMdPath);
+  const beforeMtime = fs.statSync(taskMdPath).mtimeMs;
+  const beforeFiles = fs.readdirSync(taskDir);
+  let providerCalls = 0;
+  const result = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [
+        { kind: 'frontmatter', set: { status: 'changed' } },
+        { kind: 'frontmatter', set: { status: 'active' } }
+      ]
+    },
+    { repoRoot, metadataProvider: () => { providerCalls += 1; return METADATA; } }
+  );
+  assert.equal(result.status, 'no-op');
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.operations.map((operation) => operation.wouldChange), [true, true]);
+  assert.equal(providerCalls, 1);
+  assert.deepEqual(fs.readFileSync(taskMdPath), before);
+  assert.equal(fs.statSync(taskMdPath).mtimeMs, beforeMtime);
+  assert.deepEqual(fs.readdirSync(taskDir), beforeFiles);
+});
+
+test('writeTask applies one metadata sample atomically and repeated mutation is no-op', () => {
+  const { repoRoot, taskDir, taskMdPath } = fixture();
+  const request = {
+    taskRef: TASK_ID,
+    expectedState: 'active' as const,
+    mutations: [{ kind: 'section' as const, aliases: ['Notes'], heading: 'Notes', body: 'new' }]
+  };
+  const applied = writeTask(request, {
+    repoRoot,
+    metadataProvider: () => METADATA,
+    randomSuffix: () => 'apply'
+  });
+  assert.equal(applied.status, 'applied');
+  assert.equal(applied.operations.at(-1)?.kind, 'metadata');
+  assert.match(fs.readFileSync(taskMdPath, 'utf8'), /updated_at: 2026-07-15 12:34:56\+00:00/);
+  assert.deepEqual(fs.readdirSync(taskDir), ['task.md']);
+
+  const repeated = writeTask(request, { repoRoot, metadataProvider: () => METADATA });
+  assert.equal(repeated.status, 'no-op');
+  assert.equal(repeated.operations.length, 1);
+});
+
+test('writeTask records metadata wouldChange false when automatic fields already match', () => {
+  const { repoRoot, taskMdPath } = fixture();
+  let content = fs.readFileSync(taskMdPath, 'utf8');
+  content = content.replace('updated_at: old', `updated_at: ${METADATA.timestamp}`)
+    .replace('agent_infra_version: v0.0.1', `agent_infra_version: ${METADATA.agentInfraVersion}`);
+  fs.writeFileSync(taskMdPath, content);
+  const result = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      dryRun: true,
+      mutations: [{ kind: 'section', aliases: ['Notes'], heading: 'Notes', body: 'new' }]
+    },
+    { repoRoot, metadataProvider: () => METADATA }
+  );
+  assert.equal(result.status, 'planned');
+  assert.deepEqual(result.operations.at(-1), {
+    index: -1,
+    kind: 'metadata',
+    fields: ['updated_at', 'agent_infra_version'],
+    wouldChange: false
+  });
+});
+
+test('writeTask rejects state mismatch before metadata or temp work', () => {
+  const { repoRoot, taskDir } = fixture('blocked');
+  let calls = 0;
+  const result = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [{ kind: 'frontmatter', set: { status: 'active' } }]
+    },
+    { repoRoot, metadataProvider: () => { calls += 1; return METADATA; } }
+  );
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'TASK_STATE_MISMATCH');
+  assert.equal(result.taskId, TASK_ID);
+  assert.equal(result.actualState, 'blocked');
+  assert.equal(result.timestamp, null);
+  assert.deepEqual(result.operations, []);
+  assert.equal(calls, 0);
+  assert.deepEqual(fs.readdirSync(taskDir), ['task.md']);
+});
+
+test('writeTask normalizes table keys before matching, summarizing and inserting', () => {
+  const { repoRoot, taskDir, taskMdPath } = fixture();
+  fs.appendFileSync(taskMdPath, '\n## IDs\n\n| id |\n|----|\n');
+  let metadataCalls = 0;
+  const request = {
+    taskRef: TASK_ID,
+    expectedState: 'active' as const,
+    mutations: [{
+      kind: 'table-row' as const,
+      action: 'upsert' as const,
+      sectionAliases: ['IDs'],
+      columns: ['id'],
+      keyColumn: 'id',
+      key: ' A ',
+      values: {}
+    }]
+  };
+  const options = {
+    repoRoot,
+    metadataProvider: () => { metadataCalls += 1; return METADATA; }
+  };
+
+  const applied = writeTask(request, options);
+  assert.equal(applied.status, 'applied');
+  assert.equal(applied.operations[0]?.kind, 'table-row');
+  assert.equal(applied.operations[0]?.key, 'A');
+  assert.match(fs.readFileSync(taskMdPath, 'utf8'), /\| A \|/);
+
+  const afterApplied = fs.readFileSync(taskMdPath);
+  const afterAppliedMtime = fs.statSync(taskMdPath).mtimeMs;
+  const afterAppliedFiles = fs.readdirSync(taskDir);
+  const repeated = writeTask(request, options);
+  assert.equal(repeated.status, 'no-op');
+  assert.equal(repeated.operations[0]?.kind, 'table-row');
+  assert.equal(repeated.operations[0]?.key, 'A');
+  assert.equal(repeated.operations[0]?.wouldChange, false);
+  assert.equal(metadataCalls, 2);
+  assert.deepEqual(fs.readFileSync(taskMdPath), afterApplied);
+  assert.equal(fs.statSync(taskMdPath).mtimeMs, afterAppliedMtime);
+  assert.deepEqual(fs.readdirSync(taskDir), afterAppliedFiles);
+});
+
+test('writeTask cleans temp files after rename failure and reports cleanup failure distinctly', () => {
+  const { repoRoot, taskDir } = fixture();
+  const renameFailure = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [{ kind: 'frontmatter', set: { status: 'changed' } }]
+    },
+    {
+      repoRoot,
+      metadataProvider: () => METADATA,
+      randomSuffix: () => 'rename-fail',
+      fileSystem: { renameSync: () => { throw new Error('rename denied'); } }
+    }
+  );
+  assert.equal(renameFailure.status, 'failed');
+  assert.equal(renameFailure.error?.code, 'RENAME_FAILED');
+  assert.deepEqual(fs.readdirSync(taskDir), ['task.md']);
+
+  const cleanupFailure = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [{ kind: 'frontmatter', set: { status: 'changed' } }]
+    },
+    {
+      repoRoot,
+      metadataProvider: () => METADATA,
+      randomSuffix: () => 'cleanup-fail',
+      fileSystem: {
+        renameSync: () => { throw new Error('rename denied'); },
+        unlinkSync: () => { throw new Error('cleanup denied'); }
+      }
+    }
+  );
+  assert.equal(cleanupFailure.status, 'failed');
+  assert.equal(cleanupFailure.error?.code, 'TEMP_CLEANUP_FAILED');
+  assert.match(cleanupFailure.error?.message ?? '', /RENAME_FAILED/);
+  fs.rmSync(path.join(taskDir, '.task.md.' + process.pid + '.cleanup-fail.tmp'));
+});
+
+test('writeTask maps metadata and temp-write failures without changing the task', () => {
+  const { repoRoot, taskMdPath, taskDir } = fixture();
+  const before = fs.readFileSync(taskMdPath);
+  const request = {
+    taskRef: TASK_ID,
+    expectedState: 'active' as const,
+    mutations: [{ kind: 'frontmatter' as const, set: { status: 'changed' } }]
+  };
+
+  const metadataFailure = writeTask(request, {
+    repoRoot,
+    metadataProvider: () => { throw new Error('clock unavailable'); }
+  });
+  assert.equal(metadataFailure.status, 'failed');
+  assert.equal(metadataFailure.error?.code, 'METADATA_CAPTURE_FAILED');
+  assert.equal(metadataFailure.timestamp, null);
+  assert.equal(metadataFailure.operations.length, 1);
+
+  const writeFailure = writeTask(request, {
+    repoRoot,
+    metadataProvider: () => METADATA,
+    randomSuffix: () => 'write-fail',
+    fileSystem: { writeFileSync: () => { throw new Error('disk full'); } }
+  });
+  assert.equal(writeFailure.status, 'failed');
+  assert.equal(writeFailure.error?.code, 'TEMP_WRITE_FAILED');
+  assert.equal(writeFailure.timestamp, METADATA.timestamp);
+  assert.deepEqual(fs.readFileSync(taskMdPath), before);
+  assert.deepEqual(fs.readdirSync(taskDir), ['task.md']);
+});
+
+test('writeTask preserves a pre-existing temp file after a default filesystem collision', () => {
+  const { repoRoot, taskDir } = fixture();
+  const suffix = 'collision-default';
+  const tempPath = path.join(taskDir, `.task.md.${process.pid}.${suffix}.tmp`);
+  const collisionBytes = Buffer.from('pre-existing collision bytes');
+  fs.writeFileSync(tempPath, collisionBytes);
+
+  const result = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [{ kind: 'frontmatter', set: { status: 'changed' } }]
+    },
+    { repoRoot, metadataProvider: () => METADATA, randomSuffix: () => suffix }
+  );
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'TEMP_WRITE_FAILED');
+  assert.deepEqual(fs.readFileSync(tempPath), collisionBytes);
+});
+
+test('writeTask does not call injected cleanup when temp creation reports EEXIST', () => {
+  const { repoRoot } = fixture();
+  let cleanupCalls = 0;
+  const collision = Object.assign(new Error('temp exists'), { code: 'EEXIST' });
+  const result = writeTask(
+    {
+      taskRef: TASK_ID,
+      expectedState: 'active',
+      mutations: [{ kind: 'frontmatter', set: { status: 'changed' } }]
+    },
+    {
+      repoRoot,
+      metadataProvider: () => METADATA,
+      randomSuffix: () => 'collision-injected',
+      fileSystem: {
+        writeFileSync: () => { throw collision; },
+        unlinkSync: () => { cleanupCalls += 1; }
+      }
+    }
+  );
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'TEMP_WRITE_FAILED');
+  assert.equal(cleanupCalls, 0);
+});
+
+test('writeTask maps read and document validation failures before metadata sampling', () => {
+  const { repoRoot, taskMdPath } = fixture();
+  let calls = 0;
+  const request = {
+    taskRef: TASK_ID,
+    expectedState: 'active' as const,
+    mutations: [{ kind: 'frontmatter' as const, set: { status: 'changed' } }]
+  };
+  const readFailure = writeTask(request, {
+    repoRoot,
+    metadataProvider: () => { calls += 1; return METADATA; },
+    fileSystem: { readFileSync: () => { throw new Error('read denied'); } }
+  });
+  assert.equal(readFailure.status, 'failed');
+  assert.equal(readFailure.error?.code, 'TASK_READ_FAILED');
+  assert.equal(calls, 0);
+
+  fs.writeFileSync(taskMdPath, 'not frontmatter\n');
+  const documentFailure = writeTask(request, {
+    repoRoot,
+    metadataProvider: () => { calls += 1; return METADATA; }
+  });
+  assert.equal(documentFailure.status, 'failed');
+  assert.equal(documentFailure.error?.code, 'TASK_DOCUMENT_INVALID');
+  assert.equal(calls, 0);
+});

--- a/tests/unit/cli/task-frontmatter.test.ts
+++ b/tests/unit/cli/task-frontmatter.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseTaskFrontmatter, extractTitle } from '../../../lib/task/frontmatter.ts';
+import {
+  parseTaskFrontmatter,
+  parseTypedTaskFrontmatter,
+  updateTaskFrontmatter
+} from '../../../lib/task/frontmatter.ts';
+import { extractTitle } from '../../../lib/task/frontmatter.ts';
 
 test('parseTaskFrontmatter returns key/value map', () => {
   const fm = parseTaskFrontmatter('---\nid: TASK-1\ntype: feature\n---\nbody\n');
@@ -44,4 +49,38 @@ test('extractTitle pulls the first H1 (plain English)', () => {
 
 test('extractTitle returns empty string when no H1 found', () => {
   assert.equal(extractTitle('## not h1\nbody\n'), '');
+});
+
+test('typed frontmatter reads scalars and preserves empty values', () => {
+  assert.deepEqual(parseTypedTaskFrontmatter('---\nname: sample\ncount: 2\nenabled: true\nempty:\nnone: null\n---\n'), {
+    name: 'sample',
+    count: 2,
+    enabled: true,
+    empty: '',
+    none: null
+  });
+});
+
+test('updateTaskFrontmatter replaces and appends scalars without touching other bytes', () => {
+  const input = '---\r\nid: TASK-1\r\nunknown: keep # comment\r\n---\r\n# Body\r\n';
+  assert.equal(
+    updateTaskFrontmatter(input, { id: 'TASK-2', enabled: true, target_date: '' }),
+    '---\r\nid: TASK-2\r\nunknown: keep # comment\r\nenabled: true\r\ntarget_date:\r\n---\r\n# Body\r\n'
+  );
+});
+
+test('updateTaskFrontmatter rejects duplicate target keys', () => {
+  assert.throws(
+    () => updateTaskFrontmatter('---\nid: one\nid: two\n---\n', { id: 'three' }),
+    (error: unknown) =>
+      error instanceof Error && 'code' in error && error.code === 'TASK_DOCUMENT_INVALID'
+  );
+});
+
+test('parseTypedTaskFrontmatter rejects nested frontmatter values', () => {
+  assert.throws(
+    () => parseTypedTaskFrontmatter('---\nlabels: [one, two]\n---\n'),
+    (error: unknown) =>
+      error instanceof Error && 'code' in error && error.code === 'TASK_DOCUMENT_INVALID'
+  );
 });

--- a/tests/unit/cli/task-issue-body.test.ts
+++ b/tests/unit/cli/task-issue-body.test.ts
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { extractSection, findSectionHeading } from "../../../lib/task/sections.ts";
+import {
+  extractSection,
+  findSectionHeading,
+  mutateTableRow,
+  upsertSection
+} from "../../../lib/task/sections.ts";
 import { renderTemplateBody } from "../../../lib/task/issue-form.ts";
 import { buildDefaultBody, issueBody } from "../../../lib/task/commands/issue-body.ts";
 
@@ -169,4 +174,212 @@ test("issueBody exits 1 with a prefixed error on an unknown task ref", () => {
   assert.equal(process.exitCode, 1);
   assert.match(captured, /^ai task issue-body: /);
   process.exitCode = originalExit;
+});
+
+test("upsertSection preserves the actual language heading and outside text", () => {
+  const input = "# T\n\n## Description\n\nold\n\n## Tail\n\nkeep\n";
+  assert.deepEqual(
+    upsertSection(input, { aliases: ["\u63cf\u8ff0", "Description"], heading: "\u63cf\u8ff0", body: "new" }),
+    {
+      content: "# T\n\n## Description\n\nnew\n\n## Tail\n\nkeep\n",
+      heading: "Description",
+      operation: "update"
+    }
+  );
+});
+
+test("upsertSection creates a missing section with the requested heading", () => {
+  assert.deepEqual(
+    upsertSection("# T\n", { aliases: ["Notes"], heading: "Notes", body: "body" }),
+    { content: "# T\n\n## Notes\n\nbody\n", heading: "Notes", operation: "create" }
+  );
+});
+
+test("upsertSection preserves existing trailing bytes when creating a missing section", () => {
+  const samples = [
+    { input: "# T", expected: "# T\n\n## Notes\n\nbody\n" },
+    { input: "# T\n", expected: "# T\n\n## Notes\n\nbody\n" },
+    { input: "# T\n\n\n\n", expected: "# T\n\n\n\n## Notes\n\nbody\n" },
+    { input: "# T\r\n", expected: "# T\r\n\r\n## Notes\r\n\r\nbody\r\n" },
+    { input: "# T\r\n\r\n\r\n", expected: "# T\r\n\r\n\r\n## Notes\r\n\r\nbody\r\n" }
+  ];
+  for (const sample of samples) {
+    const result = upsertSection(sample.input, {
+      aliases: ["Notes"],
+      heading: "Notes",
+      body: "body"
+    });
+    assert.equal(result.content, sample.expected);
+    assert.equal(result.content.startsWith(sample.input), true);
+  }
+});
+
+test("mutateTableRow merges selected cells and preserves untouched cell tokens", () => {
+  const input = "## Ledger\n\n| id | status | note |\n|----|--------|------|\n| A | open |  keep  |\n\nend\n";
+  assert.deepEqual(
+    mutateTableRow(input, {
+      kind: "table-row",
+      action: "upsert",
+      sectionAliases: ["Ledger"],
+      columns: ["id", "status", "note"],
+      keyColumn: "id",
+      key: "A",
+      values: { status: "closed" }
+    }),
+    {
+      content: "## Ledger\n\n| id | status | note |\n|----|--------|------|\n| A | closed |  keep  |\n\nend\n",
+      section: "Ledger",
+      operation: "update"
+    }
+  );
+});
+
+test("mutateTableRow supports key-only insert and repeated no-op", () => {
+  const input = "## IDs\n\n| id |\n|----|\n";
+  const first = mutateTableRow(input, {
+    kind: "table-row",
+    action: "upsert",
+    sectionAliases: ["IDs"],
+    columns: ["id"],
+    keyColumn: "id",
+    key: "A",
+    values: {}
+  });
+  assert.equal(first.operation, "insert");
+  assert.equal(first.content, "## IDs\n\n| id |\n|----|\n| A |\n");
+  const second = mutateTableRow(first.content, {
+    kind: "table-row",
+    action: "upsert",
+    sectionAliases: ["IDs"],
+    columns: ["id"],
+    keyColumn: "id",
+    key: "A",
+    values: {}
+  });
+  assert.deepEqual(second, { content: first.content, section: "IDs", operation: "update" });
+});
+
+test("mutateTableRow keeps whitespace-only cells stable for empty scalar updates", () => {
+  const input = "## Ledger\n\n| id | note |\n|----|------|\n| A |   |\n";
+  for (const value of ["", null] as const) {
+    const mutation = {
+      kind: "table-row" as const,
+      action: "upsert" as const,
+      sectionAliases: ["Ledger"],
+      columns: ["id", "note"],
+      keyColumn: "id",
+      key: "A",
+      values: { note: value }
+    };
+    const first = mutateTableRow(input, mutation);
+    const second = mutateTableRow(first.content, mutation);
+    assert.equal(first.content, input);
+    assert.equal(second.content, input);
+  }
+});
+
+test("mutateTableRow validates insert columns and delete is idempotent", () => {
+  const input = "## Ledger\n\n| id | status |\n|----|--------|\n";
+  assert.throws(
+    () => mutateTableRow(input, {
+      kind: "table-row",
+      action: "upsert",
+      sectionAliases: ["Ledger"],
+      columns: ["id", "status"],
+      keyColumn: "id",
+      key: "A",
+      values: {}
+    }),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "TABLE_MISSING_COLUMN"
+  );
+  assert.deepEqual(
+    mutateTableRow(input, {
+      kind: "table-row",
+      action: "delete",
+      sectionAliases: ["Ledger"],
+      columns: ["id", "status"],
+      keyColumn: "id",
+      key: "missing"
+    }),
+    { content: input, section: "Ledger", operation: "delete" }
+  );
+});
+
+test("upsertSection rejects ambiguous language aliases", () => {
+  assert.throws(
+    () => upsertSection(
+      "## Description\n\none\n\n## \u63cf\u8ff0\n\ntwo\n",
+      { aliases: ["Description", "\u63cf\u8ff0"], heading: "Description", body: "next" }
+    ),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "TASK_DOCUMENT_INVALID"
+  );
+});
+
+test("mutateTableRow escapes inserted cells and deletes a matching row", () => {
+  const input = "## Ledger\r\n\r\n| id | note |\r\n|----|------|\r\n";
+  const inserted = mutateTableRow(input, {
+    kind: "table-row",
+    action: "upsert",
+    sectionAliases: ["Ledger"],
+    columns: ["id", "note"],
+    keyColumn: "id",
+    key: "A|B",
+    values: { note: "x\\y|z" }
+  });
+  assert.equal(
+    inserted.content,
+    "## Ledger\r\n\r\n| id | note |\r\n|----|------|\r\n| A\\|B | x\\\\y\\|z |\r\n"
+  );
+  assert.equal(
+    mutateTableRow(inserted.content, {
+      kind: "table-row",
+      action: "delete",
+      sectionAliases: ["Ledger"],
+      columns: ["id", "note"],
+      keyColumn: "id",
+      key: "A|B"
+    }).content,
+    input
+  );
+});
+
+test("mutateTableRow returns precise validation codes", () => {
+  const base = "## Ledger\n\n| id | status |\n|----|--------|\n| A | open |\n";
+  const common = {
+    kind: "table-row" as const,
+    action: "upsert" as const,
+    sectionAliases: ["Ledger"],
+    columns: ["id", "status"],
+    keyColumn: "id",
+    key: " A "
+  };
+  const cases: { values: Record<string, string>; code: string }[] = [
+    { values: { unknown: "x" }, code: "TABLE_UNKNOWN_COLUMN" },
+    { values: { id: " A " }, code: "TABLE_KEY_COLUMN_IN_VALUES" },
+    { values: { id: " B " }, code: "TABLE_KEY_CONFLICT" },
+    { values: { status: "bad\ncell" }, code: "TABLE_CELL_INVALID" }
+  ];
+  for (const sample of cases) {
+    assert.throws(
+      () => mutateTableRow(base, { ...common, values: sample.values }),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === sample.code
+    );
+  }
+
+  assert.throws(
+    () => mutateTableRow(base.replace("| A | open |\n", "| A | open |\n| A | closed |\n"), {
+      ...common,
+      values: { status: "closed" }
+    }),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "TABLE_DUPLICATE_KEY"
+  );
+
+  assert.throws(
+    () => mutateTableRow(base, {
+      ...common,
+      action: "delete",
+      values: { status: "closed" }
+    } as never),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "TABLE_DELETE_VALUES_FORBIDDEN"
+  );
 });


### PR DESCRIPTION
## Issue

- [x] Closes #614

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

## Purpose

建立可供后续意图级 CLI 复用的任务写入内核，统一 task-ref 解析、保序 Markdown 变换、事务元数据和原子落盘语义。本 PR 不新增用户命令，不迁移现有 SKILL，也不提前实现后续任务的领域状态机。

## Changelog

- 新增纯读取 task-ref 解析器，支持完整 TASK-id、裸数字短号和 `#NN`，并返回稳定的结构化错误。
- 新增 frontmatter、section 和 table 的局部保序变换；table key 在写入边界统一规范化，匹配、冲突校验、摘要与插入共用同一规范值。
- 新增共享任务写入事务：一次性采集规范时间与 agent-infra 版本，支持 expected-state 校验、dry-run、no-op 和结构化结果。
- 使用同目录独占临时文件与 rename 原子替换；失败时保留原文件并清理临时文件。
- 补充 task-ref、文档变换、dry-run/no-op、原子替换及失败恢复的单元与集成测试。

## Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm test`。
3. 运行 `git diff --check`。

## Test coverage

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Not applicable

验证结果：

- `npm run typecheck`：通过。
- `npm test`：1495 tests，1493 passed，0 failed，2 skipped。
- 提交钩子核心测试：1215 tests，1214 passed，0 failed，1 skipped。
- `git diff --check`：通过。

## Screenshots

不适用。本 PR 不包含用户界面变更。

## Manual validation required

需要在 Windows/NTFS 且 Node.js >= 22.9.0 的真实环境中人工验证原子替换与失败恢复：

1. 正常写入返回 `applied`，目标文件完整替换且无临时文件残留。
2. 重复提交相同变更返回 `no-op`，文件字节、mtime 与目录内容不变。
3. 模拟目标被占用或 rename 失败，确认原文件字节不变、临时文件被清理，并返回稳定的 `failed` 结果。
4. 制造临时文件名冲突，确认独占创建会重试且不会覆盖既有文件。
5. 核对替换后文件的访问权限与可读写性符合 Windows/NTFS 的实际行为。

当前 Linux 环境及注入式失败测试无法替代原生 Windows 的 rename、目标占用和权限语义，因此此项必须由维护者人工裁决。

## Reviewer focus

- 非目标 frontmatter 字段、Markdown 文本、顺序和换行是否保持。
- expected-state 校验是否严格发生在事务元数据采集与临时文件创建之前。
- table key 规范化是否贯穿匹配、冲突判断、operation summary 和插入。
- 原子写入失败路径是否始终保留原文件并清理临时文件。
- operation summary 的逐步变化与最终 `changed` 字段是否分别表达其真实语义。

## Contributor checklist

- [x] The change is scoped to the linked issue.
- [x] Tests cover the changed behavior.
- [x] The full test suite passes.
- [x] No secrets or generated local artifacts are included.
- [x] Public behavior and compatibility impact are described above.
- [ ] Documentation updated (not required: this PR adds an internal typed kernel without a new user-facing workflow).

## Additional context

本 PR 是 01/10。状态事件、产物生命周期、目录迁移、审查/告警状态机、平台同步、Git/发布和并发锁语义均保留给后续任务。

Generated with AI assistance
