### PR TITLE
fix(review): 修复审查报告计数与账本状态不一致


### DIFF
--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -69,7 +69,20 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ### 6. 更新任务状态
 
-报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage analysis`，以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`。
+报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage analysis`。
+
+从该次返回值绑定并复用以下结构化映射：
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`。
 
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。
 

--- a/.agents/skills/review-analysis/reference/report-template.md
+++ b/.agents/skills/review-analysis/reference/report-template.md
@@ -22,7 +22,7 @@
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
 - **总体结论**：{通过 / 需要修改 / 拒绝}
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -84,10 +84,23 @@ agent-infra-internal task-snapshot {task-id} --format text
 ### 6. 更新任务状态
 
 - 报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage code --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行
-- 全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage code`。以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor；仅 `canAdvance=true` 可用 Approved
+- 全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage code`
+
+  从该次返回值绑定并复用以下结构化映射：
+
+  ```text
+  {unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+  {unresolved-major} = stageStatus.unresolvedFindingCounts.major
+  {unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+  report-summary.blocker = {unresolved-blockers}
+  report-summary.major = {unresolved-major}
+  report-summary.minor = {unresolved-minor}
+  ```
+
+  先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步；仅 `canAdvance=true` 可用 Approved
 - 仅当 `canAdvance=true`、本轮结论为 Approved 且 `T == R^{tree}` 时写入 `last_reviewed_commit: {R}`；Approved 快照包含未提交差异时清除旧值。否则保留既有值，不得推进或清空
 - Approved 出口继续按 `reference/output-templates.md` 采集 PR 与 required-checks 事实：未提交/未推送走 `commit`，无 PR 走 `create-pr`（无 PR 流程除外），checks 未终态走 `watch-pr`，仅 `HEAD == last_reviewed_commit == PR head` 且 checks 为 `passed|no-required` 时走 `complete-task`；不得仅按审查轮次分流
-- 完成 `last_reviewed_commit` 处理后执行 `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`
+- 完成 `last_reviewed_commit` 处理后执行 `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`
 
 完成日志必须始终写入 `Manual-validation: {n}` 字段，0 也保留。
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。

--- a/.agents/skills/review-code/reference/report-template.md
+++ b/.agents/skills/review-code/reference/report-template.md
@@ -25,7 +25,7 @@
 - **审查差异指纹**：{git-workflow snapshot 输出的 fingerprint 字段}
 - **审查快照树**：{git-workflow snapshot 输出的 tree 字段}
 - **总体结论**：{通过 / 需要修改 / 拒绝}（恰取一个；禁止写组合短语，否则 verify gate 失败）
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -69,7 +69,20 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ### 6. 更新任务状态
 
-报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage plan`，以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`。
+报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage plan`。
+
+从该次返回值绑定并复用以下结构化映射：
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`。
 
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。
 

--- a/.agents/skills/review-plan/reference/report-template.md
+++ b/.agents/skills/review-plan/reference/report-template.md
@@ -22,7 +22,7 @@
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
 - **总体结论**：{通过 / 需要修改 / 拒绝}
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -66,7 +66,20 @@ Create `.agents/workspace/active/{task-id}/{review-artifact}`.
 
 ### 6. Update Task Status
 
-After the report, submit each new finding with `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`; submit prior-response dispositions with `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {evidence}`. Do not scan ids or edit ledger rows. After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage analysis` exactly once. Derive the verdict and next-step branch from `stageStatus.canAdvance`, and blocker/major/minor event counts from `unresolvedFindingCounts`: only `canAdvance=true` permits `approved`; otherwise use `changes-requested` or `rejected`. Then run `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`.
+After the report, submit each new finding with `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`; submit prior-response dispositions with `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {evidence}`. Do not scan ids or edit ledger rows. After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage analysis` exactly once.
+
+Bind and reuse this structured mapping from that one response:
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+First replace the matching placeholders in the report summary with those values. Do not preserve estimates or total findings, and do not rescan the finding list. If replacement fails or a response field is missing, stop before the completion event. Derive the verdict and next-step branch from the same response's `stageStatus.canAdvance`: only `canAdvance=true` permits `approved`; otherwise use `changes-requested` or `rejected`. Then run `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`.
 
 `manual-validation` is the data source for the `Manual-validation` count folded into review rows in `ai task log`; do not add a parallel manual-verification field.
 

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -69,7 +69,20 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ### 6. 更新任务状态
 
