### PR TITLE
fix(workflow): 修复产物评论边界与时效门禁

### DIFF
--- a/.agents/scripts/validate-artifact.js
+++ b/.agents/scripts/validate-artifact.js
@@ -37,7 +37,6 @@ const DEFAULT_REQUIRED_FIELDS = [
   "assigned_to"
 ];
 
-const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
 const AGENT_INFRA_VERSION_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
@@ -439,18 +438,9 @@ function checkArtifact({ taskDir, config, artifactFile }) {
     }
   }
 
-  const freshnessMinutes = Number(config.freshness_minutes ?? DEFAULT_FRESHNESS_MINUTES);
-  const ageMinutes = (Date.now() - stat.mtimeMs) / 60000;
-  if (Number.isFinite(freshnessMinutes) && ageMinutes > freshnessMinutes) {
-    return failResult(
-      "artifact",
-      `${path.basename(artifactPath)} is stale (${ageMinutes.toFixed(1)}m old, limit ${freshnessMinutes}m)`
-    );
-  }
-
   return passResult(
     "artifact",
-    `${path.basename(artifactPath)} passed (${requiredSections.length} sections, ${Math.max(0, freshnessMinutes)}m freshness window)`
+    `${path.basename(artifactPath)} passed (${requiredSections.length} sections)`
   );
 }
 
@@ -559,7 +549,7 @@ function checkActivityLog({ taskDir, config }) {
     previousTimestamp = timestamp;
     // Ascending order is checked over every entry, but a `[started]` marker is
     // not a terminal action: keep latestAction/latestTimestamp on the most
-    // recent done entry so expected_action_pattern and freshness see it.
+    // recent done entry so expected_action_pattern sees it.
     if (!ACTIVITY_LOG_STARTED_RE.test(action)) {
       latestTimestamp = timestamp;
       latestAction = action;
@@ -571,17 +561,6 @@ function checkActivityLog({ taskDir, config }) {
       "activity-log",
       `Latest action '${latestAction}' does not match '${config.expected_action_pattern}'`
     );
-  }
-
-  const freshnessMinutes = Number(config.freshness_minutes ?? DEFAULT_FRESHNESS_MINUTES);
-  if (Number.isFinite(freshnessMinutes)) {
-    const ageMinutes = minutesSinceTimestamp(latestTimestamp);
-    if (ageMinutes > freshnessMinutes) {
-      return failResult(
-        "activity-log",
-        `Latest Activity Log entry is stale (${ageMinutes.toFixed(1)}m old, limit ${freshnessMinutes}m)`
-      );
-    }
   }
 
   return passResult("activity-log", `Latest entry '${latestAction}' at ${latestTimestamp}`);
@@ -1172,16 +1151,6 @@ function normalizeContent(text) {
     .replace(/\r\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-}
-
-function minutesSinceTimestamp(timestamp) {
-  const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");
-  const parsed = Date.parse(normalized);
-  if (Number.isNaN(parsed)) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  return (Date.now() - parsed) / 60000;
 }
 
 function interpolate(template, taskDir, artifactFile) {

--- a/.agents/skills/analyze-task/config/verify.json
+++ b/.agents/skills/analyze-task/config/verify.json
@@ -27,14 +27,12 @@
         "工作量和复杂度评估",
         "状态核对"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/block-task/config/verify.json
+++ b/.agents/skills/block-task/config/verify.json
@@ -18,8 +18,7 @@
       "require_blocked_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Block Task|Blocked)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Block Task|Blocked)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/cancel-task/config/verify.json
+++ b/.agents/skills/cancel-task/config/verify.json
@@ -19,8 +19,7 @@
       "require_cancelled_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Cancel Task|Cancelled)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Cancel Task|Cancelled)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/code-task/config/verify.json
+++ b/.agents/skills/code-task/config/verify.json
@@ -27,15 +27,13 @@
         "状态核对",
         "证据原文"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "implementation-input": {},
     "activity-log": {
-      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan"]

--- a/.agents/skills/commit/config/verify.json
+++ b/.agents/skills/commit/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Commit",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Commit"
     },
     "platform-sync": {
       "when": "pr_number_exists",

--- a/.agents/skills/complete-manual-validation/config/verify.json
+++ b/.agents/skills/complete-manual-validation/config/verify.json
@@ -23,14 +23,12 @@
         "验证详情",
         "PR 摘要同步"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Complete Manual Validation",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Complete Manual Validation"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan", "code"]

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -19,8 +19,7 @@
       "require_target_date": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Complete Task|Completed)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Complete Task|Completed)"
     },
     "completion-checklist": {
       "require_all_checked": true
@@ -45,8 +44,7 @@
       ],
       "required_patterns": [
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     }
   }
 }

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Create PR|PR Created)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Create PR|PR Created)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/create-task/config/verify.json
+++ b/.agents/skills/create-task/config/verify.json
@@ -18,8 +18,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Create Task|Task Created)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Create Task|Task Created)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/import-codescan/config/verify.json
+++ b/.agents/skills/import-codescan/config/verify.json
@@ -17,8 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)"
     },
     "platform-sync": null
   }

