### PR TITLE
refactor(release): 收敛发布说明平台调用与贡献者身份解析


### DIFF
--- a/.agents/rules/release-commands.md
+++ b/.agents/rules/release-commands.md
@@ -1,52 +1,28 @@
 # Release 平台命令
 
-在读取历史 release、查询已合并 PR，或发布 Release notes 前先读取本文件。
+发布说明平台操作统一使用 typed internal intent。调用方只解释结构化 JSON，不解析平台命令、原始字段、身份邮箱规则或认证错误。
 
-## Release 查询
-
-```bash
-gh release list --limit {limit} --json tagName,isDraft,isPrerelease
-gh release view "{tag}" --json body,url
-```
-
-## 已合并 PR 查询
+## 收集发布说明上下文
 
 ```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels
+agent-infra-internal platform-release-notes context \
+  --from-tag "v{prev-version}" \
+  --to-tag "v{version}" \
+  --branch "{branch}" \
+  --history-limit 3
 ```
 
-必要时读取关联 Issue：
-
-```bash
-gh issue view {issue-number} --json number,title,labels,url
-```
-
-## Contributor 映射辅助规则
-
-release notes 需要 contributors 时，已合并 PR 查询应包含 author：
-
-```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
-```
-
-关联 Issue 用于 reporter 归因时，查询应包含 author：
-
-```bash
-gh issue view {issue-number} --json number,title,labels,url,author
-```
-
-GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
+结果包含 `history`、`pullRequests`、`closingIssues` 和带规范化 `login` / `resolution` 的 commit `authors`。`status: no-op` 且错误码为 `PLATFORM_RELEASE_NOTES_UNSUPPORTED` 表示当前平台不支持远端发布说明能力。
 
 ## 发布 Release notes
 
-`v{version}` 的 GitHub Release 由 release 工作流自动创建并发布，为 Homebrew bottle 提供稳定的上传落点。本命令把精修后的 notes 写到这个已存在的 Release 上；若 Release 尚不存在则兜底创建。
+用户确认后调用：
 
 ```bash
-if gh release view "v{version}" >/dev/null 2>&1; then
-  gh release edit "v{version}" --notes-file "{notes-file}"
-else
-  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
-fi
+agent-infra-internal platform-release-notes publish \
+  --tag "v{version}" \
+  --title "v{version}" \
+  --notes-file "{notes-file}"
 ```
 
-失败时按调用方规则停止或提示人工介入。
+命令会更新已存在的 Release，缺失时创建；`--dry-run` 只返回 planned operation。退出码为 `0` 时成功，`1` 表示稳定失败，`2` 表示网络或平台阻塞。

--- a/.agents/skills/create-release-note/SKILL.md
+++ b/.agents/skills/create-release-note/SKILL.md
@@ -35,12 +35,14 @@ git rev-parse v<prev-version>
 
 ### 3. 参考历史发布说明格式与分类
 
-获取最近多条已发布的 Release Note 作为格式参考，并参考预定义的完整分类清单：
+读取一次 typed 发布说明上下文，并参考预定义的完整分类清单：
 
 执行前先读取 `.agents/rules/release-commands.md`。
 
 ```bash
-# Part A：按 `.agents/rules/release-commands.md` 的 release 查询命令逐条获取最近 3 条 Release 的 body
+agent-infra-internal platform-release-notes context \
+  --from-tag "v<prev-version>" --to-tag "v<version>" \
+  --branch "<base-branch>" --history-limit 3
 ```
 
 **Part B：完整分类清单**
@@ -58,38 +60,11 @@ git rev-parse v<prev-version>
 
 ### 4. 收集已合并的 PR 与贡献者
 
-获取标签之间的日期范围，然后查询已合并的 PR：
-
-```bash
-# 获取标签日期
-git log v<prev-version> --format=%aI -1
-git log v<version> --format=%aI -1
-
-# 获取范围内已合并的 PR（按 `.agents/rules/release-commands.md` 的 merged PR 查询命令执行）
-```
-
-同时收集没有 PR 的直接提交：
-```bash
-git log v<prev-version>..v<version> --format="%H %s" --no-merges
-```
-
-从 commit `Co-authored-by` trailer 中收集协作贡献者：
-
-```bash
-git log v<prev-version>..v<version> \
-  --no-merges \
-  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
-  | grep -v '^$' | sort | uniq -c | sort -rn
-```
-
-输出每行一个 `Name <email>`（`uniq -c` 给出该身份在范围内作为 co-author 的 commit 数）。
+使用步骤 3 返回的 `pullRequests` 与 `commits`。每个 commit 的 `authors` 已按平台事实规范化并包含 git author 与 co-author；技能不读取平台原始字段或邮箱规则。
 
 ### 5. 收集关联 Issue
 
-从每个 PR body 中提取关联的 Issue：
-- 匹配模式：`Closes #N`、`Fixes #N`、`Resolves #N`（不区分大小写）
-
-按 `.agents/rules/release-commands.md` 的关联 Issue 查询命令读取。
+使用步骤 3 中每个 PR 的 `closingIssues`，不在通用技能中解析平台专有引用语法。
 
 ### 6. 分类变更
 
@@ -131,13 +106,12 @@ git log v<prev-version>..v<version> \
 4. **贡献者搜集**：
    - **数据源**：
      - PR author：来自 `.agents/rules/release-commands.md` 中已合并 PR 查询规则
-     - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters：来自步骤 5 收集的关联 Issue author（由 `.agents/rules/release-commands.md` 返回）
+     - Commit co-authors：来自步骤 3 typed context 的 commit `authors`
+     - Issue reporters：来自步骤 3 typed context 的 `closingIssues[].author`
    - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
    - **Name → `@login` 映射**：
-     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 platform `@login`
-     - 优先从 email 提取：匹配 `.agents/rules/release-commands.md` 中的平台 no-reply 邮箱规则时，按该规则推导小写 login
-     - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
+     - `resolution` 为 `platform-user` 或 `platform-noreply` 时直接采用小写 `login`
+     - 仅当 `resolution` 为 `unresolved` 时按 Name 启发式：取首个空格前的 token 并转为小写
      - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
      - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
      - Bot 身份保留原样（如 `dependabot[bot]`）
