### PR TITLE
fix(cli): 修复 task decisions 漏列非 HD 裁决项

### DIFF
--- a/.agents/rules/next-step-output.md
+++ b/.agents/rules/next-step-output.md
@@ -93,7 +93,7 @@ Completed at: YYYY-MM-DD HH:mm:ss
 
 查看详情：
   - 全部待裁决项：ai task decisions {task-ref}
-  - 单项完整背景/选项/影响/建议：ai task decisions {task-ref} <序号|HD-id>
+  - 单项完整背景/选项/影响/建议：ai task decisions {task-ref} <序号|账本ID>
 
 完成裁决：
   1. 在 task.md `## 人工裁决` 段，逐项记录你对上述裁决项的裁定与理由。

--- a/.agents/rules/review-handshake.md
+++ b/.agents/rules/review-handshake.md
@@ -81,7 +81,7 @@
 - `evidence` 指向稳定锚点 `<artifact>#HD-N`（如 `plan-r2.md#HD-1`），不依赖易漂移的行号。
 - 人工在 task.md `## 人工裁决` 段记录裁定后，把对应 `HD-` 行翻为 `human-decided`，`evidence` 指向该裁定记录。
 
-> 查看：`ai task decisions <task-ref>` 列出全部待裁决项；`ai task decisions <task-ref> <序号|HD-id>` 展开单项详情块。该命令的账本解析与 `ai task log` 共用 `lib/task/ledger.ts`；`.agents/scripts/validate-artifact.js` 的 gate 解析器是独立实现，二者语义须手工保持同步。
+> 查看：`ai task decisions <task-ref>` 列出审查阶段中全部待裁决项；`ai task decisions <task-ref> <序号|账本ID>` 展开单项详情块。该命令的账本解析与 `ai task log` 共用 `lib/task/ledger.ts`；`.agents/scripts/validate-artifact.js` 的 gate 解析器是独立实现，二者语义须手工保持同步。
 
 ## post-review commit 门禁（仅 code 阶段）
 

--- a/lib/task/commands/decisions.ts
+++ b/lib/task/commands/decisions.ts
@@ -2,16 +2,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { formatTable } from '../../table.ts';
 import { resolveTaskRef } from '../resolve-ref.ts';
-import { parseLedger, HUMAN_DECISION_STATUSES, type LedgerRow } from '../ledger.ts';
+import { isReviewStage, parseLedger, HUMAN_DECISION_STATUSES, type LedgerRow } from '../ledger.ts';
 import { extractSubSection } from '../sections.ts';
 
 const USAGE = `Usage: ai task decisions <N | #N | TASK-id> [selector] [options]
 
-Lists the human-decision (HD-) items recorded in a task's review disagreement
+Lists decision items recorded in a task's review disagreement
 ledger, or prints the full detail block for a single item. Read-only.
 
   <ref>          Bare numeric / '#N' short id, or a full TASK-YYYYMMDD-HHMMSS id.
-  [selector]     Ordinal (1-based) or HD id (e.g. 'HD-3') to show one item's detail.
+  [selector]     Ordinal (1-based) or ledger id (e.g. 'PL-3') to show one item's detail.
 
 Options:
   --all              Include already-decided (human-decided) items, not just pending.
@@ -22,9 +22,7 @@ Options:
 Aliased as 'ai task d'.
 `;
 
-const STAGES = new Set(['analysis', 'plan', 'code']);
 const FORMATS = new Set(['text', 'markdown']);