-报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage analysis`，以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`。
+报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage analysis --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage analysis`。
+
+从该次返回值绑定并复用以下结构化映射：
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-analysis.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`。
 
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。
 

--- a/templates/.agents/skills/review-analysis/reference/report-template.en.md
+++ b/templates/.agents/skills/review-analysis/reference/report-template.en.md
@@ -22,7 +22,7 @@ Use this template when writing `review-analysis.md` or `review-analysis-r{N}.md`
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}
 - **Overall Verdict**: {Approved / Changes Requested / Rejected}
-- **Findings (AI-actionable)**: 0 blockers, 0 majors, 0 minors / **Manual validation**: 0
+- **Findings (AI-actionable)**: {unresolved-blockers} blockers, {unresolved-major} majors, {unresolved-minor} minors / **Manual validation**: 0
 
 ## Review Coverage Declaration
 

--- a/templates/.agents/skills/review-analysis/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/reference/report-template.zh-CN.md
@@ -22,7 +22,7 @@
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
 - **总体结论**：{通过 / 需要修改 / 拒绝}
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -86,10 +86,23 @@ Create `.agents/workspace/active/{task-id}/{review-artifact}`.
 
 Update task.md:
 - After the report, submit each new finding with `agent-infra-internal task-ledger {task-id} finding-upsert --stage code --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`; submit prior-response dispositions with `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {evidence}`. Do not scan ids or edit ledger rows
-- After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage code` exactly once. Derive the verdict and next-step branch from `stageStatus.canAdvance`, and blocker/major/minor event counts from `unresolvedFindingCounts`; only `canAdvance=true` permits Approved
+- After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage code` exactly once
+
+  Bind and reuse this structured mapping from that one response:
+
+  ```text
+  {unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+  {unresolved-major} = stageStatus.unresolvedFindingCounts.major
+  {unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+  report-summary.blocker = {unresolved-blockers}
+  report-summary.major = {unresolved-major}
+  report-summary.minor = {unresolved-minor}
+  ```
+
+  First replace the matching placeholders in the report summary with those values. Do not preserve estimates or total findings, and do not rescan the finding list. If replacement fails or a response field is missing, stop before the completion event. Derive the verdict and next-step branch from the same response's `stageStatus.canAdvance`; only `canAdvance=true` permits Approved
 - Only when `canAdvance=true`, the verdict is Approved, and `T == R^{tree}`, write `last_reviewed_commit: {R}`. Clear an old value for an Approved snapshot with uncommitted differences; otherwise preserve the existing value and do not advance it
 - For an Approved exit, collect PR and required-checks facts as defined in `reference/output-templates.md`: route uncommitted/unpushed code to `commit`, no PR to `create-pr` (except no-PR flow), non-terminal checks to `watch-pr`, and route to `complete-task` only when `HEAD == last_reviewed_commit == PR head` with checks `passed|no-required`; never route by review round alone
-- After handling `last_reviewed_commit`, run `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`
+- After handling `last_reviewed_commit`, run `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`
 
 Always include the `Manual-validation: {n}` field in the done log, including when it is 0.
 `manual-validation` is the data source for the `Manual-validation` count folded into review rows in `ai task log`; do not add a parallel manual-verification field.

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -84,10 +84,23 @@ agent-infra-internal task-snapshot {task-id} --format text
 ### 6. 更新任务状态
 
 - 报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage code --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行
-- 全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage code`。以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor；仅 `canAdvance=true` 可用 Approved
+- 全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage code`
+
+  从该次返回值绑定并复用以下结构化映射：
+
+  ```text
+  {unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+  {unresolved-major} = stageStatus.unresolvedFindingCounts.major
+  {unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+  report-summary.blocker = {unresolved-blockers}
+  report-summary.major = {unresolved-major}
+  report-summary.minor = {unresolved-minor}
+  ```
+
+  先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步；仅 `canAdvance=true` 可用 Approved
 - 仅当 `canAdvance=true`、本轮结论为 Approved 且 `T == R^{tree}` 时写入 `last_reviewed_commit: {R}`；Approved 快照包含未提交差异时清除旧值。否则保留既有值，不得推进或清空
 - Approved 出口继续按 `reference/output-templates.md` 采集 PR 与 required-checks 事实：未提交/未推送走 `commit`，无 PR 走 `create-pr`（无 PR 流程除外），checks 未终态走 `watch-pr`，仅 `HEAD == last_reviewed_commit == PR head` 且 checks 为 `passed|no-required` 时走 `complete-task`；不得仅按审查轮次分流
