### PR TITLE
fix(task): 恢复补充代码审查事件跃迁

### DIFF
--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -108,7 +108,7 @@ const FAMILY = {
   plan: { artifact: 'plan', started: ['requirement-analysis-review', 'technical-design-review'], completed: ['requirement-analysis-review', 'technical-design-review'], target: 'technical-design', label: 'Plan Task' },
   'review-plan': { artifact: 'review-plan', started: ['technical-design'], completed: ['technical-design'], target: 'technical-design-review', label: 'Review Plan' },
   code: { artifact: 'code', started: ['technical-design-review', 'code-review'], completed: ['technical-design-review', 'code-review'], target: 'code', label: 'Code Task' },
-  'review-code': { artifact: 'review-code', started: ['code'], completed: ['code'], target: 'code-review', label: 'Review Code' },
+  'review-code': { artifact: 'review-code', started: ['code', 'code-review'], completed: ['code', 'code-review'], target: 'code-review', label: 'Review Code' },
   'manual-validation': { artifact: 'manual-validation', started: ['code-review'], completed: ['code-review'], target: null, label: 'Complete Manual Validation' }
 } as const;
 type EventFamily = keyof typeof FAMILY;

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -22,6 +22,14 @@ function run(root: string, args: string[], env: NodeJS.ProcessEnv = process.env)
   return spawnSync('node', [INTERNAL_CLI_PATH, 'task-event', ...args], { cwd: root, encoding: 'utf8', env });
 }
 