--- a/.agents/skills/import-dependabot/config/verify.json
+++ b/.agents/skills/import-dependabot/config/verify.json
@@ -17,8 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)"
     },
     "platform-sync": null
   }

--- a/.agents/skills/import-issue/config/verify.json
+++ b/.agents/skills/import-issue/config/verify.json
@@ -18,8 +18,7 @@
       "require_issue_number": true
     },
     "activity-log": {
-      "expected_action_pattern": "Import Issue",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Import Issue"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/plan-task/config/verify.json
+++ b/.agents/skills/plan-task/config/verify.json
@@ -27,14 +27,12 @@
         "验证策略",
         "状态核对"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis"]

--- a/.agents/skills/restore-task/config/verify.json
+++ b/.agents/skills/restore-task/config/verify.json
@@ -17,8 +17,7 @@
       "require_issue_number": true
     },
     "activity-log": {
-      "expected_action_pattern": "Restore Task",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Restore Task"
     },
     "platform-sync": null
   }

--- a/.agents/skills/review-analysis/config/verify.json
+++ b/.agents/skills/review-analysis/config/verify.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### 审查决定$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/review-code/config/verify.json
+++ b/.agents/skills/review-code/config/verify.json
@@ -35,13 +35,11 @@
         "^- \\*\\*审查基线提交\\*\\*[:：]\\s*\\S",
         "^- \\*\\*审查差异指纹\\*\\*[:：]\\s*sha256:[0-9a-f]{64}\\s*$",
         "^- \\*\\*审查快照树\\*\\*[:：]\\s*[0-9a-f]{40,64}\\s*$"
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "review-fact": {},
     "activity-log": {
-      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/review-plan/config/verify.json
+++ b/.agents/skills/review-plan/config/verify.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### 审查决定$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/.agents/skills/watch-pr/config/verify.json
+++ b/.agents/skills/watch-pr/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Watch PR|Watching PR) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Watch PR|Watching PR) \\(Round \\d+\\)"
     }
   }
 }

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -261,9 +261,11 @@ function markerPrefix(taskId: string, options: SyncOptions): string {
 }
 
 function relatedComments(comments: RemoteComment[], prefix: string): RemoteComment[] {
+  const base = `${prefix} -->`;
+  const chunkNamespace = `${prefix}:`;
   return comments.filter((comment) => {
     const first = normalizeCommentContent(comment.body).split('\n', 1)[0] || '';
-    return first.startsWith(prefix) && first.endsWith(' -->');
+    return first === base || (first.startsWith(chunkNamespace) && first.endsWith(' -->'));
   });
 }
 

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -103,7 +103,7 @@ function validateTaskEventRequest(request: TaskEventRequest): TaskEventError | n
 }
 
 const FAMILY = {
-  analyze: { artifact: 'analysis', started: ['requirement-analysis', 'requirement-analysis-review'], completed: ['requirement-analysis', 'requirement-analysis-review'], target: 'requirement-analysis', label: 'Analyze Task' },
+  analyze: { artifact: 'analysis', started: ['requirement-analysis', 'requirement-analysis-review', 'code'], completed: ['requirement-analysis', 'requirement-analysis-review', 'code'], target: 'requirement-analysis', label: 'Analyze Task' },
   'review-analysis': { artifact: 'review-analysis', started: ['requirement-analysis'], completed: ['requirement-analysis'], target: 'requirement-analysis-review', label: 'Review Analysis' },
   plan: { artifact: 'plan', started: ['requirement-analysis-review', 'technical-design-review'], completed: ['requirement-analysis-review', 'technical-design-review'], target: 'technical-design', label: 'Plan Task' },
   'review-plan': { artifact: 'review-plan', started: ['technical-design'], completed: ['technical-design'], target: 'technical-design-review', label: 'Review Plan' },

--- a/templates/.agents/scripts/validate-artifact.js
+++ b/templates/.agents/scripts/validate-artifact.js
@@ -37,7 +37,6 @@ const DEFAULT_REQUIRED_FIELDS = [
   "assigned_to"
 ];
 
-const DEFAULT_FRESHNESS_MINUTES = 30;
 const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?$/;
 const AGENT_INFRA_VERSION_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const ACTIVITY_LOG_PATTERN = /^- (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2})?) — \*\*(.+?)\*\* by (.+?) — (.+)$/;