-- 完成 `last_reviewed_commit` 处理后执行 `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`
+- 完成 `last_reviewed_commit` 处理后执行 `agent-infra-internal task-event {task-id} review-code.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`
 
 完成日志必须始终写入 `Manual-validation: {n}` 字段，0 也保留。
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。

--- a/templates/.agents/skills/review-code/reference/report-template.en.md
+++ b/templates/.agents/skills/review-code/reference/report-template.en.md
@@ -25,7 +25,7 @@ Use this template when writing `review-code.md` or `review-code-r{N}.md`.
 - **Reviewed Diff Fingerprint**: {fingerprint field from git-workflow snapshot}
 - **Reviewed Snapshot Tree**: {tree field from git-workflow snapshot}
 - **Overall Verdict**: {Approved / Changes Requested / Rejected} (pick exactly one; combined phrases will fail the verify gate)
-- **Findings (AI-actionable)**: 0 blockers, 0 majors, 0 minors / **Manual validation**: 0
+- **Findings (AI-actionable)**: {unresolved-blockers} blockers, {unresolved-major} majors, {unresolved-minor} minors / **Manual validation**: 0
 
 ## Review Coverage Declaration
 

--- a/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
@@ -25,7 +25,7 @@
 - **审查差异指纹**：{git-workflow snapshot 输出的 fingerprint 字段}
 - **审查快照树**：{git-workflow snapshot 输出的 tree 字段}
 - **总体结论**：{通过 / 需要修改 / 拒绝}（恰取一个；禁止写组合短语，否则 verify gate 失败）
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -66,7 +66,20 @@ Create `.agents/workspace/active/{task-id}/{review-artifact}`.
 
 ### 6. Update Task Status
 
-After the report, submit each new finding with `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`; submit prior-response dispositions with `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {evidence}`. Do not scan ids or edit ledger rows. After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage plan` exactly once. Derive the verdict and next-step branch from `stageStatus.canAdvance`, and blocker/major/minor event counts from `unresolvedFindingCounts`: only `canAdvance=true` permits `approved`; otherwise use `changes-requested` or `rejected`. Then run `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`.
+After the report, submit each new finding with `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`; submit prior-response dispositions with `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {evidence}`. Do not scan ids or edit ledger rows. After all ledger writes, call `agent-infra-internal task-ledger {task-id} stage-status --stage plan` exactly once.
+
+Bind and reuse this structured mapping from that one response:
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+First replace the matching placeholders in the report summary with those values. Do not preserve estimates or total findings, and do not rescan the finding list. If replacement fails or a response field is missing, stop before the completion event. Derive the verdict and next-step branch from the same response's `stageStatus.canAdvance`: only `canAdvance=true` permits `approved`; otherwise use `changes-requested` or `rejected`. Then run `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`.
 
 `manual-validation` is the data source for the `Manual-validation` count folded into review rows in `ai task log`; do not add a parallel manual-verification field.
 

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -69,7 +69,20 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ### 6. 更新任务状态
 
-报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage plan`，以 `stageStatus.canAdvance` 决定 verdict 和下一步，并以 `unresolvedFindingCounts` 填写 blocker/major/minor：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {n} --major {n} --minor {n} --manual-validation {n}`。
+报告完成后，新 finding 逐条调用 `agent-infra-internal task-ledger {task-id} finding-upsert --stage plan --review-artifact {review-artifact} --ordinal {n} --severity {blocker|major|minor} --evidence {review-artifact}#{anchor}`；复核上一轮响应时调用 `finding-review --id {ledger-id} --status {confirmed|closed|open|needs-human-decision} --evidence {相称证据}`。不得扫描编号或手写账本行。全部账本写入完成后只调用一次 `agent-infra-internal task-ledger {task-id} stage-status --stage plan`。
+
+从该次返回值绑定并复用以下结构化映射：
+
+```text
+{unresolved-blockers} = stageStatus.unresolvedFindingCounts.blocker
+{unresolved-major} = stageStatus.unresolvedFindingCounts.major
+{unresolved-minor} = stageStatus.unresolvedFindingCounts.minor
+report-summary.blocker = {unresolved-blockers}
+report-summary.major = {unresolved-major}
+report-summary.minor = {unresolved-minor}
+```
+
+先用上述值替换报告模板摘要中的同名占位符，不得保留预估值、finding 总数或再次扫描问题清单；替换失败或返回字段缺失时，停止在完成事件之前。以同一次返回的 `stageStatus.canAdvance` 决定 verdict 和下一步：仅 `canAdvance=true` 可用 `approved`，否则必须用 `changes-requested` 或 `rejected`。随后执行 `agent-infra-internal task-event {task-id} review-plan.completed --agent {agent} --artifact {review-artifact} --verdict {approved|changes-requested|rejected} --blockers {unresolved-blockers} --major {unresolved-major} --minor {unresolved-minor} --manual-validation {n}`。
 
 `manual-validation` 是 `ai task log` 中 review 行「人工校验点」（EN `Manual-validation`）计数的数据源；不要新增并行人工验证字段。
 