@@ -170,7 +144,12 @@ NOTES_FILE="$(mktemp "${TMPDIR:-/tmp}/agent-infra-release-notes.XXXXXX")"
 
 把 notes 内容写入 `$NOTES_FILE`。
 
-9.2 按 `.agents/rules/release-commands.md` 的「发布 Release notes」命令执行（命令中的 `{notes-file}` 用 `$NOTES_FILE`；写入已由 release 工作流自动创建/发布的 Release，不存在时兜底创建）。
+9.2 调用 typed publish intent（命令中的 `{notes-file}` 用 `$NOTES_FILE`）；它会更新已存在的 Release，不存在时创建：
+
+```bash
+agent-infra-internal platform-release-notes publish \
+  --tag "v<version>" --title "v<version>" --notes-file "$NOTES_FILE"
+```
 
 9.3 无论发布成功或失败，都删除临时文件：
 

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -21,6 +21,11 @@ switch (command) {
     await releaseWorkflow(process.argv.slice(3));
     break;
   }
+  case 'platform-release-notes': {
+    const { platformReleaseNotes } = await import('../lib/internal/platform-release-notes.ts');
+    platformReleaseNotes(process.argv.slice(3));
+    break;
+  }
   case 'platform-context': {
     const { platformContext } = await import('../lib/internal/platform-context.ts');
     platformContext(process.argv.slice(3));

--- a/lib/internal/platform-release-notes.ts
+++ b/lib/internal/platform-release-notes.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { publishReleaseNotes, releaseNoteContext } from '../platform/release-notes.ts';
+
+function option(args: string[], name: string): string | null {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? args[index + 1]! : null;
+}
+
+function finish(result: { status: string; [key: string]: unknown }): void {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exitCode = result.status === 'blocked' ? 2 : result.status === 'failed' ? 1 : 0;
+}
+
+function platformReleaseNotes(args: string[] = []): void {
+  const [action, ...rest] = args;
+  const cwd = path.resolve(option(rest, '--cwd') || process.cwd());
+  if (action === 'context') {
+    const historyRaw = option(rest, '--history-limit');
+    finish(releaseNoteContext({
+      fromTag: option(rest, '--from-tag') || '',
+      toTag: option(rest, '--to-tag') || '',
+      branch: option(rest, '--branch') || '',
+      historyLimit: historyRaw === null ? undefined : Number(historyRaw)
+    }, { cwd }));
+    return;
+  }
+  if (action === 'publish') {
+    const notesPath = option(rest, '--notes-file');
+    if (!notesPath) {
+      finish({ status: 'failed', changed: false, error: { code: 'RELEASE_NOTES_INPUT_INVALID', message: 'notes-file is required', retryable: false } });
+      return;
+    }
+    let resolvedNotesPath = notesPath;
+    if (notesPath === '-') {
+      resolvedNotesPath = path.join(process.env.TMPDIR || '/tmp', `agent-infra-release-notes-${process.pid}.md`);
+      fs.writeFileSync(resolvedNotesPath, fs.readFileSync(0));
+    }
+    try {
+      finish(publishReleaseNotes({
+        tag: option(rest, '--tag') || '',
+        title: option(rest, '--title') || option(rest, '--tag') || '',
+        notesFile: resolvedNotesPath,
+        dryRun: rest.includes('--dry-run')
+      }, { cwd }));
+    } finally {
+      if (notesPath === '-') fs.rmSync(resolvedNotesPath, { force: true });
+    }
+    return;
+  }
+  finish({ status: 'failed', changed: false, error: { code: 'RELEASE_NOTES_INPUT_INVALID', message: 'Usage: platform-release-notes context|publish', retryable: false } });
+}
+
+export { platformReleaseNotes };

--- a/lib/platform/github-release-notes.ts
+++ b/lib/platform/github-release-notes.ts
@@ -1,0 +1,132 @@
+import type { GitHubClient } from './github-client.ts';
+import { createGitHubClient } from './github-client.ts';
+
+type GitHubActorInput = {
+  name?: string | null;
+  email?: string | null;
+  user?: { login?: string | null } | null;
+};
+
+type ReleaseNoteActor = {
+  name: string;
+  email: string | null;
+  login: string | null;
+  bot: boolean;
+  resolution: 'platform-user' | 'platform-noreply' | 'unresolved';
+};
+
+type GitHubReleaseNoteOptions = { cwd?: string; client?: GitHubClient };
+
+function normalizeGitHubActor(actor: GitHubActorInput): ReleaseNoteActor {
+  const name = String(actor.name || '').trim();
+  const email = actor.email ? String(actor.email).trim() : null;
+  const platformLogin = actor.user?.login?.trim().toLowerCase() || null;
+  const noReplyLogin = email
+    ? /^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/i.exec(email)?.[1]?.toLowerCase() || null
+    : null;
+  const login = platformLogin || noReplyLogin;
+  return {
+    name,
+    email,
+    login,
+    bot: Boolean(login?.endsWith('[bot]')),
+    resolution: platformLogin ? 'platform-user' : noReplyLogin ? 'platform-noreply' : 'unresolved'
+  };
+}
+
+function failure(error: { code: string; message: string; retryable: boolean }) {
+  return {
+    status: error.retryable ? 'blocked' as const : 'failed' as const,
+    changed: false,
+    operation: null,
+    url: null,
+    error
+  };
+}
+
+function publishGitHubReleaseNotes(
+  input: { repository: string; tag: string; title: string; notesFile: string; dryRun?: boolean },
+  options: GitHubReleaseNoteOptions = {}
+) {
+  const client = options.client ?? createGitHubClient();
+  const inspected = client.json<{ url?: string }>(
+    ['release', 'view', input.tag, '--repo', input.repository, '--json', 'url'],
+    { cwd: options.cwd }
+  );
+  if (!inspected.ok && inspected.error.code !== 'RESOURCE_NOT_FOUND') return failure(inspected.error);
+  const exists = inspected.ok;
+  const operation = exists ? 'release:update-notes' as const : 'release:create' as const;
+  if (input.dryRun) {
+    return {
+      status: 'planned' as const,
+      changed: false,
+      operation,
+      url: inspected.ok ? inspected.value.url || null : null,
+      error: null
+    };
+  }
+  const args = exists
+    ? ['release', 'edit', input.tag, '--repo', input.repository, '--notes-file', input.notesFile]
+    : ['release', 'create', input.tag, '--repo', input.repository, '--title', input.title, '--notes-file', input.notesFile];
+  const written = client.text(args, { cwd: options.cwd, method: exists ? 'PATCH' : 'POST' });
+  if (!written.ok) return failure(written.error);
+  return {
+    status: 'applied' as const,
+    changed: true,
+    operation,
+    url: written.value || (inspected.ok ? inspected.value.url || null : null),
+    error: null
+  };
+}
+
+function fetchGitHubReleaseNoteData(
+  input: { repository: string; commitOids: string[]; branch: string; historyLimit: number; fromTime: string; toTime: string },
+  options: GitHubReleaseNoteOptions = {}
+) {
+  const client = options.client ?? createGitHubClient();
+  const releases = client.json<Array<{ tagName?: string; isDraft?: boolean; isPrerelease?: boolean }>>(
+    ['release', 'list', '--repo', input.repository, '--limit', String(input.historyLimit + 10), '--json', 'tagName,isDraft,isPrerelease'],
+    { cwd: options.cwd }
+  );
+  if (!releases.ok) return failure(releases.error);
+  const history = [];
+  for (const item of releases.value.filter((entry) => !entry.isDraft && !entry.isPrerelease).slice(0, input.historyLimit)) {
+    const viewed = client.json<{ body?: string; url?: string }>(
+      ['release', 'view', String(item.tagName), '--repo', input.repository, '--json', 'body,url'],
+      { cwd: options.cwd }
+    );
+    if (!viewed.ok) return failure(viewed.error);
+    history.push({ tag: String(item.tagName), body: String(viewed.value.body || ''), url: viewed.value.url || null });
+  }
+  const prs = client.json<Array<Record<string, unknown>>>(
+    ['pr', 'list', '--repo', input.repository, '--state', 'merged', '--base', input.branch, '--limit', '1000', '--json', 'number,title,body,url,mergedAt,labels,author,closingIssuesReferences'],
+    { cwd: options.cwd }
+  );
+  if (!prs.ok) return failure(prs.error);
+  const authors = new Map<string, ReleaseNoteActor[]>();
+  for (const oid of input.commitOids) {
+    const query = `query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{authors(first:100){nodes{name email user{login}} pageInfo{hasNextPage}}}}}}`;
+    const [owner, name] = input.repository.split('/');
+    const result = client.json<{
+      data?: { repository?: { object?: { authors?: { nodes?: GitHubActorInput[]; pageInfo?: { hasNextPage?: boolean } } } } };
+    }>([
+      'api', 'graphql', '-f', `query=${query}`, '-F', `owner=${owner}`, '-F', `name=${name}`, '-F', `oid=${oid}`
+    ], { cwd: options.cwd });
+    if (!result.ok) return failure(result.error);
+    const connection = result.value.data?.repository?.object?.authors;
+    if (connection?.pageInfo?.hasNextPage) {
+      return failure({ code: 'RELEASE_NOTES_AUTHORS_TRUNCATED', message: `Commit authors exceeded the supported page size for ${oid}`, retryable: false });
+    }
+    authors.set(oid, (connection?.nodes || []).map(normalizeGitHubActor));
+  }
+  const fromTime = Date.parse(input.fromTime);
+  const toTime = Date.parse(input.toTime);
+  const pullRequests = prs.value.filter((item) => {
+    const mergedAt = Date.parse(String(item.mergedAt || ''));
+    return Number.isFinite(mergedAt) && mergedAt > fromTime && mergedAt <= toTime;
+  });
+  return { status: 'no-op' as const, changed: false, history, pullRequests, authors, error: null };
+}
+
+export { fetchGitHubReleaseNoteData, normalizeGitHubActor, publishGitHubReleaseNotes };
+export type { ReleaseNoteActor };

--- a/lib/platform/release-notes.ts
+++ b/lib/platform/release-notes.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { resolvePlatformContext } from './context.ts';
+import {
+  fetchGitHubReleaseNoteData,
+  publishGitHubReleaseNotes
+} from './github-release-notes.ts';
+import type { ReleaseNoteActor } from './github-release-notes.ts';
+import type { GitHubClient } from './github-client.ts';
+
+type ReleaseNoteOptions = {
+  cwd?: string;
+  platformType?: string;
+  client?: GitHubClient;
+};
+
+type ReleaseNoteCommit = { oid: string; title: string; authors: ReleaseNoteActor[] };
+
+const unsupportedError = {
+  code: 'PLATFORM_RELEASE_NOTES_UNSUPPORTED',
+  message: 'Release notes are not supported for the configured platform',
+  retryable: false
+};
+
+function baseResult(status: 'no-op' | 'failed' | 'blocked') {
+  return {
+    status,
+    changed: false,
+    range: null,
+    history: [],
+    pullRequests: [],
+    commits: [] as ReleaseNoteCommit[],
+    error: status === 'no-op' ? unsupportedError : null
+  };
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function configuredPlatform(cwd: string): string | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(path.join(cwd, '.agents', '.airc.json'), 'utf8'));
+    return typeof value?.platform?.type === 'string' ? value.platform.type : null;
+  } catch {
+    return null;
+  }
+}
+
+function releaseNoteContext(
+  input: { fromTag: string; toTag: string; branch: string; historyLimit?: number },
+  options: ReleaseNoteOptions = {}
+) {
+  const historyLimit = input.historyLimit ?? 3;
+  if (!input.fromTag || !input.toTag || !input.branch || !Number.isInteger(historyLimit) || historyLimit < 1 || historyLimit > 20) {
+    return { ...baseResult('failed'), error: { code: 'RELEASE_NOTES_INPUT_INVALID', message: 'from-tag, to-tag, branch, and a history limit from 1 to 20 are required', retryable: false } };
+  }
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const platformType = options.platformType ?? configuredPlatform(cwd);
+  if (platformType !== 'github') return baseResult('no-op');
+  let fromOid: string;
+  let toOid: string;
+  let fromTime: string;
+  let toTime: string;
+  let commitFacts: Array<{ oid: string; title: string }>;
+  try {
+    fromOid = git(cwd, ['rev-parse', '--verify', `${input.fromTag}^{commit}`]);
+    toOid = git(cwd, ['rev-parse', '--verify', `${input.toTag}^{commit}`]);
+    git(cwd, ['merge-base', '--is-ancestor', fromOid, toOid]);
+    fromTime = git(cwd, ['show', '-s', '--format=%cI', fromOid]);
+    toTime = git(cwd, ['show', '-s', '--format=%cI', toOid]);
+    const raw = git(cwd, ['log', '--reverse', '--no-merges', '--format=%H%x00%s', `${fromOid}..${toOid}`]);
+    commitFacts = raw ? raw.split('\n').map((line) => {
+      const [oid = '', title = ''] = line.split('\0');
+      return { oid, title };
+    }) : [];
+  } catch {
+    return { ...baseResult('failed'), error: { code: 'RELEASE_NOTES_RANGE_INVALID', message: 'The release tag range is missing or is not ancestral', retryable: false } };
+  }
+  const context = resolvePlatformContext({ cwd, platformType, client: options.client });
+  if (!context.platform.repository) {
+    return {
+      ...baseResult(context.status === 'blocked' ? 'blocked' : 'failed'),
+      error: context.error || { code: 'PLATFORM_CONTEXT_UNAVAILABLE', message: 'Platform repository is unavailable', retryable: context.status === 'blocked' }
+    };
+  }
+  const platform = fetchGitHubReleaseNoteData(
+    {
+      repository: context.platform.repository,
+      commitOids: commitFacts.map((item) => item.oid),
+      branch: input.branch,
+      historyLimit,
+      fromTime,
+      toTime
+    },
+    { cwd, client: options.client }
+  );
+  if (platform.status === 'blocked' || platform.status === 'failed' || !('authors' in platform)) {
+    return { ...baseResult(platform.status), error: platform.error };
+  }
+  const commits = commitFacts.map((commit) => {
+    const seen = new Set<string>();
+    const authors = (platform.authors.get(commit.oid) || []).filter((actor) => {
+      const key = actor.login || actor.email?.toLowerCase() || actor.name.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return { ...commit, authors };
+  });
+  const pullRequests = platform.pullRequests
+    .map((item) => ({
+      number: Number(item.number),
+      title: String(item.title || ''),
+      body: String(item.body || ''),
+      url: String(item.url || ''),
+      mergedAt: String(item.mergedAt || ''),
+      labels: Array.isArray(item.labels) ? item.labels.map((label) => String((label as { name?: string }).name || label)) : [],
+      author: item.author && typeof item.author === 'object'
+        ? { login: String((item.author as { login?: string }).login || '').toLowerCase(), bot: String((item.author as { login?: string }).login || '').endsWith('[bot]') }
+        : null,
+      closingIssues: Array.isArray(item.closingIssuesReferences)
+        ? item.closingIssuesReferences.map((issue) => {
+          const value = issue as Record<string, unknown>;
+          return {
+            number: Number(value.number),
+            title: String(value.title || ''),
+            url: String(value.url || ''),
+            labels: Array.isArray(value.labels) ? value.labels.map((label) => String((label as { name?: string }).name || label)) : [],
+            author: value.author && typeof value.author === 'object'
+              ? { login: String((value.author as { login?: string }).login || '').toLowerCase(), bot: String((value.author as { login?: string }).login || '').endsWith('[bot]') }
+              : null
+          };
+        }) : []
+    }))
+    .sort((left, right) => left.number - right.number);
+  return {
+    status: 'no-op' as const,
+    changed: false,
+    range: { fromTag: input.fromTag, toTag: input.toTag, fromOid, toOid },
+    history: platform.history,
+    pullRequests,
+    commits,
+    error: null
+  };
+}
+
+function publishReleaseNotes(
+  input: { tag: string; title: string; notesFile: string; dryRun?: boolean },
+  options: ReleaseNoteOptions = {}
+) {
+  if (!input.tag || !input.title || !input.notesFile) {
+    return { status: 'failed' as const, changed: false, operation: null, url: null, error: { code: 'RELEASE_NOTES_INPUT_INVALID', message: 'tag, title, and notes-file are required', retryable: false } };
+  }
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const platformType = options.platformType ?? configuredPlatform(cwd);
+  if (platformType !== 'github') return { status: 'no-op' as const, changed: false, operation: null, url: null, error: unsupportedError };
+  const context = resolvePlatformContext({ cwd, platformType, client: options.client });
+  if (!context.platform.repository) {
+    return { status: context.status === 'blocked' ? 'blocked' as const : 'failed' as const, changed: false, operation: null, url: null, error: context.error };
+  }
+  return publishGitHubReleaseNotes({ ...input, repository: context.platform.repository }, { cwd, client: options.client });
+}
+
+export { publishReleaseNotes, releaseNoteContext };

--- a/templates/.agents/rules/release-commands.en.md
+++ b/templates/.agents/rules/release-commands.en.md
@@ -1,5 +1,5 @@
 # Release Commands
 
-This code platform does not provide built-in release commands.
+This code platform does not provide a release-note adapter.
 
-Remote release automation is skipped for custom platforms unless you provide matching `.{platform}.en.md` rule templates and scripts. Continue using local release artifacts or your platform-specific release process.
+Use `agent-infra-internal platform-release-notes context` to receive a structured `PLATFORM_RELEASE_NOTES_UNSUPPORTED` no-op. Do not probe another platform client. Publishing remains a no-op until an adapter is provided.

--- a/templates/.agents/rules/release-commands.github.en.md
+++ b/templates/.agents/rules/release-commands.github.en.md
@@ -1,52 +1,22 @@
 # Release Platform Commands
 
-Read this file before loading release history, querying merged PRs, or publishing the Release notes.
+Release-note platform operations use a typed internal intent. Callers consume structured JSON and do not interpret platform commands, raw fields, identity email rules, or authentication errors.
 
-## Query Releases
-
-```bash
-gh release list --limit {limit} --json tagName,isDraft,isPrerelease
-gh release view "{tag}" --json body,url
-```
-
-## Query Merged PRs
+## Collect Release-note Context
 
 ```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels
+agent-infra-internal platform-release-notes context \
+  --from-tag "v{prev-version}" --to-tag "v{version}" \
+  --branch "{branch}" --history-limit 3
 ```
 
-When needed, read the linked Issue:
+The result contains release history, pull requests, closing Issues, and normalized contributor identities. Unsupported platforms return a stable `PLATFORM_RELEASE_NOTES_UNSUPPORTED` no-op.
+
+## Publish Release Notes
 
 ```bash
-gh issue view {issue-number} --json number,title,labels,url
+agent-infra-internal platform-release-notes publish \
+  --tag "v{version}" --title "v{version}" --notes-file "{notes-file}"
 ```
 
-## Contributor Mapping Helpers
-
-Merged PR queries used for release notes should include authors when contributors are needed:
-
-```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
-```
-
-Linked Issue queries used for reporter attribution should include the author:
-
-```bash
-gh issue view {issue-number} --json number,title,labels,url,author
-```
-
-Map GitHub no-reply emails with this rule: if `Name <email>` contains an email matching `(\d+\+)?(\S+?)@users\.noreply\.github\.com`, use the second capture group lowercased as the login. This covers both `{id}+{login}@users.noreply.github.com` and `{login}@users.noreply.github.com`.
-
-## Publish the Release Notes
-
-The GitHub Release for `v{version}` is created and published automatically by the release workflow so Homebrew bottles have a stable upload target. This command writes the curated notes onto that existing Release, falling back to creating it if it does not exist yet.
-
-```bash
-if gh release view "v{version}" >/dev/null 2>&1; then
-  gh release edit "v{version}" --notes-file "{notes-file}"
-else
-  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
-fi
-```
-
-If commands fail, stop or escalate according to the calling skill.
+The command updates an existing Release or creates a missing one. `--dry-run` only plans the operation. Exit codes `0/1/2` mean success, failure, and blocked.

--- a/templates/.agents/rules/release-commands.github.zh-CN.md
+++ b/templates/.agents/rules/release-commands.github.zh-CN.md
@@ -1,52 +1,22 @@
 # Release 平台命令
 
-在读取历史 release、查询已合并 PR，或发布 Release notes 前先读取本文件。
+发布说明平台操作统一使用 typed internal intent。调用方只解释结构化 JSON，不解析平台命令、原始字段、身份邮箱规则或认证错误。
 
-## Release 查询
-
-```bash
-gh release list --limit {limit} --json tagName,isDraft,isPrerelease
-gh release view "{tag}" --json body,url
-```
-
-## 已合并 PR 查询
+## 收集发布说明上下文
 
 ```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels
+agent-infra-internal platform-release-notes context \
+  --from-tag "v{prev-version}" --to-tag "v{version}" \
+  --branch "{branch}" --history-limit 3
 ```
 
-必要时读取关联 Issue：
-
-```bash
-gh issue view {issue-number} --json number,title,labels,url
-```
-
-## Contributor 映射辅助规则
-
-release notes 需要 contributors 时，已合并 PR 查询应包含 author：
-
-```bash
-gh pr list --state merged --base "{branch}" --json number,title,mergedAt,labels,author
-```
-
-关联 Issue 用于 reporter 归因时，查询应包含 author：
-
-```bash
-gh issue view {issue-number} --json number,title,labels,url,author
-```
-
-GitHub no-reply 邮箱映射规则：如果 `Name <email>` 中的 email 匹配 `(\d+\+)?(\S+?)@users\.noreply\.github\.com`，使用第二个捕获组的小写形式作为 login。该规则同时覆盖 `{id}+{login}@users.noreply.github.com` 和 `{login}@users.noreply.github.com`。
+结果包含历史发布、PR、关联 Issue 和规范化贡献者身份。不支持的平台返回稳定的 `PLATFORM_RELEASE_NOTES_UNSUPPORTED` no-op。
 
 ## 发布 Release notes
 
-`v{version}` 的 GitHub Release 由 release 工作流自动创建并发布，为 Homebrew bottle 提供稳定的上传落点。本命令把精修后的 notes 写到这个已存在的 Release 上；若 Release 尚不存在则兜底创建。
-
 ```bash
-if gh release view "v{version}" >/dev/null 2>&1; then
-  gh release edit "v{version}" --notes-file "{notes-file}"
-else
-  gh release create "v{version}" --title "v{version}" --notes-file "{notes-file}"
-fi
+agent-infra-internal platform-release-notes publish \
+  --tag "v{version}" --title "v{version}" --notes-file "{notes-file}"
 ```
 
-失败时按调用方规则停止或提示人工介入。
+命令更新既有 Release，缺失时创建；`--dry-run` 只规划操作。退出码 `0/1/2` 分别表示成功、失败和阻塞。

--- a/templates/.agents/rules/release-commands.zh-CN.md
+++ b/templates/.agents/rules/release-commands.zh-CN.md
@@ -1,5 +1,5 @@
 # Release 命令
 
-当前代码平台未内置发布命令支持。
+当前代码平台未提供发布说明 adapter。
 
-自定义平台会跳过远端发布自动化，除非你提供匹配的 `.{platform}.zh-CN.md` 规则模板和脚本。请继续使用本地发布产物或你的平台专属发布流程。
+调用 `agent-infra-internal platform-release-notes context` 会返回结构化的 `PLATFORM_RELEASE_NOTES_UNSUPPORTED` no-op，不得探测其他平台 client。在提供 adapter 前，发布操作同样保持 no-op。

--- a/templates/.agents/skills/create-release-note/SKILL.en.md
+++ b/templates/.agents/skills/create-release-note/SKILL.en.md
@@ -35,12 +35,14 @@ git rev-parse v<prev-version>
 
 ### 3. Reference Historical Release Notes Format and Categories
 
-Fetch multiple published release notes as format references, then use a predefined complete category list:
+Load one typed release-note context, then use a predefined complete category list:
 
 Read `.agents/rules/release-commands.md` before this step.
 
 ```bash
-# Part A: fetch the latest 3 published release bodies by following the release query commands in `.agents/rules/release-commands.md`
+agent-infra-internal platform-release-notes context \
+  --from-tag "v<prev-version>" --to-tag "v<version>" \
+  --branch "<base-branch>" --history-limit 3
 ```
 
 **Part B: Complete Category List**
@@ -58,38 +60,11 @@ Read `.agents/rules/release-commands.md` before this step.
 
 ### 4. Collect Merged PRs and Contributors
 
-Get the date range between tags, then query merged PRs:
-
-```bash
-# Get tag dates
-git log v<prev-version> --format=%aI -1
-git log v<version> --format=%aI -1
-
-# Get merged PRs in range by following the merged-PR query command in `.agents/rules/release-commands.md`
-```
-
-Also collect direct commits without PRs:
-```bash
-git log v<prev-version>..v<version> --format="%H %s" --no-merges
-```
-
-Collect collaborative contributors from commit `Co-authored-by` trailers:
-
-```bash
-git log v<prev-version>..v<version> \
-  --no-merges \
-  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
-  | grep -v '^$' | sort | uniq -c | sort -rn
-```
-
-Each output line is `Name <email>` and `uniq -c` provides the number of commits where that identity appeared as a co-author within the range.
+Use `pullRequests` and `commits` from Step 3. Each commit's `authors` are normalized platform facts containing the git author and co-authors; the skill does not interpret raw platform fields or email rules.
 
 ### 5. Collect Related Issues
 
-From each PR body, extract linked Issues:
-- Match patterns: `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive)
-
-Read linked Issues by following `.agents/rules/release-commands.md`.
+Use each PR's `closingIssues` from Step 3. Do not parse platform-specific reference syntax in this generic skill.
 
 ### 6. Classify Changes
 
@@ -130,14 +105,13 @@ If no historical release notes exist, use the following default Markdown format:
 3. Description: Use PR title, remove `type(scope):` prefix, capitalize first letter
 4. **Contributor collection**:
    - **Data sources**:
-     - PR authors returned by the merged-PR query rule in `.agents/rules/release-commands.md`
-     - Commit co-authors from Step 4 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters from linked Issues collected in Step 5 (author login returned by `.agents/rules/release-commands.md`)
+     - PR authors from the typed context
+     - Commit co-authors from the typed context's commit `authors`
+     - Issue reporters from typed `closingIssues[].author`
    - **Contribution count**: `PR count + co-authored commit count` for the same identity, merged across both sources
    - **Name -> `@login` mapping**:
-     - Raw `Co-authored-by` values are `Name <email>` and must be mapped to a platform `@login`
-     - Prefer email extraction: if it matches the platform no-reply email rule in `.agents/rules/release-commands.md`, use that rule to derive the lowercased login
-     - Otherwise use a Name heuristic: take the first token before a space and lowercase it, for example `Claude Opus 4.6 (1M context)` -> `@claude`, `Codex` -> `@codex`, `Gemini` -> `@gemini`
+     - For `platform-user` or `platform-noreply`, use the lowercased `login`
+     - Only for `unresolved`, use the Name heuristic: take the first token before a space and lowercase it
      - If the login already appears in the PR author list, merge counts into that login so `Claude` and `@claude` do not become separate entries
      - Merge all Name variants that map to the same login before counting and sorting; for example, `Claude` and `Claude Opus 4.6 (1M context)` should both collapse into `@claude`
      - Preserve bot identities as-is, for example `dependabot[bot]`
@@ -170,7 +144,12 @@ NOTES_FILE="$(mktemp "${TMPDIR:-/tmp}/agent-infra-release-notes.XXXXXX")"
 
 Write the notes content to `$NOTES_FILE`.
 
-9.2 Publish by following the "Publish the Release Notes" command in `.agents/rules/release-commands.md` (use `$NOTES_FILE` for `{notes-file}`; it updates the Release already created and published by the release workflow, falling back to creating it if missing).
+9.2 Call the typed publish intent (use `$NOTES_FILE` for `{notes-file}`); it updates an existing Release or creates a missing one:
+
+```bash
+agent-infra-internal platform-release-notes publish \
+  --tag "v<version>" --title "v<version>" --notes-file "$NOTES_FILE"
+```
 
 9.3 Remove the temp file whether publishing succeeds or fails:
 

--- a/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-release-note/SKILL.zh-CN.md
@@ -35,12 +35,14 @@ git rev-parse v<prev-version>
 
 ### 3. 参考历史发布说明格式与分类
 
-获取最近多条已发布的 Release Note 作为格式参考，并参考预定义的完整分类清单：
+读取一次 typed 发布说明上下文，并参考预定义的完整分类清单：
 
 执行前先读取 `.agents/rules/release-commands.md`。
 
 ```bash
-# Part A：按 `.agents/rules/release-commands.md` 的 release 查询命令逐条获取最近 3 条 Release 的 body
+agent-infra-internal platform-release-notes context \
+  --from-tag "v<prev-version>" --to-tag "v<version>" \
+  --branch "<base-branch>" --history-limit 3
 ```
 
 **Part B：完整分类清单**
@@ -58,38 +60,11 @@ git rev-parse v<prev-version>
 
 ### 4. 收集已合并的 PR 与贡献者
 
-获取标签之间的日期范围，然后查询已合并的 PR：
-
-```bash
-# 获取标签日期
-git log v<prev-version> --format=%aI -1
-git log v<version> --format=%aI -1
-
-# 获取范围内已合并的 PR（按 `.agents/rules/release-commands.md` 的 merged PR 查询命令执行）
-```
-
-同时收集没有 PR 的直接提交：
-```bash
-git log v<prev-version>..v<version> --format="%H %s" --no-merges
-```
-
-从 commit `Co-authored-by` trailer 中收集协作贡献者：
-
-```bash
-git log v<prev-version>..v<version> \
-  --no-merges \
-  --format='%(trailers:key=Co-authored-by,valueonly,unfold)' \
-  | grep -v '^$' | sort | uniq -c | sort -rn
-```
-
-输出每行一个 `Name <email>`（`uniq -c` 给出该身份在范围内作为 co-author 的 commit 数）。
+使用步骤 3 返回的 `pullRequests` 与 `commits`。每个 commit 的 `authors` 已按平台事实规范化并包含 git author 与 co-author；技能不读取平台原始字段或邮箱规则。
 
 ### 5. 收集关联 Issue
 
-从每个 PR body 中提取关联的 Issue：
-- 匹配模式：`Closes #N`、`Fixes #N`、`Resolves #N`（不区分大小写）
-
-按 `.agents/rules/release-commands.md` 的关联 Issue 查询命令读取。
+使用步骤 3 中每个 PR 的 `closingIssues`，不在通用技能中解析平台专有引用语法。
 
 ### 6. 分类变更
 
@@ -131,13 +106,12 @@ git log v<prev-version>..v<version> \
 4. **贡献者搜集**：
    - **数据源**：
      - PR author：来自 `.agents/rules/release-commands.md` 中已合并 PR 查询规则
-     - Commit co-authors：来自步骤 4 的 `git log ... --format='%(trailers:key=Co-authored-by,valueonly,unfold)'`
-     - Issue reporters：来自步骤 5 收集的关联 Issue author（由 `.agents/rules/release-commands.md` 返回）
+     - Commit co-authors：来自步骤 3 typed context 的 commit `authors`
+     - Issue reporters：来自步骤 3 typed context 的 `closingIssues[].author`
    - **贡献数定义**：`该人的 PR 数 + 该人作为 co-author 的 commit 数`（同一身份跨来源合并计数）
    - **Name → `@login` 映射**：
-     - `Co-authored-by` 原始格式为 `Name <email>`，需要推断对应的 platform `@login`
-     - 优先从 email 提取：匹配 `.agents/rules/release-commands.md` 中的平台 no-reply 邮箱规则时，按该规则推导小写 login
-     - 否则按 Name 启发式：取首个空格前的 token 并转为小写（例如 `Claude Opus 4.6 (1M context)` → `@claude`、`Codex` → `@codex`、`Gemini` → `@gemini`）
+     - `resolution` 为 `platform-user` 或 `platform-noreply` 时直接采用小写 `login`
+     - 仅当 `resolution` 为 `unresolved` 时按 Name 启发式：取首个空格前的 token 并转为小写
      - 已出现在 PR author 列表中的 login，必须按该 login 合并计数，避免把 `Claude` 和 `@claude` 拆成两个条目
      - 同一 login 的所有 Name 变体都必须归并后再计数与排序；例如 `Claude` 与 `Claude Opus 4.6 (1M context)` 都映射到 `@claude` 时，应先合并为同一个贡献者
      - Bot 身份保留原样（如 `dependabot[bot]`）
@@ -170,7 +144,12 @@ NOTES_FILE="$(mktemp "${TMPDIR:-/tmp}/agent-infra-release-notes.XXXXXX")"
 
 把 notes 内容写入 `$NOTES_FILE`。
 
-9.2 按 `.agents/rules/release-commands.md` 的「发布 Release notes」命令执行（命令中的 `{notes-file}` 用 `$NOTES_FILE`；写入已由 release 工作流自动创建/发布的 Release，不存在时兜底创建）。
+9.2 调用 typed publish intent（命令中的 `{notes-file}` 用 `$NOTES_FILE`）；它会更新已存在的 Release，不存在时创建：
+
+```bash
+agent-infra-internal platform-release-notes publish \
+  --tag "v<version>" --title "v<version>" --notes-file "$NOTES_FILE"
+```
 
 9.3 无论发布成功或失败，都删除临时文件：
 

--- a/tests/integration/cli/platform-release-notes.test.ts
+++ b/tests/integration/cli/platform-release-notes.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+test('platform-release-notes rejects invalid context input with JSON and exit 1', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'bin/internal-cli.ts', 'platform-release-notes', 'context'],
+    { cwd: process.cwd(), encoding: 'utf8' }
+  );
+  assert.equal(result.status, 1);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, 'failed');
+  assert.equal(output.error.code, 'RELEASE_NOTES_INPUT_INVALID');
+});
+
+test('platform-release-notes rejects publish without notes input', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'bin/internal-cli.ts', 'platform-release-notes', 'publish', '--tag', 'v1.0.0'],
+    { cwd: process.cwd(), encoding: 'utf8' }
+  );
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).error.code, 'RELEASE_NOTES_INPUT_INVALID');
+});

