### PR TITLE
fix(sandbox): 修复沙箱 GitHub HTTPS 认证


### DIFF
--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -116,6 +116,15 @@ const HOST_PROXY_ENV_KEYS = [
   'no_proxy',
   'NO_PROXY'
 ] as const;
+const MANAGED_GITHUB_GIT_CONFIG = [
+  '[credential]',
+  '\thelper = !gh auth git-credential',
+  '[credential "https://github.com"]',
+  '\thelper =',
+  '\thelper = !gh auth git-credential',
+  '[url "https://github.com/"]',
+  '\tinsteadOf = git@github.com:'
+];
 
 type SandboxCreateConfig = ReturnType<typeof loadConfig>;
 type PreparedDockerfile = ReturnType<typeof prepareDockerfile>;
@@ -255,6 +264,16 @@ function normalizeContainerHomeSeparators(content: string): string {
   return content.replace(containerHomePattern, (value) => value.replaceAll('\\', '/'));
 }
 
+function isGitHubCliCredentialHelper(line: string): boolean {
+  const helperMatch = line.match(/^\s*helper\s*=\s*(.+?)\s*$/i);
+  if (!helperMatch) {
+    return false;
+  }
+
+  const helper = (helperMatch[1] ?? '').trim().replace(/^"(.*)"$/, '$1');
+  return /^!\s*(?:"[^"]*[\\/]+gh"|(?:\S*[\\/]+)?gh)\s+auth\s+git-credential(?:\s|$)/i.test(helper);
+}
+
 export function sanitizeGitConfig(
   gitconfig: string,
   home: string,
@@ -272,11 +291,13 @@ export function sanitizeGitConfig(
   const sanitized = [];
   let inGpgSection = false;
   let currentSection = '';
+  let currentSectionName = '';
 
   for (const line of lines) {
     const sectionMatch = line.match(/^\s*\[([^\]]+)\]\s*$/);
     if (sectionMatch) {
       const sectionName = (sectionMatch[1] ?? '').trim();
+      currentSectionName = sectionName;
       currentSection = ((sectionName.match(/^([^\s"]+)/)?.[1]) ?? '').toLowerCase();
       inGpgSection = /^gpg(?:\s+"[^"]+")?$/i.test(sectionName);
       if (stripGpg && inGpgSection) {
@@ -304,11 +325,23 @@ export function sanitizeGitConfig(
     if (stripGpg && currentSection === 'user' && /^\s*signingKey\s*=.*$/i.test(line)) {
       continue;
     }
+    if (currentSection === 'credential' && isGitHubCliCredentialHelper(line)) {
+      continue;
+    }
+    if (
+      /^url\s+"https:\/\/github\.com\/"$/i.test(currentSectionName)
+      && /^\s*insteadOf\s*=\s*git@github\.com:\s*$/i.test(line)
+    ) {
+      continue;
+    }
 
     sanitized.push(line);
   }
 
-  return appendSafeDirectories(sanitized, repoRoot).join('\n');
+  return [
+    ...appendSafeDirectories(sanitized, repoRoot),
+    ...MANAGED_GITHUB_GIT_CONFIG
+  ].join('\n');
 }
 
 export function hostHasGpgKeys(home: string, execFn: ExecSyncFn = execFileSync): boolean {

--- a/tests/integration/cli/sandbox-git-config.test.ts
+++ b/tests/integration/cli/sandbox-git-config.test.ts
@@ -70,6 +70,16 @@ function required<T>(value: T | undefined, message = "expected value"): T {
   return value;
 }
 
+const managedGitHubConfig = [
+  "[credential]",
+  "\thelper = !gh auth git-credential",
+  "[credential \"https://github.com\"]",
+  "\thelper =",
+  "\thelper = !gh auth git-credential",
+  "[url \"https://github.com/\"]",
+  "\tinsteadOf = git@github.com:"
+];
+
 test("hostHasGpgKeys reports whether the host keyring is available", async () => {
   const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
 
@@ -156,7 +166,8 @@ test("prepareHostShellConfig writes sanitized config files and returns read-only
         "  excludesfile = /home/devuser/.gitignore_global",
         "[safe]",
         "\tdirectory = /workspace",
-        "\tdirectory = /repo"
+        "\tdirectory = /repo",
+        ...managedGitHubConfig
       ]
     );
     assert.equal(
@@ -193,7 +204,8 @@ test("prepareHostShellConfig writes a minimal .gitconfig with safe.directory ent
     assert.deepEqual(lines, [
       "[safe]",
       "\tdirectory = /workspace",
-      "\tdirectory = /repo"
+      "\tdirectory = /repo",
+      ...managedGitHubConfig
     ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -262,7 +274,8 @@ test("sanitizeGitConfig rewrites host paths and appends safe.directory entries",
     "  excludesfile = /home/devuser/.gitignore_global",
     "[safe]",
     "\tdirectory = /workspace",
-    "\tdirectory = /repo"
+    "\tdirectory = /repo",
+    ...managedGitHubConfig
   ]);
 });
 
@@ -327,7 +340,8 @@ test("sanitizeGitConfig appends missing safe.directory entries to an existing sa
     "  directory = /workspace",
     "\tdirectory = /repo",
     "[user]",
-    "  name = Demo User"
+    "  name = Demo User",
+    ...managedGitHubConfig
   ]);
 });
 
@@ -364,8 +378,65 @@ test("sanitizeGitConfig strips GPG settings from non-gpg sections when host keys
     "  editor = vim",
     "[safe]",
     "\tdirectory = /workspace",
-    "\tdirectory = /repo"
+    "\tdirectory = /repo",
+    ...managedGitHubConfig
   ]);
+});
+
+test("sanitizeGitConfig installs one canonical GitHub credential and URL rewrite block", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const gitconfig = [
+    "[credential]",
+    "  helper = cache",
+    "  helper = !/opt/homebrew/bin/gh auth git-credential",
+    "  helper = !/usr/bin/gh auth git-credential",
+    "  helper = !gh auth git-credential",
+    "  helper = \"!/opt/homebrew/bin/gh auth git-credential\"",
+    "[credential \"https://gitlab.com\"]",
+    "  helper = store",
+    "[url \"https://github.com/\"]",
+    "  insteadOf = git@github.com:",
+    "[url \"https://gitlab.com/\"]",
+    "  insteadOf = git@gitlab.com:",
+    ""
+  ].join("\n");
+
+  const sanitized = sandboxCreate.sanitizeGitConfig(gitconfig, "/Users/demo");
+  const lines = sanitized.split("\n").filter(Boolean);
+
+  assert.deepEqual(lines, [
+    "[credential]",
+    "  helper = cache",
+    "[credential \"https://gitlab.com\"]",
+    "  helper = store",
+    "[url \"https://github.com/\"]",
+    "[url \"https://gitlab.com/\"]",
+    "  insteadOf = git@gitlab.com:",
+    ...managedGitHubConfig
+  ]);
+  assert.equal(lines.filter((line) => line === "\thelper = !gh auth git-credential").length, 2);
+  assert.equal(lines.filter((line) => line === "\tinsteadOf = git@github.com:").length, 1);
+});
+
+test("prepareHostShellConfig leaves the host gitconfig unchanged", async () => {
+  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-host-gitconfig-unchanged-"));
+  const original = "[credential]\n  helper = !/opt/homebrew/bin/gh auth git-credential\n";
+
+  try {
+    fs.writeFileSync(path.join(tmpDir, ".gitconfig"), original, "utf8");
+    sandboxCreate.ensureSandboxAliasesFile(tmpDir);
+    sandboxCreate.prepareHostShellConfig({
+      home: tmpDir,
+      project: "demo",
+      branch: "feature/demo",
+      repoRoot: "/repo"
+    });
+
+    assert.equal(fs.readFileSync(path.join(tmpDir, ".gitconfig"), "utf8"), original);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("writeSanitizedGitconfig rewrites the mounted gitconfig without replacing the inode", async () => {
@@ -399,7 +470,8 @@ test("writeSanitizedGitconfig rewrites the mounted gitconfig without replacing t
       "  name = Updated User",
       "[safe]",
       "\tdirectory = /workspace",
-      "\tdirectory = /repo"
+      "\tdirectory = /repo",
+      ...managedGitHubConfig
     ]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #703

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change

Closes #703

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

Linux sandbox 不再挂载宿主 SSH 私钥，但仍需可靠地访问和推送 GitHub。宿主 Git 配置中的 macOS `gh` 绝对路径在 Linux 容器内不可执行，且 GitHub SCP-like SSH remote 会在无 SSH 配置时失败。

本变更在沙箱专用 Git 配置副本中建立确定性的 GitHub HTTPS 认证路径，同时保持 Token 只通过 `GH_TOKEN` 环境变量注入。

## 📋 主要变更 / Brief Changelog

- 过滤继承配置中裸命令、绝对路径及整体引号形式的 `gh auth git-credential` helper。
- 追加 canonical global helper 和 GitHub scoped helper reset，避免磁盘 credential helper 绕过 `GH_TOKEN`。
- 将 `git@github.com:` 运行时精确改写为 HTTPS，不修改保存的 origin 或非 GitHub SSH remote。
- 增加离线集成测试，覆盖 helper 去重、URL rewrite、宿主配置不变和无宿主配置场景。

## 🧪 验证变更 / Verifying this Change

### 自动测试 / Automated Tests

1. `npm run typecheck`
2. `npm run test:smoke`（825/825）
3. `npm run test:core`
4. `npm test`
5. `sandbox-git-config.test.ts`（14/14）
6. sandbox token 生命周期与无 SSH mount 回归（84/84）

### 待人工验证 / Manual Validation Required

- [ ] 在新建 Linux sandbox 中确认 `gh auth status` 通过 `GH_TOKEN`。
- [ ] 对 HTTPS 与 `git@github.com:` origin 执行非交互 `ls-remote` 和唯一临时分支 push/query/delete。
- [ ] 移除 `GH_TOKEN` 后确认非交互写操作失败，且不提示凭据、不回退 SSH、不命中磁盘 Token。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只解决 Issue #703
- [x] Commit 具有明确的 Conventional Commit 标题和说明
- [x] 代码遵循项目现有风格
- [x] 已完成代码审查
- [x] 已添加必要的自动测试
- [x] 类型检查和自动测试通过
- [x] 已考虑向后兼容性
- [ ] 已完成上述真实环境人工验证

## 📋 附加信息 / Additional Notes

- 不挂载、复制或生成宿主 `~/.ssh`。
- Token 不写入 Git 配置、remote URL、argv 或 credential 文件。
- 不为自定义 sandbox Dockerfile 自动安装 GitHub CLI。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 GitHub scoped 空 helper 的重置顺序、整体引号 helper 的规范化，以及 `git@github.com:` rewrite 的精确范围。

Generated with AI assistance