--- a/templates/.agents/skills/review-plan/reference/report-template.en.md
+++ b/templates/.agents/skills/review-plan/reference/report-template.en.md
@@ -22,7 +22,7 @@ Use this template when writing `review-plan.md` or `review-plan-r{N}.md`.
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}
 - **Overall Verdict**: {Approved / Changes Requested / Rejected}
-- **Findings (AI-actionable)**: 0 blockers, 0 majors, 0 minors / **Manual validation**: 0
+- **Findings (AI-actionable)**: {unresolved-blockers} blockers, {unresolved-major} majors, {unresolved-minor} minors / **Manual validation**: 0
 
 ## Review Coverage Declaration
 

--- a/templates/.agents/skills/review-plan/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-plan/reference/report-template.zh-CN.md
@@ -22,7 +22,7 @@
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}
 - **总体结论**：{通过 / 需要修改 / 拒绝}
-- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0
+- **发现（AI 可处理）**：{unresolved-blockers} 阻塞项，{unresolved-major} 主要，{unresolved-minor} 次要 / **人工校验**：0
 
 ## 检视覆盖声明
 

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -267,6 +267,75 @@ test("workflow state-check consumers use the typed task snapshot entrypoint", ()
   });
 });
 
+test("review skills reuse one unresolved-count snapshot for reports and completion events", () => {
+  const reviewFamilies = [
+    { name: "review-analysis", stage: "analysis", event: "review-analysis.completed" },
+    { name: "review-plan", stage: "plan", event: "review-plan.completed" },
+    { name: "review-code", stage: "code", event: "review-code.completed" }
+  ];
+  const countMappings = [
+    { field: "blocker", placeholder: "{unresolved-blockers}", reportField: "blocker", flag: "--blockers" },
+    { field: "major", placeholder: "{unresolved-major}", reportField: "major", flag: "--major" },
+    { field: "minor", placeholder: "{unresolved-minor}", reportField: "minor", flag: "--minor" }
+  ];
+
+  reviewFamilies.forEach(({ name, stage, event }) => {
+    skillDocPaths(name).forEach((relativePath) => {
+      const content = read(relativePath);
+      const stageCommand = `agent-infra-internal task-ledger {task-id} stage-status --stage ${stage}`;
+      const eventCommand = `agent-infra-internal task-event {task-id} ${event}`;
+      const stageIndex = content.indexOf(stageCommand);
+      const eventIndex = content.indexOf(eventCommand);
+
+      assert.equal(
+        [...content.matchAll(new RegExp(escapeRegExp(stageCommand), "g"))].length,
+        1,
+        `${relativePath} should read the stage status exactly once`
+      );
+      assert.notEqual(eventIndex, -1, `${relativePath} should declare its completion event`);
+
+      countMappings.forEach(({ field, placeholder, reportField, flag }) => {
+        const binding = `${placeholder} = stageStatus.unresolvedFindingCounts.${field}`;
+        const reportMapping = `report-summary.${reportField} = ${placeholder}`;
+        const bindingIndex = content.indexOf(binding);
+        const reportIndex = content.indexOf(reportMapping);
+
+        assert.ok(stageIndex < bindingIndex, `${relativePath} should bind ${placeholder} after stage-status`);
+        assert.ok(bindingIndex < reportIndex, `${relativePath} should map ${placeholder} into the report`);
+        assert.ok(reportIndex < eventIndex, `${relativePath} should finalize the report before the completion event`);
+        assert.ok(
+          content.includes(`${flag} ${placeholder}`),
+          `${relativePath} should reuse ${placeholder} for ${flag}`
+        );
+      });
+    });
+  });
+});
+
+test("review report templates expose unresolved-count placeholders exactly once", () => {
+  const reportTemplates = [
+    ...["review-analysis", "review-plan", "review-code"].map(
+      (name) => `.agents/skills/${name}/reference/report-template.md`
+    ),
+    ...["review-analysis", "review-plan", "review-code"].flatMap((name) => [
+      `templates/.agents/skills/${name}/reference/report-template.zh-CN.md`,
+      `templates/.agents/skills/${name}/reference/report-template.en.md`
+    ])
+  ];
+
+  reportTemplates.forEach((relativePath) => {
+    const content = read(relativePath);
+
+    ["{unresolved-blockers}", "{unresolved-major}", "{unresolved-minor}"].forEach((placeholder) => {
+      assert.equal(
+        [...content.matchAll(new RegExp(escapeRegExp(placeholder), "g"))].length,
+        1,
+        `${relativePath} should contain ${placeholder} exactly once`
+      );
+    });
+  });
+});
+
 test("workflow verification consumers declare their business verification events", () => {
   const expectations: Record<string, string[]> = {
     "analyze-task": ["analyze.awaiting-input", "analyze.completed"],

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -280,6 +280,8 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".agents/scripts/find-existing-task.js", "templates/.agents/scripts/find-existing-task.js"],
     [".agents/skills/init-labels/SKILL.md", "templates/.agents/skills/init-labels/SKILL.en.md"],
     [".agents/skills/plan-task/SKILL.md", "templates/.agents/skills/plan-task/SKILL.en.md"],
+    [".agents/skills/review-analysis/SKILL.md", "templates/.agents/skills/review-analysis/SKILL.en.md"],
+    [".agents/skills/review-plan/SKILL.md", "templates/.agents/skills/review-plan/SKILL.en.md"],
     [".agents/skills/review-code/SKILL.md", "templates/.agents/skills/review-code/SKILL.en.md"],
     [".agents/skills/watch-pr/SKILL.md", "templates/.agents/skills/watch-pr/SKILL.en.md"],
     [".agents/skills/update-agent-infra/SKILL.md", "templates/.agents/skills/update-agent-infra/SKILL.en.md"],


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #736

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that doesn't need an issue

Closes #736

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

统一三个审查技能的未解决 finding 计数数据源，避免报告摘要、审查账本和完成事件对同一次审查给出冲突结果，并防止已批准产物被下游误判为 `Approved-with-issues`。

Use one unresolved-finding snapshot across review reports and completion events so approved artifacts remain consistent with the review ledger.

## 📋 主要变更 / Brief Changelog

- 让 `review-analysis`、`review-plan` 和 `review-code` 从同一次 `stage-status` 结果绑定未解决 blocker、major 和 minor 计数。
- 在发送完成事件前，用相同计数最终化三类审查报告摘要。
- 同步已部署技能、英文和中文模板，以及九份报告模板的占位符契约。
- 增加结构性测试，覆盖三类审查族、三种技能变体、执行顺序和模板镜像一致性。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run test:smoke` 和 `npm run test:core`。
3. 运行 `npm test` 与 `git diff --check`。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

结果：1879 passed，2 skipped，0 failed；代码审查结论为 Approved，0 blocker / 0 major / 0 minor，无需人工校验。

## 📸 截图 / Screenshots

不适用 / Not applicable.

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 有 GitHub Issue 对应这个变更 / A GitHub Issue exists for this change
- [x] 本 PR 只解决一个 Issue / This PR addresses one issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project conventions
- [x] 已完成代码审查 / Code review is complete
- [x] 变更保持在批准的写入端范围内 / Changes stay within the approved writer-side scope

### 测试要求 / Testing Requirements

- [x] 已编写必要单元测试 / Necessary unit tests are included
- [x] TypeScript 类型检查通过 / TypeScript type checking passes
- [x] 单元与完整回归测试通过 / Unit and full regression tests pass
- [ ] 代码检查通过 / Lint checks pass（项目当前未配置 lint）

### 文档和兼容性 / Documentation and Compatibility

- [x] 已同步技能文档和双语模板 / Skill documentation and bilingual templates are synchronized
- [x] 已考虑向后兼容性 / Backward compatibility is considered
- [x] 无破坏性变更 / No breaking changes

## 📋 附加信息 / Additional Notes

- 保持现有 parser、任务事件核心和历史产物语义不变。
- `manual-validation` 计数继续独立处理，不复用 finding 计数。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 `stage-status → 计数绑定 → 报告最终化 → completed 事件` 的顺序，以及部署技能与双语模板的结构一致性。

Generated with AI assistance