@@ -439,18 +438,9 @@ function checkArtifact({ taskDir, config, artifactFile }) {
     }
   }
 
-  const freshnessMinutes = Number(config.freshness_minutes ?? DEFAULT_FRESHNESS_MINUTES);
-  const ageMinutes = (Date.now() - stat.mtimeMs) / 60000;
-  if (Number.isFinite(freshnessMinutes) && ageMinutes > freshnessMinutes) {
-    return failResult(
-      "artifact",
-      `${path.basename(artifactPath)} is stale (${ageMinutes.toFixed(1)}m old, limit ${freshnessMinutes}m)`
-    );
-  }
-
   return passResult(
     "artifact",
-    `${path.basename(artifactPath)} passed (${requiredSections.length} sections, ${Math.max(0, freshnessMinutes)}m freshness window)`
+    `${path.basename(artifactPath)} passed (${requiredSections.length} sections)`
   );
 }
 
@@ -559,7 +549,7 @@ function checkActivityLog({ taskDir, config }) {
     previousTimestamp = timestamp;
     // Ascending order is checked over every entry, but a `[started]` marker is
     // not a terminal action: keep latestAction/latestTimestamp on the most
-    // recent done entry so expected_action_pattern and freshness see it.
+    // recent done entry so expected_action_pattern sees it.
     if (!ACTIVITY_LOG_STARTED_RE.test(action)) {
       latestTimestamp = timestamp;
       latestAction = action;
@@ -571,17 +561,6 @@ function checkActivityLog({ taskDir, config }) {
       "activity-log",
       `Latest action '${latestAction}' does not match '${config.expected_action_pattern}'`
     );
-  }
-
-  const freshnessMinutes = Number(config.freshness_minutes ?? DEFAULT_FRESHNESS_MINUTES);
-  if (Number.isFinite(freshnessMinutes)) {
-    const ageMinutes = minutesSinceTimestamp(latestTimestamp);
-    if (ageMinutes > freshnessMinutes) {
-      return failResult(
-        "activity-log",
-        `Latest Activity Log entry is stale (${ageMinutes.toFixed(1)}m old, limit ${freshnessMinutes}m)`
-      );
-    }
   }
 
   return passResult("activity-log", `Latest entry '${latestAction}' at ${latestTimestamp}`);
@@ -1172,16 +1151,6 @@ function normalizeContent(text) {
     .replace(/\r\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-}
-
-function minutesSinceTimestamp(timestamp) {
-  const normalized = timestamp.includes("T") ? timestamp : timestamp.replace(" ", "T");
-  const parsed = Date.parse(normalized);
-  if (Number.isNaN(parsed)) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  return (Date.now() - parsed) / 60000;
 }
 
 function interpolate(template, taskDir, artifactFile) {

--- a/templates/.agents/skills/analyze-task/config/verify.en.json
+++ b/templates/.agents/skills/analyze-task/config/verify.en.json
@@ -27,14 +27,12 @@
         "Effort and Complexity Assessment",
         "State Check"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/analyze-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/analyze-task/config/verify.zh-CN.json
@@ -27,14 +27,12 @@
         "工作量和复杂度评估",
         "状态核对"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Analyze Task|Requirement Analysis) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/block-task/config/verify.json
+++ b/templates/.agents/skills/block-task/config/verify.json
@@ -18,8 +18,7 @@
       "require_blocked_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Block Task|Blocked)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Block Task|Blocked)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/cancel-task/config/verify.json
+++ b/templates/.agents/skills/cancel-task/config/verify.json
@@ -19,8 +19,7 @@
       "require_cancelled_at": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Cancel Task|Cancelled)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Cancel Task|Cancelled)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/code-task/config/verify.en.json
