### PR TITLE
fix(cli): 修复 lifecycle hook 与总控二进制版本不一致导致编排死锁


### DIFF
--- a/.agents/QUICKSTART.md
+++ b/.agents/QUICKSTART.md
@@ -18,6 +18,23 @@ git config core.hooksPath .git-hooks
 
 这样 Git 才会调用项目仓库 `.git-hooks/` 目录下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
 
+## 开发检出中的 CLI 对齐
+
+从源码检出开发 agent-infra 时，请先安装依赖并重新构建本地 CLI，再运行生命周期编排：
+
+```bash
+npm install
+npm run build
+```
+
+本地 `dist/bin/internal-cli.js` 存在时，生命周期 hook 会优先使用它；不存在时则回退到 `PATH` 上的 `agent-infra-internal`。修改 CLI 源码后需要重新构建。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
+
+```bash
+npm link
+ai version --raw
+node -p "'v' + require('./package.json').version"
+```
+
 ## 外部模板与 Skill
 
 如果团队维护私有平台模板或共享自定义 skill，可在 `.agents/.airc.json` 中配置本地源：

--- a/.agents/hooks/lifecycle-delegation.js
+++ b/.agents/hooks/lifecycle-delegation.js
@@ -1,6 +1,9 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const MAX_INPUT_BYTES = 64 * 1024;
+const localInternalCli = fileURLToPath(new URL('../../dist/bin/internal-cli.js', import.meta.url));
 const clientIndex = process.argv.indexOf('--client');
 const client = clientIndex >= 0 ? process.argv[clientIndex + 1] : '';
 if (client !== 'claude-code') {
@@ -50,9 +53,12 @@ process.stdin.on('end', () => {
     );
   }
   try {
-    const output = execFileSync('agent-infra-internal', args, {
+    const useLocal = existsSync(localInternalCli);
+    const command = useLocal ? process.execPath : 'agent-infra-internal';
+    const commandArgs = useLocal ? [localInternalCli, ...args] : args;
+    const output = execFileSync(command, commandArgs, {
       encoding: 'utf8',
-      shell: process.platform === 'win32',
+      shell: !useLocal && process.platform === 'win32',
       stdio: ['ignore', 'pipe', 'pipe']
     });
     process.stdout.write(output);

--- a/templates/.agents/QUICKSTART.en.md
+++ b/templates/.agents/QUICKSTART.en.md
@@ -18,6 +18,23 @@ git config core.hooksPath .git-hooks
 
 This makes Git invoke the hooks in the project repository's `.git-hooks/` directory, including `pre-commit` and `check-version-format.sh`.
 
+## Development Checkout CLI Alignment
+
+When developing agent-infra from a source checkout, install dependencies and rebuild the local CLI before running lifecycle orchestration:
+
+```bash
+npm install
+npm run build
+```
+
+Lifecycle hooks prefer the checkout's `dist/bin/internal-cli.js` when it exists and fall back to `agent-infra-internal` on `PATH` otherwise. Rebuild after CLI source changes. If shell commands must also resolve to this checkout, link it and compare the active version with the package version:
+
+```bash
+npm link
+ai version --raw
+node -p "'v' + require('./package.json').version"
+```
+
 ## External Templates And Skills
 
 If your team maintains private platform templates or shared custom skills, configure local sources in `.agents/.airc.json`:

--- a/templates/.agents/QUICKSTART.zh-CN.md
+++ b/templates/.agents/QUICKSTART.zh-CN.md
@@ -18,6 +18,23 @@ git config core.hooksPath .git-hooks
 
 这样 Git 才会调用项目仓库 `.git-hooks/` 目录下的 hook，包括 `pre-commit` 和 `check-version-format.sh`。
 
+## 开发检出中的 CLI 对齐
+
+从源码检出开发 agent-infra 时，请先安装依赖并重新构建本地 CLI，再运行生命周期编排：
+
+```bash
+npm install
+npm run build
+```
+
+本地 `dist/bin/internal-cli.js` 存在时，生命周期 hook 会优先使用它；不存在时则回退到 `PATH` 上的 `agent-infra-internal`。修改 CLI 源码后需要重新构建。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
+
+```bash
+npm link
+ai version --raw
+node -p "'v' + require('./package.json').version"
+```
+
 ## 外部模板与 Skill
 
 如果团队维护私有平台模板或共享自定义 skill，可在 `.agents/.airc.json` 中配置本地源：

--- a/templates/.agents/hooks/lifecycle-delegation.js
+++ b/templates/.agents/hooks/lifecycle-delegation.js
@@ -1,6 +1,9 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const MAX_INPUT_BYTES = 64 * 1024;
+const localInternalCli = fileURLToPath(new URL('../../dist/bin/internal-cli.js', import.meta.url));
 const clientIndex = process.argv.indexOf('--client');
 const client = clientIndex >= 0 ? process.argv[clientIndex + 1] : '';
 if (client !== 'claude-code') {
@@ -50,9 +53,12 @@ process.stdin.on('end', () => {
     );
   }
   try {
-    const output = execFileSync('agent-infra-internal', args, {
+    const useLocal = existsSync(localInternalCli);
+    const command = useLocal ? process.execPath : 'agent-infra-internal';
+    const commandArgs = useLocal ? [localInternalCli, ...args] : args;
+    const output = execFileSync(command, commandArgs, {
       encoding: 'utf8',
-      shell: process.platform === 'win32',
+      shell: !useLocal && process.platform === 'win32',
       stdio: ['ignore', 'pipe', 'pipe']
     });
     process.stdout.write(output);

--- a/tests/integration/cli/orchestration-hooks.test.ts
+++ b/tests/integration/cli/orchestration-hooks.test.ts
@@ -10,8 +10,49 @@ import { envWithPrependedPath, writeNodeCommandShim } from '../../helpers.ts';
 const HOOK = path.resolve('.agents/hooks/lifecycle-delegation.js');
 const FIXTURES = path.resolve('tests/fixtures/lifecycle-hooks');
 
-function run(input: string, client = 'claude-code', env = process.env) {
-  return spawnSync('node', [HOOK, '--client', client], { cwd: path.resolve('.'), input, encoding: 'utf8', env });
+interface RunOptions {
+  client?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  hook?: string;
+}
+
+type LocalCliState = 'missing' | 'working' | 'broken';
+
+function run(input: string, options: RunOptions = {}) {
+  const {
+    client = 'claude-code',
+    cwd = path.resolve('.'),
+    env = process.env,
+    hook = HOOK
+  } = options;
+  return spawnSync('node', [hook, '--client', client], { cwd, input, encoding: 'utf8', env });
+}
+
+function createHookFixture(localCliState: LocalCliState) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lifecycle-hook-'));
+  const repoDir = path.join(root, 'repo');
+  const hook = path.join(repoDir, '.agents', 'hooks', 'lifecycle-delegation.js');
+  const cwd = path.join(repoDir, 'nested');
+  const binDir = path.join(root, 'bin');
+  const pathCli = path.join(root, 'path-internal-cli.mjs');
+  fs.mkdirSync(path.dirname(hook), { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.copyFileSync(HOOK, hook);
+  fs.writeFileSync(path.join(repoDir, 'package.json'), '{"type":"module"}\n');
+  fs.writeFileSync(pathCli, "process.stdout.write(JSON.stringify({ source: 'path', args: process.argv.slice(2) }))\n");
+  writeNodeCommandShim(path.join(binDir, 'agent-infra-internal'), pathCli);
+
+  if (localCliState !== 'missing') {
+    const localCli = path.join(repoDir, 'dist', 'bin', 'internal-cli.js');
+    fs.mkdirSync(path.dirname(localCli), { recursive: true });
+    const localCliSource = localCliState === 'broken'
+      ? "process.stderr.write('Local lifecycle CLI failed\\n'); process.exit(23)\n"
+      : "process.stdout.write(JSON.stringify({ source: 'local', args: process.argv.slice(2) }))\n";
+    fs.writeFileSync(localCli, localCliSource);
+  }
+
+  return { cwd, env: envWithPrependedPath(process.env, binDir), hook };
 }
 
 test('lifecycle hook ignores unrelated subagents without touching orchestration state', () => {
@@ -24,41 +65,79 @@ test('lifecycle hook ignores unrelated subagents without touching orchestration 
   assert.equal(result.stdout, '');
 });
 
-test('lifecycle hook maps a native Claude start payload to automatic core correlation', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lifecycle-hook-'));
-  const binDir = path.join(root, 'bin');
-  const shim = path.join(root, 'internal-cli.mjs');
-  fs.writeFileSync(shim, 'process.stdout.write(JSON.stringify(process.argv.slice(2)))\n');
-  writeNodeCommandShim(path.join(binDir, 'agent-infra-internal'), shim);
+test('lifecycle hook falls back to PATH and maps native Claude payloads', () => {
+  const fixture = createHookFixture('missing');
 
   const result = run(
     fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'),
-    'claude-code',
-    envWithPrependedPath(process.env, binDir)
+    fixture
   );
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    'task-orchestration', 'auto', 'hook-start',
-    '--client', 'claude-code',
-    '--native-agent', 'agent-infra-lifecycle-reviewer',
-    '--child-id', 'claude-child',
-    '--parent-id', 'claude-parent',
-    '--spawn-mode', 'fresh'
-  ]);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    source: 'path',
+    args: [
+      'task-orchestration', 'auto', 'hook-start',
+      '--client', 'claude-code',
+      '--native-agent', 'agent-infra-lifecycle-reviewer',
+      '--child-id', 'claude-child',
+      '--parent-id', 'claude-parent',
+      '--spawn-mode', 'fresh'
+    ]
+  });
 
   const stop = run(
     fs.readFileSync(path.join(FIXTURES, 'claude-subagent-stop.json'), 'utf8'),
-    'claude-code',
-    envWithPrependedPath(process.env, binDir)
+    fixture
   );
   assert.equal(stop.status, 0, stop.stderr);
-  assert.deepEqual(JSON.parse(stop.stdout), [
-    'task-orchestration', 'auto', 'hook-stop',
-    '--client', 'claude-code',
-    '--native-agent', 'agent-infra-lifecycle-reviewer',
-    '--child-id', 'claude-child'
-  ]);
+  assert.deepEqual(JSON.parse(stop.stdout), {
+    source: 'path',
+    args: [
+      'task-orchestration', 'auto', 'hook-stop',
+      '--client', 'claude-code',
+      '--native-agent', 'agent-infra-lifecycle-reviewer',
+      '--child-id', 'claude-child'
+    ]
+  });
+});
+
+test('lifecycle hook prefers the repository-local CLI independently of cwd', () => {
+  const fixture = createHookFixture('working');
+
+  const start = run(
+    fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'),
+    fixture
+  );
+  assert.equal(start.status, 0, start.stderr);
+  assert.equal(JSON.parse(start.stdout).source, 'local');
+
+  const stop = run(
+    fs.readFileSync(path.join(FIXTURES, 'claude-subagent-stop.json'), 'utf8'),
+    fixture
+  );
+  assert.equal(stop.status, 0, stop.stderr);
+  assert.deepEqual(JSON.parse(stop.stdout), {
+    source: 'local',
+    args: [
+      'task-orchestration', 'auto', 'hook-stop',
+      '--client', 'claude-code',
+      '--native-agent', 'agent-infra-lifecycle-reviewer',
+      '--child-id', 'claude-child'
+    ]
+  });
+});
+
+test('lifecycle hook fails closed when the repository-local CLI fails', () => {
+  const fixture = createHookFixture('broken');
+
+  const result = run(
+    fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'),
+    fixture
+  );
+  assert.equal(result.status, 23);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr, 'Local lifecycle CLI failed\n');
 });
 
 test('lifecycle hook rejects malformed payloads before invoking core', () => {

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -290,6 +290,7 @@ test("update-agent-infra template copies stay in sync with working files", () =>
     [".git-hooks/check-version-format.sh", "templates/.git-hooks/check-version-format.sh"],
     [".agents/hooks/check-version-format.sh", "templates/.agents/hooks/check-version-format.sh"],
     [".agents/hooks/auto-resume.sh", "templates/.agents/hooks/auto-resume.sh"],
+    [".agents/hooks/lifecycle-delegation.js", "templates/.agents/hooks/lifecycle-delegation.js"],
     [".codex/hooks.json", "templates/.codex/hooks.json"],
     ...buildCommandSyncFiles(project),
     ...referenceSyncFiles


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #779

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #779

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

开发检出中的 lifecycle hook 原先固定调用 `PATH` 上的全局 `agent-infra-internal`，可能与总控正在运行的本地源码版本不一致。快照语义错位会污染 reviewer 的 `changedPaths`，触发 `DELEGATION_REVIEWER_WRITE_FORBIDDEN` 并使编排停滞。

本变更让 hook 在本地构建可用时优先使用仓库内 `dist/bin/internal-cli.js`，缺失时保持全局 PATH 回退，从而对齐 hook 与总控版本，同时兼容已发布安装场景。

## 📋 主要变更 / Brief Changelog

- 通过 hook 文件位置定位本地 `dist/bin/internal-cli.js`，使用当前 Node 进程执行；仅在本地入口缺失时回退 PATH。
- 增加本地优先、PATH 回退、cwd 无关和本地入口损坏时 fail-closed 的集成测试，并锁定工作副本与模板同步。
- 更新英文、中文和当前部署 QUICKSTART，记录开发态 build、link 与版本核对流程。
- 在对齐本地 build/link 后恢复既有阻塞 run，确认 reviewer receipt 已 sealed/consumed 且编排继续推进。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm test`。
3. 核对本地优先、PATH 回退和损坏本地入口 fail-closed 的 hook 集成测试。
4. 核对 `review-code-r2.md` 的 Approved 结论与既有 run 的恢复证据。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

测试结果：1943 passed，0 failed，3 skipped；TypeScript typecheck 通过。

## 📸 截图 / Screenshots

不适用；本次变更为 lifecycle hook、测试和开发文档。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 本任务只处理 hook/总控环境对齐，不修改 workspace snapshot scope、reviewer 写入白名单或 receipt 协议。
- 本地 `dist` 存在但损坏时显式失败，不会静默回退到可能版本不一致的全局 CLI。

## 审查者注意事项 / Reviewer Notes

- 重点关注本地 CLI 的路径锚定、Windows PATH shim 回退，以及损坏本地入口的 fail-closed 行为。
- 代码审查 Round 2 已通过；上一轮唯一 minor finding 已关闭，无人工校验待办。

Generated with AI assistance
