### PR TITLE
refactor(agent-clients): 插件化客户端项目文件装配与卸载


### DIFF
--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -65,16 +65,12 @@ const DEFAULTS = {
       ".agents/templates/",
       ".agents/workflows/",
       ".agents/workspace/README.md",
-      ".claude/commands/",
-      ".codex/hooks.json",
-      ".gemini/commands/",
       ".git-hooks/check-large-files.cjs",
       ".git-hooks/check-version-format.sh",
       ".github/scripts/",
       ".github/workflows/metadata-sync.yml",
       ".github/workflows/pr-label.yml",
-      ".github/workflows/status-label.yml",
-      ".opencode/commands/"
+      ".github/workflows/status-label.yml"
     ],
     "guardedManaged": [
       ".github/workflows/metadata-sync.yml",
@@ -93,8 +89,6 @@ const DEFAULTS = {
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",
       ".agents/skills/upgrade-dependency/SKILL.*",
-      ".claude/settings.json",
-      ".gemini/settings.json",
       ".git-hooks/pre-commit",
       ".gitignore"
     ],
@@ -108,28 +102,52 @@ const AGENT_CLIENT_MANIFEST = [
     "displayName": "Claude Code",
     "ownedPathPrefixes": [
       ".claude/"
-    ]
+    ],
+    "managed": [
+      ".claude/commands/"
+    ],
+    "merged": [
+      ".claude/settings.json"
+    ],
+    "ejected": []
   },
   {
     "id": "codex",
     "displayName": "Codex",
     "ownedPathPrefixes": [
       ".codex/"
-    ]
+    ],
+    "managed": [
+      ".codex/hooks.json"
+    ],
+    "merged": [],
+    "ejected": []
   },
   {
     "id": "gemini-cli",
     "displayName": "Gemini CLI",
     "ownedPathPrefixes": [
       ".gemini/"
-    ]
+    ],
+    "managed": [
+      ".gemini/commands/"
+    ],
+    "merged": [
+      ".gemini/settings.json"
+    ],
+    "ejected": []
   },
   {
     "id": "opencode",
     "displayName": "OpenCode",
     "ownedPathPrefixes": [
       ".opencode/"
-    ]
+    ],
+    "managed": [
+      ".opencode/commands/"
+    ],
+    "merged": [],
+    "ejected": []
   }
 ];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
@@ -140,9 +158,6 @@ const KNOWN_PLATFORMS = new Set(['github', 'none']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
 
 const BUILTIN_TUI_IDS = AGENT_CLIENT_MANIFEST.map((entry) => entry.id);
-const BUILTIN_TUI_OWNED_PATH_PREFIXES = Object.fromEntries(
-  AGENT_CLIENT_MANIFEST.map((entry) => [entry.id, entry.ownedPathPrefixes])
-);
 
 function resolveEnabledTUIs(value) {
   // Missing field / null / non-array → full set (backward compat).
@@ -155,16 +170,99 @@ function resolveEnabledTUIs(value) {
   return set;
 }
 
-function isPathOwnedByDisabledTUI(rel, enabledSet) {
-  const normalized = String(rel || '').replace(/\\/g, '/').replace(/^\.\//, '');
-  for (const tui of BUILTIN_TUI_IDS) {
-    if (enabledSet.has(tui)) continue;
-    for (const prefix of BUILTIN_TUI_OWNED_PATH_PREFIXES[tui]) {
-      const trimmed = prefix.replace(/\/$/, '');
-      if (normalized === trimmed || normalized.startsWith(prefix)) return true;
-    }
+function resolveEnabledAgentClients(cfg) {
+  if (!Object.prototype.hasOwnProperty.call(cfg, 'agentClients')) {
+    return { enabled: resolveEnabledTUIs(cfg.tuis), error: null };
   }
-  return false;
+  if (!Array.isArray(cfg.agentClients)) {
+    return { enabled: null, error: 'INVALID_AGENT_CLIENTS at agentClients' };
+  }
+
+  const entries = new Map();
+  for (const [index, candidate] of cfg.agentClients.entries()) {
+    const entryPath = `agentClients[${index}]`;
+    if (
+      typeof candidate !== 'object'
+      || candidate === null
+      || Array.isArray(candidate)
+      || typeof candidate.id !== 'string'
+      || !BUILTIN_TUI_IDS.includes(candidate.id)
+      || typeof candidate.enabled !== 'boolean'
+      || typeof candidate.installInSandbox !== 'boolean'
+    ) {
+      return { enabled: null, error: `INVALID_AGENT_CLIENTS at ${entryPath}` };
+    }
+    if (entries.has(candidate.id)) {
+      return { enabled: null, error: `DUPLICATE_AGENT_CLIENT at ${entryPath}.id` };
+    }
+    entries.set(candidate.id, candidate.enabled);
+  }
+  if (entries.size !== BUILTIN_TUI_IDS.length) {
+    return { enabled: null, error: 'MISSING_AGENT_CLIENT at agentClients' };
+  }
+  return {
+    enabled: new Set(BUILTIN_TUI_IDS.filter((id) => entries.get(id))),
+    error: null
+  };
+}
+
+function assetMatches(entry, target) {
+  const normalizedEntry = norm(entry);
+  const normalizedTarget = norm(target);
+  return normalizedEntry.endsWith('/')
+    ? normalizedTarget.startsWith(normalizedEntry)
+    : normalizedTarget === normalizedEntry;
+}
+
+function adapterAssets(adapters, category) {
+  return adapters.flatMap((adapter) => adapter[category]);
+}
+
+function planProjectRegistry(current, sharedDefaults, enabledSet) {
+  const enabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => enabledSet.has(adapter.id));
+  const disabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledSet.has(adapter.id));
+  const allAdapterAssets = new Set(
+    AGENT_CLIENT_MANIFEST.flatMap((adapter) => [
+      ...adapter.managed,
+      ...adapter.merged,
+      ...adapter.ejected
+    ])
+  );
+  const enabled = {
+    managed: adapterAssets(enabledAdapters, 'managed'),
+    merged: adapterAssets(enabledAdapters, 'merged'),
+    ejected: adapterAssets(enabledAdapters, 'ejected')
+  };
+  const unique = (values) => [...new Set(values)];
+  const ejected = unique([
+    ...current.ejected,
+    ...enabled.ejected,
+    ...sharedDefaults.ejected
+  ]);
+  const ejectedSet = new Set(ejected);
+  const preserve = (values, enabledValues) => values.filter((entry) =>
+    !ejectedSet.has(entry)
+    && (!allAdapterAssets.has(entry) || enabledValues.includes(entry))
+  );
+  const managed = unique([
+    ...preserve(current.managed, enabled.managed),
+    ...enabled.managed.filter((entry) => !ejectedSet.has(entry)),
+    ...sharedDefaults.managed.filter((entry) => !ejectedSet.has(entry))
+  ]);
+  const managedSet = new Set(managed);
+  const merged = unique([
+    ...preserve(current.merged, enabled.merged),
+    ...enabled.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry)),
+    ...sharedDefaults.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry))
+  ]);
+
+  return {
+    registry: { managed, merged, ejected },
+    enabledManaged: enabled.managed,
+    enabledMerged: enabled.merged,
+    enabledEjected: enabled.ejected,
+    disabledManaged: adapterAssets(disabledAdapters, 'managed')
+  };
 }
 
 function isLegacyDefaultSandboxTools(value) {
@@ -789,27 +887,34 @@ function learnAndGenerateCommands(projectRoot, customSkills, tool, templateSkill
   }
 }
 