--- a/tests/unit/platform/github-release-notes.test.ts
+++ b/tests/unit/platform/github-release-notes.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeGitHubActor,
+  publishGitHubReleaseNotes
+} from '../../../lib/platform/github-release-notes.ts';
+import type { GitHubClient } from '../../../lib/platform/github-client.ts';
+
+test('GitHub actors prefer platform users, then no-reply identities, without guessing ordinary email', () => {
+  assert.deepEqual(
+    normalizeGitHubActor({ name: 'Alice Example', email: 'alice@example.com', user: { login: 'Alice' } }),
+    { name: 'Alice Example', email: 'alice@example.com', login: 'alice', bot: false, resolution: 'platform-user' }
+  );
+  assert.equal(
+    normalizeGitHubActor({ name: 'Robot', email: '123+Dependabot[bot]@users.noreply.github.com', user: null }).login,
+    'dependabot[bot]'
+  );
+  assert.deepEqual(
+    normalizeGitHubActor({ name: 'Unknown Person', email: 'unknown@example.com', user: null }),
+    { name: 'Unknown Person', email: 'unknown@example.com', login: null, bot: false, resolution: 'unresolved' }
+  );
+});
+
+test('publishing edits an existing published release and creates a missing release', () => {
+  const calls: string[][] = [];
+  const existing: GitHubClient = {
+    version: () => ({ ok: true, value: '2.16.0' }),
+    json: () => ({ ok: true, value: { tagName: 'v1.0.0', url: 'https://example/release' } }) as never,
+    text(args) {
+      calls.push(args);
+      return { ok: true, value: 'https://example/release' };
+    }
+  };
+  const edited = publishGitHubReleaseNotes(
+    { repository: 'acme/widgets', tag: 'v1.0.0', title: 'v1.0.0', notesFile: '/tmp/notes' },
+    { client: existing }
+  );
+  assert.equal(edited.operation, 'release:update-notes');
+  assert.deepEqual(calls[0], ['release', 'edit', 'v1.0.0', '--repo', 'acme/widgets', '--notes-file', '/tmp/notes']);
+
+  const missing: GitHubClient = {
+    ...existing,
+    json: () => ({ ok: false, error: { code: 'RESOURCE_NOT_FOUND', message: 'missing', retryable: false } }) as never
+  };
+  const created = publishGitHubReleaseNotes(
+    { repository: 'acme/widgets', tag: 'v1.0.0', title: 'Release 1', notesFile: '/tmp/notes' },
+    { client: missing }
+  );
+  assert.equal(created.operation, 'release:create');
+});
+
+test('dry-run plans publishing without invoking a write', () => {
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.16.0' }),
+    json: () => ({ ok: true, value: { tagName: 'v1.0.0', url: 'https://example/release' } }) as never,
+    text() {
+      throw new Error('write must not be called');
+    }
+  };
+  const result = publishGitHubReleaseNotes(
+    { repository: 'acme/widgets', tag: 'v1.0.0', title: 'v1.0.0', notesFile: '/tmp/notes', dryRun: true },
+    { client }
+  );
+  assert.equal(result.status, 'planned');
+  assert.equal(result.operation, 'release:update-notes');
+});