-const HD_ID_RE = /^HD-\d+$/;
 
 function fail(message: string): void {
   process.stderr.write(`ai task decisions: ${message}\n`);
@@ -86,7 +84,7 @@ function roundOf(file: string): number {
   return m ? Number.parseInt(m[1]!, 10) : 1;
 }
 
-// Locate the `### HD-N` detail block for a row. Prefer the artifact named by the
+// Locate the `### {ledger-id}` detail block for a row. Prefer the artifact named by the
 // row's evidence anchor; otherwise scan analysis/plan/code artifacts and return
 // the block from the highest-round file that contains it. Returns '' when none
 // is found (caller degrades gracefully — plan B3).
@@ -118,7 +116,7 @@ function findDetailBlock(row: LedgerRow, taskDir: string): string {
   return best;
 }
 
-// Pull the `## 人工裁决` record lines that mention this HD id, so a decided item
+// Pull the `## 人工裁决` record lines that mention this ledger id, so a decided item
 // shows the human's recorded ruling alongside its detail block.
 function findDecisionRecord(id: string, content: string): string[] {
   const lines = content.split('\n');
@@ -239,7 +237,7 @@ function decisions(args: string[] = []): void {
     process.exitCode = 1;
     return;
   }
-  if (parsed.stage !== undefined && !STAGES.has(parsed.stage)) {
+  if (parsed.stage !== undefined && !isReviewStage(parsed.stage)) {
     fail(`invalid --stage '${parsed.stage}' (expected analysis|plan|code)`);
     return;
   }
@@ -255,7 +253,7 @@ function decisions(args: string[] = []): void {
   }
 
   const content = fs.readFileSync(resolved.taskMdPath, 'utf8');
-  let rows = parseLedger(content).filter((r) => HD_ID_RE.test(r.id));
+  let rows = parseLedger(content).filter((r) => isReviewStage(r.stage));
   rows = rows.filter((r) =>
     parsed.all ? HUMAN_DECISION_STATUSES.has(r.status) : r.status === 'needs-human-decision'
   );

--- a/lib/task/commands/log.ts
+++ b/lib/task/commands/log.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { formatTable } from '../../table.ts';
 import { resolveTaskRef } from '../resolve-ref.ts';
-import { parseLedger, type LedgerRow } from '../ledger.ts';
+import { isReviewStage, parseLedger, type LedgerRow, type ReviewStage } from '../ledger.ts';
 
 const USAGE = `Usage: ai task log <N | #N | TASK-id>
 
@@ -29,7 +29,6 @@ const ENTRY_RE =
   /^- (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}) — \*\*(.+?)\*\* by (.+?) — (.*)$/;
 
 type LogEntry = { time: string; step: string; agent: string; note: string };
-type ReviewStage = 'analysis' | 'plan' | 'code';
 
 // One rendered row = one step instance. `started`/`done` are timestamps; an empty
 // `done` with a non-empty `started` means the step is still in flight, while an
@@ -112,10 +111,6 @@ function countHumanDecisionsByStage(rows: LedgerRow[]): Map<ReviewStage, number>
     counts.set(row.stage, (counts.get(row.stage) ?? 0) + 1);
   }
   return counts;
-}
-
-function isReviewStage(stage: string): stage is ReviewStage {
-  return stage === 'analysis' || stage === 'plan' || stage === 'code';
 }
 
 function reviewStageForStep(step: string): ReviewStage | undefined {

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -2,7 +2,7 @@ const USAGE = `Usage: ai task <command> [options]
 
 Commands:
   cat <ref> <artifact | N>               Print a task artifact (by name or number)
-  decisions, d <ref> [selector]          List human-decision (HD-) items, or show one's detail
+  decisions, d <ref> [selector]          List review decisions, or show one item's detail
   files <ref>                            List artifacts in a task dir (numbered)
   grep <pattern> [ref] [artifact | N]    Literal search across task artifacts (omit ref to scan all)
   issue-body <ref> [--template <path>]   Print a deterministic Issue body from task.md (描述 + 需求, or an Issue Form)
@@ -15,7 +15,7 @@ Examples:
   ai task cat 11 analysis
   ai task cat 11 3
   ai task decisions 11
-  ai task d 11 HD-3 --format markdown
+  ai task d 11 PL-3 --format markdown
   ai task files 11
   ai task grep resolveArtifact
   ai task grep resolveArtifact 11

--- a/lib/task/ledger.ts
+++ b/lib/task/ledger.ts
@@ -17,10 +17,16 @@ type LedgerRow = {
   evidence: string;
 };
 
+type ReviewStage = 'analysis' | 'plan' | 'code';
+
 // Terminal statuses the completion gates treat as resolved.
 const LEDGER_TERMINAL = new Set(['confirmed', 'closed', 'human-decided']);
-// Statuses that represent an executor-raised human-decision row (pending or done).
+// Statuses that represent a decision row awaiting or carrying a human ruling.
 const HUMAN_DECISION_STATUSES = new Set(['needs-human-decision', 'human-decided']);
+
+function isReviewStage(stage: string): stage is ReviewStage {
+  return stage === 'analysis' || stage === 'plan' || stage === 'code';
+}
 
 // Parse all rows of the disagreement ledger table. Skips the heading, the
 // header row (`| id | ... |`) and the `|---|` separator; ignores non-`|` lines.
@@ -69,5 +75,5 @@ function nextHdId(rows: readonly LedgerRow[]): string {
   return `HD-${max + 1}`;
 }
 
-export { parseLedger, nextHdId, LEDGER_TERMINAL, HUMAN_DECISION_STATUSES };
-export type { LedgerRow };
+export { parseLedger, nextHdId, isReviewStage, LEDGER_TERMINAL, HUMAN_DECISION_STATUSES };
+export type { LedgerRow, ReviewStage };

--- a/lib/task/sections.ts
+++ b/lib/task/sections.ts
@@ -432,9 +432,9 @@ function findSectionHeading(content: string, aliases: string[]): string {
 /**
  * Return the body of the first `### {headingPrefix}` sub-section, from the
  * heading line (inclusive) to the next `### ` / `## ` heading or EOF. Used to
- * pull a single `### HD-N` human-decision detail block out of an artifact. The
- * prefix must be followed by a word boundary so `HD-1` does not match `HD-10`
- * (e.g. `### HD-1`, `### HD-1：标题`, `### HD-1 [needs-human-decision]`). Leading
+ * pull a single `### {ledger-id}` detail block out of an artifact. The prefix
+ * must be followed by a word boundary so `PL-1` does not match `PL-10`
+ * (e.g. `### PL-1`, `### PL-1：标题`, `### PL-1 [needs-human-decision]`). Leading
  * and trailing blank lines are trimmed. Returns '' when no match is present.
  */
 function extractSubSection(content: string, headingPrefix: string): string {

--- a/templates/.agents/rules/next-step-output.en.md
+++ b/templates/.agents/rules/next-step-output.en.md
@@ -93,7 +93,7 @@ This section is a **third standalone rule, co-equal with the two above**, used o
 
 View details:
   - All pending decisions: ai task decisions {task-ref}
-  - A single item's full background/options/impact/recommendation: ai task decisions {task-ref} <ordinal|HD-id>
+  - A single item's full background/options/impact/recommendation: ai task decisions {task-ref} <ordinal|ledger-id>
 
 To resolve:
   1. In the task.md `## 人工裁决` section, record your ruling and rationale for each item above.

--- a/templates/.agents/rules/next-step-output.zh-CN.md
+++ b/templates/.agents/rules/next-step-output.zh-CN.md
@@ -93,7 +93,7 @@ Completed at: YYYY-MM-DD HH:mm:ss
 
 查看详情：
   - 全部待裁决项：ai task decisions {task-ref}
-  - 单项完整背景/选项/影响/建议：ai task decisions {task-ref} <序号|HD-id>
+  - 单项完整背景/选项/影响/建议：ai task decisions {task-ref} <序号|账本ID>
 
 完成裁决：
   1. 在 task.md `## 人工裁决` 段，逐项记录你对上述裁决项的裁定与理由。

--- a/templates/.agents/rules/review-handshake.en.md
+++ b/templates/.agents/rules/review-handshake.en.md
@@ -81,7 +81,7 @@ When an executor judges an item to be a key design decision that needs human rul
 - `evidence` points to the stable anchor `<artifact>#HD-N` (e.g. `plan-r2.md#HD-1`), not a drift-prone line number.
 - After a human records the ruling in task.md `## Human Rulings`, flip the matching `HD-` row to `human-decided` and point `evidence` to that ruling.
 
-> View: `ai task decisions <task-ref>` lists all pending decisions; `ai task decisions <task-ref> <ordinal|HD-id>` expands a single item's detail block. This command shares the ledger parser `lib/task/ledger.ts` with `ai task log`; the gate parser in `.agents/scripts/validate-artifact.js` is a separate implementation and the two must be kept semantically in sync by hand.
+> View: `ai task decisions <task-ref>` lists all pending decisions from review stages; `ai task decisions <task-ref> <ordinal|ledger-id>` expands a single item's detail block. This command shares the ledger parser `lib/task/ledger.ts` with `ai task log`; the gate parser in `.agents/scripts/validate-artifact.js` is a separate implementation and the two must be kept semantically in sync by hand.
 
 ## post-review commit gate (code stage only)
 

--- a/templates/.agents/rules/review-handshake.zh-CN.md
+++ b/templates/.agents/rules/review-handshake.zh-CN.md
@@ -81,7 +81,7 @@
 - `evidence` 指向稳定锚点 `<artifact>#HD-N`（如 `plan-r2.md#HD-1`），不依赖易漂移的行号。
 - 人工在 task.md `## 人工裁决` 段记录裁定后，把对应 `HD-` 行翻为 `human-decided`，`evidence` 指向该裁定记录。
 
-> 查看：`ai task decisions <task-ref>` 列出全部待裁决项；`ai task decisions <task-ref> <序号|HD-id>` 展开单项详情块。该命令的账本解析与 `ai task log` 共用 `lib/task/ledger.ts`；`.agents/scripts/validate-artifact.js` 的 gate 解析器是独立实现，二者语义须手工保持同步。
+> 查看：`ai task decisions <task-ref>` 列出审查阶段中全部待裁决项；`ai task decisions <task-ref> <序号|账本ID>` 展开单项详情块。该命令的账本解析与 `ai task log` 共用 `lib/task/ledger.ts`；`.agents/scripts/validate-artifact.js` 的 gate 解析器是独立实现，二者语义须手工保持同步。
 
 ## post-review commit 门禁（仅 code 阶段）
 

--- a/tests/integration/cli/task-decisions.test.ts
+++ b/tests/integration/cli/task-decisions.test.ts
@@ -28,7 +28,7 @@ function mkFixture(): { repoRoot: string; activeDir: string } {
 }
 
 // Write task.md with a ledger + a 人工裁决 record, and optional artifact files
-// holding `### HD-N` detail blocks.
+// holding `### <ledger-id>` detail blocks.
 function writeTask(
   activeDir: string,
   taskId: string,
@@ -52,25 +52,34 @@ function runCli(args: string[], cwd: string) {
   return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
 }
 
+const AN1_BLOCK = '### AN-1：分析边界待裁定 [needs-human-decision]\n\n- **说明**：分析 finding 已升级。\n';
 const HD1_BLOCK = '### HD-1：引用入口是否扩展 [needs-human-decision]\n\n- **背景**：是否支持更多入口。\n- **推荐**：(A) 仅三种标准形式。\n';
+const PL1_BLOCK = '### PL-1：方案回退范围 [needs-human-decision]\n\n- **说明**：方案 finding 已升级。\n';
+const CD1_BLOCK = '### CD-1：实现兼容边界 [needs-human-decision]\n\n- **说明**：代码 finding 已升级。\n';
 const HD3_BLOCK = '### HD-3：命令输出格式 [needs-human-decision]\n\n- **背景**：markdown 细节。\n- **推荐**：附锚点文本。\n';
 
-// A canonical fixture: HD-1 pending (analysis, has detail block in analysis.md),
-// HD-2 decided (plan), HD-3 pending (plan, detail block in plan.md), plus a
-// closed non-HD finding that must never appear in decisions output.
+// A canonical fixture spanning pending review findings, executor-raised
+// decisions, a decided row, terminal rows, and a post-review exemption.
 function writeCanonical(activeDir: string, taskId: string): void {
   writeTask(
     activeDir,
     taskId,
     [
-      '| AN-1 | analysis | 2 | blocker | closed | review-analysis-r2.md#AN-1 |',
+      '| AN-1 | analysis | 2 | minor | needs-human-decision | review-analysis-r2.md#AN-1 |',
       '| HD-1 | analysis | - | decision | needs-human-decision | analysis.md#HD-1 |',
+      '| PL-1 | plan | 3 | blocker | needs-human-decision | review-plan-r3.md#PL-1 |',
       '| HD-2 | plan | - | decision | human-decided | task.md#人工裁决 |',
-      '| HD-3 | plan | - | decision | needs-human-decision | plan.md#HD-3 |'
+      '| CD-1 | code | 3 | blocker | needs-human-decision | code-r3.md#CD-1 |',
+      '| HD-3 | plan | - | decision | needs-human-decision | plan.md#HD-3 |',
+      '| AN-2 | analysis | 2 | minor | closed | review-analysis-r2.md#AN-2 |',
+      '| PRC-1 | post-review-commit | - | - | human-decided | task.md#PRC-1 |'
     ],
     {
       artifacts: {
+        'review-analysis-r2.md': `# 分析审查\n\n${AN1_BLOCK}`,
         'analysis.md': `# 分析\n\n## 人工裁决待办\n\n${HD1_BLOCK}`,
+        'review-plan-r3.md': `# 方案审查\n\n${PL1_BLOCK}`,
+        'code-r3.md': `# 实现\n\n${CD1_BLOCK}`,
         'plan.md': `# 方案\n\n## 人工裁决待办\n\n${HD3_BLOCK}`
       },
       decisionRecords: ['- 2026-06-29 09:36:59+08:00 — **HD-2**：选择 A，采用独立段。']
@@ -117,18 +126,20 @@ test('A3: --help exits 0 with usage; no args exits 1 with usage', () => {
   assert.match(none.stdout, /Usage: ai task decisions/);
 });
 
-test('A4: default list shows pending HD rows with id/stage/severity/status/evidence/title', () => {
+test('A4: default list shows pending decision rows from every review stage', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000003';
   writeCanonical(activeDir, taskId);
   const out = runCli(['task', 'd', taskId], repoRoot);
   assert.equal(out.status, 0, out.stderr);
-  // Pending rows only (HD-1, HD-3); decided HD-2 and non-HD AN-1 excluded.
+  assert.match(out.stdout, /AN-1\s+analysis\s+minor\s+needs-human-decision\s+review-analysis-r2\.md#AN-1/);
   assert.match(out.stdout, /HD-1\s+analysis\s+decision\s+needs-human-decision\s+analysis\.md#HD-1/);
+  assert.match(out.stdout, /PL-1\s+plan\s+blocker\s+needs-human-decision\s+review-plan-r3\.md#PL-1/);
+  assert.match(out.stdout, /CD-1\s+code\s+blocker\s+needs-human-decision\s+code-r3\.md#CD-1/);
   assert.match(out.stdout, /HD-3\s+plan\s+decision\s+needs-human-decision\s+plan\.md#HD-3/);
   assert.doesNotMatch(out.stdout, /HD-2/);
-  assert.doesNotMatch(out.stdout, /AN-1/);
-  // Title comes from the `### HD-N` heading.
+  assert.doesNotMatch(out.stdout, /AN-2/);
+  assert.doesNotMatch(out.stdout, /PRC-1/);
   assert.match(out.stdout, /引用入口是否扩展/);
 });
 
@@ -142,18 +153,16 @@ test('A5: empty candidate set prints a notice and exits 0', () => {
   assert.match(out.stdout, /无待裁决项/);
 });
 
-test('A6: select a single item by ordinal and by HD id', () => {
+test('A6: select a review finding by ordinal and ledger id', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000005';
   writeCanonical(activeDir, taskId);
-  const byId = runCli(['task', 'd', taskId, 'HD-1'], repoRoot);
+  const byId = runCli(['task', 'd', taskId, 'PL-1'], repoRoot);
   assert.equal(byId.status, 0, byId.stderr);
-  assert.match(byId.stdout, /### HD-1：引用入口是否扩展/);
-  assert.match(byId.stdout, /推荐.*仅三种标准形式/);
-  // Ordinal 1 selects the first pending row (HD-1) -> same detail block.
-  const byOrdinal = runCli(['task', 'd', taskId, '1'], repoRoot);
+  assert.match(byId.stdout, /### PL-1：方案回退范围/);
+  const byOrdinal = runCli(['task', 'd', taskId, '3'], repoRoot);
   assert.equal(byOrdinal.status, 0, byOrdinal.stderr);
-  assert.match(byOrdinal.stdout, /### HD-1：引用入口是否扩展/);
+  assert.match(byOrdinal.stdout, /### PL-1：方案回退范围/);
 });
 
 test('A7: --all includes decided rows; --stage filters; --format markdown', () => {
@@ -164,10 +173,14 @@ test('A7: --all includes decided rows; --stage filters; --format markdown', () =
   const all = runCli(['task', 'd', taskId, '--all'], repoRoot);
   assert.equal(all.status, 0, all.stderr);
   assert.match(all.stdout, /HD-2\s+plan\s+decision\s+human-decided/);
+  assert.doesNotMatch(all.stdout, /PRC-1/);
 
   const stage = runCli(['task', 'd', taskId, '--all', '--stage', 'analysis'], repoRoot);
   assert.equal(stage.status, 0, stage.stderr);
+  assert.match(stage.stdout, /AN-1/);
   assert.match(stage.stdout, /HD-1/);
+  assert.doesNotMatch(stage.stdout, /PL-1/);
+  assert.doesNotMatch(stage.stdout, /CD-1/);
   assert.doesNotMatch(stage.stdout, /HD-3/);
 
   const md = runCli(['task', 'd', taskId, '--format', 'markdown'], repoRoot);
@@ -187,7 +200,8 @@ test('A8: command is read-only (task.md unchanged)', () => {
   const taskMd = path.join(activeDir, taskId, 'task.md');
   const before = fs.readFileSync(taskMd);
   runCli(['task', 'd', taskId], repoRoot);
-  runCli(['task', 'd', taskId, 'HD-1'], repoRoot);
+  runCli(['task', 'd', taskId, 'PL-1'], repoRoot);
+  runCli(['task', 'd', taskId, '3'], repoRoot);
   runCli(['task', 'd', taskId, '--all', '--format', 'markdown'], repoRoot);
   const after = fs.readFileSync(taskMd);
   assert.ok(before.equals(after), 'task.md must not be modified by decisions');
@@ -196,25 +210,23 @@ test('A8: command is read-only (task.md unchanged)', () => {
 test('B3: missing detail block degrades gracefully and exits 0', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000008';
-  // HD-1 references analysis.md#HD-1 but no artifact holds the block.
-  writeTask(activeDir, taskId, ['| HD-1 | analysis | - | decision | needs-human-decision | analysis.md#HD-1 |']);
-  const out = runCli(['task', 'd', taskId, 'HD-1'], repoRoot);
+  writeTask(activeDir, taskId, ['| CD-9 | code | 3 | blocker | needs-human-decision | review-code-r3.md#CD-9 |']);
+  const out = runCli(['task', 'd', taskId, 'CD-9'], repoRoot);
   assert.equal(out.status, 0, out.stderr);
   assert.match(out.stdout, /详情块未找到/);
 });
 
-test('PL-2: duplicate HD id errors on id select but works by ordinal', () => {
+test('PL-2: duplicate ledger id errors on id select but works by ordinal', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000009';
-  // Two rows sharing id HD-1 (a legacy collision the global allocator prevents).
   writeTask(activeDir, taskId, [
-    '| HD-1 | analysis | - | decision | needs-human-decision | analysis.md#HD-1 |',
-    '| HD-1 | plan | - | decision | needs-human-decision | plan.md#HD-1 |'
+    '| PL-1 | analysis | 3 | blocker | needs-human-decision | analysis-r3.md#PL-1 |',
+    '| PL-1 | plan | 3 | blocker | needs-human-decision | plan-r3.md#PL-1 |'
   ]);
-  const byId = runCli(['task', 'd', taskId, 'HD-1'], repoRoot);
+  const byId = runCli(['task', 'd', taskId, 'PL-1'], repoRoot);
   assert.equal(byId.status, 1);
   assert.match(byId.stderr, /duplicate id/);
   const byOrdinal = runCli(['task', 'd', taskId, '2'], repoRoot);
   assert.equal(byOrdinal.status, 0, byOrdinal.stderr);
-  assert.match(byOrdinal.stdout, /HD-1 \(plan\/decision\)/);
+  assert.match(byOrdinal.stdout, /PL-1 \(plan\/blocker\)/);
 });

--- a/tests/unit/cli/task-ledger.test.ts
+++ b/tests/unit/cli/task-ledger.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseLedger, nextHdId } from '../../../lib/task/ledger.ts';
+import { isReviewStage, parseLedger, nextHdId } from '../../../lib/task/ledger.ts';
 
 const HEADER = '| id | stage | round | severity | status | evidence |';
 const SEP = '|----|-------|-------|----------|--------|----------|';
@@ -51,6 +51,13 @@ test('parseLedger stops at the next H2 and ignores malformed rows', () => {
   );
   assert.equal(rows.length, 1);
   assert.equal(rows[0]!.id, 'HD-1');
+});
+
+test('isReviewStage accepts workflow review stages and rejects reserved stages', () => {
+  assert.equal(isReviewStage('analysis'), true);
+  assert.equal(isReviewStage('plan'), true);
+  assert.equal(isReviewStage('code'), true);
+  assert.equal(isReviewStage('post-review-commit'), false);
 });
 
 test('nextHdId returns HD-1 for an empty ledger', () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #644

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #644

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 `ai task decisions` 仅按 `HD-*` 前缀列出裁决项、遗漏 `AN-*`、`PL-*`、`CD-*` 待人工裁决 finding 的问题。候选集现在与审查协议和 `ai task log` 统一：以 review stage 与裁决状态为准，并继续排除 `post-review-commit` 的 `PRC-*` 行。

## 📋 主要变更 / Brief Changelog

- 将 `ReviewStage` 与 `isReviewStage` 提升到共享账本模块，供 `task log` 和 `task decisions` 复用。
- 将裁决候选过滤从 `HD-*` 正则改为审查阶段与状态过滤，保持 `--all`、`--stage`、序号、账本 ID、evidence 详情与只读语义一致。
- 扩展集成测试以覆盖 AN/PL/CD/HD、终态、PRC 排除、review evidence、缺失详情和只读行为。
- 同步 CLI 帮助、审查协议、下一步提示及英中双语部署模板。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm test`。
3. 运行 `git diff --check`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：

- `npm run typecheck`：通过。
- 定向回归：48 tests，48 passed，0 failed。
- `npm test`：1511 tests，1509 passed，0 failed，2 skipped。
- 提交钩子核心测试：1231 tests，1230 passed，0 failed，1 skipped。
- `git diff --check`：通过。

## 📸 截图 / Screenshots

不适用。本 PR 不包含图形界面变更。

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 只解决一个 Issue，没有包含其他不相关的变更 / This PR addresses one issue only
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project standards
- [x] 已完成自我代码审查 / A self-review has been performed
- [x] 复杂逻辑已提供必要注释 / Complex logic has necessary comments

### 测试要求 / Testing Requirements

- [x] 已编写必要的单元和集成测试 / Necessary unit and integration tests are included
- [x] 跨模块行为由真实 CLI 集成 fixture 覆盖 / Cross-module behavior is covered by CLI integration fixtures
- [x] 代码检查通过 / Checks pass
- [x] 单元测试通过 / Unit tests pass

### 文档和兼容性 / Documentation and Compatibility

- [x] 已更新相应文档 / Documentation has been updated
- [x] 无破坏性变更 / No breaking changes
- [x] 已考虑向后兼容性 / Backward compatibility has been considered

## 📋 附加信息 / Additional Notes

`ai decide` 与服务端 `/decide` 的写入语义仍保持 HD-only，不在本次修复范围内。详情回退仍以 evidence 为权威，并保留现有限定扫描，避免跨 review/执行产物轮次做猜测性排序。

---

**审查者注意事项 / Reviewer Notes:**

- 重点检查 `isReviewStage` 是否正确统一两个命令的审查阶段边界。
- 确认 `--all` 加入 review-stage `human-decided` 行时仍排除 `post-review-commit`。
- 确认 evidence 指向 review artifact 时详情解析和缺失详情降级保持既有契约。

Generated with AI assistance
