### PR TITLE
fix(deps): 同步 node-pty 的最低声明版本

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "node": ">=22.9.0"
       },
       "optionalDependencies": {
-        "@lydell/node-pty": "^1.2.0-beta.12"
+        "@lydell/node-pty": "^1.2.0-beta.14"
       }
     },
     "node_modules/@clack/core": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "~7.0"
   },
   "optionalDependencies": {
-    "@lydell/node-pty": "^1.2.0-beta.12"
+    "@lydell/node-pty": "^1.2.0-beta.14"
   },
   "overrides": {
     "axios": "1.18.1"


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

- [ ] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [x] 这是一个微小的修改，不需要 Issue / This is a trivial change that doesn't need an issue

Related: #753, #754

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [x] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

#753 updated the lockfile resolution of `@lydell/node-pty` to `1.2.0-beta.14`, but left the declared optional dependency floor at `^1.2.0-beta.12`. This made the dependency upgrade incomplete at the manifest level.

将 `package.json` 和 lockfile 根包元数据中的最低声明版本同步到 `^1.2.0-beta.14`，确保项目不再声明兼容较低的 beta.12/beta.13 版本。

## 📋 主要变更 / Brief Changelog

- Raise `optionalDependencies["@lydell/node-pty"]` from `^1.2.0-beta.12` to `^1.2.0-beta.14`.
- Keep the root package metadata in `package-lock.json` aligned with `package.json`.
- Leave #754's cleanup of the duplicate lockfile `dependencies` entry independent, avoiding cross-PR overwrite.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run `npm run test:core`.
3. Run `npm test` and confirm the manifest range and locked version are both beta.14 or newer.

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests（仅依赖元数据变更，无需新增测试）
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：

- `npm run typecheck`：通过
- `npm run test:core`：1573 passed、2 skipped、0 failed
- `npm test`：1880 passed、5 skipped、0 failed

## 📸 截图 / Screenshots

不适用；本次仅修正依赖元数据。

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 本次为无需单独 Issue 的微小依赖元数据修正
- [x] 本 PR 只修正 node-pty 的最低声明版本
- [x] Commit 包含有意义的主题和说明

### 代码质量 / Code Quality

- [x] 变更遵循项目规范
- [x] 已完成自我审查
- [x] 无复杂代码需要新增注释

### 测试要求 / Testing Requirements

- [x] 本次无需新增单元测试
- [x] 不涉及跨模块 mock
- [x] 项目当前未配置 lint
- [x] 类型检查、核心测试和完整测试均通过

### 文档和兼容性 / Documentation and Compatibility

- [x] 无需额外文档更新
- [x] 无破坏性 API 变化
- [x] 已考虑与 #754 的合并顺序及向后兼容性

## 📋 附加信息 / Additional Notes

- 当前 lockfile 仍解析 `@lydell/node-pty@1.2.0-beta.14`。
- 仓库现有的 1 个 moderate audit 告警不属于本次变更范围。
- #754 合并后会独立移除 lockfile 中重复的 `dependencies` 元数据行；本 PR 不会重新引入该行。

---

**审查者注意事项 / Reviewer Notes:**

请确认 manifest 与 lockfile 的 optional dependency 范围均为 `^1.2.0-beta.14`，并确认与 #754 的变更可独立合并。

Generated with AI assistance