+++ b/templates/.agents/skills/code-task/config/verify.en.json
@@ -27,15 +27,13 @@
         "State Check",
         "Evidence"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "implementation-input": {},
     "activity-log": {
-      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan"]

--- a/templates/.agents/skills/code-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/code-task/config/verify.zh-CN.json
@@ -27,15 +27,13 @@
         "状态核对",
         "证据原文"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "implementation-input": {},
     "activity-log": {
-      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Code Task|Code) \\(Round \\d+(?:(?:, fix for review-code(?:-r\\d+)?\\.md)|(?:, decision II-[1-9]\\d*))?\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan"]

--- a/templates/.agents/skills/commit/config/verify.json
+++ b/templates/.agents/skills/commit/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Commit",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Commit"
     },
     "platform-sync": {
       "when": "pr_number_exists",

--- a/templates/.agents/skills/complete-manual-validation/config/verify.en.json
+++ b/templates/.agents/skills/complete-manual-validation/config/verify.en.json
@@ -23,14 +23,12 @@
         "Validation Details",
         "PR Summary Sync"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Complete Manual Validation",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Complete Manual Validation"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan", "code"]

--- a/templates/.agents/skills/complete-manual-validation/config/verify.zh-CN.json
+++ b/templates/.agents/skills/complete-manual-validation/config/verify.zh-CN.json
@@ -23,14 +23,12 @@
         "验证详情",
         "PR 摘要同步"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "Complete Manual Validation",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Complete Manual Validation"
     },
     "review-ledger": {
       "stage_scope": ["analysis", "plan", "code"]

--- a/templates/.agents/skills/complete-task/config/verify.en.json
+++ b/templates/.agents/skills/complete-task/config/verify.en.json
@@ -19,8 +19,7 @@
       "require_target_date": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Complete Task|Completed)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Complete Task|Completed)"
     },
     "completion-checklist": {
       "require_all_checked": true
@@ -45,8 +44,7 @@
       ],
       "required_patterns": [
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     }
   }
 }

--- a/templates/.agents/skills/complete-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/complete-task/config/verify.zh-CN.json
@@ -19,8 +19,7 @@
       "require_target_date": true
     },
     "activity-log": {
-      "expected_action_pattern": "(Complete Task|Completed)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Complete Task|Completed)"
     },
     "completion-checklist": {
       "require_all_checked": true
@@ -45,8 +44,7 @@
       ],
       "required_patterns": [
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     }
   }
 }

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Create PR|PR Created)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Create PR|PR Created)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/create-task/config/verify.json
+++ b/templates/.agents/skills/create-task/config/verify.json
@@ -18,8 +18,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Create Task|Task Created)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Create Task|Task Created)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/import-codescan/config/verify.json
+++ b/templates/.agents/skills/import-codescan/config/verify.json
@@ -17,8 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Import Codescan|Import Code Scanning Alert)"
     },
     "platform-sync": null
   }

