### PR TITLE
refactor(agent-client): 迁移 Codex Agent Client Adapter


### DIFF
--- a/lib/agent-clients/adapter.ts
+++ b/lib/agent-clients/adapter.ts
@@ -11,6 +11,7 @@ import {
   SANDBOX_HOOK_PHASES
 } from '../sandbox/tool-types.ts';
 import type {
+  AgentClientSandboxRecoveryCheck,
   AgentClientSandboxDescriptor,
   SandboxAlias,
   SandboxTool,
@@ -61,6 +62,28 @@ type AgentClientManifestEntry = Readonly<{
 const PROJECT_ASSET_CATEGORIES = ['managed', 'merged', 'ejected'] as const;
 const MAX_SANDBOX_HOOK_TIMEOUT_MS = 300_000;
 const TOOL_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+function freezeRecoveryProbe(
+  id: AgentClientId,
+  checkId: string,
+  value: AgentClientSandboxRecoveryCheck['probe']
+): AgentClientSandboxRecoveryCheck['probe'] {
+  if (
+    !value
+    || typeof value.script !== 'string'
+    || value.script.trim() === ''
+    || !Array.isArray(value.args)
+    || value.args.some((arg) => typeof arg !== 'string')
+    || (value.user !== undefined && (typeof value.user !== 'string' || value.user === ''))
+  ) {
+    throw new Error(`Agent Client '${id}' recovery check '${checkId}' has an invalid probe`);
+  }
+  return Object.freeze({
+    script: value.script,
+    args: Object.freeze([...value.args]),
+    ...(value.user === undefined ? {} : { user: value.user })
+  });
+}
 
 function freezeTool(tool: SandboxTool): SandboxTool {
   if (typeof tool.id !== 'string' || !TOOL_ID_PATTERN.test(tool.id)) {
@@ -328,6 +351,80 @@ function defineAgentClientAdapter(
     hookIds.add(hook.id);
     return Object.freeze({ ...hook });
   }));
+  const recoveryCheckIds = new Set<string>();
+  if (
+    candidate.sandbox.recoveryChecks !== undefined
+    && !Array.isArray(candidate.sandbox.recoveryChecks)
+  ) {
+    throw new Error(`Agent Client '${candidate.id}' has invalid recovery checks`);
+  }
+  const recoveryChecks = Object.freeze(
+    (candidate.sandbox.recoveryChecks ?? []).map((check) => {
+      if (
+        !check
+        || typeof check.id !== 'string'
+        || !TOOL_ID_PATTERN.test(check.id)
+        || recoveryCheckIds.has(check.id)
+      ) {
+        throw new Error(`Agent Client '${candidate.id}' has an invalid recovery check`);
+      }
+      const probe = freezeRecoveryProbe(candidate.id, check.id, check.probe);
+      const when = check.when === undefined
+        ? undefined
+        : freezeRecoveryProbe(candidate.id, check.id, check.when);
+      if (
+        !check.finding
+        || !['permissions', 'builtin-link', 'hard-failure'].includes(check.finding.repairKind)
+        || typeof check.finding.message !== 'string'
+        || check.finding.message.trim() === ''
+        || (
+          check.finding.path !== undefined
+          && (typeof check.finding.path !== 'string' || !check.finding.path.startsWith('/'))
+        )
+        || (
+          check.finding.repairKind === 'permissions'
+          && check.finding.path === undefined
+        )
+      ) {
+        throw new Error(
+          `Agent Client '${candidate.id}' recovery check '${check.id}' has an invalid finding`
+        );
+      }
+      let repair: AgentClientSandboxRecoveryCheck['repair'];
+      if (check.repair !== undefined) {
+        if (
+          typeof check.repair.user !== 'string'
+          || check.repair.user === ''
+          || typeof check.repair.command !== 'string'
+          || check.repair.command === ''
+          || !Array.isArray(check.repair.args)
+          || check.repair.args.some((arg: unknown) => typeof arg !== 'string')
+        ) {
+          throw new Error(
+            `Agent Client '${candidate.id}' recovery check '${check.id}' has an invalid repair`
+          );
+        }
+        repair = Object.freeze({
+          user: check.repair.user,
+          command: check.repair.command,
+          args: Object.freeze([...check.repair.args])
+        });
+      }
+      if (check.finding.repairKind === 'builtin-link' && repair === undefined) {
+        throw new Error(
+          `Agent Client '${candidate.id}' recovery check '${check.id}' requires a repair`
+        );
+      }
+      recoveryCheckIds.add(check.id);
+      return Object.freeze({
+        id: check.id,
+        ...(when === undefined ? {} : { when }),
+        probe,
+        finding: Object.freeze({ ...check.finding }),
+        ...(repair === undefined ? {} : { repair })
+      });
+    })
+  );
   const aliases = freezeAliases(candidate.id, candidate.sandbox.aliases);
   const createTool = (context: SandboxToolContext): SandboxTool => {
     const tool = freezeTool(candidate.sandbox.createTool(context));
@@ -349,7 +446,7 @@ function defineAgentClientAdapter(
       ...projectAssets,
       seedCommands: Object.freeze(seedCommands)
     }),
-    sandbox: Object.freeze({ createTool, aliases, hooks })
+    sandbox: Object.freeze({ createTool, aliases, hooks, recoveryChecks })
   });
 }
 