+function inspect(root: string, args: string[]) {
+  return spawnSync('node', [INTERNAL_CLI_PATH, 'task-artifact', ...args], { cwd: root, encoding: 'utf8' });
+}
+
+function reviewCodeArtifact(input = 'code.md') {
+  return `# Code Review\n\n- **审查输入**：\`${input}\`\n`;
+}
+
 function decisionFixture() {
   const f = fixture('code-review');
   fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
@@ -146,6 +154,74 @@ test('completion without an open start fails without changing the file', () => {
   const out = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md']);
   assert.equal(out.status, 1);
   assert.equal(JSON.parse(out.stdout).error.code, 'EVENT_START_MISSING');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('review-code event completes the regular code review path', () => {
+  const f = fixture('code');
+  fs.writeFileSync(path.join(f.dir, 'code.md'), '# Code\n');
+
+  const started = run(f.root, [f.id, 'review-code.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr);
+  assert.equal(JSON.parse(started.stdout).status, 'applied');
+
+  fs.writeFileSync(path.join(f.dir, 'review-code.md'), reviewCodeArtifact());
+  const completed = run(f.root, [
+    f.id, 'review-code.completed', '--agent', 'codex', '--artifact', 'review-code.md',
+    '--verdict', 'approved', '--blockers', '0', '--major', '0', '--minor', '0', '--manual-validation', '0'
+  ]);
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(JSON.parse(completed.stdout).toStep, 'code-review');
+  const content = fs.readFileSync(f.file, 'utf8');
+  assert.match(content, /current_step: code-review/);
+  assert.match(content, /\]\(review-code\.md\)/);
+});
+
+test('review-code event completes a supplemental round against the latest code artifact', () => {
+  const f = fixture('code-review');
+  fs.writeFileSync(path.join(f.dir, 'code.md'), '# Code\n');
+  fs.writeFileSync(path.join(f.dir, 'review-code.md'), reviewCodeArtifact());
+  fs.appendFileSync(
+    f.file,
+    '- 2026-01-01 00:01:00+00:00 — **Review Code (Round 1)** by codex — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 0 → review-code.md\n'
+  );
+
+  const artifact = inspect(f.root, [f.id, 'inspect', '--family', 'review-code']);
+  assert.equal(artifact.status, 0, artifact.stderr);
+  const artifactResult = JSON.parse(artifact.stdout);
+  assert.equal(artifactResult.status, 'ready');
+  assert.deepEqual(artifactResult.next, { round: 2, name: 'review-code-r2.md' });
+  assert.equal(artifactResult.inputs[0].name, 'code.md');
+
+  const started = run(f.root, [f.id, 'review-code.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr);
+  const startedResult = JSON.parse(started.stdout);
+  assert.equal(startedResult.status, 'applied');
+  assert.equal(startedResult.fromStep, 'code-review');
+  assert.equal(startedResult.toStep, 'code-review');
+  assert.equal(startedResult.round, 2);
+  assert.equal(startedResult.artifact, 'review-code-r2.md');
+
+  fs.writeFileSync(path.join(f.dir, 'review-code-r2.md'), reviewCodeArtifact());
+  const completed = run(f.root, [
+    f.id, 'review-code.completed', '--agent', 'codex', '--artifact', 'review-code-r2.md',
+    '--verdict', 'approved', '--blockers', '0', '--major', '0', '--minor', '0', '--manual-validation', '0'
+  ]);
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(JSON.parse(completed.stdout).toStep, 'code-review');
+  const content = fs.readFileSync(f.file, 'utf8');
+  assert.match(content, /Review Code \(Round 2\) \[started\]/);
+  assert.match(content, /\]\(review-code-r2\.md\)/);
+});
+
+test('review-code event still rejects an unrelated workflow stage without changing task bytes', () => {
+  const f = fixture('technical-design');
+  fs.writeFileSync(path.join(f.dir, 'code.md'), '# Code\n');
+  const before = fs.readFileSync(f.file);
+
+  const started = run(f.root, [f.id, 'review-code.started', '--agent', 'codex']);
+  assert.notEqual(started.status, 0);
+  assert.equal(JSON.parse(started.stdout).error.code, 'EVENT_TRANSITION_INVALID');
   assert.deepEqual(fs.readFileSync(f.file), before);
 });
 


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #657

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #657

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

恢复任务已经处于 `code-review`、但上次审查后又产生代码变更时直接启动补充 `review-code` 的能力，避免维护者伪造新一轮 `code-task` 或手工回退 `current_step`。

## 📋 主要变更 / Brief Changelog

- 为 `review-code.started` 与 `review-code.completed` 精确增加 `code-review` 允许来源，同时保留现有 `code` 主路径。
- 增加常规代码审查路径的集成回归测试。
- 增加继续使用最新 `code.md` 的 Round 2 补充审查完整闭环测试。
- 增加无关工作流阶段仍拒绝跃迁且不修改任务文件的回归测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行事件 CLI 定向测试与补充审查相关 e2e 测试。
3. 运行 `npm test` 和 `git diff --check`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：

- 事件 CLI 集成测试：11/11 通过。
- 补充审查相关 e2e：38/38 通过。
- `npm run typecheck`：通过。
- `npm test`：1582 tests，1580 passed，0 failed，2 skipped。
- `git diff --check`：通过。
- Review Code Round 1：Approved，0 blockers / 0 major / 0 minor / 0 manual-validation。

## 📸 截图 / Screenshots

不适用。本 PR 不包含图形界面变更。

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 只解决一个 Issue，没有包含其他不相关的变更 / This PR addresses one issue only
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project standards
- [x] 已完成自我代码审查 / A self-review has been performed
- [x] 复杂逻辑无需额外注释 / The focused transition change needs no additional comments

### 测试要求 / Testing Requirements

- [x] 已编写必要的集成测试 / Necessary integration tests are included
- [x] 跨模块行为由真实 internal CLI 和临时任务仓库 fixture 覆盖 / Cross-module behavior is covered by the real internal CLI and temporary task repository fixtures
- [x] 代码检查通过 / Checks pass
- [x] 单元测试通过 / Unit tests pass

### 文档和兼容性 / Documentation and Compatibility

- [x] 无需文档更新 / No documentation update is required
- [x] 无破坏性变更 / No breaking changes
- [x] 保持事件身份、产物轮次、幂等配对和非法阶段拒绝行为兼容 / Event identity, artifact rounds, idempotent pairing, and unrelated-stage rejection remain compatible

## 📋 附加信息 / Additional Notes

本修复只扩展 `review-code` 事件族的允许来源，不把 Git 差异判断下沉到事件层，也不改变 artifact lifecycle 或 review-code 技能。

---

**审查者注意事项 / Reviewer Notes:**

- 确认 `code-review` 仅新增到 `review-code` 的 started/completed 来源，其他事件族与目标阶段保持不变。
- 确认补充审查继续输入 `code.md`，未创建或要求 `code-r2.md`。
- 确认非法来源失败路径保持 task.md 字节不变。

Generated with AI assistance