--- a/tests/unit/platform/release-notes.test.ts
+++ b/tests/unit/platform/release-notes.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { releaseNoteContext, publishReleaseNotes } from '../../../lib/platform/release-notes.ts';
+import type { GitHubClient } from '../../../lib/platform/github-client.ts';
+
+const unavailable: GitHubClient = {
+  version() { throw new Error('GitHub client must not be probed'); },
+  json() { throw new Error('GitHub client must not be probed'); },
+  text() { throw new Error('GitHub client must not be probed'); }
+};
+
+test('unsupported platforms return a stable no-op without probing GitHub', () => {
+  const context = releaseNoteContext(
+    { fromTag: 'v0.9.0', toTag: 'v0.9.1', branch: 'main' },
+    { platformType: 'none', client: unavailable }
+  );
+  assert.equal(context.status, 'no-op');
+  assert.equal(context.error?.code, 'PLATFORM_RELEASE_NOTES_UNSUPPORTED');
+  assert.deepEqual(context.pullRequests, []);
+
+  const publish = publishReleaseNotes(
+    { tag: 'v0.9.1', title: 'v0.9.1', notesFile: '/tmp/notes' },
+    { platformType: 'custom', client: unavailable }
+  );
+  assert.equal(publish.status, 'no-op');
+});
+
+test('context validates its range before platform access', () => {
+  const result = releaseNoteContext(
+    { fromTag: '', toTag: 'v0.9.1', branch: 'main' },
+    { platformType: 'github', client: unavailable }
+  );
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'RELEASE_NOTES_INPUT_INVALID');
+});

