### PR TITLE
feat(config): 定义 Agent Client 配置与能力模型


### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -85,7 +85,7 @@ An **AI Coding Agent Client**, or **Agent Client** for short, is a supported cod
 Three configuration concepts remain independent:
 
 - `agentClients` records the project's desired state for built-in clients.
-- `sandbox.tools` contains non-client sandbox tools after migration, including `agent-infra` and custom tools.
+- `sandbox.tools` contains non-Agent Client sandbox tools, including `agent-infra` and custom tools.
 - Adapter capabilities describe what a client integration can do. They do not change when a project disables that client.
 
 Each adapter capability uses one of these identifiers:

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -12,6 +12,12 @@ The generated `.agents/.airc.json` file is the central contract between the boot
   "org": "my-org",
   "language": "en",
   "templateVersion": "v0.6.5",
+  "agentClients": [
+    { "id": "claude-code", "enabled": true, "installInSandbox": true },
+    { "id": "codex", "enabled": true, "installInSandbox": true },
+    { "id": "gemini-cli", "enabled": true, "installInSandbox": true },
+    { "id": "opencode", "enabled": true, "installInSandbox": true }
+  ],
   "templates": {
     "sources": [
       { "type": "local", "path": "~/private-templates" }
@@ -57,6 +63,7 @@ The generated `.agents/.airc.json` file is the central contract between the boot
 | `org` | GitHub organization or owner used by generated metadata and links. |
 | `language` | Primary project language or locale used by rendered templates. |
 | `templateVersion` | Exact `v`-prefixed SemVer of the installed template package, including prerelease or build metadata, for future upgrades and drift tracking. |
+| `agentClients` | Canonical configuration for the four built-in AI Coding Agent Clients. |
 | `templates` | Optional external template overlay configuration. |
 | `templates.sources` | Optional ordered list of external template sources. Only `type: "local"` is supported today. |
 | `skills` | Optional custom skill sync configuration. |
@@ -64,6 +71,56 @@ The generated `.agents/.airc.json` file is the central contract between the boot
 | `customTUIs` | Optional top-level list of custom AI TUI adapters. |
 | `files` | Per-path update strategy configuration for managed, merged, and ejected files. |
 | `files.managedBaselines` | Tool-maintained SHA-256 source baselines for built-in guarded managed files. Do not edit manually; they enable safe three-way updates for the GitHub lifecycle workflows. |
+
+## Agent Client contract
+
+An **AI Coding Agent Client**, or **Agent Client** for short, is a supported coding-agent application such as Claude Code, Codex, Gemini CLI, or OpenCode. The canonical `agentClients` array contains each built-in client exactly once. Array order has no runtime meaning; agent-infra serializes entries in the stable order shown above.
+
+| Field | Meaning |
+|-------|---------|
+| `id` | Closed built-in client identifier: `claude-code`, `codex`, `gemini-cli`, or `opencode`. |
+| `enabled` | Whether the project enables client-specific files and integration. |
+| `installInSandbox` | Whether sandbox assembly should install this client. This is independent of `enabled`. |
+
+Three configuration concepts remain independent:
+
+- `agentClients` records the project's desired state for built-in clients.
+- `sandbox.tools` contains non-client sandbox tools after migration, including `agent-infra` and custom tools.
+- Adapter capabilities describe what a client integration can do. They do not change when a project disables that client.
+
+Each adapter capability uses one of these identifiers:
+
+| Capability | Boundary |
+|------------|----------|
+| `instructions` | Discovers or consumes persistent repository and directory instructions. |
+| `skills` | Discovers, loads, or invokes `SKILL.md` workflow packages. |
+| `commands` | Provides client-native command entry points, files, and invocation syntax. |
+| `hooks` | Integrates lifecycle, tool-call, or event callbacks. |
+| `sandbox` | Supports CLI installation, version detection, configuration or credential mounting, initialization, and status. |
+| `verification` | Participates in project checks, required checks, or task artifact verification. |
+
+Support maturity is recorded per capability as a single closed level:
+
+| Level | Meaning |
+|-------|---------|
+| `compatible` | The client can consume the generic contract without client-specific assembly. |
+| `integrated` | Client-specific integration exists. |
+| `verified` | The integration has reproducible evidence for the current supported version. |
+| `experimental` | The capability is usable, but its contract or behavior may change. |
+
+The `verification` capability names an integration area; the `verified` support level names maturity. They are not interchangeable.
+
+### Legacy migration
+
+The old built-in `tuis` field and built-in Agent Client IDs in `sandbox.tools` are migration inputs only:
+
+- If `agentClients` is absent, a valid `tuis` array maps membership to `enabled`. A missing, `null`, or non-array value enables all four clients; an empty array disables all four.
+- A non-empty `sandbox.tools` array maps built-in client membership to `installInSandbox`. Missing, non-array, and empty arrays preserve the previous runtime behavior by installing all four clients.
+- Built-in client IDs are removed from the migrated `sandbox.tools`. `agent-infra`, custom tools, and other non-client string IDs retain their original order.
+- `customTUIs` remains an independent extension mechanism and is not migrated into `agentClients`.
+- When canonical and legacy fields coexist, their projected client states must agree. A conflict fails validation instead of silently choosing one source.
+
+Normalization and migration are currently exposed as a pure configuration contract. Existing init, update, and sandbox workflows adopt it in a later integration phase.
 
 ## External template and skill sources
 

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -85,7 +85,7 @@
 以下三类配置概念相互独立：
 
 - `agentClients` 记录项目对内建客户端的期望状态。
-- 迁移后的 `sandbox.tools` 保存非客户端沙箱工具，包括 `agent-infra` 和自定义工具。
+- `sandbox.tools` 保存非 Agent Client 的沙箱工具，包括 `agent-infra` 和自定义工具。
 - Adapter capability 描述客户端集成能做什么；项目禁用客户端不会改变其能力声明。
 
 每项 adapter capability 使用以下标识之一：

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -12,6 +12,12 @@
   "org": "my-org",
   "language": "en",
   "templateVersion": "v0.6.5",
+  "agentClients": [
+    { "id": "claude-code", "enabled": true, "installInSandbox": true },
+    { "id": "codex", "enabled": true, "installInSandbox": true },
+    { "id": "gemini-cli", "enabled": true, "installInSandbox": true },
+    { "id": "opencode", "enabled": true, "installInSandbox": true }
+  ],
   "templates": {
     "sources": [
       { "type": "local", "path": "~/private-templates" }
@@ -57,6 +63,7 @@
 | `org` | 生成元数据和链接时使用的 GitHub 组织或拥有者。 |
 | `language` | 渲染模板时采用的项目主语言或区域设置。 |
 | `templateVersion` | 当前安装模板包的精确 `v` 前缀 SemVer（可包含 prerelease 或 build metadata），用于升级和差异追踪。 |
+| `agentClients` | 四个内建 AI Coding Agent Client 的 canonical 配置。 |
 | `templates` | 可选的外部模板叠加配置。 |
 | `templates.sources` | 可选的外部模板源列表，按顺序应用。当前仅支持 `type: "local"`。 |
 | `skills` | 可选的自定义 skill 同步配置。 |
@@ -64,6 +71,56 @@
 | `customTUIs` | 可选的顶层自定义 AI TUI 适配配置列表。 |
 | `files` | 针对具体路径配置 `managed`、`merged`、`ejected` 三类更新策略。 |
 | `files.managedBaselines` | 工具维护的内建 guarded managed 文件 SHA-256 来源基线。请勿手工编辑；该映射用于安全三方更新 GitHub 生命周期 workflows。 |
+
+## Agent Client 契约
+
+**AI Coding Agent Client**（简称 **Agent Client**）是受支持的编码代理应用，例如 Claude Code、Codex、Gemini CLI 或 OpenCode。Canonical `agentClients` 数组必须恰好包含每个内建客户端一次。数组顺序没有运行时语义；agent-infra 会按上方示例中的稳定顺序序列化。
+
+| 字段 | 含义 |
+|------|------|
+| `id` | 封闭的内建客户端标识：`claude-code`、`codex`、`gemini-cli` 或 `opencode`。 |
+| `enabled` | 项目是否启用该客户端专属文件与集成。 |
+| `installInSandbox` | 沙箱装配是否安装该客户端；此状态与 `enabled` 相互独立。 |
+
+以下三类配置概念相互独立：
+
+- `agentClients` 记录项目对内建客户端的期望状态。
+- 迁移后的 `sandbox.tools` 保存非客户端沙箱工具，包括 `agent-infra` 和自定义工具。
+- Adapter capability 描述客户端集成能做什么；项目禁用客户端不会改变其能力声明。
+
+每项 adapter capability 使用以下标识之一：
+
+| Capability | 边界 |
+|------------|------|
+| `instructions` | 发现或消费仓库级和目录级持续指令。 |
+| `skills` | 发现、加载或调用 `SKILL.md` 工作流包。 |
+| `commands` | 提供客户端原生命令入口、文件与调用语法。 |
+| `hooks` | 集成生命周期、工具调用或事件回调。 |
+| `sandbox` | 支持 CLI 安装、版本检测、配置或凭证挂载、初始化与状态。 |
+| `verification` | 参与项目检查、required checks 或任务产物验证。 |
+
+每项 capability 使用一个封闭的支持成熟度等级：
+
+| 等级 | 含义 |
+|------|------|
+| `compatible` | 客户端可消费通用契约，但尚无客户端专属装配。 |
+| `integrated` | 已存在客户端专属集成。 |
+| `verified` | 集成对当前支持版本具有可复现证据。 |
+| `experimental` | 能力可用，但其契约或行为可能变化。 |
+
+`verification` capability 表示集成领域，`verified` 支持等级表示成熟度，两者不可互换。
+
+### 旧配置迁移
+
+旧的内建 `tuis` 字段和 `sandbox.tools` 中的内建 Agent Client ID 仅作为迁移输入：
+
+- 缺少 `agentClients` 时，有效的 `tuis` 数组按成员关系投影为 `enabled`。字段缺失、为 `null` 或非数组时启用全部四个客户端；空数组禁用全部四个客户端。
+- 非空 `sandbox.tools` 数组按内建客户端成员关系投影为 `installInSandbox`。字段缺失、非数组或空数组时，为保持原有运行行为，安装全部四个客户端。
+- 迁移后的 `sandbox.tools` 会移除内建客户端 ID；`agent-infra`、自定义工具和其他非客户端字符串 ID 保持原有顺序。
+- `customTUIs` 仍是独立扩展机制，不迁移到 `agentClients`。
+- Canonical 与旧字段共存时，投影出的客户端状态必须一致；冲突会使校验失败，而不是静默选择某一来源。
+
+当前规范化与迁移以纯配置契约形式提供；现有 init、update 和 sandbox 工作流将在后续集成阶段接入。
 
 ## 外部模板与 skill 源
 

--- a/lib/agent-clients/config.ts
+++ b/lib/agent-clients/config.ts
@@ -1,0 +1,275 @@
+import {
+  AGENT_CLIENT_IDS,
+  isAgentClientId
+} from './types.ts';
+import type {
+  AgentClientConfig,
+  AgentClientId,
+  AgentClientsConfig,
+  AgentClientState
+} from './types.ts';
+
+type AgentClientConfigInput = Readonly<{
+  agentClients?: unknown;
+  tuis?: unknown;
+  sandbox?: unknown;
+  customTUIs?: unknown;
+}>;
+
+type AgentClientDiagnosticCode =
+  | 'INVALID_AGENT_CLIENTS'
+  | 'DUPLICATE_AGENT_CLIENT'
+  | 'MISSING_AGENT_CLIENT'
+  | 'UNKNOWN_AGENT_CLIENT'
+  | 'LEGACY_CONFLICT'
+  | 'LEGACY_VALUE_IGNORED';
+
+type AgentClientDiagnostic = Readonly<{
+  code: AgentClientDiagnosticCode;
+  path: string;
+}>;
+
+type NormalizeAgentClientsResult = Readonly<{
+  source: 'canonical' | 'legacy';
+  state: AgentClientState;
+  canonical: AgentClientsConfig;
+  remainingSandboxTools: readonly string[] | undefined;
+  removeLegacyTuis: boolean;
+  changed: boolean;
+  diagnostics: readonly AgentClientDiagnostic[];
+}>;
+
+class AgentClientConfigError extends Error {
+  readonly code: AgentClientDiagnosticCode;
+  readonly path: string;
+  readonly diagnostics: readonly AgentClientDiagnostic[];
+
+  constructor(diagnostic: AgentClientDiagnostic) {
+    super(`${diagnostic.code} at ${diagnostic.path}`);
+    this.name = 'AgentClientConfigError';
+    this.code = diagnostic.code;
+    this.path = diagnostic.path;
+    this.diagnostics = [diagnostic];
+  }
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function fail(code: AgentClientDiagnosticCode, path: string): never {
+  throw new AgentClientConfigError({ code, path });
+}
+
+function parseCanonical(value: unknown): AgentClientState {
+  if (!Array.isArray(value)) fail('INVALID_AGENT_CLIENTS', 'agentClients');
+
+  const entries = new Map<AgentClientId, Readonly<{
+    enabled: boolean;
+    installInSandbox: boolean;
+  }>>();
+
+  for (const [index, candidate] of value.entries()) {
+    const path = `agentClients[${index}]`;
+    if (!isRecord(candidate)) fail('INVALID_AGENT_CLIENTS', path);
+
+    const keys = Object.keys(candidate);
+    if (
+      keys.length !== 3
+      || !hasOwn(candidate, 'id')
+      || !hasOwn(candidate, 'enabled')
+      || !hasOwn(candidate, 'installInSandbox')
+    ) {
+      fail('INVALID_AGENT_CLIENTS', path);
+    }
+    if (!isAgentClientId(candidate.id)) {
+      fail('UNKNOWN_AGENT_CLIENT', `${path}.id`);
+    }
+    if (entries.has(candidate.id)) {
+      fail('DUPLICATE_AGENT_CLIENT', `${path}.id`);
+    }
+    if (
+      typeof candidate.enabled !== 'boolean'
+      || typeof candidate.installInSandbox !== 'boolean'
+    ) {
+      fail('INVALID_AGENT_CLIENTS', path);
+    }
+    entries.set(candidate.id, {
+      enabled: candidate.enabled,
+      installInSandbox: candidate.installInSandbox
+    });
+  }
+
+  for (const id of AGENT_CLIENT_IDS) {
+    if (!entries.has(id)) fail('MISSING_AGENT_CLIENT', 'agentClients');
+  }
+
+  return Object.fromEntries(
+    AGENT_CLIENT_IDS.map((id) => [id, entries.get(id)!])
+  ) as AgentClientState;
+}
+
+function serializeAgentClients(state: AgentClientState): AgentClientsConfig {
+  return AGENT_CLIENT_IDS.map((id): AgentClientConfig => ({
+    id,
+    enabled: state[id].enabled,
+    installInSandbox: state[id].installInSandbox
+  }));
+}
+
+function projectLegacyTuis(
+  value: unknown,
+  diagnostics: AgentClientDiagnostic[]
+): Readonly<Record<AgentClientId, boolean>> {
+  if (!Array.isArray(value)) {
+    return Object.fromEntries(
+      AGENT_CLIENT_IDS.map((id) => [id, true])
+    ) as Readonly<Record<AgentClientId, boolean>>;
+  }
+
+  const enabled = new Set<AgentClientId>();
+  for (const [index, candidate] of value.entries()) {
+    if (isAgentClientId(candidate)) {
+      enabled.add(candidate);
+    } else {
+      diagnostics.push({
+        code: 'LEGACY_VALUE_IGNORED',
+        path: `tuis[${index}]`
+      });
+    }
+  }
+  return Object.fromEntries(
+    AGENT_CLIENT_IDS.map((id) => [id, enabled.has(id)])
+  ) as Readonly<Record<AgentClientId, boolean>>;
+}
+
+type SandboxProjection = Readonly<{
+  installed: Readonly<Record<AgentClientId, boolean>>;
+  remainingTools: readonly string[] | undefined;
+}>;
+
+function projectLegacySandbox(
+  value: unknown,
+  diagnostics: AgentClientDiagnostic[]
+): SandboxProjection {
+  if (!Array.isArray(value) || value.length === 0) {
+    return {
+      installed: Object.fromEntries(
+        AGENT_CLIENT_IDS.map((id) => [id, true])
+      ) as Readonly<Record<AgentClientId, boolean>>,
+      remainingTools: Array.isArray(value) ? [] : undefined
+    };
+  }
+
+  const installed = new Set<AgentClientId>();
+  const remainingTools: string[] = [];
+  for (const [index, candidate] of value.entries()) {
+    if (isAgentClientId(candidate)) {
+      installed.add(candidate);
+    } else if (typeof candidate === 'string') {
+      remainingTools.push(candidate);
+    } else {
+      diagnostics.push({
+        code: 'LEGACY_VALUE_IGNORED',
+        path: `sandbox.tools[${index}]`
+      });
+    }
+  }
+  return {
+    installed: Object.fromEntries(
+      AGENT_CLIENT_IDS.map((id) => [id, installed.has(id)])
+    ) as Readonly<Record<AgentClientId, boolean>>,
+    remainingTools
+  };
+}
+
+function stateFromLegacy(
+  enabled: Readonly<Record<AgentClientId, boolean>>,
+  installed: Readonly<Record<AgentClientId, boolean>>
+): AgentClientState {
+  return Object.fromEntries(
+    AGENT_CLIENT_IDS.map((id) => [
+      id,
+      {
+        enabled: enabled[id],
+        installInSandbox: installed[id]
+      }
+    ])
+  ) as AgentClientState;
+}
+
+function sameCanonicalOrder(value: unknown): boolean {
+  return Array.isArray(value)
+    && value.every((entry, index) => isRecord(entry) && entry.id === AGENT_CLIENT_IDS[index]);
+}
+
+function normalizeAgentClients(
+  input: AgentClientConfigInput
+): NormalizeAgentClientsResult {
+  const diagnostics: AgentClientDiagnostic[] = [];
+  const hasCanonical = hasOwn(input, 'agentClients');
+  const hasLegacyTuis = hasOwn(input, 'tuis');
+  const sandbox = isRecord(input.sandbox) ? input.sandbox : undefined;
+  const hasLegacySandboxTools = sandbox !== undefined && hasOwn(sandbox, 'tools');
+  const tuiProjection = projectLegacyTuis(input.tuis, diagnostics);
+  const sandboxProjection = projectLegacySandbox(sandbox?.tools, diagnostics);
+
+  if (!hasCanonical) {
+    const state = stateFromLegacy(tuiProjection, sandboxProjection.installed);
+    return {
+      source: 'legacy',
+      state,
+      canonical: serializeAgentClients(state),
+      remainingSandboxTools: sandboxProjection.remainingTools,
+      removeLegacyTuis: hasLegacyTuis,
+      changed: true,
+      diagnostics
+    };
+  }
+
+  const state = parseCanonical(input.agentClients);
+  if (hasLegacyTuis) {
+    for (const id of AGENT_CLIENT_IDS) {
+      if (state[id].enabled !== tuiProjection[id]) {
+        fail('LEGACY_CONFLICT', 'tuis');
+      }
+    }
+  }
+  if (hasLegacySandboxTools) {
+    for (const id of AGENT_CLIENT_IDS) {
+      if (state[id].installInSandbox !== sandboxProjection.installed[id]) {
+        fail('LEGACY_CONFLICT', 'sandbox.tools');
+      }
+    }
+  }
+
+  return {
+    source: 'canonical',
+    state,
+    canonical: serializeAgentClients(state),
+    remainingSandboxTools: hasLegacySandboxTools
+      ? sandboxProjection.remainingTools
+      : undefined,
+    removeLegacyTuis: hasLegacyTuis,
+    changed: hasLegacyTuis
+      || hasLegacySandboxTools
+      || !sameCanonicalOrder(input.agentClients),
+    diagnostics
+  };
+}
+
+export {
+  AgentClientConfigError,
+  normalizeAgentClients,
+  serializeAgentClients
+};
+export type {
+  AgentClientConfigInput,
+  AgentClientDiagnostic,
+  AgentClientDiagnosticCode,
+  NormalizeAgentClientsResult
+};

--- a/lib/agent-clients/schema.ts
+++ b/lib/agent-clients/schema.ts
@@ -1,0 +1,49 @@
+import {
+  AGENT_CLIENT_CAPABILITY_IDS,
+  AGENT_CLIENT_IDS,
+  AGENT_CLIENT_SUPPORT_LEVELS
+} from './types.ts';
+
+const AGENT_CLIENTS_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: ['agentClients'],
+  properties: {
+    agentClients: {
+      type: 'array',
+      minItems: AGENT_CLIENT_IDS.length,
+      maxItems: AGENT_CLIENT_IDS.length,
+      uniqueItems: true,
+      description: 'Canonical Agent Client configuration. Object ID completeness and uniqueness are enforced by the runtime normalizer.',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'enabled', 'installInSandbox'],
+        properties: {
+          id: {
+            type: 'string',
+            enum: [...AGENT_CLIENT_IDS]
+          },
+          enabled: {
+            type: 'boolean'
+          },
+          installInSandbox: {
+            type: 'boolean'
+          }
+        }
+      }
+    }
+  },
+  definitions: {
+    agentClientCapabilityId: {
+      type: 'string',
+      enum: [...AGENT_CLIENT_CAPABILITY_IDS]
+    },
+    agentClientSupportLevel: {
+      type: 'string',
+      enum: [...AGENT_CLIENT_SUPPORT_LEVELS]
+    }
+  }
+} as const;
+
+export { AGENT_CLIENTS_SCHEMA };

--- a/lib/agent-clients/types.ts
+++ b/lib/agent-clients/types.ts
@@ -1,0 +1,75 @@
+const AGENT_CLIENT_IDS = [
+  'claude-code',
+  'codex',
+  'gemini-cli',
+  'opencode'
+] as const;
+
+type AgentClientId = (typeof AGENT_CLIENT_IDS)[number];
+
+type AgentClientConfig = Readonly<{
+  id: AgentClientId;
+  enabled: boolean;
+  installInSandbox: boolean;
+}>;
+
+type AgentClientsConfig = readonly AgentClientConfig[];
+
+type AgentClientState = Readonly<
+  Record<
+    AgentClientId,
+    Readonly<{
+      enabled: boolean;
+      installInSandbox: boolean;
+    }>
+  >
+>;
+
+const AGENT_CLIENT_CAPABILITY_IDS = [
+  'instructions',
+  'skills',
+  'commands',
+  'hooks',
+  'sandbox',
+  'verification'
+] as const;
+
+const AGENT_CLIENT_SUPPORT_LEVELS = [
+  'compatible',
+  'integrated',
+  'verified',
+  'experimental'
+] as const;
+
+type AgentClientCapabilityId = (typeof AGENT_CLIENT_CAPABILITY_IDS)[number];
+type AgentClientSupportLevel = (typeof AGENT_CLIENT_SUPPORT_LEVELS)[number];
+
+type AgentClientCapabilitySupport = Readonly<{
+  level: AgentClientSupportLevel;
+}>;
+
+type AgentClientCapabilityMap = Readonly<
+  Record<AgentClientCapabilityId, AgentClientCapabilitySupport>
+>;
+
+function isAgentClientId(value: unknown): value is AgentClientId {
+  return typeof value === 'string'
+    && (AGENT_CLIENT_IDS as readonly string[]).includes(value);
+}
+
+export {
+  AGENT_CLIENT_IDS,
+  AGENT_CLIENT_CAPABILITY_IDS,
+  AGENT_CLIENT_SUPPORT_LEVELS,
+  isAgentClientId
+};
+export type {
+  AgentClientId,
+  AgentClientConfig,
+  AgentClientsConfig,
+  AgentClientState,
+  AgentClientCapabilityId,
+  AgentClientSupportLevel,
+  AgentClientCapabilitySupport,
+  AgentClientCapabilityMap
+};

--- a/lib/builtin-tuis.ts
+++ b/lib/builtin-tuis.ts
@@ -1,5 +1,8 @@
-const BUILTIN_TUI_IDS = ['claude-code', 'codex', 'gemini-cli', 'opencode'] as const;
-type BuiltinTUIId = (typeof BUILTIN_TUI_IDS)[number];
+import { AGENT_CLIENT_IDS, isAgentClientId } from './agent-clients/types.ts';
+import type { AgentClientId } from './agent-clients/types.ts';
+
+const BUILTIN_TUI_IDS = AGENT_CLIENT_IDS;
+type BuiltinTUIId = AgentClientId;
 
 const BUILTIN_TUI_DISPLAY: Record<BuiltinTUIId, string> = {
   'claude-code': 'Claude Code',
@@ -16,7 +19,7 @@ const BUILTIN_TUI_OWNED_PATH_PREFIXES: Record<BuiltinTUIId, string[]> = {
 };
 
 function isBuiltinTUIId(value: unknown): value is BuiltinTUIId {
-  return typeof value === 'string' && (BUILTIN_TUI_IDS as readonly string[]).includes(value);
+  return isAgentClientId(value);
 }
 
 function resolveEnabledTUIs(value: unknown): Set<BuiltinTUIId> {

--- a/tests/unit/core/agent-client-config.test.ts
+++ b/tests/unit/core/agent-client-config.test.ts
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AGENT_CLIENT_CAPABILITY_IDS,
+  AGENT_CLIENT_IDS,
+  AGENT_CLIENT_SUPPORT_LEVELS,
+  isAgentClientId
+} from '../../../lib/agent-clients/types.ts';
+import type { AgentClientState } from '../../../lib/agent-clients/types.ts';
+import {
+  normalizeAgentClients,
+  serializeAgentClients
+} from '../../../lib/agent-clients/config.ts';
+import { AGENT_CLIENTS_SCHEMA } from '../../../lib/agent-clients/schema.ts';
+import {
+  BUILTIN_TUI_DISPLAY,
+  BUILTIN_TUI_IDS,
+  BUILTIN_TUI_OWNED_PATH_PREFIXES,
+  isBuiltinTUIId,
+  isPathOwnedByDisabledTUI,
+  resolveEnabledTUIs
+} from '../../../lib/builtin-tuis.ts';
+
+const ALL_ENABLED = Object.fromEntries(
+  AGENT_CLIENT_IDS.map((id) => [id, { enabled: true, installInSandbox: true }])
+) as AgentClientState;
+
+function canonical(
+  enabled: readonly string[] = AGENT_CLIENT_IDS,
+  sandbox: readonly string[] = AGENT_CLIENT_IDS
+) {
+  return AGENT_CLIENT_IDS.map((id) => ({
+    id,
+    enabled: enabled.includes(id),
+    installInSandbox: sandbox.includes(id)
+  }));
+}
+
+function errorCode(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    if (typeof error !== 'object' || error === null || !('code' in error)) {
+      assert.fail('Expected an error with a stable code');
+    }
+    return String(error.code);
+  }
+  assert.fail('Expected normalization to fail');
+}
+
+test('agent client vocabulary is closed, unique, and recognized by the shared guard', () => {
+  assert.deepEqual(AGENT_CLIENT_IDS, ['claude-code', 'codex', 'gemini-cli', 'opencode']);
+  assert.equal(new Set(AGENT_CLIENT_IDS).size, AGENT_CLIENT_IDS.length);
+  assert.deepEqual(AGENT_CLIENT_CAPABILITY_IDS, [
+    'instructions',
+    'skills',
+    'commands',
+    'hooks',
+    'sandbox',
+    'verification'
+  ]);
+  assert.equal(new Set(AGENT_CLIENT_CAPABILITY_IDS).size, AGENT_CLIENT_CAPABILITY_IDS.length);
+  assert.deepEqual(AGENT_CLIENT_SUPPORT_LEVELS, [
+    'compatible',
+    'integrated',
+    'verified',
+    'experimental'
+  ]);
+  assert.equal(new Set(AGENT_CLIENT_SUPPORT_LEVELS).size, AGENT_CLIENT_SUPPORT_LEVELS.length);
+  assert.equal(isAgentClientId('codex'), true);
+  assert.equal(isAgentClientId('other'), false);
+});
+
+test('schema is JSON-safe and derives its closed enums from shared constants', () => {
+  const json = JSON.stringify(AGENT_CLIENTS_SCHEMA);
+  assert.deepEqual(JSON.parse(json), AGENT_CLIENTS_SCHEMA);
+
+  const schema = AGENT_CLIENTS_SCHEMA as Record<string, any>;
+  assert.equal(schema.$schema, 'http://json-schema.org/draft-07/schema#');
+  assert.deepEqual(schema.required, ['agentClients']);
+  assert.equal(schema.properties.agentClients.minItems, AGENT_CLIENT_IDS.length);
+  assert.equal(schema.properties.agentClients.maxItems, AGENT_CLIENT_IDS.length);
+  assert.equal(schema.properties.agentClients.items.additionalProperties, false);
+  assert.deepEqual(
+    schema.properties.agentClients.items.properties.id.enum,
+    AGENT_CLIENT_IDS
+  );
+  assert.deepEqual(
+    schema.properties.agentClients.items.required,
+    ['id', 'enabled', 'installInSandbox']
+  );
+  assert.equal(schema.properties.agentClients.items.properties.enabled.type, 'boolean');
+  assert.equal(
+    schema.properties.agentClients.items.properties.installInSandbox.type,
+    'boolean'
+  );
+  assert.deepEqual(
+    schema.definitions.agentClientCapabilityId.enum,
+    AGENT_CLIENT_CAPABILITY_IDS
+  );
+  assert.deepEqual(
+    schema.definitions.agentClientSupportLevel.enum,
+    AGENT_CLIENT_SUPPORT_LEVELS
+  );
+});
+
+test('canonical input is normalized to stable ID order without mutation', () => {
+  const input = [...canonical()].reverse();
+  const before = structuredClone(input);
+  const result = normalizeAgentClients({ agentClients: input });
+
+  assert.equal(result.source, 'canonical');
+  assert.deepEqual(result.state, ALL_ENABLED);
+  assert.deepEqual(result.canonical, canonical());
+  assert.equal(result.changed, true);
+  assert.equal(result.removeLegacyTuis, false);
+  assert.equal(result.remainingSandboxTools, undefined);
+  assert.deepEqual(result.diagnostics, []);
+  assert.deepEqual(input, before);
+
+  const second = normalizeAgentClients({ agentClients: result.canonical });
+  assert.equal(second.changed, false);
+  assert.deepEqual(second.canonical, result.canonical);
+  assert.notEqual(second.canonical, result.canonical);
+});
+
+test('serializer returns a new stable array and does not mutate state', () => {
+  const state = structuredClone(ALL_ENABLED);
+  const before = structuredClone(state);
+  const first = serializeAgentClients(state);
+  const second = serializeAgentClients(state);
+
+  assert.deepEqual(first, canonical());
+  assert.deepEqual(second, first);
+  assert.notEqual(first, second);
+  assert.deepEqual(state, before);
+});
+
+test('canonical validation reports stable structural error codes', () => {
+  const cases: Array<[string, unknown]> = [
+    ['INVALID_AGENT_CLIENTS', null],
+    ['MISSING_AGENT_CLIENT', canonical().slice(0, 3)],
+    [
+      'DUPLICATE_AGENT_CLIENT',
+      canonical().map((entry, index) => index === 3 ? { ...entry, id: 'codex' } : entry)
+    ],
+    [
+      'UNKNOWN_AGENT_CLIENT',
+      canonical().map((entry, index) => index === 3 ? { ...entry, id: 'other' } : entry)
+    ],
+    [
+      'INVALID_AGENT_CLIENTS',
+      canonical().map((entry, index) => index === 0 ? { ...entry, enabled: 'yes' } : entry)
+    ],
+    [
+      'INVALID_AGENT_CLIENTS',
+      canonical().map((entry, index) => index === 0 ? { ...entry, extra: true } : entry)
+    ]
+  ];
+
+  for (const [expected, agentClients] of cases) {
+    assert.equal(errorCode(() => normalizeAgentClients({ agentClients })), expected);
+  }
+
+  const missing = canonical().slice(0, 3);
+  missing.push({ id: 'codex', enabled: true, installInSandbox: true });
+  assert.equal(
+    errorCode(() => normalizeAgentClients({ agentClients: missing })),
+    'DUPLICATE_AGENT_CLIENT'
+  );
+});
+
+test('legacy defaults preserve current enabled and sandbox behavior', () => {
+  for (const input of [
+    {},
+    { tuis: null, sandbox: null },
+    { tuis: 'invalid', sandbox: { tools: 'invalid' } },
+    { sandbox: { tools: [] } }
+  ]) {
+    const result = normalizeAgentClients(input);
+    assert.equal(result.source, 'legacy');
+    assert.deepEqual(result.state, ALL_ENABLED);
+    assert.deepEqual(result.canonical, canonical());
+    assert.equal(result.changed, true);
+  }
+});
+
+test('legacy arrays project independent enabled and sandbox states', () => {
+  const input = {
+    tuis: ['codex', 'opencode', 'unknown'],
+    sandbox: {
+      tools: ['agent-infra', 'claude-code', 'opencode', 'custom-tool', 'unknown-tool']
+    },
+    customTUIs: [{ name: 'custom' }]
+  };
+  const before = structuredClone(input);
+  const result = normalizeAgentClients(input);
+
+  assert.deepEqual(
+    result.canonical,
+    canonical(['codex', 'opencode'], ['claude-code', 'opencode'])
+  );
+  assert.deepEqual(
+    result.remainingSandboxTools,
+    ['agent-infra', 'custom-tool', 'unknown-tool']
+  );
+  assert.equal(result.removeLegacyTuis, true);
+  assert.deepEqual(
+    result.diagnostics.map((diagnostic) => diagnostic.code),
+    ['LEGACY_VALUE_IGNORED']
+  );
+  assert.deepEqual(input, before);
+});
+
+test('an empty legacy tuis array disables all clients independently of sandbox defaults', () => {
+  const result = normalizeAgentClients({ tuis: [], sandbox: { tools: [] } });
+  assert.deepEqual(result.canonical, canonical([], AGENT_CLIENT_IDS));
+  assert.deepEqual(result.remainingSandboxTools, []);
+});
+
+test('canonical and present legacy signals must be equivalent', () => {
+  const equivalent = normalizeAgentClients({
+    agentClients: canonical(['codex'], ['claude-code']),
+    tuis: ['codex'],
+    sandbox: { tools: ['agent-infra', 'claude-code', 'custom-tool'] }
+  });
+  assert.equal(equivalent.source, 'canonical');
+  assert.equal(equivalent.changed, true);
+  assert.equal(equivalent.removeLegacyTuis, true);
+  assert.deepEqual(equivalent.remainingSandboxTools, ['agent-infra', 'custom-tool']);
+
+  assert.equal(
+    errorCode(() => normalizeAgentClients({
+      agentClients: canonical(['codex'], ['claude-code']),
+      tuis: ['opencode']
+    })),
+    'LEGACY_CONFLICT'
+  );
+  assert.equal(
+    errorCode(() => normalizeAgentClients({
+      agentClients: canonical(['codex'], ['claude-code']),
+      sandbox: { tools: ['codex'] }
+    })),
+    'LEGACY_CONFLICT'
+  );
+});
+
+test('invalid canonical input never falls back to legacy values', () => {
+  assert.equal(
+    errorCode(() => normalizeAgentClients({
+      agentClients: [],
+      tuis: AGENT_CLIENT_IDS,
+      sandbox: { tools: AGENT_CLIENT_IDS }
+    })),
+    'MISSING_AGENT_CLIENT'
+  );
+});
+
+test('builtin TUI exports remain compatible aliases over shared client IDs', () => {
+  assert.equal(BUILTIN_TUI_IDS, AGENT_CLIENT_IDS);
+  assert.deepEqual(Object.keys(BUILTIN_TUI_DISPLAY), AGENT_CLIENT_IDS);
+  assert.deepEqual(Object.keys(BUILTIN_TUI_OWNED_PATH_PREFIXES), AGENT_CLIENT_IDS);
+  assert.equal(isBuiltinTUIId('codex'), true);
+  assert.equal(isBuiltinTUIId('unknown'), false);
+  assert.deepEqual(resolveEnabledTUIs([]), new Set());
+  assert.deepEqual(resolveEnabledTUIs(undefined), new Set(AGENT_CLIENT_IDS));
+  assert.equal(isPathOwnedByDisabledTUI('.codex/skills', new Set()), true);
+  assert.equal(
+    isPathOwnedByDisabledTUI('.codex/skills', new Set(AGENT_CLIENT_IDS)),
+    false
+  );
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #662

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Define one canonical Agent Client configuration and capability contract for Claude Code, Codex, Gemini CLI, and OpenCode. This contract separates project enablement, sandbox installation, and adapter capability maturity so later registry and runtime integration tasks can consume a single source of truth.

## 📋 主要变更 / Brief Changelog

- Add shared Agent Client IDs, configuration/state types, six capability IDs, and four support levels.
- Add a Draft-07 schema plus pure canonical validation, stable serialization, legacy projection, and conflict detection.
- Preserve all existing built-in TUI exports while documenting the canonical and migration contracts in English and Chinese.
- Add structural tests for schema consistency, canonical validation, legacy behavior, conflict handling, immutability, and compatibility exports.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run `node --experimental-strip-types --no-warnings --test tests/unit/core/agent-client-config.test.ts`.
3. Run `npm test`.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Full test result: 1,843 passed, 0 failed, and 2 platform-conditional tests skipped.

## 📸 截图 / Screenshots

Not applicable; this change defines a configuration contract and has no UI.

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [ ] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- Runtime adoption by init, update, configure, and sandbox workflows remains intentionally deferred to the follow-up integration task.
- The legacy `sandbox.tools: []` projection preserves the previously approved all-installed runtime behavior.

---

**审查者注意事项 / Reviewer Notes:**

- Review canonical/legacy coexistence conflict handling and stable diagnostic codes.
- Manually compare the English and Chinese Agent Client terminology, capability boundaries, support levels, and migration wording.

Closes #662

Generated with AI assistance