--- a/templates/.agents/skills/import-dependabot/config/verify.json
+++ b/templates/.agents/skills/import-dependabot/config/verify.json
@@ -17,8 +17,7 @@
       "expected_status": "active"
     },
     "activity-log": {
-      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Import Dependabot|Import Dependabot Alert)"
     },
     "platform-sync": null
   }

--- a/templates/.agents/skills/import-issue/config/verify.json
+++ b/templates/.agents/skills/import-issue/config/verify.json
@@ -18,8 +18,7 @@
       "require_issue_number": true
     },
     "activity-log": {
-      "expected_action_pattern": "Import Issue",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Import Issue"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/plan-task/config/verify.en.json
+++ b/templates/.agents/skills/plan-task/config/verify.en.json
@@ -27,14 +27,12 @@
         "Verification Strategy",
         "State Check"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis"]

--- a/templates/.agents/skills/plan-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/plan-task/config/verify.zh-CN.json
@@ -27,14 +27,12 @@
         "验证策略",
         "状态核对"
       ],
-      "freshness_minutes": 30,
       "required_patterns": [
         "^\\$ "
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Plan Task|Technical Design) \\(Round \\d+\\)"
     },
     "review-ledger": {
       "stage_scope": ["analysis"]

--- a/templates/.agents/skills/restore-task/config/verify.json
+++ b/templates/.agents/skills/restore-task/config/verify.json
@@ -17,8 +17,7 @@
       "require_issue_number": true
     },
     "activity-log": {
-      "expected_action_pattern": "Restore Task",
-      "freshness_minutes": 30
+      "expected_action_pattern": "Restore Task"
     },
     "platform-sync": null
   }

--- a/templates/.agents/skills/review-analysis/config/verify.en.json
+++ b/templates/.agents/skills/review-analysis/config/verify.en.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### Approval Decision$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/review-analysis/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-analysis/config/verify.zh-CN.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### 审查决定$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Analysis|Analysis Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/review-code/config/verify.en.json
+++ b/templates/.agents/skills/review-code/config/verify.en.json
@@ -35,13 +35,11 @@
         "^- \\*\\*Review Baseline Commit\\*\\*[:：]\\s*\\S",
         "^- \\*\\*Reviewed Diff Fingerprint\\*\\*[:：]\\s*sha256:[0-9a-f]{64}\\s*$",
         "^- \\*\\*Reviewed Snapshot Tree\\*\\*[:：]\\s*[0-9a-f]{40,64}\\s*$"
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "review-fact": {},
     "activity-log": {
-      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/review-code/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-code/config/verify.zh-CN.json
@@ -35,13 +35,11 @@
         "^- \\*\\*审查基线提交\\*\\*[:：]\\s*\\S",
         "^- \\*\\*审查差异指纹\\*\\*[:：]\\s*sha256:[0-9a-f]{64}\\s*$",
         "^- \\*\\*审查快照树\\*\\*[:：]\\s*[0-9a-f]{40,64}\\s*$"
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "review-fact": {},
     "activity-log": {
-      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Code|Code Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/review-plan/config/verify.en.json
+++ b/templates/.agents/skills/review-plan/config/verify.en.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### Approval Decision$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/review-plan/config/verify.zh-CN.json
+++ b/templates/.agents/skills/review-plan/config/verify.zh-CN.json
@@ -31,12 +31,10 @@
       "required_patterns": [
         "^### 审查决定$",
         "^\\$ "
-      ],
-      "freshness_minutes": 30
+      ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Review Plan|Plan Review) \\(Round \\d+\\)"
     },
     "platform-sync": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/watch-pr/config/verify.json
+++ b/templates/.agents/skills/watch-pr/config/verify.json
@@ -15,8 +15,7 @@
       ]
     },
     "activity-log": {
-      "expected_action_pattern": "(Watch PR|Watching PR) \\(Round \\d+\\)",
-      "freshness_minutes": 30
+      "expected_action_pattern": "(Watch PR|Watching PR) \\(Round \\d+\\)"
     }
   }
 }

