### PR TITLE
fix(task-event): 校验 approved finding 计数


### DIFF
--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -16,6 +16,8 @@ import {
   parseImplementationInputs,
   renderImplementationInputs
 } from './implementation-inputs.ts';
+import { parseLedger, summarizeLedgerStage, validateLedgerRows } from './ledger.ts';
+import type { ReviewStage } from './ledger.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
 import { findSectionHeading } from './sections.ts';
 import { captureTaskWriteMetadata, writeTask } from './write.ts';
@@ -35,7 +37,8 @@ type Verdict = 'approved' | 'changes-requested' | 'rejected';
 type TaskEventErrorCode =
   | 'EVENT_UNKNOWN' | 'EVENT_PAYLOAD_INVALID' | 'EVENT_TRANSITION_INVALID'
   | 'EVENT_LOG_MISSING' | 'EVENT_START_MISSING' | 'EVENT_ALREADY_COMPLETED'
-  | 'EVENT_LOG_CONFLICT' | 'EVENT_ARTIFACT_CONFLICT' | ArtifactErrorCode | TaskWriteErrorCode;
+  | 'EVENT_LOG_CONFLICT' | 'EVENT_ARTIFACT_CONFLICT' | 'EVENT_FINDING_COUNT_MISMATCH'
+  | ArtifactErrorCode | TaskWriteErrorCode;
 type TaskEventRequest = {
   taskRef: string; event: TaskEventName | string; agent: string; dryRun?: boolean;
   round?: number; question?: number; artifact?: string; fixFor?: string; implementationInput?: string;
@@ -112,6 +115,45 @@ const FAMILY = {
   'manual-validation': { artifact: 'manual-validation', started: ['code-review', 'commit'], completed: ['code-review', 'commit'], target: null, label: 'Complete Manual Validation' }
 } as const;
 type EventFamily = keyof typeof FAMILY;
+
+const REVIEW_LEDGER_STAGES: Partial<Record<EventFamily, ReviewStage>> = {
+  'review-analysis': 'analysis',
+  'review-plan': 'plan',
+  'review-code': 'code'
+};
+
+function validateApprovedFindingCounts(
+  request: TaskEventRequest,
+  content: string,
+  family: EventFamily
+): TaskEventError | null {
+  const stage = REVIEW_LEDGER_STAGES[family];
+  if (request.verdict !== 'approved' || !stage) return null;
+  const rows = parseLedger(content);
+  const invalid = validateLedgerRows(rows);
+  if (invalid) return { code: 'TASK_DOCUMENT_INVALID', message: `${invalid.code}: ${invalid.message}` };
+  const expected = summarizeLedgerStage(rows, stage).unresolvedFindingCounts;
+  const received = {
+    blocker: request.blockers!,
+    major: request.major!,
+    minor: request.minor!
+  };
+  const fields = [
+    ['blocker', 'blockers'],
+    ['major', 'major'],
+    ['minor', 'minor']
+  ] as const;
+  const differences = fields.flatMap(([severity, cliField]) => (
+    expected[severity] === received[severity]
+      ? []
+      : [`${cliField} expected ${expected[severity]}, received ${received[severity]}`]
+  ));
+  if (differences.length === 0) return null;
+  return {
+    code: 'EVENT_FINDING_COUNT_MISMATCH',
+    message: `approved finding counts do not match the ${stage} ledger: ${differences.join('; ')}`
+  };
+}
 
 function eventParts(event: string): { family: EventFamily; phase: 'started' | 'waiting' | 'completed' } {
   const [family, suffix] = event.split('.') as [EventFamily, string];
@@ -256,6 +298,8 @@ function applyTaskEvent(request: TaskEventRequest, options: TaskWriteOptions = {
   }
   const allowed = FAMILY[eventIdentity.family][eventIdentity.phase === 'started' ? 'started' : 'completed'];
   if (!(allowed as readonly string[]).includes(currentStep)) return failed(normalized, { code: 'EVENT_TRANSITION_INVALID', message: `${normalized.event} is not allowed from '${currentStep}'` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+  const findingCountError = validateApprovedFindingCounts(normalized, content, eventIdentity.family);
+  if (findingCountError) return failed(normalized, findingCountError, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
   let metadata;
   try { metadata = (options.metadataProvider ?? captureTaskWriteMetadata)(); }
   catch (error) { return failed(normalized, { code: 'METADATA_CAPTURE_FAILED', message: String(error) }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath }); }

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -34,6 +34,60 @@ function reviewArtifact(title: string, input: string) {
   return `# ${title}\n\n- **审查输入**：\`${input}\`\n`;
 }
 
+type ReviewCounts = { blockers: number; major: number; minor: number };
+
+const reviewScenarios = [
+  {
+    family: 'review-analysis', stage: 'analysis', step: 'requirement-analysis-review',
+    input: 'analysis.md', artifact: 'review-analysis.md', title: 'Analysis Review', findingId: 'AN-1'
+  },
+  {
+    family: 'review-plan', stage: 'plan', step: 'technical-design-review',
+    input: 'plan.md', artifact: 'review-plan.md', title: 'Plan Review', findingId: 'PL-1'
+  },
+  {
+    family: 'review-code', stage: 'code', step: 'code',
+    input: 'code.md', artifact: 'review-code.md', title: 'Code Review', findingId: 'CD-1'
+  }
+] as const;
+
+function setLedger(file: string, rows: string[]) {
+  const content = fs.readFileSync(file, 'utf8');
+  const ledger = [
+    '## Review Disagreement Ledger',
+    '',
+    '| id | stage | round | severity | status | evidence |',
+    '|----|-------|-------|----------|--------|----------|',
+    ...rows,
+    ''
+  ].join('\n');
+  fs.writeFileSync(file, content.replace('## Activity Log', `${ledger}\n## Activity Log`));
+}
+
+function prepareReview(scenario: (typeof reviewScenarios)[number], rows: string[]) {
+  const f = fixture(scenario.step);
+  fs.writeFileSync(path.join(f.dir, scenario.input), `# ${scenario.input}\n`);
+  setLedger(f.file, rows);
+  const started = run(f.root, [f.id, `${scenario.family}.started`, '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr);
+  fs.writeFileSync(path.join(f.dir, scenario.artifact), reviewArtifact(scenario.title, scenario.input));
+  return f;
+}
+
+function completeReview(
+  f: ReturnType<typeof fixture>,
+  scenario: (typeof reviewScenarios)[number],
+  verdict: 'approved' | 'changes-requested' | 'rejected',
+  counts: ReviewCounts,
+  extra: string[] = []
+) {
+  return run(f.root, [
+    f.id, `${scenario.family}.completed`, '--agent', 'codex', '--artifact', scenario.artifact,
+    '--verdict', verdict, '--blockers', String(counts.blockers), '--major', String(counts.major),
+    '--minor', String(counts.minor), '--manual-validation', '0', ...extra
+  ]);
+}
+
 function decisionFixture() {
   const f = fixture('code-review');
   fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
@@ -282,6 +336,108 @@ test('review-code event completes the regular code review path', () => {
   const content = fs.readFileSync(f.file, 'utf8');
   assert.match(content, /current_step: code-review/);
   assert.match(content, /\]\(review-code\.md\)/);
+});
+
+for (const scenario of reviewScenarios) {
+  test(`${scenario.family} rejects approved finding counts that differ from the ${scenario.stage} ledger`, () => {
+    const f = prepareReview(scenario, [
+      `| ${scenario.findingId} | ${scenario.stage} | 1 | minor | open | ${scenario.artifact}#finding |`
+    ]);
+    const before = fs.readFileSync(f.file);
+    const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+    const result = JSON.parse(completed.stdout);
+
+    assert.equal(completed.status, 1);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.changed, false);
+    assert.equal(result.error.code, 'EVENT_FINDING_COUNT_MISMATCH');
+    assert.match(result.error.message, new RegExp(`${scenario.stage} ledger`));
+    assert.match(result.error.message, /minor expected 1, received 0/);
+    assert.deepEqual(fs.readFileSync(f.file), before);
+  });
+}
+
+test('approved review completion accepts matching non-zero finding counts', () => {
+  const scenario = reviewScenarios[2];
+  const f = prepareReview(scenario, [
+    '| CD-1 | code | 1 | blocker | open | review-code.md#CD-1 |',
+    '| CD-2 | code | 1 | major | adjusted | review-code.md#CD-2 |',
+    '| CD-3 | code | 1 | minor | needs-human-decision | review-code.md#CD-3 |'
+  ]);
+  const completed = completeReview(f, scenario, 'approved', { blockers: 1, major: 1, minor: 1 });
+
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(JSON.parse(completed.stdout).status, 'applied');
+  assert.match(fs.readFileSync(f.file, 'utf8'), /Verdict: Approved, blockers: 1, major: 1, minor: 1/);
+});
+
+for (const verdict of ['changes-requested', 'rejected'] as const) {
+  test(`${verdict} review completion bypasses approved finding count validation`, () => {
+    const scenario = reviewScenarios[2];
+    const row = verdict === 'changes-requested'
+      ? '| invalid | invalid | invalid | invalid | invalid | invalid |'
+      : '| CD-1 | code | 1 | minor | open | review-code.md#CD-1 |';
+    const f = prepareReview(scenario, [row]);
+    const completed = completeReview(f, scenario, verdict, { blockers: 0, major: 0, minor: 0 });
+
+    assert.equal(completed.status, 0, completed.stderr);
+    assert.equal(JSON.parse(completed.stdout).status, 'applied');
+  });
+}
+
+test('approved dry-run rejects mismatched finding counts without changing task bytes', () => {
+  const scenario = reviewScenarios[1];
+  const f = prepareReview(scenario, [
+    '| PL-1 | plan | 1 | major | open | review-plan.md#PL-1 |'
+  ]);
+  const before = fs.readFileSync(f.file);
+  const completed = completeReview(
+    f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 }, ['--dry-run']
+  );
+  const result = JSON.parse(completed.stdout);
+
+  assert.equal(completed.status, 1);
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error.code, 'EVENT_FINDING_COUNT_MISMATCH');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('approved review completion reports an invalid ledger as an invalid task document', () => {
+  const scenario = reviewScenarios[0];
+  const f = prepareReview(scenario, [
+    '| invalid | analysis | 1 | minor | open | review-analysis.md#finding |'
+  ]);
+  const before = fs.readFileSync(f.file);
+  const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+  const result = JSON.parse(completed.stdout);
+
+  assert.equal(completed.status, 1);
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error.code, 'TASK_DOCUMENT_INVALID');
+  assert.match(result.error.message, /LEDGER_ID_INVALID/);
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('completed approved review remains a no-op after the ledger changes', () => {
+  const scenario = reviewScenarios[2];
+  const f = prepareReview(scenario, []);
+  const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+  assert.equal(completed.status, 0, completed.stderr);
+
+  const content = fs.readFileSync(f.file, 'utf8');
+  fs.writeFileSync(
+    f.file,
+    content.replace(
+      '|----|-------|-------|----------|--------|----------|',
+      '|----|-------|-------|----------|--------|----------|\n| CD-1 | code | 1 | minor | open | review-code.md#CD-1 |'
+    )
+  );
+  const beforeReplay = fs.readFileSync(f.file);
+  const replayed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+
+  assert.equal(replayed.status, 0, replayed.stderr);
+  assert.equal(JSON.parse(replayed.stdout).status, 'no-op');
+  assert.deepEqual(fs.readFileSync(f.file), beforeReplay);
 });
 
 test('review-code event completes a supplemental round against the latest code artifact', () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #732

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #732

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

Prevent approved review events from recording Activity Log finding counts that disagree with the current review ledger. This closes the ordering gap where a caller could complete a review before resolving ledger findings and permanently persist contradictory counts.

防止 approved 审查事件把与当前审查账本不一致的 finding 计数写入 Activity Log，避免因调用顺序错误固化矛盾状态。

## 📋 主要变更 / Brief Changelog

- Map the three review event families explicitly to their ledger stages.
- Compare approved `blockers` / `major` / `minor` values with shared `unresolvedFindingCounts` before any write metadata is captured.
- Return `EVENT_FINDING_COUNT_MISMATCH` with field-level expected and received values while preserving non-approved, dry-run, conflict, and idempotent replay behavior.
- Add integration coverage for all three stages, matching and mismatching counts, verdict bypasses, invalid ledgers, dry-run, and replay.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run `node --experimental-strip-types --no-warnings --test tests/integration/cli/task-event.test.ts`.
3. Run `npm run test:core` and `npm test`.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Results:

- Focused integration: 28 passed, 0 failed.
- Core: 1566 passed, 0 failed, 1 skipped.
- Full: 1867 passed, 0 failed, 2 skipped.
- Code review: Approved, 0 blocker / 0 major / 0 minor, no manual validation required.

## 📸 截图 / Screenshots

Not applicable; this change affects internal CLI validation behavior.

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a GitHub issue filed for the change
- [x] PR 只解决一个 Issue / This PR addresses one issue without unrelated changes
- [x] 每个 commit 都有有意义的主题和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 代码遵循项目规范 / The code follows the project's coding standards
- [x] 已进行自我代码审查 / I have performed a self-review
- [x] 复杂逻辑通过清晰命名和聚焦函数保持可读 / Complex logic remains readable through focused functions and clear naming

**测试要求 / Testing Requirements:**

- [x] 已编写必要测试验证逻辑 / I have written the necessary tests
- [x] TypeScript 类型检查通过 / TypeScript checks pass
- [x] 单元与集成测试通过 / Unit and integration tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 不需要用户文档变更 / No user-facing documentation change is required
- [x] 没有破坏性变更 / This change is non-breaking
- [x] 已考虑向后兼容性 / Backward compatibility was considered

## 📋 附加信息 / Additional Notes

- The gate intentionally runs after no-op, artifact, conflict, and transition checks, but before metadata capture and mutation construction.
- Non-approved verdicts do not parse or validate the ledger.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on the validation ordering in `applyTaskEvent`, the explicit review-family mapping, and the idempotent replay regression coverage.

Generated with AI assistance