-function generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs) {
+function generateCustomCommands(
+  projectRoot,
+  customSkills,
+  project,
+  lang,
+  report,
+  customTUIs,
+  templateSkillNames,
+  enabledTUIs,
+  managedWriter
+) {
   for (const skill of customSkills) {
     if (enabledTUIs.has('claude-code')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.claude/commands/${skill.dirName}.md`,
         generateClaudeCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('gemini-cli')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         '.gemini/commands/' + project + '/' + skill.dirName + '.toml',
         generateGeminiCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('opencode')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.opencode/commands/${skill.dirName}.md`,
         generateOpenCodeCommand(skill, lang),
         report.custom.commands
@@ -980,16 +1085,37 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const { project, org, language: lang = 'en' } = cfg;
   const platformType = cfg.platform?.type || DEFAULTS.platform.type;
-  const enabledTUIs = resolveEnabledTUIs(cfg.tuis);
+  const enabledResolution = resolveEnabledAgentClients(cfg);
+  if (enabledResolution.error) {
+    return { error: enabledResolution.error };
+  }
+  const enabledTUIs = enabledResolution.enabled;
   const customTUIsConfig = Array.isArray(cfg.customTUIs) ? cfg.customTUIs : [];
   const vars = { project, org };
   const templateSkillNames = listTemplateSkillNames(templateRoot);
   const protectedCustomSkills = detectCustomSkills(projectRoot, templateSkillNames);
 
-  const managed = [...(cfg.files.managed || [])];
-  const merged  = [...(cfg.files.merged  || [])];
-  const ejected = [...(cfg.files.ejected || [])];
+  cfg.files ||= {};
+  const currentRegistry = {
+    managed: [...(cfg.files.managed || [])],
+    merged: [...(cfg.files.merged || [])],
+    ejected: [...(cfg.files.ejected || [])]
+  };
+  const sharedDefaults = {
+    managed: (DEFAULTS.files.managed || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    merged: (DEFAULTS.files.merged || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    ejected: [...(DEFAULTS.files.ejected || [])]
+  };
+  const assetPlan = planProjectRegistry(currentRegistry, sharedDefaults, enabledTUIs);
+  const managed = [...assetPlan.registry.managed];
+  const merged = [...assetPlan.registry.merged];
+  const ejected = [...assetPlan.registry.ejected];
   const guardedManaged = new Set((DEFAULTS.files.guardedManaged || []).map(norm));
+  const allClientManaged = adapterAssets(AGENT_CLIENT_MANIFEST, 'managed');
   const managedBaselines = cfg.files.managedBaselines && typeof cfg.files.managedBaselines === 'object'
     && !Array.isArray(cfg.files.managedBaselines)
     ? { ...cfg.files.managedBaselines }
@@ -997,7 +1123,10 @@ function syncTemplates(projectRoot, templateRootOverride) {
   let baselinesChanged = false;
 
   for (const target of Object.keys(managedBaselines)) {
-    if (!guardedManaged.has(norm(target))) {
+    if (
+      !guardedManaged.has(norm(target))
+      && !allClientManaged.some((entry) => assetMatches(entry, target))
+    ) {
       delete managedBaselines[target];
       baselinesChanged = true;
     }
@@ -1007,6 +1136,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateVersion: version,
     templateRoot: norm(templateRoot),
     registryAdded: [],
+    registryRemoved: [],
     templateSources: {
       configured: 0,
       loaded: 0,
@@ -1047,17 +1177,23 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateSkillNames
   );
 
-  const known = new Set([...managed, ...merged, ...ejected]);
-  for (const e of (DEFAULTS.files.managed || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { managed.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'managed' }); }
+  for (const category of ['managed', 'merged', 'ejected']) {
+    const before = currentRegistry[category];
+    const after = assetPlan.registry[category];
+    for (const entry of after) {
+      if (!before.includes(entry)) report.registryAdded.push({ entry, list: category });
+    }
+    for (const entry of before) {
+      if (!after.includes(entry)) report.registryRemoved.push({ entry, list: category });
+    }
   }
-  for (const e of (DEFAULTS.files.merged || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { merged.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'merged' }); }
-  }
+  report.managed.skippedTUI.push(
+    ...assetPlan.disabledManaged,
+    ...adapterAssets(
+      AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledTUIs.has(adapter.id)),
+      'merged'
+    )
+  );
 
   const templateSources = Array.isArray(cfg.templates?.sources) ? cfg.templates.sources : [];
   report.templateSources.configured = templateSources.length;
@@ -1079,6 +1215,97 @@ function syncTemplates(projectRoot, templateRootOverride) {
     return isBinary(srcFull)
       ? fs.readFileSync(srcFull)
       : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
+  }
+
+  function selectedTargetsForEntry(entry) {
+    let entryRels;
+    if (entry.endsWith('/')) {
+      const builtinDir = path.join(templateRoot, entry);
+      const builtinRels = fs.existsSync(builtinDir)
+        ? walkDir(builtinDir).map((filePath) => norm(path.relative(templateRoot, filePath)))
+        : [];
+      const prefix = norm(entry);
+      const externalRels = allRels.filter((rel) =>
+        rel.startsWith(prefix) && !builtinRels.includes(rel)
+      );
+      entryRels = [...builtinRels, ...externalRels];
+    } else {
+      entryRels = entryVariantRels(entry, allSet, platformType);
+    }
+    return platformSelect(
+      langSelect(entryRels, lang, allSet, project),
+      platformType,
+      project
+    );
+  }
+
+  function writeProtectedManaged(target, content, bucket) {
+    const dstFull = path.join(projectRoot, target);
+    const exists = fs.existsSync(dstFull);
+    const rawBaseline = managedBaselines[target];
+    const baseline = trustedBaseline(rawBaseline);
+    const templateHash = sha256(content);
+    const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
+
+    if (rawBaseline !== undefined && baseline === null) {
+      delete managedBaselines[target];
+      baselinesChanged = true;
+    }
+    if (baseline === null && localHash !== null && localHash !== templateHash) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'unknown-origin',
+        baseline: null,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (baseline !== null && templateHash === baseline && localHash !== baseline) {
+      report.managed.protected.push({
+        target,
+        reason: localHash === null ? 'user-deleted' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (
+      baseline !== null
+      && localHash !== baseline
+      && templateHash !== baseline
+      && localHash !== templateHash
+    ) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'both-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (localHash === templateHash) {
+      bucket.unchanged.push(target);
+      if (managedBaselines[target] !== templateHash) {
+        managedBaselines[target] = templateHash;
+        baselinesChanged = true;
+      }
+      return false;
+    }
+
+    const dir = path.dirname(dstFull);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(dstFull, content);
+    managedBaselines[target] = templateHash;
+    baselinesChanged = true;
+    if (Object.prototype.hasOwnProperty.call(bucket, 'written')) {
+      (exists ? bucket.written : bucket.created).push(target);
+    } else {
+      (exists ? bucket.updated : bucket.generated).push(target);
+    }
+    return true;
   }
 
   for (const entry of [...managed, ...merged, ...ejected]) {
@@ -1134,39 +1361,81 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
   }
 
-  // Cleanup files owned by disabled built-in TUIs. Iterates managed + merged
-  // only (ejected entries are explicitly user-retained, see ejected loop below).
-  //
-  // Protection rule: only skip files registered as customTUI command targets
-  // (e.g. a customTUI configured with dir=.codex/commands/ when codex is
-  // disabled). Built-in TUI custom-skill commands like
-  // .gemini/commands/<project>/<dirName>.toml are intentionally NOT protected
-  // here so that disabling gemini-cli actually frees the gemini directory —
-  // they will be regenerated only for still-enabled TUIs (see
-  // generateCustomCommands).
-  for (const entry of [...managed, ...merged]) {
-    if (!isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+  // Disabled clients are converged conservatively: only exact manifest
+  // managed targets or previously baselined generated targets are candidates.
+  // Merged/ejected and content without trustworthy origin evidence are kept.
+  for (const entry of assetPlan.disabledManaged) {
+    const selectedTargets = selectedTargetsForEntry(entry);
+    const candidates = new Set(
+      Object.keys(managedBaselines).filter((target) => assetMatches(entry, target))
+    );
+    for (const target of selectedTargets.keys()) candidates.add(target);
 
-    if (entry.endsWith('/')) {
-      const dir = path.join(projectRoot, entry);
-      if (!fs.existsSync(dir)) continue;
+    for (const target of candidates) {
+      const dstFull = path.join(projectRoot, target);
+      const baseline = trustedBaseline(managedBaselines[target]);
+      const selectedSource = selectedTargets.get(target);
+      const sourceRoot = selectedSource ? (sourceMap.get(selectedSource) || templateRoot) : null;
+      const templateContent = selectedSource && sourceRoot === templateRoot
+        ? (
+            isBinary(path.join(sourceRoot, selectedSource))
+              ? fs.readFileSync(path.join(sourceRoot, selectedSource))
+              : renderContent(fs.readFileSync(path.join(sourceRoot, selectedSource), 'utf8'), vars)
+          )
+        : null;
+      const localHash = fs.existsSync(dstFull) ? sha256(fs.readFileSync(dstFull)) : null;
+      const templateHash = templateContent === null ? null : sha256(templateContent);
+      const protectedByEjection = ejected.some((pattern) =>
+        assetMatches(pattern, target) || globMatch(pattern, target)
+      );
+      const protectedByCustom = customTUICommandTargets.has(target);
 
-      for (const filePath of walkDir(dir)) {
-        const relProj = norm(path.relative(projectRoot, filePath));
-        if (customTUICommandTargets.has(relProj)) continue;
-        fs.unlinkSync(filePath);
-        report.managed.removed.push(relProj);
+      if (protectedByEjection || protectedByCustom || (sourceRoot && sourceRoot !== templateRoot)) {
+        report.managed.protected.push({
+          target,
+          reason: protectedByEjection
+            ? 'ejected'
+            : protectedByCustom
+              ? 'custom'
+              : 'external-source',
+          baseline,
+          local: localHash,
+          template: templateHash
+        });
+        continue;
       }
-      removeEmptyDirs(dir);
-      continue;
+      if (localHash === null) {
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        continue;
+      }
+      const legacyManaged = currentRegistry.managed.includes(entry);
+      if (
+        (baseline !== null && localHash === baseline)
+        || (baseline === null && legacyManaged && templateHash !== null && localHash === templateHash)
+      ) {
+        fs.unlinkSync(dstFull);
+        report.managed.removed.push(target);
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        removeEmptyDirs(path.dirname(dstFull));
+        continue;
+      }
+      report.managed.protected.push({
+        target,
+        reason: baseline === null ? 'unknown-origin' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
     }
-
-    const target = path.join(projectRoot, renderPathname(entry, project));
-    if (!fs.existsSync(target)) continue;
-    const relProj = norm(path.relative(projectRoot, target));
-    if (customTUICommandTargets.has(relProj)) continue;
-    fs.unlinkSync(target);
-    report.managed.removed.push(relProj);
+    if (entry.endsWith('/')) {
+      removeEmptyDirs(path.join(projectRoot, entry));
+    }
   }
 
   for (const entry of managed) {
@@ -1174,11 +1443,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     const isDir = entry.endsWith('/');
     let entryRels;
     const expectedTargets = isDir ? new Set() : null;
@@ -1216,65 +1480,14 @@ function syncTemplates(projectRoot, templateRootOverride) {
         : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
 
       const exists = fs.existsSync(dstFull);
-      if (guardedManaged.has(tgt)) {
-        const rawBaseline = managedBaselines[tgt];
-        const baseline = trustedBaseline(rawBaseline);
-        const templateHash = sha256(content);
-        const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
-
-        if (rawBaseline !== undefined && baseline === null) {
-          delete managedBaselines[tgt];
-          baselinesChanged = true;
+      const clientManagedTarget = assetPlan.enabledManaged.some((asset) =>
+        assetMatches(asset, tgt)
+      );
+      if (guardedManaged.has(tgt) || (clientManagedTarget && srcRoot === templateRoot)) {
+        const written = writeProtectedManaged(tgt, content, report.managed);
+        if (written && tgt.endsWith('.sh')) {
+          try { fs.chmodSync(dstFull, 0o755); } catch { /* Windows */ }
         }
-
-        if (baseline === null && localHash !== null && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'unknown-origin',
-            baseline: null,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && templateHash === baseline && localHash !== baseline) {
-          report.managed.protected.push({
-            target: tgt,
-            reason: localHash === null ? 'user-deleted' : 'user-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && localHash !== baseline && templateHash !== baseline && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'both-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (localHash === templateHash) {
-          report.managed.unchanged.push(tgt);
-          if (managedBaselines[tgt] !== templateHash) {
-            managedBaselines[tgt] = templateHash;
-            baselinesChanged = true;
-          }
-          continue;
-        }
-
-        const dir = path.dirname(dstFull);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(dstFull, content);
-        managedBaselines[tgt] = templateHash;
-        baselinesChanged = true;
-        (exists ? report.managed.written : report.managed.created).push(tgt);
         continue;
       }
 
@@ -1306,7 +1519,25 @@ function syncTemplates(projectRoot, templateRootOverride) {
           if (projFile === configPathRel) continue;
           if (isCustomProtected(projFile, protectedCustomSkills, project, customTUICommandTargets)) continue;
           if (matchesAny(projFile, merged) || matchesAny(projFile, ejected)) continue;
-
+          if (assetPlan.enabledManaged.includes(entry)) {
+            const baseline = trustedBaseline(managedBaselines[projFile]);
+            const localHash = sha256(fs.readFileSync(path.join(projectRoot, projFile)));
+            if (baseline !== null && localHash === baseline) {
+              fs.unlinkSync(path.join(projectRoot, projFile));
+              delete managedBaselines[projFile];
+              baselinesChanged = true;
+              report.managed.removed.push(projFile);
+            } else {
+              report.managed.protected.push({
+                target: projFile,
+                reason: baseline === null ? 'unknown-origin' : 'user-modified',
+                baseline,
+                local: localHash,
+                template: null
+              });
+            }
+            continue;
+          }
           fs.unlinkSync(path.join(projectRoot, projFile));
           report.managed.removed.push(projFile);
         }
@@ -1325,7 +1556,17 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const customSkills = detectCustomSkills(projectRoot, templateSkillNames);
   report.custom.detected = customSkills.map((skill) => skill.dirName);
-  generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs);
+  generateCustomCommands(
+    projectRoot,
+    customSkills,
+    project,
+    lang,
+    report,
+    customTUIs,
+    templateSkillNames,
+    enabledTUIs,
+    writeProtectedManaged
+  );
 
   for (const entry of ejected) {
     const dstFull = path.join(projectRoot, entry);
@@ -1335,7 +1576,11 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
     // Do not (re)create ejected files for disabled TUIs. Existing files are
     // never touched by sync (handled above); this guard only blocks creation.
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+    const disabledEjected = AGENT_CLIENT_MANIFEST.some((adapter) =>
+      !enabledTUIs.has(adapter.id)
+      && adapter.ejected.some((asset) => assetMatches(asset, entry))
+    );
+    if (disabledEjected) continue;
 
     const selected = platformSelect(langSelect(entryVariantRels(entry, allSet, platformType), lang, allSet, project), platformType, project);
     const target = norm(renderPathname(entry, project));
@@ -1356,11 +1601,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     if (entry.includes('*')) {
       const hits = allRels.filter(r => {
         const t = norm(renderPathname(stripLangVariant(r), project));
@@ -1391,7 +1631,8 @@ function syncTemplates(projectRoot, templateRootOverride) {
     report.custom.commands.generated.length +
     report.custom.commands.updated.length +
     report.ejected.created.length +
-    report.registryAdded.length
+    report.registryAdded.length +
+    report.registryRemoved.length
   ) > 0;
 
   const prevVersion = cfg.templateVersion;

--- a/lib/agent-clients/adapter.ts
+++ b/lib/agent-clients/adapter.ts
@@ -12,6 +12,9 @@ type AgentClientCapabilities = AgentClientCapabilityMap;
 
 type AgentClientProjectDescriptor = Readonly<{
   ownedPathPrefixes: readonly string[];
+  managed: readonly string[];
+  merged: readonly string[];
+  ejected: readonly string[];
 }>;
 
 type AgentClientAdapter = Readonly<{
@@ -29,7 +32,25 @@ type AgentClientManifestEntry = Readonly<{
   id: AgentClientId;
   displayName: string;
   ownedPathPrefixes: readonly string[];
+  managed: readonly string[];
+  merged: readonly string[];
+  ejected: readonly string[];
 }>;
+
+const PROJECT_ASSET_CATEGORIES = ['managed', 'merged', 'ejected'] as const;
+
+function isProjectRelativeLiteral(value: string): boolean {
+  if (
+    value.length === 0
+    || value.startsWith('/')
+    || /^[a-zA-Z]:/.test(value)
+    || value.includes('\\')
+    || /[*?[\]{}]/.test(value)
+  ) {
+    return false;
+  }
+  return !value.split('/').some((segment) => segment === '..');
+}
 
 function defineAgentClientAdapter(
   candidate: AgentClientAdapter
@@ -89,8 +110,7 @@ function defineAgentClientAdapter(
   const paths = ownedPathPrefixes.map((prefix) => {
     if (
       typeof prefix !== 'string'
-      || prefix.length === 0
-      || prefix.includes('\\')
+      || !isProjectRelativeLiteral(prefix)
       || !prefix.endsWith('/')
     ) {
       throw new Error(
@@ -103,12 +123,58 @@ function defineAgentClientAdapter(
     throw new Error(`Agent Client '${candidate.id}' has duplicate owned path prefixes`);
   }
 
+  const projectAssets = Object.fromEntries(
+    PROJECT_ASSET_CATEGORIES.map((category) => {
+      const values = candidate.project[category];
+      if (!Array.isArray(values)) {
+        throw new Error(
+          `Agent Client '${candidate.id}' has invalid '${category}' project assets`
+        );
+      }
+      const assets = values.map((asset) => {
+        if (
+          typeof asset !== 'string'
+          || !isProjectRelativeLiteral(asset)
+          || !paths.some((prefix) =>
+            asset === prefix.slice(0, -1) || asset.startsWith(prefix)
+          )
+        ) {
+          throw new Error(
+            `Agent Client '${candidate.id}' has invalid '${category}' project asset '${String(asset)}'`
+          );
+        }
+        return asset;
+      });
+      if (new Set(assets).size !== assets.length) {
+        throw new Error(
+          `Agent Client '${candidate.id}' has duplicate '${category}' project assets`
+        );
+      }
+      return [category, Object.freeze(assets)];
+    })
+  ) as Pick<AgentClientProjectDescriptor, 'managed' | 'merged' | 'ejected'>;
+
+  const categorizedAssets = PROJECT_ASSET_CATEGORIES.flatMap((category) =>
+    projectAssets[category].map((asset) => ({ asset, category }))
+  );
+  const seenAssets = new Map<string, string>();
+  for (const { asset, category } of categorizedAssets) {
+    const previous = seenAssets.get(asset);
+    if (previous) {
+      throw new Error(
+        `Agent Client '${candidate.id}' project asset '${asset}' overlaps '${previous}' and '${category}'`
+      );
+    }
+    seenAssets.set(asset, category);
+  }
+
   return Object.freeze({
     id: candidate.id,
     displayName: candidate.displayName,
     capabilities: Object.freeze(capabilities),
     project: Object.freeze({
-      ownedPathPrefixes: Object.freeze(paths)
+      ownedPathPrefixes: Object.freeze(paths),
+      ...projectAssets
     })
   });
 }

--- a/lib/agent-clients/adapters/claude-code.ts
+++ b/lib/agent-clients/adapters/claude-code.ts
@@ -12,7 +12,10 @@ const claudeCodeAdapter = defineAgentClientAdapter({
     verification: { level: 'compatible' }
   },
   project: {
-    ownedPathPrefixes: ['.claude/']
+    ownedPathPrefixes: ['.claude/'],
+    managed: ['.claude/commands/'],
+    merged: ['.claude/settings.json'],
+    ejected: []
   }
 });
 

--- a/lib/agent-clients/adapters/codex.ts
+++ b/lib/agent-clients/adapters/codex.ts
@@ -12,7 +12,10 @@ const codexAdapter = defineAgentClientAdapter({
     verification: { level: 'compatible' }
   },
   project: {
-    ownedPathPrefixes: ['.codex/']
+    ownedPathPrefixes: ['.codex/'],
+    managed: ['.codex/hooks.json'],
+    merged: [],
+    ejected: []
   }
 });
 

--- a/lib/agent-clients/adapters/gemini-cli.ts
+++ b/lib/agent-clients/adapters/gemini-cli.ts
@@ -12,7 +12,10 @@ const geminiCliAdapter = defineAgentClientAdapter({
     verification: { level: 'compatible' }
   },
   project: {
-    ownedPathPrefixes: ['.gemini/']
+    ownedPathPrefixes: ['.gemini/'],
+    managed: ['.gemini/commands/'],
+    merged: ['.gemini/settings.json'],
+    ejected: []
   }
 });
 

--- a/lib/agent-clients/adapters/opencode.ts
+++ b/lib/agent-clients/adapters/opencode.ts
@@ -12,7 +12,10 @@ const opencodeAdapter = defineAgentClientAdapter({
     verification: { level: 'compatible' }
   },
   project: {
-    ownedPathPrefixes: ['.opencode/']
+    ownedPathPrefixes: ['.opencode/'],
+    managed: ['.opencode/commands/'],
+    merged: [],
+    ejected: []
   }
 });
 

--- a/lib/agent-clients/project-assets.ts
+++ b/lib/agent-clients/project-assets.ts
@@ -1,0 +1,96 @@
+import type { AgentClientAdapter } from './adapter.ts';
+
+type ProjectFileRegistry = Readonly<{
+  managed: readonly string[];
+  merged: readonly string[];
+  ejected: readonly string[];
+}>;
+
+type AgentClientProjectAssetPlan = Readonly<{
+  registry: ProjectFileRegistry;
+  enabledManaged: readonly string[];
+  enabledMerged: readonly string[];
+  enabledEjected: readonly string[];
+  disabledManaged: readonly string[];
+}>;
+
+function unique(values: readonly string[]): readonly string[] {
+  return Object.freeze([...new Set(values)]);
+}
+
+function planAgentClientProjectAssets(input: Readonly<{
+  current: ProjectFileRegistry;
+  sharedDefaults: ProjectFileRegistry;
+  enabledAdapters: readonly AgentClientAdapter[];
+  allAdapters: readonly AgentClientAdapter[];
+}>): AgentClientProjectAssetPlan {
+  const enabledIds = new Set(input.enabledAdapters.map((adapter) => adapter.id));
+  const enabledAdapters = input.allAdapters.filter((adapter) =>
+    enabledIds.has(adapter.id)
+  );
+  const disabledAdapters = input.allAdapters.filter((adapter) =>
+    !enabledIds.has(adapter.id)
+  );
+
+  const enabledManaged = unique(
+    enabledAdapters.flatMap((adapter) => adapter.project.managed)
+  );
+  const enabledMerged = unique(
+    enabledAdapters.flatMap((adapter) => adapter.project.merged)
+  );
+  const enabledEjected = unique(
+    enabledAdapters.flatMap((adapter) => adapter.project.ejected)
+  );
+  const disabledManaged = unique(
+    disabledAdapters.flatMap((adapter) => adapter.project.managed)
+  );
+
+  const allAdapterAssets = new Set(
+    input.allAdapters.flatMap((adapter) => [
+      ...adapter.project.managed,
+      ...adapter.project.merged,
+      ...adapter.project.ejected
+    ])
+  );
+  const ejected = unique([
+    ...input.current.ejected,
+    ...enabledEjected,
+    ...input.sharedDefaults.ejected
+  ]);
+  const ejectedSet = new Set(ejected);
+
+  const preserveCurrent = (
+    values: readonly string[],
+    enabledValues: readonly string[]
+  ) => values.filter((entry) =>
+    !ejectedSet.has(entry)
+    && (!allAdapterAssets.has(entry) || enabledValues.includes(entry))
+  );
+
+  const managed = unique([
+    ...preserveCurrent(input.current.managed, enabledManaged),
+    ...enabledManaged.filter((entry) => !ejectedSet.has(entry)),
+    ...input.sharedDefaults.managed.filter((entry) => !ejectedSet.has(entry))
+  ]);
+  const managedSet = new Set(managed);
+  const merged = unique([
+    ...preserveCurrent(input.current.merged, enabledMerged),
+    ...enabledMerged.filter((entry) =>
+      !ejectedSet.has(entry) && !managedSet.has(entry)
+    ),
+    ...input.sharedDefaults.merged.filter((entry) =>
+      !ejectedSet.has(entry) && !managedSet.has(entry)
+    )
+  ]);
+
+  return Object.freeze({
+    registry: Object.freeze({ managed, merged, ejected }),
+    enabledManaged,
+    enabledMerged,
+    enabledEjected,
+    disabledManaged
+  });
+}
+
+export { planAgentClientProjectAssets };
+export type { AgentClientProjectAssetPlan, ProjectFileRegistry };

--- a/lib/agent-clients/registry.ts
+++ b/lib/agent-clients/registry.ts
@@ -115,7 +115,10 @@ function createAgentClientManifest(): readonly AgentClientManifestEntry[] {
     AGENT_CLIENT_ADAPTERS.map((adapter) => Object.freeze({
       id: adapter.id,
       displayName: adapter.displayName,
-      ownedPathPrefixes: Object.freeze([...adapter.project.ownedPathPrefixes])
+      ownedPathPrefixes: Object.freeze([...adapter.project.ownedPathPrefixes]),
+      managed: Object.freeze([...adapter.project.managed]),
+      merged: Object.freeze([...adapter.project.merged]),
+      ejected: Object.freeze([...adapter.project.ejected])
     }))
   );
 }

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -39,16 +39,12 @@
       ".agents/templates/",
       ".agents/workflows/",
       ".agents/workspace/README.md",
-      ".claude/commands/",
-      ".codex/hooks.json",
-      ".gemini/commands/",
       ".git-hooks/check-large-files.cjs",
       ".git-hooks/check-version-format.sh",
       ".github/scripts/",
       ".github/workflows/metadata-sync.yml",
       ".github/workflows/pr-label.yml",
-      ".github/workflows/status-label.yml",
-      ".opencode/commands/"
+      ".github/workflows/status-label.yml"
     ],
     "guardedManaged": [
       ".github/workflows/metadata-sync.yml",
@@ -67,8 +63,6 @@
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",
       ".agents/skills/upgrade-dependency/SKILL.*",
-      ".claude/settings.json",
-      ".gemini/settings.json",
       ".git-hooks/pre-commit",
       ".gitignore"
     ],

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -11,10 +11,11 @@ import { VERSION } from './version.ts';
 import {
   BUILTIN_TUI_IDS,
   BUILTIN_TUI_DISPLAY,
-  isPathOwnedByDisabledTUI,
   resolveEnabledTUIs
 } from './builtin-tuis.ts';
-import type { BuiltinTUIId } from './builtin-tuis.ts';
+import { listAgentClientAdapters } from './agent-clients/registry.ts';
+import { planAgentClientProjectAssets } from './agent-clients/project-assets.ts';
+import type { AgentClientAdapter } from './agent-clients/adapter.ts';
 
 type FileRegistry = {
   managed: string[];
@@ -68,17 +69,26 @@ function isPathOwnedByOtherPlatform(relativePath: string, platformType: string):
   return candidate !== platformType;
 }
 
-function buildDefaultFiles(platformType: string, enabledTUIs: Set<BuiltinTUIId>): FileRegistry {
-  const ownedByDisabled = (entry: string) => isPathOwnedByDisabledTUI(entry, enabledTUIs);
-  return {
+function buildDefaultFiles(
+  platformType: string,
+  enabledAdapters: readonly AgentClientAdapter[]
+): FileRegistry {
+  const sharedDefaults = {
     managed: (defaults.files.managed || []).filter(
-      (entry) => !isPathOwnedByOtherPlatform(entry, platformType) && !ownedByDisabled(entry)
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
     ),
     merged: (defaults.files.merged || []).filter(
-      (entry) => !isPathOwnedByOtherPlatform(entry, platformType) && !ownedByDisabled(entry)
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
     ),
     ejected: structuredClone(defaults.files.ejected || [])
   };
+  const plan = planAgentClientProjectAssets({
+    current: { managed: [], merged: [], ejected: [] },
+    sharedDefaults,
+    enabledAdapters,
+    allAdapters: listAgentClientAdapters()
+  });
+  return structuredClone(plan.registry) as FileRegistry;
 }
 
 function detectProjectName(): string {
@@ -235,6 +245,9 @@ async function cmdInit(): Promise<void> {
     return;
   }
   const enabledTUISet = resolveEnabledTUIs(enabledTUIs);
+  const enabledAdapters = listAgentClientAdapters().filter((adapter) =>
+    enabledTUISet.has(adapter.id)
+  );
 
   const templateSources = parseLocalSources(await prompt(
     'Template sources (optional, comma-separated local paths, e.g. ~/my-templates; Enter to skip)',
@@ -325,7 +338,7 @@ async function cmdInit(): Promise<void> {
     sandbox: structuredClone(defaults.sandbox),
     task: structuredClone(defaults.task),
     labels: structuredClone(defaults.labels),
-    files: buildDefaultFiles(platformType, enabledTUISet),
+    files: buildDefaultFiles(platformType, enabledAdapters),
     tuis: enabledTUIs
   };
 

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -1,11 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { AGENT_CLIENT_IDS } from './agent-clients/types.ts';
+import { listAgentClientAdapters } from './agent-clients/registry.ts';
+import { planAgentClientProjectAssets } from './agent-clients/project-assets.ts';
 import { info, ok, err } from './log.ts';
 import { resolveTemplateDir } from './paths.ts';
 import { renderFile, copySkillDir, KNOWN_PLATFORMS } from './render.ts';
-import { isPathOwnedByDisabledTUI, resolveEnabledTUIs } from './builtin-tuis.ts';
-import type { BuiltinTUIId } from './builtin-tuis.ts';
+import { resolveEnabledTUIs } from './builtin-tuis.ts';
 
 type FileRegistry = {
   managed: string[];
@@ -93,7 +94,11 @@ function isPathOwnedByOtherPlatform(relativePath: string, platformType: string):
   return candidate !== platformType;
 }
 
-function syncFileRegistry(config: UpdateConfig, platformType: string, enabledTUIs: Set<BuiltinTUIId>) {
+function syncFileRegistry(
+  config: UpdateConfig,
+  platformType: string,
+  enabledTUIIds: ReadonlySet<string>
+) {
   config.files ||= {};
   const before = JSON.stringify({
     files: {
@@ -102,33 +107,34 @@ function syncFileRegistry(config: UpdateConfig, platformType: string, enabledTUI
       ejected: config.files.ejected || []
     }
   });
-  config.files.managed = config.files.managed || [];
-  config.files.merged = config.files.merged || [];
-  config.files.ejected = config.files.ejected || [];
-
-  const allExisting = [
-    ...config.files.managed,
-    ...config.files.merged,
-    ...config.files.ejected
-  ];
-  const added: Pick<FileRegistry, 'managed' | 'merged'> = { managed: [], merged: [] };
-
-  for (const entry of defaults.files.managed) {
-    if (isPathOwnedByOtherPlatform(entry, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
-    if (!allExisting.includes(entry)) {
-      config.files.managed.push(entry);
-      added.managed.push(entry);
-    }
-  }
-  for (const entry of defaults.files.merged) {
-    if (isPathOwnedByOtherPlatform(entry, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
-    if (!allExisting.includes(entry)) {
-      config.files.merged.push(entry);
-      added.merged.push(entry);
-    }
-  }
+  const current: FileRegistry = {
+    managed: config.files.managed || [],
+    merged: config.files.merged || [],
+    ejected: config.files.ejected || []
+  };
+  const sharedDefaults: FileRegistry = {
+    managed: defaults.files.managed.filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    merged: defaults.files.merged.filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    ejected: defaults.files.ejected
+  };
+  const adapters = listAgentClientAdapters();
+  const plan = planAgentClientProjectAssets({
+    current,
+    sharedDefaults,
+    enabledAdapters: adapters.filter((adapter) => enabledTUIIds.has(adapter.id)),
+    allAdapters: adapters
+  });
+  const added: Pick<FileRegistry, 'managed' | 'merged'> = {
+    managed: plan.registry.managed.filter((entry) => !current.managed.includes(entry)),
+    merged: plan.registry.merged.filter((entry) => !current.merged.includes(entry))
+  };
+  config.files.managed = [...plan.registry.managed];
+  config.files.merged = [...plan.registry.merged];
+  config.files.ejected = [...plan.registry.ejected];
 
   const after = JSON.stringify({
     files: {

--- a/scripts/build-inline.js
+++ b/scripts/build-inline.js
@@ -53,13 +53,17 @@ function validateManifest(manifest, registry) {
     throw new Error('Agent Client manifest IDs do not match the Registry');
   }
   for (const entry of manifest) {
+    const arrayFields = ['ownedPathPrefixes', 'managed', 'merged', 'ejected'];
     if (
       typeof entry.id !== 'string'
       || typeof entry.displayName !== 'string'
       || entry.displayName.trim() === ''
-      || !Array.isArray(entry.ownedPathPrefixes)
-      || entry.ownedPathPrefixes.some((prefix) => typeof prefix !== 'string')
-      || Object.keys(entry).sort().join(',') !== 'displayName,id,ownedPathPrefixes'
+      || arrayFields.some((field) =>
+        !Array.isArray(entry[field])
+        || entry[field].some((value) => typeof value !== 'string')
+      )
+      || Object.keys(entry).sort().join(',')
+        !== 'displayName,ejected,id,managed,merged,ownedPathPrefixes'
     ) {
       throw new Error(`Invalid Agent Client manifest entry '${String(entry?.id)}'`);
     }

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -37,9 +37,6 @@ const KNOWN_PLATFORMS = new Set(['github', 'none']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
 
 const BUILTIN_TUI_IDS = AGENT_CLIENT_MANIFEST.map((entry) => entry.id);
-const BUILTIN_TUI_OWNED_PATH_PREFIXES = Object.fromEntries(
-  AGENT_CLIENT_MANIFEST.map((entry) => [entry.id, entry.ownedPathPrefixes])
-);
 
 function resolveEnabledTUIs(value) {
   // Missing field / null / non-array → full set (backward compat).
@@ -52,16 +49,99 @@ function resolveEnabledTUIs(value) {
   return set;
 }
 
-function isPathOwnedByDisabledTUI(rel, enabledSet) {
-  const normalized = String(rel || '').replace(/\\/g, '/').replace(/^\.\//, '');
-  for (const tui of BUILTIN_TUI_IDS) {
-    if (enabledSet.has(tui)) continue;
-    for (const prefix of BUILTIN_TUI_OWNED_PATH_PREFIXES[tui]) {
-      const trimmed = prefix.replace(/\/$/, '');
-      if (normalized === trimmed || normalized.startsWith(prefix)) return true;
-    }
+function resolveEnabledAgentClients(cfg) {
+  if (!Object.prototype.hasOwnProperty.call(cfg, 'agentClients')) {
+    return { enabled: resolveEnabledTUIs(cfg.tuis), error: null };
   }
-  return false;
+  if (!Array.isArray(cfg.agentClients)) {
+    return { enabled: null, error: 'INVALID_AGENT_CLIENTS at agentClients' };
+  }
+
+  const entries = new Map();
+  for (const [index, candidate] of cfg.agentClients.entries()) {
+    const entryPath = `agentClients[${index}]`;
+    if (
+      typeof candidate !== 'object'
+      || candidate === null
+      || Array.isArray(candidate)
+      || typeof candidate.id !== 'string'
+      || !BUILTIN_TUI_IDS.includes(candidate.id)
+      || typeof candidate.enabled !== 'boolean'
+      || typeof candidate.installInSandbox !== 'boolean'
+    ) {
+      return { enabled: null, error: `INVALID_AGENT_CLIENTS at ${entryPath}` };
+    }
+    if (entries.has(candidate.id)) {
+      return { enabled: null, error: `DUPLICATE_AGENT_CLIENT at ${entryPath}.id` };
+    }
+    entries.set(candidate.id, candidate.enabled);
+  }
+  if (entries.size !== BUILTIN_TUI_IDS.length) {
+    return { enabled: null, error: 'MISSING_AGENT_CLIENT at agentClients' };
+  }
+  return {
+    enabled: new Set(BUILTIN_TUI_IDS.filter((id) => entries.get(id))),
+    error: null
+  };
+}
+
+function assetMatches(entry, target) {
+  const normalizedEntry = norm(entry);
+  const normalizedTarget = norm(target);
+  return normalizedEntry.endsWith('/')
+    ? normalizedTarget.startsWith(normalizedEntry)
+    : normalizedTarget === normalizedEntry;
+}
+
+function adapterAssets(adapters, category) {
+  return adapters.flatMap((adapter) => adapter[category]);
+}
+
+function planProjectRegistry(current, sharedDefaults, enabledSet) {
+  const enabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => enabledSet.has(adapter.id));
+  const disabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledSet.has(adapter.id));
+  const allAdapterAssets = new Set(
+    AGENT_CLIENT_MANIFEST.flatMap((adapter) => [
+      ...adapter.managed,
+      ...adapter.merged,
+      ...adapter.ejected
+    ])
+  );
+  const enabled = {
+    managed: adapterAssets(enabledAdapters, 'managed'),
+    merged: adapterAssets(enabledAdapters, 'merged'),
+    ejected: adapterAssets(enabledAdapters, 'ejected')
+  };
+  const unique = (values) => [...new Set(values)];
+  const ejected = unique([
+    ...current.ejected,
+    ...enabled.ejected,
+    ...sharedDefaults.ejected
+  ]);
+  const ejectedSet = new Set(ejected);
+  const preserve = (values, enabledValues) => values.filter((entry) =>
+    !ejectedSet.has(entry)
+    && (!allAdapterAssets.has(entry) || enabledValues.includes(entry))
+  );
+  const managed = unique([
+    ...preserve(current.managed, enabled.managed),
+    ...enabled.managed.filter((entry) => !ejectedSet.has(entry)),
+    ...sharedDefaults.managed.filter((entry) => !ejectedSet.has(entry))
+  ]);
+  const managedSet = new Set(managed);
+  const merged = unique([
+    ...preserve(current.merged, enabled.merged),
+    ...enabled.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry)),
+    ...sharedDefaults.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry))
+  ]);
+
+  return {
+    registry: { managed, merged, ejected },
+    enabledManaged: enabled.managed,
+    enabledMerged: enabled.merged,
+    enabledEjected: enabled.ejected,
+    disabledManaged: adapterAssets(disabledAdapters, 'managed')
+  };
 }
 
 function isLegacyDefaultSandboxTools(value) {
@@ -686,27 +766,34 @@ function learnAndGenerateCommands(projectRoot, customSkills, tool, templateSkill
   }
 }
 
-function generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs) {
+function generateCustomCommands(
+  projectRoot,
+  customSkills,
+  project,
+  lang,
+  report,
+  customTUIs,
+  templateSkillNames,
+  enabledTUIs,
+  managedWriter
+) {
   for (const skill of customSkills) {
     if (enabledTUIs.has('claude-code')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.claude/commands/${skill.dirName}.md`,
         generateClaudeCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('gemini-cli')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         '.gemini/commands/' + project + '/' + skill.dirName + '.toml',
         generateGeminiCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('opencode')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.opencode/commands/${skill.dirName}.md`,
         generateOpenCodeCommand(skill, lang),
         report.custom.commands
@@ -877,16 +964,37 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const { project, org, language: lang = 'en' } = cfg;
   const platformType = cfg.platform?.type || DEFAULTS.platform.type;
-  const enabledTUIs = resolveEnabledTUIs(cfg.tuis);
+  const enabledResolution = resolveEnabledAgentClients(cfg);
+  if (enabledResolution.error) {
+    return { error: enabledResolution.error };
+  }
+  const enabledTUIs = enabledResolution.enabled;
   const customTUIsConfig = Array.isArray(cfg.customTUIs) ? cfg.customTUIs : [];
   const vars = { project, org };
   const templateSkillNames = listTemplateSkillNames(templateRoot);
   const protectedCustomSkills = detectCustomSkills(projectRoot, templateSkillNames);
 
-  const managed = [...(cfg.files.managed || [])];
-  const merged  = [...(cfg.files.merged  || [])];
-  const ejected = [...(cfg.files.ejected || [])];
+  cfg.files ||= {};
+  const currentRegistry = {
+    managed: [...(cfg.files.managed || [])],
+    merged: [...(cfg.files.merged || [])],
+    ejected: [...(cfg.files.ejected || [])]
+  };
+  const sharedDefaults = {
+    managed: (DEFAULTS.files.managed || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    merged: (DEFAULTS.files.merged || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    ejected: [...(DEFAULTS.files.ejected || [])]
+  };
+  const assetPlan = planProjectRegistry(currentRegistry, sharedDefaults, enabledTUIs);
+  const managed = [...assetPlan.registry.managed];
+  const merged = [...assetPlan.registry.merged];
+  const ejected = [...assetPlan.registry.ejected];
   const guardedManaged = new Set((DEFAULTS.files.guardedManaged || []).map(norm));
+  const allClientManaged = adapterAssets(AGENT_CLIENT_MANIFEST, 'managed');
   const managedBaselines = cfg.files.managedBaselines && typeof cfg.files.managedBaselines === 'object'
     && !Array.isArray(cfg.files.managedBaselines)
     ? { ...cfg.files.managedBaselines }
@@ -894,7 +1002,10 @@ function syncTemplates(projectRoot, templateRootOverride) {
   let baselinesChanged = false;
 
   for (const target of Object.keys(managedBaselines)) {
-    if (!guardedManaged.has(norm(target))) {
+    if (
+      !guardedManaged.has(norm(target))
+      && !allClientManaged.some((entry) => assetMatches(entry, target))
+    ) {
       delete managedBaselines[target];
       baselinesChanged = true;
     }
@@ -904,6 +1015,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateVersion: version,
     templateRoot: norm(templateRoot),
     registryAdded: [],
+    registryRemoved: [],
     templateSources: {
       configured: 0,
       loaded: 0,
@@ -944,17 +1056,23 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateSkillNames
   );
 
-  const known = new Set([...managed, ...merged, ...ejected]);
-  for (const e of (DEFAULTS.files.managed || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { managed.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'managed' }); }
+  for (const category of ['managed', 'merged', 'ejected']) {
+    const before = currentRegistry[category];
+    const after = assetPlan.registry[category];
+    for (const entry of after) {
+      if (!before.includes(entry)) report.registryAdded.push({ entry, list: category });
+    }
+    for (const entry of before) {
+      if (!after.includes(entry)) report.registryRemoved.push({ entry, list: category });
+    }
   }
-  for (const e of (DEFAULTS.files.merged || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { merged.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'merged' }); }
-  }
+  report.managed.skippedTUI.push(
+    ...assetPlan.disabledManaged,
+    ...adapterAssets(
+      AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledTUIs.has(adapter.id)),
+      'merged'
+    )
+  );
 
   const templateSources = Array.isArray(cfg.templates?.sources) ? cfg.templates.sources : [];
   report.templateSources.configured = templateSources.length;
@@ -976,6 +1094,97 @@ function syncTemplates(projectRoot, templateRootOverride) {
     return isBinary(srcFull)
       ? fs.readFileSync(srcFull)
       : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
+  }
+
+  function selectedTargetsForEntry(entry) {
+    let entryRels;
+    if (entry.endsWith('/')) {
+      const builtinDir = path.join(templateRoot, entry);
+      const builtinRels = fs.existsSync(builtinDir)
+        ? walkDir(builtinDir).map((filePath) => norm(path.relative(templateRoot, filePath)))
+        : [];
+      const prefix = norm(entry);
+      const externalRels = allRels.filter((rel) =>
+        rel.startsWith(prefix) && !builtinRels.includes(rel)
+      );
+      entryRels = [...builtinRels, ...externalRels];
+    } else {
+      entryRels = entryVariantRels(entry, allSet, platformType);
+    }
+    return platformSelect(
+      langSelect(entryRels, lang, allSet, project),
+      platformType,
+      project
+    );
+  }
+
+  function writeProtectedManaged(target, content, bucket) {
+    const dstFull = path.join(projectRoot, target);
+    const exists = fs.existsSync(dstFull);
+    const rawBaseline = managedBaselines[target];
+    const baseline = trustedBaseline(rawBaseline);
+    const templateHash = sha256(content);
+    const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
+
+    if (rawBaseline !== undefined && baseline === null) {
+      delete managedBaselines[target];
+      baselinesChanged = true;
+    }
+    if (baseline === null && localHash !== null && localHash !== templateHash) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'unknown-origin',
+        baseline: null,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (baseline !== null && templateHash === baseline && localHash !== baseline) {
+      report.managed.protected.push({
+        target,
+        reason: localHash === null ? 'user-deleted' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (
+      baseline !== null
+      && localHash !== baseline
+      && templateHash !== baseline
+      && localHash !== templateHash
+    ) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'both-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (localHash === templateHash) {
+      bucket.unchanged.push(target);
+      if (managedBaselines[target] !== templateHash) {
+        managedBaselines[target] = templateHash;
+        baselinesChanged = true;
+      }
+      return false;
+    }
+
+    const dir = path.dirname(dstFull);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(dstFull, content);
+    managedBaselines[target] = templateHash;
+    baselinesChanged = true;
+    if (Object.prototype.hasOwnProperty.call(bucket, 'written')) {
+      (exists ? bucket.written : bucket.created).push(target);
+    } else {
+      (exists ? bucket.updated : bucket.generated).push(target);
+    }
+    return true;
   }
 
   for (const entry of [...managed, ...merged, ...ejected]) {
@@ -1031,39 +1240,81 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
   }
 
-  // Cleanup files owned by disabled built-in TUIs. Iterates managed + merged
-  // only (ejected entries are explicitly user-retained, see ejected loop below).
-  //
-  // Protection rule: only skip files registered as customTUI command targets
-  // (e.g. a customTUI configured with dir=.codex/commands/ when codex is
-  // disabled). Built-in TUI custom-skill commands like
-  // .gemini/commands/<project>/<dirName>.toml are intentionally NOT protected
-  // here so that disabling gemini-cli actually frees the gemini directory —
-  // they will be regenerated only for still-enabled TUIs (see
-  // generateCustomCommands).
-  for (const entry of [...managed, ...merged]) {
-    if (!isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+  // Disabled clients are converged conservatively: only exact manifest
+  // managed targets or previously baselined generated targets are candidates.
+  // Merged/ejected and content without trustworthy origin evidence are kept.
+  for (const entry of assetPlan.disabledManaged) {
+    const selectedTargets = selectedTargetsForEntry(entry);
+    const candidates = new Set(
+      Object.keys(managedBaselines).filter((target) => assetMatches(entry, target))
+    );
+    for (const target of selectedTargets.keys()) candidates.add(target);
 
-    if (entry.endsWith('/')) {
-      const dir = path.join(projectRoot, entry);
-      if (!fs.existsSync(dir)) continue;
+    for (const target of candidates) {
+      const dstFull = path.join(projectRoot, target);
+      const baseline = trustedBaseline(managedBaselines[target]);
+      const selectedSource = selectedTargets.get(target);
+      const sourceRoot = selectedSource ? (sourceMap.get(selectedSource) || templateRoot) : null;
+      const templateContent = selectedSource && sourceRoot === templateRoot
+        ? (
+            isBinary(path.join(sourceRoot, selectedSource))
+              ? fs.readFileSync(path.join(sourceRoot, selectedSource))
+              : renderContent(fs.readFileSync(path.join(sourceRoot, selectedSource), 'utf8'), vars)
+          )
+        : null;
+      const localHash = fs.existsSync(dstFull) ? sha256(fs.readFileSync(dstFull)) : null;
+      const templateHash = templateContent === null ? null : sha256(templateContent);
+      const protectedByEjection = ejected.some((pattern) =>
+        assetMatches(pattern, target) || globMatch(pattern, target)
+      );
+      const protectedByCustom = customTUICommandTargets.has(target);
 
-      for (const filePath of walkDir(dir)) {
-        const relProj = norm(path.relative(projectRoot, filePath));
-        if (customTUICommandTargets.has(relProj)) continue;
-        fs.unlinkSync(filePath);
-        report.managed.removed.push(relProj);
+      if (protectedByEjection || protectedByCustom || (sourceRoot && sourceRoot !== templateRoot)) {
+        report.managed.protected.push({
+          target,
+          reason: protectedByEjection
+            ? 'ejected'
+            : protectedByCustom
+              ? 'custom'
+              : 'external-source',
+          baseline,
+          local: localHash,
+          template: templateHash
+        });
+        continue;
       }
-      removeEmptyDirs(dir);
-      continue;
+      if (localHash === null) {
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        continue;
+      }
+      const legacyManaged = currentRegistry.managed.includes(entry);
+      if (
+        (baseline !== null && localHash === baseline)
+        || (baseline === null && legacyManaged && templateHash !== null && localHash === templateHash)
+      ) {
+        fs.unlinkSync(dstFull);
+        report.managed.removed.push(target);
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        removeEmptyDirs(path.dirname(dstFull));
+        continue;
+      }
+      report.managed.protected.push({
+        target,
+        reason: baseline === null ? 'unknown-origin' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
     }
-
-    const target = path.join(projectRoot, renderPathname(entry, project));
-    if (!fs.existsSync(target)) continue;
-    const relProj = norm(path.relative(projectRoot, target));
-    if (customTUICommandTargets.has(relProj)) continue;
-    fs.unlinkSync(target);
-    report.managed.removed.push(relProj);
+    if (entry.endsWith('/')) {
+      removeEmptyDirs(path.join(projectRoot, entry));
+    }
   }
 
   for (const entry of managed) {
@@ -1071,11 +1322,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     const isDir = entry.endsWith('/');
     let entryRels;
     const expectedTargets = isDir ? new Set() : null;
@@ -1113,65 +1359,14 @@ function syncTemplates(projectRoot, templateRootOverride) {
         : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
 
       const exists = fs.existsSync(dstFull);
-      if (guardedManaged.has(tgt)) {
-        const rawBaseline = managedBaselines[tgt];
-        const baseline = trustedBaseline(rawBaseline);
-        const templateHash = sha256(content);
-        const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
-
-        if (rawBaseline !== undefined && baseline === null) {
-          delete managedBaselines[tgt];
-          baselinesChanged = true;
+      const clientManagedTarget = assetPlan.enabledManaged.some((asset) =>
+        assetMatches(asset, tgt)
+      );
+      if (guardedManaged.has(tgt) || (clientManagedTarget && srcRoot === templateRoot)) {
+        const written = writeProtectedManaged(tgt, content, report.managed);
+        if (written && tgt.endsWith('.sh')) {
+          try { fs.chmodSync(dstFull, 0o755); } catch { /* Windows */ }
         }
-
-        if (baseline === null && localHash !== null && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'unknown-origin',
-            baseline: null,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && templateHash === baseline && localHash !== baseline) {
-          report.managed.protected.push({
-            target: tgt,
-            reason: localHash === null ? 'user-deleted' : 'user-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && localHash !== baseline && templateHash !== baseline && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'both-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (localHash === templateHash) {
-          report.managed.unchanged.push(tgt);
-          if (managedBaselines[tgt] !== templateHash) {
-            managedBaselines[tgt] = templateHash;
-            baselinesChanged = true;
-          }
-          continue;
-        }
-
-        const dir = path.dirname(dstFull);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(dstFull, content);
-        managedBaselines[tgt] = templateHash;
-        baselinesChanged = true;
-        (exists ? report.managed.written : report.managed.created).push(tgt);
         continue;
       }
 
@@ -1203,7 +1398,25 @@ function syncTemplates(projectRoot, templateRootOverride) {
           if (projFile === configPathRel) continue;
           if (isCustomProtected(projFile, protectedCustomSkills, project, customTUICommandTargets)) continue;
           if (matchesAny(projFile, merged) || matchesAny(projFile, ejected)) continue;
-
+          if (assetPlan.enabledManaged.includes(entry)) {
+            const baseline = trustedBaseline(managedBaselines[projFile]);
+            const localHash = sha256(fs.readFileSync(path.join(projectRoot, projFile)));
+            if (baseline !== null && localHash === baseline) {
+              fs.unlinkSync(path.join(projectRoot, projFile));
+              delete managedBaselines[projFile];
+              baselinesChanged = true;
+              report.managed.removed.push(projFile);
+            } else {
+              report.managed.protected.push({
+                target: projFile,
+                reason: baseline === null ? 'unknown-origin' : 'user-modified',
+                baseline,
+                local: localHash,
+                template: null
+              });
+            }
+            continue;
+          }
           fs.unlinkSync(path.join(projectRoot, projFile));
           report.managed.removed.push(projFile);
         }
@@ -1222,7 +1435,17 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const customSkills = detectCustomSkills(projectRoot, templateSkillNames);
   report.custom.detected = customSkills.map((skill) => skill.dirName);
-  generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs);
+  generateCustomCommands(
+    projectRoot,
+    customSkills,
+    project,
+    lang,
+    report,
+    customTUIs,
+    templateSkillNames,
+    enabledTUIs,
+    writeProtectedManaged
+  );
 
   for (const entry of ejected) {
     const dstFull = path.join(projectRoot, entry);
@@ -1232,7 +1455,11 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
     // Do not (re)create ejected files for disabled TUIs. Existing files are
     // never touched by sync (handled above); this guard only blocks creation.
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+    const disabledEjected = AGENT_CLIENT_MANIFEST.some((adapter) =>
+      !enabledTUIs.has(adapter.id)
+      && adapter.ejected.some((asset) => assetMatches(asset, entry))
+    );
+    if (disabledEjected) continue;
 
     const selected = platformSelect(langSelect(entryVariantRels(entry, allSet, platformType), lang, allSet, project), platformType, project);
     const target = norm(renderPathname(entry, project));
@@ -1253,11 +1480,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     if (entry.includes('*')) {
       const hits = allRels.filter(r => {
         const t = norm(renderPathname(stripLangVariant(r), project));
@@ -1288,7 +1510,8 @@ function syncTemplates(projectRoot, templateRootOverride) {
     report.custom.commands.generated.length +
     report.custom.commands.updated.length +
     report.ejected.created.length +
-    report.registryAdded.length
+    report.registryAdded.length +
+    report.registryRemoved.length
   ) > 0;
 
   const prevVersion = cfg.templateVersion;

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -65,16 +65,12 @@ const DEFAULTS = {
       ".agents/templates/",
       ".agents/workflows/",
       ".agents/workspace/README.md",
-      ".claude/commands/",
-      ".codex/hooks.json",
-      ".gemini/commands/",
       ".git-hooks/check-large-files.cjs",
       ".git-hooks/check-version-format.sh",
       ".github/scripts/",
       ".github/workflows/metadata-sync.yml",
       ".github/workflows/pr-label.yml",
-      ".github/workflows/status-label.yml",
-      ".opencode/commands/"
+      ".github/workflows/status-label.yml"
     ],
     "guardedManaged": [
       ".github/workflows/metadata-sync.yml",
@@ -93,8 +89,6 @@ const DEFAULTS = {
       ".agents/skills/test-integration/SKILL.*",
       ".agents/skills/test/SKILL.*",
       ".agents/skills/upgrade-dependency/SKILL.*",
-      ".claude/settings.json",
-      ".gemini/settings.json",
       ".git-hooks/pre-commit",
       ".gitignore"
     ],
@@ -108,28 +102,52 @@ const AGENT_CLIENT_MANIFEST = [
     "displayName": "Claude Code",
     "ownedPathPrefixes": [
       ".claude/"
-    ]
+    ],
+    "managed": [
+      ".claude/commands/"
+    ],
+    "merged": [
+      ".claude/settings.json"
+    ],
+    "ejected": []
   },
   {
     "id": "codex",
     "displayName": "Codex",
     "ownedPathPrefixes": [
       ".codex/"
-    ]
+    ],
+    "managed": [
+      ".codex/hooks.json"
+    ],
+    "merged": [],
+    "ejected": []
   },
   {
     "id": "gemini-cli",
     "displayName": "Gemini CLI",
     "ownedPathPrefixes": [
       ".gemini/"
-    ]
+    ],
+    "managed": [
+      ".gemini/commands/"
+    ],
+    "merged": [
+      ".gemini/settings.json"
+    ],
+    "ejected": []
   },
   {
     "id": "opencode",
     "displayName": "OpenCode",
     "ownedPathPrefixes": [
       ".opencode/"
-    ]
+    ],
+    "managed": [
+      ".opencode/commands/"
+    ],
+    "merged": [],
+    "ejected": []
   }
 ];
 const AGENT_INFRA_SANDBOX_TOOL = 'agent-infra';
@@ -140,9 +158,6 @@ const KNOWN_PLATFORMS = new Set(['github', 'none']);
 const KNOWN_LANGUAGES = new Set(['en', 'zh-CN']);
 
 const BUILTIN_TUI_IDS = AGENT_CLIENT_MANIFEST.map((entry) => entry.id);
-const BUILTIN_TUI_OWNED_PATH_PREFIXES = Object.fromEntries(
-  AGENT_CLIENT_MANIFEST.map((entry) => [entry.id, entry.ownedPathPrefixes])
-);
 
 function resolveEnabledTUIs(value) {
   // Missing field / null / non-array → full set (backward compat).
@@ -155,16 +170,99 @@ function resolveEnabledTUIs(value) {
   return set;
 }
 
-function isPathOwnedByDisabledTUI(rel, enabledSet) {
-  const normalized = String(rel || '').replace(/\\/g, '/').replace(/^\.\//, '');
-  for (const tui of BUILTIN_TUI_IDS) {
-    if (enabledSet.has(tui)) continue;
-    for (const prefix of BUILTIN_TUI_OWNED_PATH_PREFIXES[tui]) {
-      const trimmed = prefix.replace(/\/$/, '');
-      if (normalized === trimmed || normalized.startsWith(prefix)) return true;
-    }
+function resolveEnabledAgentClients(cfg) {
+  if (!Object.prototype.hasOwnProperty.call(cfg, 'agentClients')) {
+    return { enabled: resolveEnabledTUIs(cfg.tuis), error: null };
   }
-  return false;
+  if (!Array.isArray(cfg.agentClients)) {
+    return { enabled: null, error: 'INVALID_AGENT_CLIENTS at agentClients' };
+  }
+
+  const entries = new Map();
+  for (const [index, candidate] of cfg.agentClients.entries()) {
+    const entryPath = `agentClients[${index}]`;
+    if (
+      typeof candidate !== 'object'
+      || candidate === null
+      || Array.isArray(candidate)
+      || typeof candidate.id !== 'string'
+      || !BUILTIN_TUI_IDS.includes(candidate.id)
+      || typeof candidate.enabled !== 'boolean'
+      || typeof candidate.installInSandbox !== 'boolean'
+    ) {
+      return { enabled: null, error: `INVALID_AGENT_CLIENTS at ${entryPath}` };
+    }
+    if (entries.has(candidate.id)) {
+      return { enabled: null, error: `DUPLICATE_AGENT_CLIENT at ${entryPath}.id` };
+    }
+    entries.set(candidate.id, candidate.enabled);
+  }
+  if (entries.size !== BUILTIN_TUI_IDS.length) {
+    return { enabled: null, error: 'MISSING_AGENT_CLIENT at agentClients' };
+  }
+  return {
+    enabled: new Set(BUILTIN_TUI_IDS.filter((id) => entries.get(id))),
+    error: null
+  };
+}
+
+function assetMatches(entry, target) {
+  const normalizedEntry = norm(entry);
+  const normalizedTarget = norm(target);
+  return normalizedEntry.endsWith('/')
+    ? normalizedTarget.startsWith(normalizedEntry)
+    : normalizedTarget === normalizedEntry;
+}
+
+function adapterAssets(adapters, category) {
+  return adapters.flatMap((adapter) => adapter[category]);
+}
+
+function planProjectRegistry(current, sharedDefaults, enabledSet) {
+  const enabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => enabledSet.has(adapter.id));
+  const disabledAdapters = AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledSet.has(adapter.id));
+  const allAdapterAssets = new Set(
+    AGENT_CLIENT_MANIFEST.flatMap((adapter) => [
+      ...adapter.managed,
+      ...adapter.merged,
+      ...adapter.ejected
+    ])
+  );
+  const enabled = {
+    managed: adapterAssets(enabledAdapters, 'managed'),
+    merged: adapterAssets(enabledAdapters, 'merged'),
+    ejected: adapterAssets(enabledAdapters, 'ejected')
+  };
+  const unique = (values) => [...new Set(values)];
+  const ejected = unique([
+    ...current.ejected,
+    ...enabled.ejected,
+    ...sharedDefaults.ejected
+  ]);
+  const ejectedSet = new Set(ejected);
+  const preserve = (values, enabledValues) => values.filter((entry) =>
+    !ejectedSet.has(entry)
+    && (!allAdapterAssets.has(entry) || enabledValues.includes(entry))
+  );
+  const managed = unique([
+    ...preserve(current.managed, enabled.managed),
+    ...enabled.managed.filter((entry) => !ejectedSet.has(entry)),
+    ...sharedDefaults.managed.filter((entry) => !ejectedSet.has(entry))
+  ]);
+  const managedSet = new Set(managed);
+  const merged = unique([
+    ...preserve(current.merged, enabled.merged),
+    ...enabled.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry)),
+    ...sharedDefaults.merged.filter((entry) => !ejectedSet.has(entry) && !managedSet.has(entry))
+  ]);
+
+  return {
+    registry: { managed, merged, ejected },
+    enabledManaged: enabled.managed,
+    enabledMerged: enabled.merged,
+    enabledEjected: enabled.ejected,
+    disabledManaged: adapterAssets(disabledAdapters, 'managed')
+  };
 }
 
 function isLegacyDefaultSandboxTools(value) {
@@ -789,27 +887,34 @@ function learnAndGenerateCommands(projectRoot, customSkills, tool, templateSkill
   }
 }
 
-function generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs) {
+function generateCustomCommands(
+  projectRoot,
+  customSkills,
+  project,
+  lang,
+  report,
+  customTUIs,
+  templateSkillNames,
+  enabledTUIs,
+  managedWriter
+) {
   for (const skill of customSkills) {
     if (enabledTUIs.has('claude-code')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.claude/commands/${skill.dirName}.md`,
         generateClaudeCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('gemini-cli')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         '.gemini/commands/' + project + '/' + skill.dirName + '.toml',
         generateGeminiCommand(skill, lang),
         report.custom.commands
       );
     }
     if (enabledTUIs.has('opencode')) {
-      writeIfChanged(
-        projectRoot,
+      managedWriter(
         `.opencode/commands/${skill.dirName}.md`,
         generateOpenCodeCommand(skill, lang),
         report.custom.commands
@@ -980,16 +1085,37 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const { project, org, language: lang = 'en' } = cfg;
   const platformType = cfg.platform?.type || DEFAULTS.platform.type;
-  const enabledTUIs = resolveEnabledTUIs(cfg.tuis);
+  const enabledResolution = resolveEnabledAgentClients(cfg);
+  if (enabledResolution.error) {
+    return { error: enabledResolution.error };
+  }
+  const enabledTUIs = enabledResolution.enabled;
   const customTUIsConfig = Array.isArray(cfg.customTUIs) ? cfg.customTUIs : [];
   const vars = { project, org };
   const templateSkillNames = listTemplateSkillNames(templateRoot);
   const protectedCustomSkills = detectCustomSkills(projectRoot, templateSkillNames);
 
-  const managed = [...(cfg.files.managed || [])];
-  const merged  = [...(cfg.files.merged  || [])];
-  const ejected = [...(cfg.files.ejected || [])];
+  cfg.files ||= {};
+  const currentRegistry = {
+    managed: [...(cfg.files.managed || [])],
+    merged: [...(cfg.files.merged || [])],
+    ejected: [...(cfg.files.ejected || [])]
+  };
+  const sharedDefaults = {
+    managed: (DEFAULTS.files.managed || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    merged: (DEFAULTS.files.merged || []).filter(
+      (entry) => !isPathOwnedByOtherPlatform(entry, platformType)
+    ),
+    ejected: [...(DEFAULTS.files.ejected || [])]
+  };
+  const assetPlan = planProjectRegistry(currentRegistry, sharedDefaults, enabledTUIs);
+  const managed = [...assetPlan.registry.managed];
+  const merged = [...assetPlan.registry.merged];
+  const ejected = [...assetPlan.registry.ejected];
   const guardedManaged = new Set((DEFAULTS.files.guardedManaged || []).map(norm));
+  const allClientManaged = adapterAssets(AGENT_CLIENT_MANIFEST, 'managed');
   const managedBaselines = cfg.files.managedBaselines && typeof cfg.files.managedBaselines === 'object'
     && !Array.isArray(cfg.files.managedBaselines)
     ? { ...cfg.files.managedBaselines }
@@ -997,7 +1123,10 @@ function syncTemplates(projectRoot, templateRootOverride) {
   let baselinesChanged = false;
 
   for (const target of Object.keys(managedBaselines)) {
-    if (!guardedManaged.has(norm(target))) {
+    if (
+      !guardedManaged.has(norm(target))
+      && !allClientManaged.some((entry) => assetMatches(entry, target))
+    ) {
       delete managedBaselines[target];
       baselinesChanged = true;
     }
@@ -1007,6 +1136,7 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateVersion: version,
     templateRoot: norm(templateRoot),
     registryAdded: [],
+    registryRemoved: [],
     templateSources: {
       configured: 0,
       loaded: 0,
@@ -1047,17 +1177,23 @@ function syncTemplates(projectRoot, templateRootOverride) {
     templateSkillNames
   );
 
-  const known = new Set([...managed, ...merged, ...ejected]);
-  for (const e of (DEFAULTS.files.managed || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { managed.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'managed' }); }
+  for (const category of ['managed', 'merged', 'ejected']) {
+    const before = currentRegistry[category];
+    const after = assetPlan.registry[category];
+    for (const entry of after) {
+      if (!before.includes(entry)) report.registryAdded.push({ entry, list: category });
+    }
+    for (const entry of before) {
+      if (!after.includes(entry)) report.registryRemoved.push({ entry, list: category });
+    }
   }
-  for (const e of (DEFAULTS.files.merged || [])) {
-    if (isPathOwnedByOtherPlatform(e, platformType)) continue;
-    if (isPathOwnedByDisabledTUI(e, enabledTUIs)) continue;
-    if (!known.has(e)) { merged.push(e); known.add(e); report.registryAdded.push({ entry: e, list: 'merged' }); }
-  }
+  report.managed.skippedTUI.push(
+    ...assetPlan.disabledManaged,
+    ...adapterAssets(
+      AGENT_CLIENT_MANIFEST.filter((adapter) => !enabledTUIs.has(adapter.id)),
+      'merged'
+    )
+  );
 
   const templateSources = Array.isArray(cfg.templates?.sources) ? cfg.templates.sources : [];
   report.templateSources.configured = templateSources.length;
@@ -1079,6 +1215,97 @@ function syncTemplates(projectRoot, templateRootOverride) {
     return isBinary(srcFull)
       ? fs.readFileSync(srcFull)
       : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
+  }
+
+  function selectedTargetsForEntry(entry) {
+    let entryRels;
+    if (entry.endsWith('/')) {
+      const builtinDir = path.join(templateRoot, entry);
+      const builtinRels = fs.existsSync(builtinDir)
+        ? walkDir(builtinDir).map((filePath) => norm(path.relative(templateRoot, filePath)))
+        : [];
+      const prefix = norm(entry);
+      const externalRels = allRels.filter((rel) =>
+        rel.startsWith(prefix) && !builtinRels.includes(rel)
+      );
+      entryRels = [...builtinRels, ...externalRels];
+    } else {
+      entryRels = entryVariantRels(entry, allSet, platformType);
+    }
+    return platformSelect(
+      langSelect(entryRels, lang, allSet, project),
+      platformType,
+      project
+    );
+  }
+
+  function writeProtectedManaged(target, content, bucket) {
+    const dstFull = path.join(projectRoot, target);
+    const exists = fs.existsSync(dstFull);
+    const rawBaseline = managedBaselines[target];
+    const baseline = trustedBaseline(rawBaseline);
+    const templateHash = sha256(content);
+    const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
+
+    if (rawBaseline !== undefined && baseline === null) {
+      delete managedBaselines[target];
+      baselinesChanged = true;
+    }
+    if (baseline === null && localHash !== null && localHash !== templateHash) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'unknown-origin',
+        baseline: null,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (baseline !== null && templateHash === baseline && localHash !== baseline) {
+      report.managed.protected.push({
+        target,
+        reason: localHash === null ? 'user-deleted' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (
+      baseline !== null
+      && localHash !== baseline
+      && templateHash !== baseline
+      && localHash !== templateHash
+    ) {
+      report.managed.conflicts.push({
+        target,
+        reason: 'both-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
+      return false;
+    }
+    if (localHash === templateHash) {
+      bucket.unchanged.push(target);
+      if (managedBaselines[target] !== templateHash) {
+        managedBaselines[target] = templateHash;
+        baselinesChanged = true;
+      }
+      return false;
+    }
+
+    const dir = path.dirname(dstFull);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(dstFull, content);
+    managedBaselines[target] = templateHash;
+    baselinesChanged = true;
+    if (Object.prototype.hasOwnProperty.call(bucket, 'written')) {
+      (exists ? bucket.written : bucket.created).push(target);
+    } else {
+      (exists ? bucket.updated : bucket.generated).push(target);
+    }
+    return true;
   }
 
   for (const entry of [...managed, ...merged, ...ejected]) {
@@ -1134,39 +1361,81 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
   }
 
-  // Cleanup files owned by disabled built-in TUIs. Iterates managed + merged
-  // only (ejected entries are explicitly user-retained, see ejected loop below).
-  //
-  // Protection rule: only skip files registered as customTUI command targets
-  // (e.g. a customTUI configured with dir=.codex/commands/ when codex is
-  // disabled). Built-in TUI custom-skill commands like
-  // .gemini/commands/<project>/<dirName>.toml are intentionally NOT protected
-  // here so that disabling gemini-cli actually frees the gemini directory —
-  // they will be regenerated only for still-enabled TUIs (see
-  // generateCustomCommands).
-  for (const entry of [...managed, ...merged]) {
-    if (!isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+  // Disabled clients are converged conservatively: only exact manifest
+  // managed targets or previously baselined generated targets are candidates.
+  // Merged/ejected and content without trustworthy origin evidence are kept.
+  for (const entry of assetPlan.disabledManaged) {
+    const selectedTargets = selectedTargetsForEntry(entry);
+    const candidates = new Set(
+      Object.keys(managedBaselines).filter((target) => assetMatches(entry, target))
+    );
+    for (const target of selectedTargets.keys()) candidates.add(target);
 
-    if (entry.endsWith('/')) {
-      const dir = path.join(projectRoot, entry);
-      if (!fs.existsSync(dir)) continue;
+    for (const target of candidates) {
+      const dstFull = path.join(projectRoot, target);
+      const baseline = trustedBaseline(managedBaselines[target]);
+      const selectedSource = selectedTargets.get(target);
+      const sourceRoot = selectedSource ? (sourceMap.get(selectedSource) || templateRoot) : null;
+      const templateContent = selectedSource && sourceRoot === templateRoot
+        ? (
+            isBinary(path.join(sourceRoot, selectedSource))
+              ? fs.readFileSync(path.join(sourceRoot, selectedSource))
+              : renderContent(fs.readFileSync(path.join(sourceRoot, selectedSource), 'utf8'), vars)
+          )
+        : null;
+      const localHash = fs.existsSync(dstFull) ? sha256(fs.readFileSync(dstFull)) : null;
+      const templateHash = templateContent === null ? null : sha256(templateContent);
+      const protectedByEjection = ejected.some((pattern) =>
+        assetMatches(pattern, target) || globMatch(pattern, target)
+      );
+      const protectedByCustom = customTUICommandTargets.has(target);
 
-      for (const filePath of walkDir(dir)) {
-        const relProj = norm(path.relative(projectRoot, filePath));
-        if (customTUICommandTargets.has(relProj)) continue;
-        fs.unlinkSync(filePath);
-        report.managed.removed.push(relProj);
+      if (protectedByEjection || protectedByCustom || (sourceRoot && sourceRoot !== templateRoot)) {
+        report.managed.protected.push({
+          target,
+          reason: protectedByEjection
+            ? 'ejected'
+            : protectedByCustom
+              ? 'custom'
+              : 'external-source',
+          baseline,
+          local: localHash,
+          template: templateHash
+        });
+        continue;
       }
-      removeEmptyDirs(dir);
-      continue;
+      if (localHash === null) {
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        continue;
+      }
+      const legacyManaged = currentRegistry.managed.includes(entry);
+      if (
+        (baseline !== null && localHash === baseline)
+        || (baseline === null && legacyManaged && templateHash !== null && localHash === templateHash)
+      ) {
+        fs.unlinkSync(dstFull);
+        report.managed.removed.push(target);
+        if (Object.prototype.hasOwnProperty.call(managedBaselines, target)) {
+          delete managedBaselines[target];
+          baselinesChanged = true;
+        }
+        removeEmptyDirs(path.dirname(dstFull));
+        continue;
+      }
+      report.managed.protected.push({
+        target,
+        reason: baseline === null ? 'unknown-origin' : 'user-modified',
+        baseline,
+        local: localHash,
+        template: templateHash
+      });
     }
-
-    const target = path.join(projectRoot, renderPathname(entry, project));
-    if (!fs.existsSync(target)) continue;
-    const relProj = norm(path.relative(projectRoot, target));
-    if (customTUICommandTargets.has(relProj)) continue;
-    fs.unlinkSync(target);
-    report.managed.removed.push(relProj);
+    if (entry.endsWith('/')) {
+      removeEmptyDirs(path.join(projectRoot, entry));
+    }
   }
 
   for (const entry of managed) {
@@ -1174,11 +1443,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     const isDir = entry.endsWith('/');
     let entryRels;
     const expectedTargets = isDir ? new Set() : null;
@@ -1216,65 +1480,14 @@ function syncTemplates(projectRoot, templateRootOverride) {
         : renderContent(fs.readFileSync(srcFull, 'utf8'), vars);
 
       const exists = fs.existsSync(dstFull);
-      if (guardedManaged.has(tgt)) {
-        const rawBaseline = managedBaselines[tgt];
-        const baseline = trustedBaseline(rawBaseline);
-        const templateHash = sha256(content);
-        const localHash = exists ? sha256(fs.readFileSync(dstFull)) : null;
-
-        if (rawBaseline !== undefined && baseline === null) {
-          delete managedBaselines[tgt];
-          baselinesChanged = true;
+      const clientManagedTarget = assetPlan.enabledManaged.some((asset) =>
+        assetMatches(asset, tgt)
+      );
+      if (guardedManaged.has(tgt) || (clientManagedTarget && srcRoot === templateRoot)) {
+        const written = writeProtectedManaged(tgt, content, report.managed);
+        if (written && tgt.endsWith('.sh')) {
+          try { fs.chmodSync(dstFull, 0o755); } catch { /* Windows */ }
         }
-
-        if (baseline === null && localHash !== null && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'unknown-origin',
-            baseline: null,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && templateHash === baseline && localHash !== baseline) {
-          report.managed.protected.push({
-            target: tgt,
-            reason: localHash === null ? 'user-deleted' : 'user-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (baseline !== null && localHash !== baseline && templateHash !== baseline && localHash !== templateHash) {
-          report.managed.conflicts.push({
-            target: tgt,
-            reason: 'both-modified',
-            baseline,
-            local: localHash,
-            template: templateHash
-          });
-          continue;
-        }
-
-        if (localHash === templateHash) {
-          report.managed.unchanged.push(tgt);
-          if (managedBaselines[tgt] !== templateHash) {
-            managedBaselines[tgt] = templateHash;
-            baselinesChanged = true;
-          }
-          continue;
-        }
-
-        const dir = path.dirname(dstFull);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(dstFull, content);
-        managedBaselines[tgt] = templateHash;
-        baselinesChanged = true;
-        (exists ? report.managed.written : report.managed.created).push(tgt);
         continue;
       }
 
@@ -1306,7 +1519,25 @@ function syncTemplates(projectRoot, templateRootOverride) {
           if (projFile === configPathRel) continue;
           if (isCustomProtected(projFile, protectedCustomSkills, project, customTUICommandTargets)) continue;
           if (matchesAny(projFile, merged) || matchesAny(projFile, ejected)) continue;
-
+          if (assetPlan.enabledManaged.includes(entry)) {
+            const baseline = trustedBaseline(managedBaselines[projFile]);
+            const localHash = sha256(fs.readFileSync(path.join(projectRoot, projFile)));
+            if (baseline !== null && localHash === baseline) {
+              fs.unlinkSync(path.join(projectRoot, projFile));
+              delete managedBaselines[projFile];
+              baselinesChanged = true;
+              report.managed.removed.push(projFile);
+            } else {
+              report.managed.protected.push({
+                target: projFile,
+                reason: baseline === null ? 'unknown-origin' : 'user-modified',
+                baseline,
+                local: localHash,
+                template: null
+              });
+            }
+            continue;
+          }
           fs.unlinkSync(path.join(projectRoot, projFile));
           report.managed.removed.push(projFile);
         }
@@ -1325,7 +1556,17 @@ function syncTemplates(projectRoot, templateRootOverride) {
 
   const customSkills = detectCustomSkills(projectRoot, templateSkillNames);
   report.custom.detected = customSkills.map((skill) => skill.dirName);
-  generateCustomCommands(projectRoot, customSkills, project, lang, report, customTUIs, templateSkillNames, enabledTUIs);
+  generateCustomCommands(
+    projectRoot,
+    customSkills,
+    project,
+    lang,
+    report,
+    customTUIs,
+    templateSkillNames,
+    enabledTUIs,
+    writeProtectedManaged
+  );
 
   for (const entry of ejected) {
     const dstFull = path.join(projectRoot, entry);
@@ -1335,7 +1576,11 @@ function syncTemplates(projectRoot, templateRootOverride) {
     }
     // Do not (re)create ejected files for disabled TUIs. Existing files are
     // never touched by sync (handled above); this guard only blocks creation.
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) continue;
+    const disabledEjected = AGENT_CLIENT_MANIFEST.some((adapter) =>
+      !enabledTUIs.has(adapter.id)
+      && adapter.ejected.some((asset) => assetMatches(asset, entry))
+    );
+    if (disabledEjected) continue;
 
     const selected = platformSelect(langSelect(entryVariantRels(entry, allSet, platformType), lang, allSet, project), platformType, project);
     const target = norm(renderPathname(entry, project));
@@ -1356,11 +1601,6 @@ function syncTemplates(projectRoot, templateRootOverride) {
       report.managed.skippedPlatform.push(entry);
       continue;
     }
-    if (isPathOwnedByDisabledTUI(entry, enabledTUIs)) {
-      report.managed.skippedTUI.push(entry);
-      continue;
-    }
-
     if (entry.includes('*')) {
       const hits = allRels.filter(r => {
         const t = norm(renderPathname(stripLangVariant(r), project));
@@ -1391,7 +1631,8 @@ function syncTemplates(projectRoot, templateRootOverride) {
     report.custom.commands.generated.length +
     report.custom.commands.updated.length +
     report.ejected.created.length +
-    report.registryAdded.length
+    report.registryAdded.length +
+    report.registryRemoved.length
   ) > 0;
 
   const prevVersion = cfg.templateVersion;

--- a/tests/helpers/esm.ts
+++ b/tests/helpers/esm.ts
@@ -6,6 +6,7 @@ type RegistryEntry = {
   list?: string;
 };
 type SyncTemplatesReport = {
+  error?: string;
   templateRoot: string;
   templateVersion: string;
   configUpdated: boolean;
@@ -17,6 +18,7 @@ type SyncTemplatesReport = {
     conflicts: Array<Record<string, unknown>>;
   };
   registryAdded: RegistryEntry[];
+  registryRemoved: RegistryEntry[];
   managed: {
     created: string[];
     protected: Array<{ target: string; reason: string; baseline: string | null; local: string | null; template: string }>;

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -584,9 +584,12 @@ test("GitHub init full sync installs lifecycle workflows in the downstream proje
     assert.ok(fs.existsSync(path.join(tmpDir, ".github/scripts/sync-labels-to-set.sh")));
 
     const config = JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents/.airc.json"), "utf8"));
-    assert.deepEqual(Object.keys(config.files.managedBaselines).sort(), lifecycleWorkflows
-      .map((workflow) => `.github/workflows/${workflow}`)
-      .sort());
+    const baselineTargets = Object.keys(config.files.managedBaselines);
+    for (const workflow of lifecycleWorkflows) {
+      assert.ok(baselineTargets.includes(`.github/workflows/${workflow}`));
+    }
+    assert.ok(baselineTargets.some((target) => target.startsWith(".claude/commands/")));
+    assert.ok(baselineTargets.includes(".codex/hooks.json"));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -608,7 +611,12 @@ test("non-GitHub init full sync excludes GitHub lifecycle workflows", async () =
 
     assert.ok(!fs.existsSync(path.join(tmpDir, ".github")));
     const config = JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents/.airc.json"), "utf8"));
-    assert.equal(config.files.managedBaselines, undefined);
+    const baselineTargets = Object.keys(config.files.managedBaselines);
+    assert.ok(baselineTargets.some((target) => target.startsWith(".claude/commands/")));
+    assert.ok(baselineTargets.includes(".codex/hooks.json"));
+    for (const baseline of Object.values(config.files.managedBaselines)) {
+      assert.match(String(baseline), /^sha256:[a-f0-9]{64}$/);
+    }
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -745,7 +753,10 @@ test("agent-infra update refreshes seed files and syncs file registry", async ()
       assert.ok(fs.existsSync(path.join(tmpDir, ".github/workflows", workflow)));
     }
     const synced = JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents/.airc.json"), "utf8"));
-    assert.equal(Object.keys(synced.files.managedBaselines).length, 3);
+    const baselineTargets = Object.keys(synced.files.managedBaselines);
+    assert.ok(baselineTargets.includes(".github/workflows/metadata-sync.yml"));
+    assert.ok(baselineTargets.includes(".codex/hooks.json"));
+    assert.ok(baselineTargets.some((target) => target.startsWith(".gemini/commands/")));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/core/builtin-tui-selection.test.ts
+++ b/tests/integration/core/builtin-tui-selection.test.ts
@@ -85,6 +85,14 @@ function makeProject(projectRoot: string, overrides: Record<string, unknown> = {
   );
 }
 
+function canonicalAgentClients(enabled: readonly string[]) {
+  return ["claude-code", "codex", "gemini-cli", "opencode"].map((id) => ({
+    id,
+    enabled: enabled.includes(id),
+    installInSandbox: false
+  }));
+}
+
 test("syncTemplates: missing tuis field keeps full built-in TUI behavior (regression)", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tui-default-"));
   try {
@@ -154,7 +162,13 @@ test("syncTemplates: switching tuis cleans up previously written owned files", a
     assert.ok(secondReport.managed.removed.some((p) => p.startsWith(".gemini/commands/")));
     assert.ok(!fs.existsSync(path.join(projectRoot, ".gemini/commands/demo/update-agent-infra.toml")));
     // Empty .gemini/commands/ directory should be cleaned up.
-    assert.ok(!fs.existsSync(path.join(projectRoot, ".gemini/commands")));
+    const commandsDir = path.join(projectRoot, ".gemini/commands");
+    assert.ok(
+      !fs.existsSync(commandsDir),
+      `expected disabled Gemini commands directory to be removed, found ${
+        fs.existsSync(commandsDir) ? JSON.stringify(fs.readdirSync(commandsDir)) : "nothing"
+      }`
+    );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -289,5 +303,112 @@ test("syncTemplates: ejected entries owned by disabled TUIs are preserved and no
     assert.ok(!report.managed.removed.includes(".codex/hooks.json"));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncTemplates: canonical agentClients controls assets and rejects incomplete input", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-agent-clients-canonical-"));
+  try {
+    const projectRoot = path.join(tmpDir, "project");
+    const templateRoot = makeTemplateRoot(tmpDir);
+    makeProject(projectRoot, {
+      tuis: ["claude-code", "codex", "gemini-cli", "opencode"],
+      agentClients: canonicalAgentClients([])
+    });
+    const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(
+      ".agents/skills/update-agent-infra/scripts/sync-templates.js"
+    );
+
+    syncTemplates(projectRoot, templateRoot);
+    assert.ok(!fs.existsSync(path.join(projectRoot, ".codex/hooks.json")));
+
+    const cfgPath = path.join(projectRoot, ".agents/.airc.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    cfg.agentClients = canonicalAgentClients(["codex"]).slice(0, 3);
+    fs.writeFileSync(cfgPath, `${JSON.stringify(cfg, null, 2)}\n`);
+    const invalidReport = syncTemplates(projectRoot, templateRoot);
+    assert.equal(invalidReport.error, "MISSING_AGENT_CLIENT at agentClients");
+    assert.ok(!fs.existsSync(path.join(projectRoot, ".codex/hooks.json")));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncTemplates: disabling a client preserves modified and unknown managed files", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tui-safe-disable-"));
+  try {
+    const projectRoot = path.join(tmpDir, "project");
+    const templateRoot = makeTemplateRoot(tmpDir);
+    makeProject(projectRoot, { tuis: ["gemini-cli"] });
+    const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(
+      ".agents/skills/update-agent-infra/scripts/sync-templates.js"
+    );
+    syncTemplates(projectRoot, templateRoot);
+
+    const generated = ".gemini/commands/demo/update-agent-infra.toml";
+    writeFile(projectRoot, generated, "user modified\n");
+    writeFile(projectRoot, ".gemini/commands/user-owned.toml", "user owned\n");
+    const cfgPath = path.join(projectRoot, ".agents/.airc.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    cfg.tuis = [];
+    fs.writeFileSync(cfgPath, `${JSON.stringify(cfg, null, 2)}\n`);
+
+    const report = syncTemplates(projectRoot, templateRoot);
+    assert.equal(fs.readFileSync(path.join(projectRoot, generated), "utf8"), "user modified\n");
+    assert.equal(
+      fs.readFileSync(path.join(projectRoot, ".gemini/commands/user-owned.toml"), "utf8"),
+      "user owned\n"
+    );
+    assert.ok(
+      report.managed.protected.some((entry) =>
+        entry.target === generated && entry.reason === "user-modified"
+      )
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("syncTemplates: every built-in client subset converges idempotently", async () => {
+  const ids = ["claude-code", "codex", "gemini-cli", "opencode"];
+  const { syncTemplates } = await loadFreshEsm<SyncTemplatesModule>(
+    ".agents/skills/update-agent-infra/scripts/sync-templates.js"
+  );
+
+  for (let mask = 0; mask < 16; mask += 1) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ai-tui-matrix-${mask}-`));
+    try {
+      const projectRoot = path.join(tmpDir, "project");
+      const templateRoot = makeTemplateRoot(tmpDir);
+      const enabled = ids.filter((_, index) => (mask & (1 << index)) !== 0);
+      makeProject(projectRoot, { tuis: [...enabled].reverse() });
+
+      syncTemplates(projectRoot, templateRoot);
+      const cfgPath = path.join(projectRoot, ".agents/.airc.json");
+      const afterFirst = fs.readFileSync(cfgPath, "utf8");
+      const second = syncTemplates(projectRoot, templateRoot);
+      const afterSecond = fs.readFileSync(cfgPath, "utf8");
+
+      assert.equal(afterSecond, afterFirst, `subset ${mask}: config must be idempotent`);
+      assert.deepEqual(second.managed.created, [], `subset ${mask}: unexpected create`);
+      assert.deepEqual(second.managed.written, [], `subset ${mask}: unexpected write`);
+      assert.deepEqual(second.managed.removed, [], `subset ${mask}: unexpected removal`);
+      const config = JSON.parse(afterSecond);
+      for (const [index, id] of ids.entries()) {
+        const adapterPath = {
+          "claude-code": ".claude/commands/",
+          codex: ".codex/hooks.json",
+          "gemini-cli": ".gemini/commands/",
+          opencode: ".opencode/commands/"
+        }[id]!;
+        assert.equal(
+          config.files.managed.includes(adapterPath),
+          (mask & (1 << index)) !== 0,
+          `subset ${mask}: ${id} managed registry`
+        );
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 });

--- a/tests/unit/core/agent-client-project-assets.test.ts
+++ b/tests/unit/core/agent-client-project-assets.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  planAgentClientProjectAssets
+} from '../../../lib/agent-clients/project-assets.ts';
+import { listAgentClientAdapters } from '../../../lib/agent-clients/registry.ts';
+
+const adapters = listAgentClientAdapters();
+const sharedDefaults = {
+  managed: ['.agents/README.md'],
+  merged: ['.gitignore'],
+  ejected: []
+};
+
+test('project asset planning preserves user entries and appends enabled assets canonically', () => {
+  const current = {
+    managed: ['docs/user.md', '.opencode/commands/', '.claude/commands/'],
+    merged: ['settings/user.json', '.gemini/settings.json'],
+    ejected: ['.claude/commands/']
+  };
+  const before = structuredClone(current);
+  const plan = planAgentClientProjectAssets({
+    current,
+    sharedDefaults,
+    enabledAdapters: [adapters[3]!, adapters[1]!],
+    allAdapters: adapters
+  });
+
+  assert.deepEqual(current, before);
+  assert.deepEqual(plan.registry, {
+    managed: [
+      'docs/user.md',
+      '.opencode/commands/',
+      '.codex/hooks.json',
+      '.agents/README.md'
+    ],
+    merged: ['settings/user.json', '.gitignore'],
+    ejected: ['.claude/commands/']
+  });
+  assert.deepEqual(plan.enabledManaged, [
+    '.codex/hooks.json',
+    '.opencode/commands/'
+  ]);
+  assert.deepEqual(plan.disabledManaged, [
+    '.claude/commands/',
+    '.gemini/commands/'
+  ]);
+});
+
+test('project asset planning supports an empty enabled set and is idempotent', () => {
+  const first = planAgentClientProjectAssets({
+    current: {
+      managed: ['.claude/commands/', 'docs/user.md'],
+      merged: ['.claude/settings.json'],
+      ejected: []
+    },
+    sharedDefaults,
+    enabledAdapters: [],
+    allAdapters: adapters
+  });
+  const second = planAgentClientProjectAssets({
+    current: first.registry,
+    sharedDefaults,
+    enabledAdapters: [],
+    allAdapters: adapters
+  });
+
+  assert.deepEqual(first.registry, {
+    managed: ['docs/user.md', '.agents/README.md'],
+    merged: ['.gitignore'],
+    ejected: []
+  });
+  assert.deepEqual(second, first);
+});
+
+test('project asset planning returns deeply frozen stable output', () => {
+  const plan = planAgentClientProjectAssets({
+    current: { managed: [], merged: [], ejected: [] },
+    sharedDefaults,
+    enabledAdapters: adapters,
+    allAdapters: adapters
+  });
+
+  assert.ok(Object.isFrozen(plan));
+  assert.ok(Object.isFrozen(plan.registry));
+  for (const values of [
+    plan.registry.managed,
+    plan.registry.merged,
+    plan.registry.ejected,
+    plan.enabledManaged,
+    plan.enabledMerged,
+    plan.enabledEjected,
+    plan.disabledManaged
+  ]) {
+    assert.ok(Object.isFrozen(values));
+  }
+});

--- a/tests/unit/core/agent-client-registry.test.ts
+++ b/tests/unit/core/agent-client-registry.test.ts
@@ -76,7 +76,12 @@ function adapterInput(
     id: 'codex',
     displayName: 'Codex',
     capabilities: capabilityMap(),
-    project: { ownedPathPrefixes: ['.codex/'] },
+    project: {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['.codex/hooks.json'],
+      merged: [],
+      ejected: []
+    },
     ...overrides
   };
 }
@@ -105,6 +110,9 @@ test('adapter definitions validate their closed contract without mutating input'
   assert.ok(Object.isFrozen(adapter.capabilities.commands));
   assert.ok(Object.isFrozen(adapter.project));
   assert.ok(Object.isFrozen(adapter.project.ownedPathPrefixes));
+  assert.ok(Object.isFrozen(adapter.project.managed));
+  assert.ok(Object.isFrozen(adapter.project.merged));
+  assert.ok(Object.isFrozen(adapter.project.ejected));
 
   const invalidInputs: unknown[] = [
     adapterInput({ id: 'unknown' as never }),
@@ -122,14 +130,92 @@ test('adapter definitions validate their closed contract without mutating input'
           .map((capability) => [capability, { level: 'compatible' }])
       ) as AgentClientCapabilityMap
     }),
-    adapterInput({ project: { ownedPathPrefixes: [] } }),
-    adapterInput({ project: { ownedPathPrefixes: ['.codex'] } }),
-    adapterInput({ project: { ownedPathPrefixes: ['.codex\\'] } }),
-    adapterInput({ project: { ownedPathPrefixes: ['.codex/', '.codex/'] } })
+    adapterInput({
+      project: {
+        ownedPathPrefixes: [],
+        managed: [],
+        merged: [],
+        ejected: []
+      }
+    }),
+    adapterInput({
+      project: {
+        ownedPathPrefixes: ['.codex'],
+        managed: [],
+        merged: [],
+        ejected: []
+      }
+    }),
+    adapterInput({
+      project: {
+        ownedPathPrefixes: ['.codex\\'],
+        managed: [],
+        merged: [],
+        ejected: []
+      }
+    }),
+    adapterInput({
+      project: {
+        ownedPathPrefixes: ['.codex/', '.codex/'],
+        managed: [],
+        merged: [],
+        ejected: []
+      }
+    })
   ];
 
   for (const invalid of invalidInputs) {
     assert.throws(() => defineAgentClientAdapter(invalid as AgentClientAdapter));
+  }
+});
+
+test('adapter project assets must be literal owned relative paths without overlaps', () => {
+  const invalidProjects = [
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: undefined,
+      merged: [],
+      ejected: []
+    },
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['/tmp/hooks.json'],
+      merged: [],
+      ejected: []
+    },
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['.codex/../outside.json'],
+      merged: [],
+      ejected: []
+    },
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['.other/hooks.json'],
+      merged: [],
+      ejected: []
+    },
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['.codex/hooks.json', '.codex/hooks.json'],
+      merged: [],
+      ejected: []
+    },
+    {
+      ownedPathPrefixes: ['.codex/'],
+      managed: ['.codex/hooks.json'],
+      merged: ['.codex/hooks.json'],
+      ejected: []
+    }
+  ];
+
+  for (const project of invalidProjects) {
+    assert.throws(
+      () => defineAgentClientAdapter(adapterInput({
+        project: project as AgentClientAdapter['project']
+      })),
+      /Agent Client 'codex'.*(project asset|owned path)/
+    );
   }
 });
 
@@ -193,6 +279,41 @@ test('registry is complete, canonical, deeply frozen, and matches the capability
   }
 });
 
+test('registry exposes the exact built-in project asset matrix', () => {
+  assert.deepEqual(
+    Object.fromEntries(listAgentClientAdapters().map((adapter) => [
+      adapter.id,
+      adapter.project
+    ])),
+    {
+      'claude-code': {
+        ownedPathPrefixes: ['.claude/'],
+        managed: ['.claude/commands/'],
+        merged: ['.claude/settings.json'],
+        ejected: []
+      },
+      codex: {
+        ownedPathPrefixes: ['.codex/'],
+        managed: ['.codex/hooks.json'],
+        merged: [],
+        ejected: []
+      },
+      'gemini-cli': {
+        ownedPathPrefixes: ['.gemini/'],
+        managed: ['.gemini/commands/'],
+        merged: ['.gemini/settings.json'],
+        ejected: []
+      },
+      opencode: {
+        ownedPathPrefixes: ['.opencode/'],
+        managed: ['.opencode/commands/'],
+        merged: [],
+        ejected: []
+      }
+    }
+  );
+});
+
 test('registry queries preserve canonical order and keep enabled separate from sandbox install state', () => {
   const state = stateFor(['opencode', 'codex']);
 
@@ -253,8 +374,14 @@ test('manifest is a fresh frozen JSON-safe projection of registry metadata', () 
   assert.deepEqual(JSON.parse(JSON.stringify(first)), first);
 
   for (const entry of first) {
-    assert.deepEqual(Object.keys(entry), ['id', 'displayName', 'ownedPathPrefixes']);
+    assert.deepEqual(
+      Object.keys(entry),
+      ['id', 'displayName', 'ownedPathPrefixes', 'managed', 'merged', 'ejected']
+    );
     assert.ok(Object.isFrozen(entry));
     assert.ok(Object.isFrozen(entry.ownedPathPrefixes));
+    assert.ok(Object.isFrozen(entry.managed));
+    assert.ok(Object.isFrozen(entry.merged));
+    assert.ok(Object.isFrozen(entry.ejected));
   }
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #664

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #664

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [x] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

让 Agent Client adapter 成为客户端项目资产分类的单一代码来源，并通过统一 reconciler 支持按客户端选择安装、幂等切换和保守卸载。

## 📋 主要变更 / Brief Changelog

- 扩展 adapter 契约，声明 owned、managed、merged 与 ejected 项目资产，并将完整资产矩阵投影到 manifest。
- 新增纯项目资产计划器，将初始化、更新与 standalone 模板同步统一到 canonical 客户端选择和安全卸载语义。
- 使用 managed baseline 保护用户修改、外部插件资产与 ejected 文件，并覆盖空集合、切换、卸载及 16 种客户端组合的幂等测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck` 验证 TypeScript 与 JavaScript 类型检查。
2. 运行 `npm run test:core` 验证单元和集成测试。
3. 运行 `npm test` 验证完整测试与生成文件一致性。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：1866 tests，1864 passed，2 skipped，0 failed；`npm run typecheck`、`node scripts/build-inline.js --check` 与 `git diff --check` 均通过。

## 📸 截图 / Screenshots

不适用：本次变更不涉及可视界面。

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 确保有 GitHub Issue 对应这个变更 / A GitHub issue exists for this change
- [x] PR 只解决一个 Issue / This PR addresses one issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project conventions
- [x] 已完成独立代码审查 / An independent code review was completed
- [x] 复杂逻辑包含必要说明 / Complex logic contains the necessary context

### 测试要求 / Testing Requirements

- [x] 已编写必要的单元测试 / Necessary unit tests were added
- [x] 跨模块测试使用既有隔离方式 / Existing isolation patterns are used
- [ ] 代码检查通过 / Lint checks pass（项目暂未配置 lint）
- [x] 单元测试通过 / Unit tests pass

### 文档和兼容性 / Documentation and Compatibility

- [ ] 已更新相应文档 / Corresponding documentation was updated（无用户文档变更）
- [x] 无破坏性变更 / No breaking change
- [x] 已考虑向后兼容性 / Backward compatibility was considered

## 📋 附加信息 / Additional Notes

- 保留 legacy `tuis` 配置解析和 `lib/builtin-tuis.ts` 兼容导出。
- 独立代码审查结论为 Approved，无 blocker、major 或人工校验项。

---

**审查者注意事项 / Reviewer Notes:**

请重点关注 managed baseline 三方状态机、禁用客户端时的保护优先级，以及 TypeScript 与 standalone JavaScript 计划器的等价语义。

Generated with AI assistance