--- a/tests/e2e/core/validate-artifact.test.ts
+++ b/tests/e2e/core/validate-artifact.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 
 import {
@@ -409,7 +410,21 @@ test("validate-artifact artifact check fails when a required section is missing"
   })
 ));
 
-test("validate-artifact activity-log freshness uses local timestamps", () => (
+test("validate-artifact artifact check accepts an old valid artifact", () => (
+  withTempRoot("agent-infra-gate-old-artifact-", (tempRoot) => {
+    const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+    write(path.join(taskDir, "task.md"), buildTaskContent());
+    writeCodeFixture(taskDir);
+    const old = new Date(Date.now() - 45 * 60_000);
+    fs.utimesSync(path.join(taskDir, "code.md"), old, old);
+
+    const result = runValidator(["check", "artifact", taskDir, "code.md", "--skill", "code-task"]);
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "artifact", status: "pass" });
+  })
+));
+
+test("validate-artifact activity-log accepts an old valid local timestamp", () => (
   withTempRoot("agent-infra-gate-stale-", (tempRoot) => {
     const taskDir = path.join(tempRoot, "TASK-20260328-000001");
     const staleTimestamp = formatTimestampInTimeZone(new Date(Date.now() - 45 * 60_000), localTimeZone);
@@ -422,8 +437,8 @@ test("validate-artifact activity-log freshness uses local timestamps", () => (
     const result = runValidator(["check", "activity-log", taskDir, "--skill", "code-task"], {
       env: { TZ: localTimeZone }
     });
-    assert.equal(result.status, 1);
-    assertPayloadStatus(result, { type: "activity-log", status: "fail", message: /stale/i });
+    assert.equal(result.status, 0, result.stderr);
+    assertPayloadStatus(result, { type: "activity-log", status: "pass" });
   })
 ));
 

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -157,6 +157,40 @@ test('completion without an open start fails without changing the file', () => {
   assert.deepEqual(fs.readFileSync(f.file), before);
 });
 
+test('analysis can restart from code when task requirements expand', () => {
+  const f = fixture('code');
+
+  const started = run(f.root, [f.id, 'analyze.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr);
+  const startedResult = JSON.parse(started.stdout);
+  assert.equal(startedResult.status, 'applied');
+  assert.equal(startedResult.fromStep, 'code');
+  assert.equal(startedResult.toStep, 'code');
+  assert.equal(startedResult.round, 2);
+  assert.equal(startedResult.artifact, 'analysis-r2.md');
+
+  fs.writeFileSync(path.join(f.dir, 'analysis-r2.md'), '# Analysis round 2\n');
+  const completed = run(f.root, [
+    f.id, 'analyze.completed', '--agent', 'codex', '--artifact', 'analysis-r2.md'
+  ]);
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(JSON.parse(completed.stdout).toStep, 'requirement-analysis');
+  const content = fs.readFileSync(f.file, 'utf8');
+  assert.match(content, /current_step: requirement-analysis/);
+  assert.match(content, /Analyze Task \(Round 2\) \[started\]/);
+  assert.match(content, /\]\(analysis-r2\.md\)/);
+});
+
+test('analysis restart still rejects an unrelated workflow stage without changing task bytes', () => {
+  const f = fixture('technical-design');
+  const before = fs.readFileSync(f.file);
+
+  const started = run(f.root, [f.id, 'analyze.started', '--agent', 'codex']);
+  assert.notEqual(started.status, 0);
+  assert.equal(JSON.parse(started.stdout).error.code, 'EVENT_TRANSITION_INVALID');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
 test('review-code event completes the regular code review path', () => {
   const f = fixture('code');
   fs.writeFileSync(path.join(f.dir, 'code.md'), '# Code\n');

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -68,6 +68,14 @@ test('chunk marker validation rejects incomplete and contradictory sets', () => 
     { id: 1, body: `${prefix} -->\na` },
     { id: 2, body: `${prefix}:1/1 -->\nb` }
   ], prefix).code, 'COMMENT_MARKER_CONFLICT');
+  assert.equal(validateRelatedMarkerSet([
+    { id: 1, body: `${prefix}:1/2 -->\na` },
+    { id: 2, body: `${prefix}:1/2 -->\nb` }
+  ], prefix).code, 'COMMENT_MARKER_CONFLICT');
+  assert.equal(validateRelatedMarkerSet([
+    { id: 1, body: `${prefix}:1/2 -->\na` },
+    { id: 2, body: `${prefix}:2/3 -->\nb` }
+  ], prefix).code, 'COMMENT_MARKER_CONFLICT');
 });
 
 function syncFixture() {
@@ -79,6 +87,10 @@ function syncFixture() {
   fs.writeFileSync(
     path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'task.md'),
     '---\nid: TASK-20260101-000001\ntype: feature\nissue_number: 7\n---\n\n# Task\n'
+  );
+  fs.writeFileSync(
+    path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'analysis.md'),
+    '# Analysis\n'
   );
   return root;
 }
@@ -129,6 +141,62 @@ test('comment sync refuses duplicate registered markers without writing', () => 
     text() { throw new Error('write must not be attempted'); }
   } as unknown as GitHubClient;
   const result = syncPlatformComment('TASK-20260101-000001', { kind: 'task', agent: 'codex', cwd: root, client });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'COMMENT_MARKER_CONFLICT');
+});
+
+test('artifact sync isolates sibling stems and becomes a no-op on replay', () => {
+  const root = syncFixture();
+  const siblingBody = `${MARKERS.artifact('TASK-20260101-000001', 'analysis-r2')}\nexisting sibling`;
+  const comments = [{ id: 20, body: siblingBody, user: { login: 'codex' } }];
+  const client = {
+    json(args: string[], options?: { input?: string }) {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
+      if (args.at(-1) === 'user') return { ok: true, value: { login: 'codex' } };
+      if (endpoint.endsWith('/comments?per_page=100')) return { ok: true, value: [comments] };
+      if (args.includes('POST')) {
+        const body = JSON.parse(options?.input || '{}').body;
+        comments.push({ id: 21, body, user: { login: 'codex' } });
+        return { ok: true, value: { id: 21 } };
+      }
+      throw new Error(`unexpected request: ${args.join(' ')}`);
+    },
+    text() { throw new Error('delete must not be attempted'); }
+  } as unknown as GitHubClient;
+
+  const options = { kind: 'artifact' as const, artifact: 'analysis.md', agent: 'codex', cwd: root, client };
+  const first = syncPlatformComment('TASK-20260101-000001', options);
+  assert.equal(first.status, 'applied');
+  assert.equal(comments.length, 2);
+  assert.deepEqual(comments[0], { id: 20, body: siblingBody, user: { login: 'codex' } });
+
+  const second = syncPlatformComment('TASK-20260101-000001', options);
+  assert.equal(second.status, 'no-op');
+  assert.equal(comments.length, 2);
+  assert.deepEqual(comments[0], { id: 20, body: siblingBody, user: { login: 'codex' } });
+});
+
+test('artifact sync refuses duplicate base markers without writing', () => {
+  const root = syncFixture();
+  const marker = MARKERS.artifact('TASK-20260101-000001', 'analysis');
+  const client = {
+    json(args: string[]) {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: {} } };
+      if (args.at(-1) === 'user') return { ok: true, value: { login: 'codex' } };
+      if (endpoint.endsWith('/comments?per_page=100')) return { ok: true, value: [[
+        { id: 1, body: `${marker}\na`, user: { login: 'codex' } },
+        { id: 2, body: `${marker}\nb`, user: { login: 'codex' } }
+      ]] };
+      throw new Error('write must not be attempted');
+    },
+    text() { throw new Error('write must not be attempted'); }
+  } as unknown as GitHubClient;
+
+  const result = syncPlatformComment('TASK-20260101-000001', {
+    kind: 'artifact', artifact: 'analysis.md', agent: 'codex', cwd: root, client
+  });
   assert.equal(result.status, 'failed');
   assert.equal(result.error?.code, 'COMMENT_MARKER_CONFLICT');
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #682

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that does not need an issue