--- a/lib/agent-clients/adapters/codex-sandbox.ts
+++ b/lib/agent-clients/adapters/codex-sandbox.ts
@@ -1,0 +1,245 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import * as toml from 'smol-toml';
+
+import type {
+  AgentClientSandboxHook,
+  AgentClientSandboxRecoveryCheck
+} from '../../sandbox/tool-types.ts';
+
+type JsonObject = Record<string, unknown>;
+
+function isJsonObjectRecord(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function resolveHostCatalogPath(value: unknown, hostHomeDir: string): string | null {
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+  let resolved: string;
+  if (value === '~' || value.startsWith('~/') || value.startsWith('~\\')) {
+    resolved = path.join(hostHomeDir, value.slice(1).replace(/^[/\\]+/, ''));
+  } else if (path.isAbsolute(value)) {
+    resolved = value;
+  } else {
+    resolved = path.join(hostHomeDir, '.codex', value);
+  }
+  try {
+    if (!fs.statSync(resolved).isFile()) {
+      return null;
+    }
+    fs.accessSync(resolved, fs.constants.R_OK);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+const CODEX_DISABLED_FEATURE_FLAGS = ['apps', 'enable_mcp_apps'] as const;
+
+function removeCodexMcpServers(sandboxParsed: JsonObject): boolean {
+  if (!Object.hasOwn(sandboxParsed, 'mcp_servers')) {
+    return false;
+  }
+  delete sandboxParsed.mcp_servers;
+  return true;
+}
+
+function inheritDisabledCodexFeatureFlags(
+  sandboxParsed: JsonObject,
+  hostParsed: JsonObject
+): boolean {
+  if (!isJsonObjectRecord(hostParsed.features)) {
+    return false;
+  }
+  if (Object.hasOwn(sandboxParsed, 'features') && !isJsonObjectRecord(sandboxParsed.features)) {
+    return false;
+  }
+
+  let sandboxFeatures = sandboxParsed.features as JsonObject | undefined;
+  let changed = false;
+  for (const key of CODEX_DISABLED_FEATURE_FLAGS) {
+    if (hostParsed.features[key] !== false) {
+      continue;
+    }
+    if (!sandboxFeatures) {
+      sandboxFeatures = {};
+      sandboxParsed.features = sandboxFeatures;
+    }
+    if (sandboxFeatures[key] !== false) {
+      sandboxFeatures[key] = false;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function ensureCodexModelInheritance(
+  toolDir: string,
+  hostHomeDir?: string,
+  containerCodexDir: string = '/home/devuser/.codex'
+): void {
+  if (!hostHomeDir) {
+    return;
+  }
+
+  const hostConfigPath = path.join(hostHomeDir, '.codex', 'config.toml');
+  if (!fs.existsSync(hostConfigPath)) {
+    return;
+  }
+
+  let hostParsed: JsonObject;
+  try {
+    hostParsed = toml.parse(fs.readFileSync(hostConfigPath, 'utf8')) as JsonObject;
+  } catch {
+    return;
+  }
+
+  const sandboxConfigPath = path.join(toolDir, 'config.toml');
+  // This rewrites sandbox-side TOML and drops comments; the host config stays untouched.
+  let sandboxParsed: JsonObject = {};
+  if (fs.existsSync(sandboxConfigPath)) {
+    try {
+      sandboxParsed = toml.parse(fs.readFileSync(sandboxConfigPath, 'utf8')) as JsonObject;
+    } catch {
+      return;
+    }
+  }
+
+  let changed = removeCodexMcpServers(sandboxParsed);
+  changed = inheritDisabledCodexFeatureFlags(sandboxParsed, hostParsed) || changed;
+
+  const inheritSpecs: Array<readonly [string, 'string' | 'number']> = [
+    ['model', 'string'],
+    ['model_reasoning_effort', 'string'],
+    ['model_auto_compact_token_limit', 'number']
+  ];
+
+  for (const [key, type] of inheritSpecs) {
+    if (Object.hasOwn(sandboxParsed, key)) {
+      continue;
+    }
+    const value = hostParsed[key];
+    if (type === 'string' && (typeof value !== 'string' || value === '')) {
+      continue;
+    }
+    if (type === 'number' && (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)) {
+      continue;
+    }
+    sandboxParsed[key] = value;
+    changed = true;
+  }
+
+  if (!Object.hasOwn(sandboxParsed, 'model_catalog_json')) {
+    const hostCatalogPath = resolveHostCatalogPath(hostParsed['model_catalog_json'], hostHomeDir);
+    if (hostCatalogPath) {
+      try {
+        const basename = path.basename(hostCatalogPath);
+        const destDir = path.join(toolDir, 'model-catalogs');
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.copyFileSync(hostCatalogPath, path.join(destDir, basename));
+        sandboxParsed['model_catalog_json'] = path.posix.join(
+          containerCodexDir,
+          'model-catalogs',
+          basename
+        );
+        changed = true;
+      } catch {
+        // Copy failed (e.g. permissions): skip catalog, keep scalar inheritance intact.
+      }
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(sandboxConfigPath, `${toml.stringify(sandboxParsed)}\n`, 'utf8');
+  }
+}
+
+function ensureCodexWorkspaceTrust(toolDir: string): void {
+  const configPath = path.join(toolDir, 'config.toml');
+  let content = '';
+  if (fs.existsSync(configPath)) {
+    content = fs.readFileSync(configPath, 'utf8');
+  }
+  if (!content.includes('[projects."/workspace"]')) {
+    const entry = '\n[projects."/workspace"]\ntrust_level = "trusted"\n';
+    fs.writeFileSync(configPath, content + entry, 'utf8');
+  }
+}
+
+const codexBeforeContainerCreateHook: AgentClientSandboxHook = {
+  id: 'codex-before-container-create',
+  phase: 'before-container-create',
+  async run(context) {
+    const create = context.create;
+    const entry = create?.resolvedTools.find(({ tool }) => tool.id === 'codex');
+    if (!create || !entry) {
+      return {
+        status: 'fatal',
+        message: 'Codex sandbox hook requires its resolved tool state.'
+      };
+    }
+    ensureCodexModelInheritance(entry.dir, create.hostHome, entry.tool.containerMount);
+    ensureCodexWorkspaceTrust(entry.dir);
+    return { status: 'ready' };
+  }
+};
+
+const codexRecoveryChecks: readonly AgentClientSandboxRecoveryCheck[] = [
+  {
+    id: 'command-available',
+    probe: {
+      script: 'command -v "$1"',
+      args: ['codex']
+    },
+    finding: {
+      repairKind: 'hard-failure',
+      message: 'Codex is not available on PATH inside the sandbox.'
+    }
+  },
+  {
+    id: 'state-writable',
+    probe: {
+      script: 'probe="$1/.agent-infra-codex-state-$$"; trap \'rm -f -- "$probe"\' EXIT; : > "$probe"',
+      args: ['/home/devuser/.codex']
+    },
+    finding: {
+      repairKind: 'permissions',
+      message: 'Codex state directory is not writable by devuser.',
+      path: '/home/devuser/.codex'
+    }
+  },
+  {
+    id: 'prompts-link',
+    when: {
+      script: 'test -d "$1"',
+      args: ['/workspace/.codex/commands']
+    },
+    probe: {
+      script: 'test "$(readlink -- "$1")" = "$2"',
+      args: ['/home/devuser/.codex/prompts', '/workspace/.codex/commands']
+    },
+    finding: {
+      repairKind: 'builtin-link',
+      message: 'Codex prompts link does not point to the workspace commands directory.',
+      path: '/home/devuser/.codex/prompts'
+    },
+    repair: {
+      user: 'devuser',
+      command: 'ln',
+      args: [
+        '-sfn',
+        '/workspace/.codex/commands',
+        '/home/devuser/.codex/prompts'
+      ]
+    }
+  }
+];
+
+export {
+  codexBeforeContainerCreateHook,
+  codexRecoveryChecks,
+  ensureCodexModelInheritance,
+  ensureCodexWorkspaceTrust
+};

--- a/lib/agent-clients/adapters/codex.ts
+++ b/lib/agent-clients/adapters/codex.ts
@@ -1,5 +1,9 @@
 import { defineAgentClientAdapter } from '../adapter.ts';
 import { hostJoin } from '../../sandbox/engines/wsl2-paths.ts';
+import {
+  codexBeforeContainerCreateHook,
+  codexRecoveryChecks
+} from './codex-sandbox.ts';
 
 const codexAdapter = defineAgentClientAdapter({
   id: 'codex',
@@ -44,7 +48,8 @@ const codexAdapter = defineAgentClientAdapter({
       { name: 'codex-yolo', command: 'codex --yolo; tput ed' },
       { name: 'xy', command: 'codex --yolo; tput ed' }
     ],
-    hooks: []
+    hooks: [codexBeforeContainerCreateHook],
+    recoveryChecks: codexRecoveryChecks
   }
 });
 

--- a/lib/agent-clients/invocation.ts
+++ b/lib/agent-clients/invocation.ts
@@ -1,0 +1,19 @@
+type AgentClientInvocationInput = Readonly<{
+  skillName: string;
+  projectName?: string;
+  args?: readonly string[];
+}>;
+
+function renderAgentClientInvocation(
+  template: string,
+  input: AgentClientInvocationInput
+): string {
+  let command = template.replaceAll('${skillName}', input.skillName);
+  if (input.projectName !== undefined) {
+    command = command.replaceAll('${projectName}', input.projectName);
+  }
+  return [command, ...(input.args ?? [])].join(' ').trim();
+}
+
+export { renderAgentClientInvocation };
+export type { AgentClientInvocationInput };

--- a/lib/agent-clients/next-steps.ts
+++ b/lib/agent-clients/next-steps.ts
@@ -1,4 +1,5 @@
 import { listEnabledAgentClientAdapters } from './registry.ts';
+import { renderAgentClientInvocation } from './invocation.ts';
 import type { CustomTUI } from './custom-tuis.ts';
 import type { AgentClientId, AgentClientState } from './types.ts';
 
@@ -26,18 +27,6 @@ function requireSafeName(value: string, field: string): void {
   }
 }
 
-function renderInvocation(
-  invocation: string,
-  projectName: string,
-  skillName: string,
-  taskRef: string | undefined
-): string {
-  const command = invocation
-    .replaceAll('${projectName}', projectName)
-    .replaceAll('${skillName}', skillName);
-  return taskRef === undefined ? command : `${command} ${taskRef}`;
-}
-
 function renderNextStepCommands(
   input: RenderNextStepsInput
 ): readonly NextStepCommand[] {
@@ -52,11 +41,13 @@ function renderNextStepCommands(
       source: 'builtin',
       clientId: adapter.id,
       displayName: adapter.displayName,
-      command: renderInvocation(
+      command: renderAgentClientInvocation(
         adapter.invocation,
-        input.projectName,
-        input.skillName,
-        input.taskRef
+        {
+          projectName: input.projectName,
+          skillName: input.skillName,
+          args: input.taskRef === undefined ? [] : [input.taskRef]
+        }
       )
     })
   );
@@ -64,11 +55,13 @@ function renderNextStepCommands(
     (tool): NextStepCommand => Object.freeze({
       source: 'custom',
       displayName: tool.name,
-      command: renderInvocation(
+      command: renderAgentClientInvocation(
         tool.invocation,
-        input.projectName,
-        input.skillName,
-        input.taskRef
+        {
+          projectName: input.projectName,
+          skillName: input.skillName,
+          args: input.taskRef === undefined ? [] : [input.taskRef]
+        }
       )
     })
   );

--- a/lib/run/tui.ts
+++ b/lib/run/tui.ts
@@ -1,3 +1,6 @@
+import { renderAgentClientInvocation } from '../agent-clients/invocation.ts';
+import { getAgentClientAdapter } from '../agent-clients/registry.ts';
+
 export type TuiName = 'claude' | 'codex' | 'gemini' | 'opencode';
 
 const TUI_NAMES = new Set(['claude', 'codex', 'gemini', 'opencode']);
@@ -27,7 +30,12 @@ export function selectTui(
 
 export function renderPrompt(params: { tui: TuiName; skill: string; args: string[] }): string {
   const suffix = [params.skill, ...params.args].join(' ').trim();
-  if (params.tui === 'codex') return `$${suffix}`;
+  if (params.tui === 'codex') {
+    return renderAgentClientInvocation(getAgentClientAdapter('codex').invocation, {
+      skillName: params.skill,
+      args: params.args
+    });
+  }
   if (params.tui === 'gemini') return `/agent-infra:${suffix}`;
   return `/${suffix}`;
 }

--- a/lib/sandbox/agent-client-reconciler.ts
+++ b/lib/sandbox/agent-client-reconciler.ts
@@ -9,6 +9,7 @@ import { hostJoin } from './engines/wsl2-paths.ts';
 import type { AgentClientAdapter } from '../agent-clients/adapter.ts';
 import type { AgentClientState } from '../agent-clients/types.ts';
 import type {
+  AgentClientSandboxRecoveryCheck,
   AgentClientSandboxHook,
   AgentClientSandboxHookContext,
   AgentClientSandboxHookResult,
@@ -39,12 +40,29 @@ type SandboxRuntimeCapabilityProjection = Readonly<{
     phase: SandboxHookPhase;
     timeoutMs: number;
   }>[];
+  recoveryChecks: readonly Readonly<{
+    adapterId: string;
+    id: string;
+    when?: AgentClientSandboxRecoveryCheck['when'];
+    probe: AgentClientSandboxRecoveryCheck['probe'];
+    finding: Readonly<{
+      repairKind: AgentClientSandboxRecoveryCheck['finding']['repairKind'];
+      path?: string;
+    }>;
+    repair?: AgentClientSandboxRecoveryCheck['repair'];
+  }>[];
+}>;
+
+type PlannedAgentClientRecoveryCheck = Readonly<{
+  adapterId: string;
+  check: AgentClientSandboxRecoveryCheck;
 }>;
 
 type SandboxCapabilityPlan = Readonly<{
   tools: readonly SandboxTool[];
   selectedAgentClients: readonly AgentClientAdapter[];
   hooksByPhase: Readonly<Record<SandboxHookPhase, readonly AgentClientSandboxHook[]>>;
+  recoveryChecks: readonly PlannedAgentClientRecoveryCheck[];
   aliases: readonly SandboxAlias[];
   imageSignature: string;
   runtimeSignature: string;
@@ -136,8 +154,7 @@ function hooksByPhase(
     'prepare',
     'before-container-create',
     'after-container-start',
-    'before-enter',
-    'inspect-recovery'
+    'before-enter'
   ];
   return Object.freeze(Object.fromEntries(
     phases.map((phase) => [
@@ -199,10 +216,30 @@ function createSandboxCapabilityPlan(
       timeoutMs: hook.timeoutMs ?? DEFAULT_SANDBOX_HOOK_TIMEOUT_MS
     }))
   );
+  const recoveryChecks = Object.freeze(selectedAgentClients.flatMap((adapter) =>
+    (adapter.sandbox.recoveryChecks ?? []).map((check) => Object.freeze({
+      adapterId: adapter.id,
+      check
+    }))
+  ));
+  const recoveryCheckProjection = Object.freeze(recoveryChecks.map(({ adapterId, check }) =>
+    Object.freeze({
+      adapterId,
+      id: check.id,
+      ...(check.when === undefined ? {} : { when: check.when }),
+      probe: check.probe,
+      finding: Object.freeze({
+        repairKind: check.finding.repairKind,
+        ...(check.finding.path === undefined ? {} : { path: check.finding.path })
+      }),
+      ...(check.repair === undefined ? {} : { repair: check.repair })
+    })
+  ));
   const runtimeProjection = Object.freeze({
     tools: Object.freeze(tools.map(runtimeToolProjection)),
     selectedAgentClients: Object.freeze(selectedAgentClients.map((adapter) => adapter.id)),
-    hooks: Object.freeze(hookProjection)
+    hooks: Object.freeze(hookProjection),
+    recoveryChecks: recoveryCheckProjection
   });
   const cleanupInventory = Object.freeze([
     agentInfraTool(config.home),
@@ -215,6 +252,7 @@ function createSandboxCapabilityPlan(
     tools,
     selectedAgentClients,
     hooksByPhase: phaseHooks,
+    recoveryChecks,
     aliases: Object.freeze(
       listAgentClientAdapters().flatMap((adapter) => adapter.sandbox.aliases)
     ),
@@ -227,7 +265,6 @@ function createSandboxCapabilityPlan(
 
 function timeoutStatus(phase: SandboxHookPhase): SandboxHookStatus {
   if (phase === 'before-enter') return 'warning';
-  if (phase === 'inspect-recovery') return 'hard-failure';
   return 'fatal';
 }
 
@@ -336,5 +373,6 @@ export type {
   HookExecutionResult,
   SandboxCapabilityConfig,
   SandboxCapabilityPlan,
+  PlannedAgentClientRecoveryCheck,
   SandboxRuntimeCapabilityProjection
 };

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -7,7 +7,6 @@ import type { ExecFileSyncOptions, StdioOptions } from 'node:child_process';
 import { parseArgs } from 'node:util';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
-import * as toml from 'smol-toml';
 import { listAgentClientAdapters } from '../../agent-clients/registry.ts';
 import type { SandboxAlias } from '../tool-types.ts';
 import { loadConfig } from '../config.ts';
@@ -84,6 +83,11 @@ import {
   parseImageLabels,
   parseRefreshTimestamp
 } from '../image-build.ts';
+
+export {
+  ensureCodexModelInheritance,
+  ensureCodexWorkspaceTrust
+} from '../../agent-clients/adapters/codex-sandbox.ts';
 
 const SANDBOX_ALIAS_BLOCK_BEGIN = '# >>> agent-infra managed aliases >>>';
 const SANDBOX_ALIAS_BLOCK_END = '# <<< agent-infra managed aliases <<<';
@@ -968,154 +972,6 @@ export function ensureClaudeSettings(toolDir: string, hostHomeDir?: string): voi
   }
 }
 
-function resolveHostCatalogPath(value: unknown, hostHomeDir: string): string | null {
-  if (typeof value !== 'string' || value === '') {
-    return null;
-  }
-  let resolved: string;
-  if (value === '~' || value.startsWith('~/') || value.startsWith('~\\')) {
-    resolved = path.join(hostHomeDir, value.slice(1).replace(/^[/\\]+/, ''));
-  } else if (path.isAbsolute(value)) {
-    resolved = value;
-  } else {
-    resolved = path.join(hostHomeDir, '.codex', value);
-  }
-  try {
-    if (!fs.statSync(resolved).isFile()) {
-      return null;
-    }
-    fs.accessSync(resolved, fs.constants.R_OK);
-    return resolved;
-  } catch {
-    return null;
-  }
-}
-
-const CODEX_DISABLED_FEATURE_FLAGS = ['apps', 'enable_mcp_apps'] as const;
-
-function removeCodexMcpServers(sandboxParsed: JsonObject): boolean {
-  if (!Object.hasOwn(sandboxParsed, 'mcp_servers')) {
-    return false;
-  }
-  delete sandboxParsed.mcp_servers;
-  return true;
-}
-
-function inheritDisabledCodexFeatureFlags(sandboxParsed: JsonObject, hostParsed: JsonObject): boolean {
-  if (!isJsonObjectRecord(hostParsed.features)) {
-    return false;
-  }
-  if (Object.hasOwn(sandboxParsed, 'features') && !isJsonObjectRecord(sandboxParsed.features)) {
-    return false;
-  }
-
-  let sandboxFeatures = sandboxParsed.features as JsonObject | undefined;
-  let changed = false;
-  for (const key of CODEX_DISABLED_FEATURE_FLAGS) {
-    if (hostParsed.features[key] !== false) {
-      continue;
-    }
-    if (!sandboxFeatures) {
-      sandboxFeatures = {};
-      sandboxParsed.features = sandboxFeatures;
-    }
-    if (sandboxFeatures[key] !== false) {
-      sandboxFeatures[key] = false;
-      changed = true;
-    }
-  }
-  return changed;
-}
-
-export function ensureCodexModelInheritance(
-  toolDir: string,
-  hostHomeDir?: string,
-  containerCodexDir: string = '/home/devuser/.codex'
-): void {
-  if (!hostHomeDir) {
-    return;
-  }
-
-  const hostConfigPath = path.join(hostHomeDir, '.codex', 'config.toml');
-  if (!fs.existsSync(hostConfigPath)) {
-    return;
-  }
-
-  let hostParsed: JsonObject;
-  try {
-    hostParsed = toml.parse(fs.readFileSync(hostConfigPath, 'utf8')) as JsonObject;
-  } catch {
-    return;
-  }
-
-  const sandboxConfigPath = path.join(toolDir, 'config.toml');
-  // This rewrites sandbox-side TOML and drops comments; the host config stays untouched.
-  let sandboxParsed: JsonObject = {};
-  if (fs.existsSync(sandboxConfigPath)) {
-    try {
-      sandboxParsed = toml.parse(fs.readFileSync(sandboxConfigPath, 'utf8')) as JsonObject;
-    } catch {
-      return;
-    }
-  }
-
-  let changed = removeCodexMcpServers(sandboxParsed);
-  changed = inheritDisabledCodexFeatureFlags(sandboxParsed, hostParsed) || changed;
-
-  const inheritSpecs: Array<readonly [string, 'string' | 'number']> = [
-    ['model', 'string'],
-    ['model_reasoning_effort', 'string'],
-    ['model_auto_compact_token_limit', 'number']
-  ];
-
-  for (const [key, type] of inheritSpecs) {
-    if (Object.hasOwn(sandboxParsed, key)) {
-      continue;
-    }
-    const value = hostParsed[key];
-    if (type === 'string' && (typeof value !== 'string' || value === '')) {
-      continue;
-    }
-    if (type === 'number' && (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)) {
-      continue;
-    }
-    sandboxParsed[key] = value;
-    changed = true;
-  }
-
-  if (!Object.hasOwn(sandboxParsed, 'model_catalog_json')) {
-    const hostCatalogPath = resolveHostCatalogPath(hostParsed['model_catalog_json'], hostHomeDir);
-    if (hostCatalogPath) {
-      try {
-        const basename = path.basename(hostCatalogPath);
-        const destDir = path.join(toolDir, 'model-catalogs');
-        fs.mkdirSync(destDir, { recursive: true });
-        fs.copyFileSync(hostCatalogPath, path.join(destDir, basename));
-        sandboxParsed['model_catalog_json'] = path.posix.join(containerCodexDir, 'model-catalogs', basename);
-        changed = true;
-      } catch {
-        // Copy failed (e.g. permissions): skip catalog, keep scalar inheritance intact.
-      }
-    }
-  }
-
-  if (changed) {
-    fs.writeFileSync(sandboxConfigPath, `${toml.stringify(sandboxParsed)}\n`, 'utf8');
-  }
-}
-
-export function ensureCodexWorkspaceTrust(toolDir: string): void {
-  const configPath = path.join(toolDir, 'config.toml');
-  let content = '';
-  if (fs.existsSync(configPath)) {
-    content = fs.readFileSync(configPath, 'utf8');
-  }
-  if (!content.includes('[projects."/workspace"]')) {
-    const entry = '\n[projects."/workspace"]\ntrust_level = "trusted"\n';
-    fs.writeFileSync(configPath, content + entry, 'utf8');
-  }
-}
-
 export function ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void {
   if (!hostHomeDir) {
     return;
@@ -1640,7 +1496,14 @@ export async function create(args: string[]): Promise<void> {
             const beforeCreateResults = await runSandboxHooks({
               hooks: capabilityPlan.hooksByPhase['before-container-create'],
               phase: 'before-container-create',
-              context: { config: effectiveConfig, plan: capabilityPlan },
+              context: {
+                config: effectiveConfig,
+                plan: capabilityPlan,
+                create: {
+                  hostHome: effectiveConfig.home,
+                  resolvedTools: effectiveResolvedTools
+                }
+              },
               runCommand: runBoundedSandboxHookCommand
             });
             const beforeCreateFailure = beforeCreateResults.find(
@@ -1659,11 +1522,6 @@ export async function create(args: string[]): Promise<void> {
               // prepareClaudeCredentials wrote OAuth credentials or confirmed
               // provider/API settings are enough for Claude Code. If no usable
               // auth was present, the claude-code entry was removed above.
-            }
-            const codexEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'codex');
-            if (codexEntry) {
-              ensureCodexModelInheritance(codexEntry.dir, effectiveConfig.home, codexEntry.tool.containerMount);
-              ensureCodexWorkspaceTrust(codexEntry.dir);
             }
             const geminiEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'gemini-cli');
             if (geminiEntry) {

--- a/lib/sandbox/recovery.ts
+++ b/lib/sandbox/recovery.ts
@@ -8,10 +8,12 @@ import {
 } from './constants.ts';
 import { isAgentClientId } from '../agent-clients/types.ts';
 import {
-  createSandboxCapabilityPlan,
-  runBoundedSandboxHookCommand,
-  runSandboxHooks
+  createSandboxCapabilityPlan
 } from './agent-client-reconciler.ts';
+import type {
+  SandboxRecoveryFindingDescriptor,
+  SandboxRecoveryRepair
+} from './tool-types.ts';
 import type { SandboxConfig } from './config.ts';
 import { toEnginePath } from './engines/wsl2-paths.ts';
 import { sandboxCoreBindMounts } from './mounts.ts';
@@ -35,6 +37,16 @@ export type SandboxRecoveryFinding = {
   message: string;
   path?: string;
   seed?: TmpfsSeedEntry;
+  repair?: SandboxRecoveryRepair;
+};
+
+type SandboxAgentClientCheckSnapshot = {
+  adapterId: string;
+  checkId: string;
+  applicable: boolean;
+  healthy: boolean;
+  finding: SandboxRecoveryFindingDescriptor;
+  repair?: SandboxRecoveryRepair;
 };
 
 export type SandboxRecoverySnapshot = {
@@ -62,12 +74,7 @@ export type SandboxRecoverySnapshot = {
     targetState: 'ok' | 'missing' | 'wrong-type' | 'inaccessible';
   }>;
   aliasesReadable: boolean;
-  codex?: {
-    commandAvailable: boolean;
-    stateWritable: boolean;
-    promptsSourceExists: boolean;
-    promptsValid: boolean;
-  };
+  agentClientChecks: SandboxAgentClientCheckSnapshot[];
 };
 
 export type SandboxReadyResult = {
@@ -204,25 +211,11 @@ export function classifySandboxRecovery(snapshot: SandboxRecoverySnapshot): Sand
     });
   }
 
-  if (snapshot.codex) {
-    if (!snapshot.codex.commandAvailable) {
+  for (const check of snapshot.agentClientChecks) {
+    if (check.applicable && !check.healthy) {
       findings.push({
-        repairKind: 'hard-failure',
-        message: 'Codex is not available on PATH inside the sandbox.'
-      });
-    }
-    if (!snapshot.codex.stateWritable) {
-      findings.push({
-        repairKind: 'permissions',
-        message: 'Codex state directory is not writable by devuser.',
-        path: '/home/devuser/.codex'
-      });
-    }
-    if (snapshot.codex.promptsSourceExists && !snapshot.codex.promptsValid) {
-      findings.push({
-        repairKind: 'builtin-link',
-        message: 'Codex prompts link does not point to the workspace commands directory.',
-        path: '/home/devuser/.codex/prompts'
+        ...check.finding,
+        ...(check.repair === undefined ? {} : { repair: check.repair })
       });
     }
   }
@@ -475,7 +468,6 @@ export function collectSandboxRecoverySnapshot(params: {
       .map((tool) => tool.containerMount)
       .filter((mountPath) => mountsByDestination.has(mountPath))
     : [];
-  const hasCodex = tools.some((tool) => tool.id === 'codex');
   const mountSnapshots = expectedMounts({
     config: params.config,
     branch: params.branch,
@@ -533,38 +525,31 @@ export function collectSandboxRecoverySnapshot(params: {
       ['/home/devuser/.bash_aliases'],
       runOkFn
     ),
-    codex: hasCodex
-      ? {
-          commandAvailable: probe(
-            params.engine,
-            params.container,
-            'command -v codex',
-            [],
-            runOkFn
-          ),
-          stateWritable: probe(
-            params.engine,
-            params.container,
-            'probe="$1/.agent-infra-codex-state-$$"; trap \'rm -f -- "$probe"\' EXIT; : > "$probe"',
-            ['/home/devuser/.codex'],
-            runOkFn
-          ),
-          promptsSourceExists: probe(
-            params.engine,
-            params.container,
-            'test -d "$1"',
-            ['/workspace/.codex/commands'],
-            runOkFn
-          ),
-          promptsValid: probe(
-            params.engine,
-            params.container,
-            'test "$(readlink -- "$1")" = "$2"',
-            ['/home/devuser/.codex/prompts', '/workspace/.codex/commands'],
-            runOkFn
-          )
-        }
-      : undefined
+    agentClientChecks: capabilityPlan.recoveryChecks.map(({ adapterId, check }) => {
+      const applicable = check.when === undefined || probe(
+        params.engine,
+        params.container,
+        check.when.script,
+        [...check.when.args],
+        runOkFn,
+        check.when.user
+      );
+      return {
+        adapterId,
+        checkId: check.id,
+        applicable,
+        healthy: !applicable || probe(
+          params.engine,
+          params.container,
+          check.probe.script,
+          [...check.probe.args],
+          runOkFn,
+          check.probe.user
+        ),
+        finding: check.finding,
+        ...(check.repair === undefined ? {} : { repair: check.repair })
+      };
+    })
   };
 }
 
@@ -671,10 +656,11 @@ function repairFindings(params: {
     deps: params.deps
   });
   const runVerboseFn = params.deps?.runVerbose ?? runVerboseEngine;
-  if (params.findings.some((finding) => finding.repairKind === 'builtin-link')) {
+  for (const repair of params.findings.flatMap((finding) =>
+    finding.repair === undefined ? [] : [finding.repair]
+  )) {
     runVerboseFn(params.engine, 'docker', [
-      'exec', '--user', 'devuser', params.container, 'ln', '-sfn',
-      '/workspace/.codex/commands', '/home/devuser/.codex/prompts'
+      'exec', '--user', repair.user, params.container, repair.command, ...repair.args
     ]);
   }
 }
@@ -721,19 +707,6 @@ export async function ensureSandboxReady(params: EnsureSandboxReadyParams): Prom
   let failure: Error | null = null;
 
   try {
-    const capabilityPlan = createSandboxCapabilityPlan(params.config);
-    const hookResults = await runSandboxHooks({
-      hooks: capabilityPlan.hooksByPhase['inspect-recovery'],
-      phase: 'inspect-recovery',
-      context: { config: params.config, plan: capabilityPlan },
-      runCommand: runBoundedSandboxHookCommand
-    });
-    const hookFailure = hookResults.find((result) => result.status === 'hard-failure');
-    if (hookFailure) {
-      throw new Error(
-        hookFailure.message ?? `Sandbox hook '${hookFailure.hookId}' failed.`
-      );
-    }
     if (!params.row.running) {
       startFn(params.engine, params.row.name);
       const initial = assess({

--- a/lib/sandbox/tool-types.ts
+++ b/lib/sandbox/tool-types.ts
@@ -28,8 +28,7 @@ const SANDBOX_HOOK_PHASES = [
   'prepare',
   'before-container-create',
   'after-container-start',
-  'before-enter',
-  'inspect-recovery'
+  'before-enter'
 ] as const;
 
 type SandboxHookPhase = (typeof SANDBOX_HOOK_PHASES)[number];
@@ -58,12 +57,22 @@ type AgentClientSandboxHookResult = Readonly<{
   message?: string;
 }>;
 
+type SandboxResolvedToolState = Readonly<{
+  tool: SandboxTool;
+  dir: string;
+}>;
+
+type SandboxHookCreateContext = Readonly<{
+  hostHome: string;
+  resolvedTools: readonly SandboxResolvedToolState[];
+}>;
+
 type AgentClientSandboxHookContext = Readonly<{
   signal: AbortSignal;
   runCommand(command: SandboxHookCommand): Promise<SandboxHookCommandResult>;
   config?: Readonly<Record<string, unknown>>;
   plan?: Readonly<Record<string, unknown>>;
-  inspection?: Readonly<Record<string, unknown>>;
+  create?: SandboxHookCreateContext;
 }>;
 
 type AgentClientSandboxHook = Readonly<{
@@ -78,10 +87,37 @@ type SandboxToolContext = Readonly<{
   project: string;
 }>;
 
+type SandboxRecoveryProbe = Readonly<{
+  script: string;
+  args: readonly string[];
+  user?: string;
+}>;
+
+type SandboxRecoveryFindingDescriptor = Readonly<{
+  repairKind: 'permissions' | 'builtin-link' | 'hard-failure';
+  message: string;
+  path?: string;
+}>;
+
+type SandboxRecoveryRepair = Readonly<{
+  user: string;
+  command: string;
+  args: readonly string[];
+}>;
+
+type AgentClientSandboxRecoveryCheck = Readonly<{
+  id: string;
+  when?: SandboxRecoveryProbe;
+  probe: SandboxRecoveryProbe;
+  finding: SandboxRecoveryFindingDescriptor;
+  repair?: SandboxRecoveryRepair;
+}>;
+
 type AgentClientSandboxDescriptor = Readonly<{
   createTool(context: SandboxToolContext): SandboxTool;
   aliases: readonly SandboxAlias[];
   hooks: readonly AgentClientSandboxHook[];
+  recoveryChecks?: readonly AgentClientSandboxRecoveryCheck[];
 }>;
 
 export { SANDBOX_HOOK_PHASES };
@@ -90,11 +126,17 @@ export type {
   AgentClientSandboxHook,
   AgentClientSandboxHookContext,
   AgentClientSandboxHookResult,
+  AgentClientSandboxRecoveryCheck,
   SandboxAlias,
   SandboxHookCommand,
   SandboxHookCommandResult,
   SandboxHookPhase,
   SandboxHookStatus,
+  SandboxHookCreateContext,
+  SandboxRecoveryFindingDescriptor,
+  SandboxRecoveryProbe,
+  SandboxRecoveryRepair,
+  SandboxResolvedToolState,
   SandboxTool,
   SandboxToolContext,
   SandboxToolInstall

--- a/tests/integration/cli/sandbox-reconciler.test.ts
+++ b/tests/integration/cli/sandbox-reconciler.test.ts
@@ -49,6 +49,18 @@ test('capability plan selects clients only from installInSandbox while preservin
   assert.deepEqual(plan.selectedAgentClients.map((adapter) => adapter.id), ['codex']);
   assert.deepEqual(plan.tools.map((tool) => tool.id), ['agent-infra', 'codex']);
   assert.equal(plan.tools.some((tool) => tool.id === 'gemini-cli'), false);
+  assert.deepEqual(
+    plan.hooksByPhase['before-container-create'].map((hook) => hook.id),
+    ['codex-before-container-create']
+  );
+  assert.deepEqual(
+    plan.recoveryChecks.map(({ adapterId, check }) => `${adapterId}:${check.id}`),
+    [
+      'codex:command-available',
+      'codex:state-writable',
+      'codex:prompts-link'
+    ]
+  );
 });
 
 test('canonical all-false state does not fall back to legacy client tool ids', () => {
@@ -75,6 +87,26 @@ test('runtime signature is host-path independent and changes with selected capab
   assert.equal(first.runtimeSignature, movedHome.runtimeSignature);
   assert.notEqual(first.runtimeSignature, changedSelection.runtimeSignature);
   assert.equal(JSON.stringify(first.runtimeProjection).includes('/host/alice'), false);
+  assert.deepEqual(
+    first.runtimeProjection.recoveryChecks.map((check) => ({
+      keys: Object.keys(check),
+      finding: check.finding
+    })),
+    [
+      {
+        keys: ['adapterId', 'id', 'probe', 'finding'],
+        finding: { repairKind: 'hard-failure' }
+      },
+      {
+        keys: ['adapterId', 'id', 'probe', 'finding'],
+        finding: { repairKind: 'permissions', path: '/home/devuser/.codex' }
+      },
+      {
+        keys: ['adapterId', 'id', 'when', 'probe', 'finding', 'repair'],
+        finding: { repairKind: 'builtin-link', path: '/home/devuser/.codex/prompts' }
+      }
+    ]
+  );
 });
 
 test('cleanup inventory includes every registered client independent of selection', () => {
@@ -138,7 +170,7 @@ test('hook timeout aborts the hook and maps to the phase failure policy', async 
   let observedSignal: AbortSignal | undefined;
   const hook: AgentClientSandboxHook = {
     id: 'stuck',
-    phase: 'inspect-recovery',
+    phase: 'before-container-create',
     timeoutMs: 12,
     run: async (context) => {
       observedSignal = context.signal;
@@ -148,7 +180,7 @@ test('hook timeout aborts the hook and maps to the phase failure policy', async 
 
   const pending = runSandboxHooks({
     hooks: [hook],
-    phase: 'inspect-recovery',
+    phase: 'before-container-create',
     context: {},
     scheduleTimeout: (callback) => {
       triggerTimeout = callback;
@@ -162,8 +194,8 @@ test('hook timeout aborts the hook and maps to the phase failure policy', async 
   assert.equal(observedSignal?.aborted, true);
   assert.deepEqual(results, [{
     hookId: 'stuck',
-    phase: 'inspect-recovery',
-    status: 'hard-failure',
+    phase: 'before-container-create',
+    status: 'fatal',
     message: "Sandbox hook 'stuck' timed out after 12ms."
   }]);
 });
@@ -195,7 +227,8 @@ test('recovery treats a stale runtime signature and disabled client mount as har
     mounts: [],
     tmpfs: [],
     seeds: [],
-    aliasesReadable: true
+    aliasesReadable: true,
+    agentClientChecks: []
   });
 
   assert.deepEqual(

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -52,12 +52,26 @@ function healthyRecoverySnapshot(): SandboxRecoverySnapshot {
       }
     ],
     aliasesReadable: true,
-    codex: {
-      commandAvailable: true,
-      stateWritable: true,
-      promptsSourceExists: true,
-      promptsValid: true
-    }
+    agentClientChecks: [{
+      adapterId: 'codex',
+      checkId: 'prompts-link',
+      applicable: true,
+      healthy: true,
+      finding: {
+        repairKind: 'builtin-link',
+        message: 'Codex prompts link does not point to the workspace commands directory.',
+        path: '/home/devuser/.codex/prompts'
+      },
+      repair: {
+        user: 'devuser',
+        command: 'ln',
+        args: [
+          '-sfn',
+          '/workspace/.codex/commands',
+          '/home/devuser/.codex/prompts'
+        ]
+      }
+    }]
   };
 }
 
@@ -150,7 +164,7 @@ test("recovery classification maps faults to the smallest repair kind", () => {
   );
 
   const prompts = healthyRecoverySnapshot();
-  prompts.codex!.promptsValid = false;
+  prompts.agentClientChecks[0]!.healthy = false;
   assert.deepEqual(
     classifySandboxRecovery(prompts).map((finding) => finding.repairKind),
     ["builtin-link"]
@@ -205,6 +219,19 @@ test("recovery accepts bind sources that resolve to the same filesystem object",
     );
     assert.equal(seedMount?.sourceMatches, true);
     assert.equal(seedMount?.sourceAccessible, true);
+    assert.deepEqual(
+      snapshot.agentClientChecks.map(({ adapterId, checkId, applicable, healthy }) => ({
+        adapterId,
+        checkId,
+        applicable,
+        healthy
+      })),
+      [
+        { adapterId: 'codex', checkId: 'command-available', applicable: true, healthy: true },
+        { adapterId: 'codex', checkId: 'state-writable', applicable: true, healthy: true },
+        { adapterId: 'codex', checkId: 'prompts-link', applicable: true, healthy: true }
+      ]
+    );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -758,6 +785,13 @@ test("sandbox create skips missing tmpfs seed entries", onPlatforms("linux", "da
       dockerCalls.some((call) => call.includes("/run/agent-infra/tmpfs-seeds/codex/1")),
       false,
       `missing model-catalogs must not have a copy command, got ${JSON.stringify(dockerCalls)}`
+    );
+    assert.equal(
+      runCall.some((arg, index) =>
+        runCall[index - 1] === "-v" && isMountFor(arg, "/home/devuser/.codex/auth.json")
+      ),
+      false,
+      `missing host auth must not block create or add an auth mount, got ${JSON.stringify(runCall)}`
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/unit/core/agent-client-architecture.test.ts
+++ b/tests/unit/core/agent-client-architecture.test.ts
@@ -23,10 +23,11 @@ type Finding = Readonly<{
 
 function findClientIdLiterals(
   sourceFile: SourceFile,
-  displayPath: string
+  displayPath: string,
+  clientIds: readonly string[] = AGENT_CLIENT_IDS
 ): Finding[] {
   const findings: Finding[] = [];
-  const ids = new Set<string>(AGENT_CLIENT_IDS);
+  const ids = new Set<string>(clientIds);
 
   function visit(node: Node): void {
     if (
@@ -84,6 +85,39 @@ test('generic Agent Client core contains no client-specific ID literals', () => 
       const sourceFile = project.program.getSourceFile(candidate);
       assert.ok(sourceFile, `expected ${displayPath} in the TypeScript program`);
       return findClientIdLiterals(sourceFile, displayPath);
+    });
+
+    assert.deepEqual(
+      findings,
+      [],
+      findings.map((finding) =>
+        `${finding.file}:${finding.line}:${finding.column} contains ${finding.value}`
+      ).join('\n')
+    );
+  } finally {
+    snapshot.dispose();
+    api.close();
+  }
+});
+
+test('generic sandbox lifecycle contains no Codex-specific ID literals', () => {
+  const candidates = [
+    filePath('lib/sandbox/commands/create.ts'),
+    filePath('lib/sandbox/recovery.ts')
+  ];
+  const api = new API({ cwd: filePath('.') });
+  const snapshot = api.updateSnapshot({
+    openProjects: [filePath('tsconfig.test.json')]
+  });
+
+  try {
+    const project = snapshot.getProjects()[0];
+    assert.ok(project);
+    const findings = candidates.flatMap((candidate) => {
+      const displayPath = path.relative(filePath('.'), candidate).replace(/\\/g, '/');
+      const sourceFile = project.program.getSourceFile(candidate);
+      assert.ok(sourceFile, `expected ${displayPath} in the TypeScript program`);
+      return findClientIdLiterals(sourceFile, displayPath, ['codex']);
     });
 
     assert.deepEqual(

--- a/tests/unit/core/agent-client-next-steps.test.ts
+++ b/tests/unit/core/agent-client-next-steps.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   renderNextStepCommands
 } from '../../../lib/agent-clients/next-steps.ts';
+import { renderAgentClientInvocation } from '../../../lib/agent-clients/invocation.ts';
 import { AGENT_CLIENT_IDS } from '../../../lib/agent-clients/types.ts';
 import type { AgentClientState } from '../../../lib/agent-clients/types.ts';
 
@@ -19,6 +20,21 @@ function stateFor(enabled: readonly string[]): AgentClientState {
     ])
   ) as AgentClientState;
 }
+
+test('shared invocation renderer expands adapter placeholders and appends arguments', () => {
+  assert.equal(
+    renderAgentClientInvocation('/${projectName}:${skillName}', {
+      projectName: 'demo',
+      skillName: 'review-code',
+      args: ['19', '--strict']
+    }),
+    '/demo:review-code 19 --strict'
+  );
+  assert.equal(
+    renderAgentClientInvocation('$${skillName}', { skillName: 'code-task' }),
+    '$code-task'
+  );
+});
 
 test('custom TUI contract is JSON-safe and normalization preserves valid input order', () => {
   assert.deepEqual(JSON.parse(JSON.stringify(CUSTOM_TUI_CONTRACT)), CUSTOM_TUI_CONTRACT);

--- a/tests/unit/core/agent-client-registry.test.ts
+++ b/tests/unit/core/agent-client-registry.test.ts
@@ -387,6 +387,76 @@ test('registry exposes the exact built-in project asset matrix', () => {
   );
 });
 
+test('Codex adapter owns its lifecycle and recovery capabilities', () => {
+  const adapter = getAgentClientAdapter('codex');
+
+  assert.deepEqual(
+    adapter.sandbox.hooks.map(({ id, phase }) => ({ id, phase })),
+    [{ id: 'codex-before-container-create', phase: 'before-container-create' }]
+  );
+  assert.deepEqual(
+    adapter.sandbox.recoveryChecks?.map(({ id, finding }) => ({
+      id,
+      repairKind: finding.repairKind
+    })),
+    [
+      { id: 'command-available', repairKind: 'hard-failure' },
+      { id: 'state-writable', repairKind: 'permissions' },
+      { id: 'prompts-link', repairKind: 'builtin-link' }
+    ]
+  );
+  assert.ok(Object.isFrozen(adapter.sandbox.recoveryChecks));
+  assert.ok(adapter.sandbox.recoveryChecks?.every((check) => Object.isFrozen(check)));
+});
+
+test('adapter recovery checks validate probes, findings, repairs, and unique IDs', () => {
+  const validCheck = {
+    id: 'prompts-link',
+    probe: { script: 'test -L "$1"', args: ['/tmp/prompts'] },
+    finding: {
+      repairKind: 'builtin-link' as const,
+      message: 'Link is missing.',
+      path: '/tmp/prompts'
+    },
+    repair: {
+      user: 'devuser',
+      command: 'ln',
+      args: ['-sfn', '/workspace/commands', '/tmp/prompts']
+    }
+  };
+  const withChecks = (
+    recoveryChecks: AgentClientAdapter['sandbox']['recoveryChecks']
+  ): AgentClientAdapter => adapterInput({
+    sandbox: {
+      ...adapterInput().sandbox,
+      recoveryChecks
+    }
+  });
+
+  const adapter = defineAgentClientAdapter(withChecks([validCheck]));
+  assert.ok(Object.isFrozen(adapter.sandbox.recoveryChecks?.[0]?.probe.args));
+  assert.ok(Object.isFrozen(adapter.sandbox.recoveryChecks?.[0]?.repair?.args));
+
+  const invalidChecks: unknown[] = [
+    {},
+    [{ ...validCheck, id: 'INVALID' }],
+    [{ ...validCheck, probe: { script: '', args: [] } }],
+    [{ ...validCheck, finding: { repairKind: 'unknown', message: 'Bad.' } }],
+    [{
+      ...validCheck,
+      finding: { repairKind: 'permissions', message: 'Not writable.' },
+      repair: undefined
+    }],
+    [{ ...validCheck, repair: undefined }],
+    [validCheck, validCheck]
+  ];
+  for (const recoveryChecks of invalidChecks) {
+    assert.throws(() => defineAgentClientAdapter(withChecks(
+      recoveryChecks as AgentClientAdapter['sandbox']['recoveryChecks']
+    )));
+  }
+});
+
 test('adapter seed commands require owned literal targets and language templates', () => {
   assert.throws(() => defineAgentClientAdapter(adapterInput({
     project: {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #668

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that doesn't need an issue

Closes #668

## 📋 变更类型 / Type of Change

- [x] 🔧 重构 / Refactoring (no functional changes)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)

## 📝 变更目的 / Purpose of the Change

Move Codex-specific invocation, sandbox lifecycle, recovery checks, and configuration inheritance behind the unified Agent Client adapter boundary. This makes Codex the first complete internal adapter example while preserving native AGENTS.md and skill discovery behavior.

将 Codex 特有的调用格式、沙箱生命周期、恢复检查和配置继承收敛到统一 Agent Client adapter 边界内，使 Codex 成为首个完整的内部 adapter 样板，同时保留 AGENTS.md 和原生 skill 发现行为。

## 📋 主要变更 / Brief Changelog

- Add shared Agent Client invocation rendering and route Codex prompts through the adapter contract.
- Move Codex sandbox setup, model inheritance, workspace trust, recovery probes, and repairs into adapter-owned declarations.
- Generalize sandbox reconciliation and recovery so generic lifecycle code contains no Codex-specific branches.
- Add unit, integration, architecture, no-auth smoke, and composition coverage for the migrated contracts.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm test` to build the TypeScript output and execute the complete test suite.
2. Inspect the Agent Client registry and next-step tests for Codex invocation and lifecycle declarations.
3. Inspect sandbox reconciliation tests for recovery checks, repair behavior, missing-auth handling, and architecture boundaries.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Latest verification: 1,899 passed, 3 skipped, 0 failed.

## 📸 截图 / Screenshots

Not applicable; this change has no visual UI impact.

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a GitHub issue filed for the change
- [x] 该 PR 只解决一个 Issue，不包含无关变更 / This PR addresses one issue without unrelated changes
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body

**代码质量 / Code Quality:**

- [x] 代码遵循项目编码规范 / The code follows project standards
- [x] 已完成代码审查 / Code review is complete
- [x] 复杂逻辑包含必要注释 / Complex logic includes necessary comments

**测试要求 / Testing Requirements:**

- [x] 已编写必要的单元测试 / Necessary unit tests are included
- [x] 跨模块依赖测试使用了适当的注入与模拟 / Cross-module dependencies use appropriate injection and mocks
- [x] TypeScript 构建通过 / TypeScript build passes
- [x] 单元与集成测试通过 / Unit and integration tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 无需更新公共文档 / No public documentation update is required
- [x] 没有破坏性变更 / No breaking change is introduced
- [x] 已考虑向后兼容性 / Backward compatibility was considered

## 📋 附加信息 / Additional Notes

- The approved Round 2 code review reported no blockers, major findings, minor findings, or manual-validation items.
- The compatibility re-export for Codex setup helpers is intentionally retained as a transitional seam for existing internal tests.

---

**审查者注意事项 / Reviewer Notes:**

Please focus on the adapter-owned recovery descriptor validation, runtime signature projection, and the removal of Codex-specific branches from generic sandbox lifecycle code.

Generated with AI assistance