--- a/tests/unit/templates/custom-platform-fallback.test.ts
+++ b/tests/unit/templates/custom-platform-fallback.test.ts
@@ -83,6 +83,11 @@ test("custom platforms fall back to generic platform templates", async () => {
       );
     });
 
+    assert.match(
+      fs.readFileSync(path.join(projectRoot, ".agents", "rules", "release-commands.md"), "utf8"),
+      /PLATFORM_RELEASE_NOTES_UNSUPPORTED/
+    );
+
     [
       ".agents/skills/init-labels/scripts/init-labels.sh",
       ".agents/skills/init-milestones/scripts/init-milestones.sh",

--- a/tests/unit/templates/platform-coupling.test.ts
+++ b/tests/unit/templates/platform-coupling.test.ts
@@ -114,3 +114,17 @@ test("PR workflow documents reference typed PR and required-check intents", () =
     assert.match(read(relativePath), /agent-infra-internal platform-checks watch/, relativePath);
   });
 });
+
+test("release-note workflow documents reference the typed release-note intent", () => {
+  [
+    ".agents/skills/create-release-note/SKILL.md",
+    "templates/.agents/skills/create-release-note/SKILL.en.md",
+    "templates/.agents/skills/create-release-note/SKILL.zh-CN.md",
+    ".agents/rules/release-commands.md",
+    "templates/.agents/rules/release-commands.github.en.md",
+    "templates/.agents/rules/release-commands.github.zh-CN.md"
+  ].forEach((relativePath) => {
+    assert.match(read(relativePath), /agent-infra-internal platform-release-notes context/, relativePath);
+    assert.match(read(relativePath), /agent-infra-internal platform-release-notes publish/, relativePath);
+  });
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #701

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change

Closes #701

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring
- [x] 🚀 功能增强 / Feature enhancement

## 📝 变更目的 / Purpose of the Change

将发布说明流程中的平台专有查询、身份解析和 Release notes 写入下沉到 typed platform core 与 adapter，避免通用技能直接解释平台字段或邮箱规则，并可靠归并普通邮箱 co-author 与平台账号。

## 📋 主要变更 / Brief Changelog

- 新增 `platform-release-notes context|publish` internal intent。
- 新增发布说明 typed core 与平台 adapter，规范化 commit author 身份。
- 迁移运行时技能、英中模板与平台规则，并补充结构化单元及集成测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行目标 platform、CLI 与模板契约测试。
3. 运行 `npm test` 完整回归。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

完整回归：1805 项，1803 通过，2 项按平台条件跳过，0 失败。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只解决 Issue #701
- [x] 每个 commit 都有明确的 Conventional Commit 信息
- [x] 代码遵循项目规范并已完成代码审查
- [x] 已编写必要测试，类型检查与单元测试通过
- [x] 已同步运行时文档及英中模板
- [x] 已考虑向后兼容性，现有 release workflow 语义保持不变

## 📋 附加信息 / Additional Notes

审查重点：PR 时间范围过滤、commit authors 截断时的 fail-closed 行为，以及 publish 的 edit-or-create 语义。

Generated with AI assistance