Closes #682

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复产物评论 marker 的前缀边界冲突，并移除会让合法产物随时间失效的 30 分钟硬门槛。需求扩展后，同时允许 active 任务从 code 阶段重新进入 analysis，以便完整重走分析、方案、审查与实现流程。

This change fixes artifact-comment marker prefix collisions, removes age-only failures that invalidated otherwise valid workflow artifacts after 30 minutes, and allows active tasks to re-enter analysis after a code-stage scope expansion.

## 📋 主要变更 / Brief Changelog

- 将产物评论关联收窄为精确 base marker 或同 stem 的合法 chunk marker，避免 `analysis-r2` 被 `analysis` 错误吸入。
- 保留重复 marker、base/chunk 并存、缺片和分片总数矛盾的冲突语义，并补充 sibling stem 与幂等回归测试。
- 移除 artifact mtime 和最近完成 Activity Log 条目的 30 分钟时间年龄失败，保留存在性、结构、格式、升序和期望动作校验。
- 允许 analyze started/completed 从 code 状态迁移，同时继续拒绝无关工作流阶段。
- 同步清理 44 份本地与模板验证配置中的 68 处 `freshness_minutes` 声明。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 marker、task-event 与 validate-artifact 定向回归测试。
3. 运行 `npm run test:smoke`、`npm run test:core` 和 `npm test`。
4. 运行 `git diff --check`，并由提交钩子重新执行类型检查、构建及核心测试。
5. 独立执行代码审查，确认工作区、暂存树与批准的审查快照一致。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：

- 定向回归：54 passed，0 failed。
- Smoke：776 passed，0 failed。
- Core：1416 passed，0 failed，1 skipped。
- Full：1704 passed，0 failed，2 skipped。
- TypeScript/JavaScript 类型检查、构建和 `git diff --check`：全部通过。
- Review Code Round 1：Approved，0 blockers / 0 major / 0 minor / 0 manual-validation。
- 提交前审查快照、完整工作树和暂存树一致。

## 📸 截图 / Screenshots

不适用。本 PR 不包含图形界面变更。

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a GitHub issue filed for the change
- [x] 只解决一个 Issue，没有包含其他不相关的变更 / This PR addresses one issue only
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project standards
- [x] 已完成自我代码审查及独立代码审查 / Self-review and independent code review have been completed
- [x] marker、状态迁移和验证门禁边界均由结构化测试覆盖

### 测试要求 / Testing Requirements

- [x] 已编写必要的单元、集成和 E2E 测试 / Necessary unit, integration, and E2E tests are included
- [x] 跨模块行为由真实 internal CLI 与临时任务 fixture 覆盖
- [x] 代码检查通过 / Checks pass
- [x] 单元测试通过 / Unit tests pass

### 文档和兼容性 / Documentation and Compatibility

- [x] 已同步本地与英中模板验证资产
- [x] 无破坏性公开命令变更 / No breaking public-command changes
- [x] 保留 marker 冲突、Activity Log 结构与平台同步的既有失败语义

## 📋 附加信息 / Additional Notes

本次改动删除的仅是“经过时间”这一失败条件；产物身份、必填章节、模式、事件配对、Activity Log 格式与顺序、期望动作及平台同步门禁仍然有效。

---

**审查者注意事项 / Reviewer Notes:**

- 确认 base marker 与 chunk namespace 的边界不会误关联 sibling round/stem。
- 确认删除 freshness 后其他 artifact 与 Activity Log 校验保持完整。
- 确认 code → analysis 仅放宽 analyze family，未扩散到无关状态迁移。
- 确认本地和模板 validator/config 始终保持一致。

Generated with AI assistance
