### PR TITLE
fix(orchestration): 修复人工校验在提交前阻塞编排


### DIFF
--- a/.agents/skills/complete-manual-validation/SKILL.md
+++ b/.agents/skills/complete-manual-validation/SKILL.md
@@ -106,7 +106,7 @@ agent-infra-internal task-verify {task-id} manual-validation.completed --artifac
 - 产物路径
 - PR 摘要同步结果
 - 当次完成校验输出
-- 下一步建议：继续 `commit` / `create-pr` 或进入最终审查流程
+- 下一步建议：进入最终收尾流程，运行 /complete-task {task-ref}
 
 渲染最终输出前，先读取 `.agents/rules/next-step-output.md`，并在绝对最后一行追加 `Completed at: YYYY-MM-DD HH:mm:ss`。
 

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -87,6 +87,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 - [ ] 代码已提交（没有与此任务相关的未提交变更）
 - [ ] 测试通过
 - [ ] 审查分歧账本无未关闭分歧、无未复审的 post-review 提交；绑定 PR 路径中本地 HEAD、`last_reviewed_commit`、PR head 严格一致，或已合并 squash 的平台快照与远端 Git 等价证据完整且当前 Git 凭据可读取证据 refs；无有效 PR 路径中本地单父重写与 `last_reviewed_commit` 内容等价且之后无受保护提交
+- [ ] 人工校验项已完成（最新 review-code 的 Manual validation 计数 > 0 时，须存在通过校验的 manual-validation 产物及其完成记录，且该完成记录位于最新 review-code 之后；计数为 0 或无未决项时跳过）
 
 > **⚠️ 前置条件分支判断 — 你必须先判断“继续”还是“停止”：**
 >
@@ -145,7 +146,7 @@ agent-infra-internal task-warning {task-id} add --step complete-task --severity 
 agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 ```
 
-该事件依次执行 `review-ledger`、`post-review-commit`、`platform-sync-preflight`。任一退出码非 0（fail/blocked）时，任务必须继续留在 active；从 gate 结果取稳定 code/target，通过 `task-warning ... add --step complete-task ...` 落账后停止。若审查基线或 head 不一致，必须先重新 `commit` / `review-code`；不得回退审查基线。
+该事件依次执行 `review-ledger`、`manual-validation`、`post-review-commit`、`platform-sync-preflight`。任一退出码非 0（fail/blocked）时，任务必须继续留在 active；从 gate 结果取稳定 code/target，通过 `task-warning ... add --step complete-task ...` 落账后停止。若审查基线或 head 不一致，必须先重新 `commit` / `review-code`；不得回退审查基线。
 
 `--force` 不解除本硬门禁：未关闭分歧必须先在账本闭合，未复审提交必须重新审查、具备有效豁免，或由平台适配器为绑定的变更请求（PR/MR）提供权威合并快照与远端 refs，并在隔离临时仓库中证明单父 squash merge 等价，或在无有效变更请求时由本地 Git 对象证明唯一受保护提交是内容等价的单父重写且之后无受保护提交；平台 preflight 必须通过。适配器不支持所需能力，平台事实、Git 对象、拓扑、内容证据缺失，或当前 Git 凭据不能读取远端证据 refs 时 fail closed。required checks 由平台适配器提供规范化状态，并在合并前通过分支保护 / ruleset 以及 `review-code` / `watch-pr` 路由承担。
 
@@ -231,6 +232,7 @@ Completed at: {completion-time}
    - 代码已提交但未审查
    - 审查发现阻塞项但未修复
    - PR 已创建但未合并
+   - 人工校验项未完成
 
 2. **回滚**：如果任务被错误转移：
    ```bash

--- a/.agents/skills/complete-task/config/verify.json
+++ b/.agents/skills/complete-task/config/verify.json
@@ -25,6 +25,7 @@
       "require_all_checked": true
     },
     "review-ledger": {},
+    "manual-validation": {},
     "post-review-commit": {},
     "platform-sync-preflight": {
       "when": "issue_number_exists",

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -221,9 +221,6 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
     if (!review.ok || review.summary.manualValidation === null) {
       return failed('ORCHESTRATION_REVIEW_INVALID', 'latest code review has no numeric manual-validation count', resolved.taskId);
     }
-    if (review.summary.manualValidation > 0) {
-      return failed('ORCHESTRATION_MANUAL_VALIDATION_PENDING', 'manual validation must be completed before commit', resolved.taskId);
-    }
     const rows = parseLedger(content);
     const ledgerError = validateLedgerRows(rows);
     if (ledgerError) return failed('ORCHESTRATION_LEDGER_INVALID', ledgerError.message, resolved.taskId);

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -114,6 +114,8 @@ function runCheck(type: any, context: any, shared: any): any {
       return checkCompletionChecklist(context);
     case "review-ledger":
       return checkReviewLedger(context);
+    case "manual-validation":
+      return checkManualValidation(context);
     case "review-summary":
       return checkReviewSummary(context);
     case "review-fact":
@@ -738,6 +740,75 @@ function checkReviewLedger({ taskDir, config }: any): any {
 
   const scopeLabel = stageScope ? ` for stages [${stageScope.join(", ")}]` : "";
   return passResult("review-ledger", `Disagreement ledger clean (${inScopeCount} in-scope entries terminal${scopeLabel})`);
+}
+
+function checkManualValidation({ taskDir }: any): any {
+  // 1. Latest review-code artifact; none -> pass (no review, check not applicable).
+  const review = findAuthoritativeReviewCodeArtifact(taskDir);
+  if (!review.ok) {
+    return passResult("manual-validation", "No review-code artifact; manual validation not applicable");
+  }
+  // 2. Parse the numeric manual-validation count; unparseable/null -> fail closed
+  //    (review-code.completed already enforces a numeric count on the normal path).
+  const parsed = parseReviewSummary(fs.readFileSync(review.path!, "utf8"));
+  if (!parsed.ok || parsed.summary.manualValidation === null) {
+    return failResult("manual-validation", "Latest review-code has no numeric manual-validation count");
+  }
+  // 3. Count 0 -> pass (no pending items to cover).
+  if (parsed.summary.manualValidation === 0) {
+    return passResult("manual-validation", "No pending manual validation items");
+  }
+  // 4. Highest-round manual-validation artifact; none -> fail (items pending,
+  //    run complete-manual-validation first). A falsy artifactFile goes through
+  //    pattern parsing; resolveArtifactPath only returns { ok, path }.
+  const resolved = resolveArtifactPath(taskDir, "manual-validation.md|manual-validation-r{N}.md", "");
+  if (!resolved.ok) {
+    return failResult(
+      "manual-validation",
+      `${parsed.summary.manualValidation} manual validation item(s) pending: run /complete-manual-validation`
+    );
+  }
+  // 5. The Activity Log must record the matching completion entry; the file name
+  //    is derived with path.basename (resolveArtifactPath does not return fileName).
+  const artifactName = path.basename(resolved.path);
+  const task = loadTask(taskDir);
+  if (!task.ok) return failResult("manual-validation", task.message);
+  const log = getSectionContent(task.content, ["活动日志", "Activity Log"]);
+  const completed = new RegExp(
+    `\\*\\*Complete Manual Validation\\*\\*[\\s\\S]*?Manual validation passed → ${escapeRegExp(artifactName)};`
+  );
+  if (!completed.test(log)) {
+    return failResult(
+      "manual-validation",
+      `Manual validation artifact exists but completion is not recorded for ${artifactName}: re-run /complete-manual-validation`
+    );
+  }
+  // 6. Timing correlation (PL-3 fix, PL-4 corrected): the completion entry must
+  //    sit AFTER the latest review-code round's completion entry in the
+  //    append-only Activity Log. indexOf is a literal search, so the artifactName
+  //    must NOT be passed through escapeRegExp here (that escapes '.' to '\.',
+  //    which indexOf never matches). Not reusing completed.exec().index: exec
+  //    anchors to the first '**Complete Manual Validation**' heading, which can
+  //    belong to an earlier round's entry and misorder the standard path.
+  const reviewDoneIndex = log.indexOf(`**Review Code (Round ${review.round})** by `);
+  const completedIndex = log.indexOf(`Manual validation passed → ${artifactName};`);
+  if (reviewDoneIndex === -1) {
+    // The latest review-code round's completion entry is missing entirely (abnormal
+    // state, e.g. a restored/historical task without a review-code.completed record).
+    // Re-running complete-manual-validation cannot restore it, so the remediation
+    // targets the review record itself. Fail closed either way.
+    return failResult(
+      "manual-validation",
+      `Latest review-code (round ${review.round}) completion entry is missing from the Activity Log (abnormal state): re-run review-code or restore the completion record`
+    );
+  }
+  if (completedIndex < reviewDoneIndex) {
+    return failResult(
+      "manual-validation",
+      `Latest review-code (round ${review.round}) came after the manual validation completion recorded for ${artifactName}: re-run /complete-manual-validation to cover new pending items`
+    );
+  }
+  return passResult("manual-validation", `Manual validation completed → ${artifactName}`);
 }
 
 function checkPostReviewCommit({ taskDir, config }: any): any {

--- a/lib/task/verification.ts
+++ b/lib/task/verification.ts
@@ -64,7 +64,7 @@ const VERIFICATION_CATALOG: Readonly<Record<VerificationEvent, VerificationSpec>
   'block-task.completed': gate('block-task', 'blocked'),
   'cancel-task.completed': gate('cancel-task', 'completed'),
   'commit.completed': gate('commit', 'active'),
-  'complete-task.preflight': { skill: 'complete-task', expectedState: 'active', mode: 'checks', checks: ['review-ledger', 'post-review-commit', 'platform-sync-preflight'] },
+  'complete-task.preflight': { skill: 'complete-task', expectedState: 'active', mode: 'checks', checks: ['review-ledger', 'manual-validation', 'post-review-commit', 'platform-sync-preflight'] },
   'complete-task.completed': gate('complete-task', 'completed'),
   'create-pr.completed': gate('create-pr', 'active'),
   'create-task.completed': gate('create-task', 'active'),

--- a/templates/.agents/skills/complete-manual-validation/SKILL.en.md
+++ b/templates/.agents/skills/complete-manual-validation/SKILL.en.md
@@ -106,7 +106,7 @@ Report:
 - Artifact path
 - PR summary sync result
 - Current verification output
-- Suggested next step: continue with `commit` / `create-pr`, or enter the final review flow
+- Suggested next step: enter the final closing flow and run /complete-task {task-ref}
 
 Before rendering the final output, read `.agents/rules/next-step-output.md` and append `Completed at: YYYY-MM-DD HH:mm:ss` as the absolute last line.
 

--- a/templates/.agents/skills/complete-manual-validation/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-manual-validation/SKILL.zh-CN.md
@@ -106,7 +106,7 @@ agent-infra-internal task-verify {task-id} manual-validation.completed --artifac
 - 产物路径
 - PR 摘要同步结果
 - 当次完成校验输出
-- 下一步建议：继续 `commit` / `create-pr` 或进入最终审查流程
+- 下一步建议：进入最终收尾流程，运行 /complete-task {task-ref}
 
 渲染最终输出前，先读取 `.agents/rules/next-step-output.md`，并在绝对最后一行追加 `Completed at: YYYY-MM-DD HH:mm:ss`。
 

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -88,6 +88,7 @@ Before marking complete, verify ALL of these:
 - [ ] Code has been committed (no uncommitted changes related to this task)
 - [ ] Tests are passing
 - [ ] The disagreement ledger has no unclosed disagreements or un-re-reviewed post-review commits; on a bound-PR path local HEAD, `last_reviewed_commit`, and PR head either match strictly, or a merged squash has complete platform snapshot and remote Git equivalence evidence and current Git credentials can read the evidence refs; without a valid PR, a single-parent local rewrite is content-equivalent to `last_reviewed_commit` and has no later protected commits
+- [ ] Manual validation items are complete (when the latest review-code's Manual validation count is > 0, a passed manual-validation artifact and its completion record must exist, and that completion record must sit after the latest review-code; skipped when the count is 0 or there are no pending items)
 
 > **⚠️ Prerequisite Branch Check — you must decide whether to continue or stop before proceeding:**
 >
@@ -146,7 +147,7 @@ After platform writes succeed and before moving the directory or releasing the s
 agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 ```
 
-This event runs `review-ledger`, `post-review-commit`, then `platform-sync-preflight`. On any non-zero exit (fail/blocked), keep the task active, derive the stable code/target from the gate result, record it through `task-warning ... add --step complete-task ...`, and stop. For a review/head mismatch, rerun `commit` or `review-code`; never fall back to the review baseline.
+This event runs `review-ledger`, `manual-validation`, `post-review-commit`, then `platform-sync-preflight`. On any non-zero exit (fail/blocked), keep the task active, derive the stable code/target from the gate result, record it through `task-warning ... add --step complete-task ...`, and stop. For a review/head mismatch, rerun `commit` or `review-code`; never fall back to the review baseline.
 
 `--force` does not lift this hard gate: close ledger disagreements; re-review or exempt post-review commits, use the platform adapter's authoritative snapshot and remote refs for the bound change request (PR/MR) to prove a content-equivalent single-parent squash merge in an isolated temporary repository, or, without a valid change request, prove from local Git objects that the only protected commit is a content-equivalent single-parent rewrite with no later protected commits; then pass platform preflight. An unsupported adapter capability, missing required platform facts, Git objects, topology, or content evidence, or current Git credentials that cannot read the remote evidence refs fails closed. The platform adapter supplies normalized required-checks state, which remains enforced before merge by branch protection / rulesets and the `review-code` / `watch-pr` routes.
 
@@ -232,6 +233,7 @@ Completed at: {completion-time}
    - Code is committed but not reviewed
    - Review found blockers that haven't been fixed
    - PR is created but not merged
+   - Manual validation items are incomplete
 
 2. **Rollback**: If a task was incorrectly moved:
    ```bash

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -87,6 +87,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 - [ ] 代码已提交（没有与此任务相关的未提交变更）
 - [ ] 测试通过
 - [ ] 审查分歧账本无未关闭分歧、无未复审的 post-review 提交；绑定 PR 路径中本地 HEAD、`last_reviewed_commit`、PR head 严格一致，或已合并 squash 的平台快照与远端 Git 等价证据完整且当前 Git 凭据可读取证据 refs；无有效 PR 路径中本地单父重写与 `last_reviewed_commit` 内容等价且之后无受保护提交
+- [ ] 人工校验项已完成（最新 review-code 的 Manual validation 计数 > 0 时，须存在通过校验的 manual-validation 产物及其完成记录，且该完成记录位于最新 review-code 之后；计数为 0 或无未决项时跳过）
 
 > **⚠️ 前置条件分支判断 — 你必须先判断“继续”还是“停止”：**
 >
@@ -145,7 +146,7 @@ agent-infra-internal task-warning {task-id} add --step complete-task --severity 
 agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 ```
 
-该事件依次执行 `review-ledger`、`post-review-commit`、`platform-sync-preflight`。任一退出码非 0（fail/blocked）时，任务必须继续留在 active；从 gate 结果取稳定 code/target，通过 `task-warning ... add --step complete-task ...` 落账后停止。若审查基线或 head 不一致，必须先重新 `commit` / `review-code`；不得回退审查基线。
+该事件依次执行 `review-ledger`、`manual-validation`、`post-review-commit`、`platform-sync-preflight`。任一退出码非 0（fail/blocked）时，任务必须继续留在 active；从 gate 结果取稳定 code/target，通过 `task-warning ... add --step complete-task ...` 落账后停止。若审查基线或 head 不一致，必须先重新 `commit` / `review-code`；不得回退审查基线。
 
 `--force` 不解除本硬门禁：未关闭分歧必须先在账本闭合，未复审提交必须重新审查、具备有效豁免，或由平台适配器为绑定的变更请求（PR/MR）提供权威合并快照与远端 refs，并在隔离临时仓库中证明单父 squash merge 等价，或在无有效变更请求时由本地 Git 对象证明唯一受保护提交是内容等价的单父重写且之后无受保护提交；平台 preflight 必须通过。适配器不支持所需能力，平台事实、Git 对象、拓扑、内容证据缺失，或当前 Git 凭据不能读取远端证据 refs 时 fail closed。required checks 由平台适配器提供规范化状态，并在合并前通过分支保护 / ruleset 以及 `review-code` / `watch-pr` 路由承担。
 
@@ -231,6 +232,7 @@ Completed at: {completion-time}
    - 代码已提交但未审查
    - 审查发现阻塞项但未修复
    - PR 已创建但未合并
+   - 人工校验项未完成
 
 2. **回滚**：如果任务被错误转移：
    ```bash

--- a/templates/.agents/skills/complete-task/config/verify.en.json
+++ b/templates/.agents/skills/complete-task/config/verify.en.json
@@ -25,6 +25,7 @@
       "require_all_checked": true
     },
     "review-ledger": {},
+    "manual-validation": {},
     "post-review-commit": {},
     "platform-sync-preflight": {
       "when": "issue_number_exists",

--- a/templates/.agents/skills/complete-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/complete-task/config/verify.zh-CN.json
@@ -25,6 +25,7 @@
       "require_all_checked": true
     },
     "review-ledger": {},
+    "manual-validation": {},
     "post-review-commit": {},
     "platform-sync-preflight": {
       "when": "issue_number_exists",

--- a/tests/e2e/core/validate-artifact.test.ts
+++ b/tests/e2e/core/validate-artifact.test.ts
@@ -103,11 +103,11 @@ const gateCases = [
       assert.equal(payload.gate, "pass");
       assert.deepEqual(
         payload.checks.map((check) => check.type),
-        ["task-meta", "activity-log", "completion-checklist", "review-ledger", "post-review-commit", "platform-sync-preflight", "platform-sync", "artifact"]
+        ["task-meta", "activity-log", "completion-checklist", "review-ledger", "manual-validation", "post-review-commit", "platform-sync-preflight", "platform-sync", "artifact"]
       );
       assert.deepEqual(
         payload.checks.map((check) => check.status),
-        ["pass", "pass", "pass", "pass", "pass", "pass", "pass", "pass"]
+        ["pass", "pass", "pass", "pass", "pass", "pass", "pass", "pass", "pass"]
       );
     }
   }

--- a/tests/integration/cli/complete-task-preflight.test.ts
+++ b/tests/integration/cli/complete-task-preflight.test.ts
@@ -19,7 +19,7 @@ function fixture() {
   fs.writeFileSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json'), `${JSON.stringify({ version: 1, ids: { '01': TASK_ID } })}\n`);
   fs.writeFileSync(path.join(root, '.agents', 'skills', 'complete-task', 'config', 'verify.json'), JSON.stringify({
     skill: 'complete-task', checks: {
-      'review-ledger': null, 'post-review-commit': null,
+      'review-ledger': null, 'manual-validation': {}, 'post-review-commit': null,
       'platform-sync-preflight': null
     }
   }));
@@ -59,6 +59,7 @@ test('compiled preflight does not require a checks snapshot for a bound historic
       skill: 'complete-task',
       checks: {
         'review-ledger': null,
+        'manual-validation': {},
         'post-review-commit': null,
         'platform-sync-preflight': null
       }
@@ -82,7 +83,7 @@ test('compiled preflight does not require a checks snapshot for a bound historic
     const payload = JSON.parse(result.stdout);
     assert.deepEqual(
       payload.invocations.map((invocation: { payload: { type: string } }) => invocation.payload.type),
-      ['review-ledger', 'post-review-commit', 'platform-sync-preflight']
+      ['review-ledger', 'manual-validation', 'post-review-commit', 'platform-sync-preflight']
     );
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
@@ -95,8 +96,8 @@ test('platform-sync-preflight is a distinct typed verification result', () => {
     const result = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'json']);
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.invocations[2].payload.type, 'platform-sync-preflight');
-    assert.equal(payload.invocations[2].status, 'pass');
+    assert.equal(payload.invocations[3].payload.type, 'platform-sync-preflight');
+    assert.equal(payload.invocations[3].status, 'pass');
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
   }
@@ -107,7 +108,7 @@ test('preflight success permits one archive and releases the short id', () => {
   try {
     const preflight = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'text']);
     assert.equal(preflight.status, 0, preflight.stderr);
-    assert.equal((preflight.stdout.match(/^Check: pass/gm) ?? []).length, 3);
+    assert.equal((preflight.stdout.match(/^Check: pass/gm) ?? []).length, 4);
     const completed = run(f.root, ['task-lifecycle', TASK_ID, 'complete', '--agent', 'codex']);
     assert.equal(completed.status, 0, completed.stderr);
     assert.equal(JSON.parse(completed.stdout).status, 'applied');
@@ -126,6 +127,93 @@ test('completed verification resolves the archived task without moving it back t
     assert.equal(verified.status, 0, verified.stderr);
     assert.match(verified.stdout, /Verification: pass \| Skill: complete-task/);
     assert.equal(fs.existsSync(path.join(f.root, '.agents', 'workspace', 'active', TASK_ID)), false);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+function reviewCodeContent(manualValidation: number) {
+  return [
+    '# Code Review', '',
+    '## 审查摘要', '',
+    '- **总体结论**：通过',
+    `- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：${manualValidation}`,
+    ''
+  ].join('\n');
+}
+
+test('preflight blocks a pending manual validation item and passes after completion (scenario A)', () => {
+  const f = fixture();
+  try {
+    // Review Code (Round 1) completion entry first, then a review-code with 1
+    // pending manual-validation item and NO completion evidence.
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '\n- 2026-01-01 00:00:00+00:00 — **Review Code (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code.md\n'
+    );
+    fs.writeFileSync(path.join(f.activeDir, 'review-code.md'), reviewCodeContent(1));
+
+    const blocked = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'json']);
+    assert.equal(blocked.status, 1, blocked.stderr);
+    const blockedPayload = JSON.parse(blocked.stdout);
+    assert.equal(blockedPayload.invocations[1].payload.type, 'manual-validation');
+    assert.equal(blockedPayload.invocations[1].status, 'fail');
+    assert.match(blockedPayload.invocations[1].payload.message, /manual validation item\(s\) pending/);
+
+    // Complete the manual validation AFTER the Review Code (Round 1) entry.
+    fs.writeFileSync(path.join(f.activeDir, 'manual-validation.md'), '# Manual Validation\n');
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation.md; verified on staging\n'
+    );
+
+    const passed = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'text']);
+    assert.equal(passed.status, 0, passed.stderr);
+    assert.match(passed.stdout, /Manual validation completed → manual-validation\.md/);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('preflight intercepts out-of-order manual validation that predates a newer review round (scenario B)', () => {
+  const f = fixture();
+  try {
+    // ① review-code round 1 with 1 pending item + its completion entry.
+    fs.writeFileSync(path.join(f.activeDir, 'review-code.md'), reviewCodeContent(1));
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '\n- 2026-01-01 00:00:00+00:00 — **Review Code (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code.md\n'
+    );
+    // ② manual-validation completes for round 1, after the round 1 entry.
+    fs.writeFileSync(path.join(f.activeDir, 'manual-validation.md'), '# Manual Validation\n');
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation.md; verified on staging\n'
+    );
+    // ③ a newer review-code round adds a new pending item, after the completion entry.
+    fs.writeFileSync(path.join(f.activeDir, 'review-code-r2.md'), reviewCodeContent(1));
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '- 2026-01-01 00:00:00+00:00 — **Review Code (Round 2)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code-r2.md\n'
+    );
+
+    const intercepted = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'json']);
+    assert.equal(intercepted.status, 1, intercepted.stderr);
+    const interceptedPayload = JSON.parse(intercepted.stdout);
+    assert.equal(interceptedPayload.invocations[1].payload.type, 'manual-validation');
+    assert.equal(interceptedPayload.invocations[1].status, 'fail');
+    assert.match(interceptedPayload.invocations[1].payload.message, /Latest review-code \(round 2\) came after/);
+
+    // ④ complete a new manual-validation for round 2, after the round 2 entry.
+    fs.writeFileSync(path.join(f.activeDir, 'manual-validation-r2.md'), '# Manual Validation Round 2\n');
+    fs.appendFileSync(
+      path.join(f.activeDir, 'task.md'),
+      '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation-r2.md; verified on staging\n'
+    );
+
+    const passed = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'text']);
+    assert.equal(passed.status, 0, passed.stderr);
+    assert.match(passed.stdout, /Manual validation completed → manual-validation-r2\.md/);
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
   }

--- a/tests/integration/cli/task-verify.test.ts
+++ b/tests/integration/cli/task-verify.test.ts
@@ -24,7 +24,7 @@ test('internal task-verify resolves task identity and invokes the typed engine',
     writeJson(path.join(root, '.agents/skills/code-task/config/verify.json'), { skill: 'code-task', checks: {} });
     writeJson(path.join(root, '.agents/skills/complete-task/config/verify.json'), {
       skill: 'complete-task', checks: {
-        'review-ledger': null, 'post-review-commit': null,
+        'review-ledger': null, 'manual-validation': {}, 'post-review-commit': null,
         'platform-sync-preflight': null
       }
     });
@@ -35,7 +35,7 @@ test('internal task-verify resolves task identity and invokes the typed engine',
 
     const preflight = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-verify', id, 'complete-task.preflight', '--format', 'text'], { cwd: root, encoding: 'utf8' });
     assert.equal(preflight.status, 0, preflight.stderr);
-    assert.equal((preflight.stdout.match(/^Check: pass/gm) ?? []).length, 3);
+    assert.equal((preflight.stdout.match(/^Check: pass/gm) ?? []).length, 4);
 
     const duplicate = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-verify', id, 'commit.completed', '--format', 'json', '--format', 'text'], { cwd: root, encoding: 'utf8' });
     assert.equal(duplicate.status, 1);

--- a/tests/unit/cli/task-verification.test.ts
+++ b/tests/unit/cli/task-verification.test.ts
@@ -49,7 +49,7 @@ test('verification catalog is a closed mapping of all business events', () => {
     'block-task.completed': ['block-task', 'blocked', 'gate', undefined, undefined],
     'cancel-task.completed': ['cancel-task', 'completed', 'gate', undefined, undefined],
     'commit.completed': ['commit', 'active', 'gate', undefined, undefined],
-    'complete-task.preflight': ['complete-task', 'active', 'checks', undefined, ['review-ledger', 'post-review-commit', 'platform-sync-preflight']],
+    'complete-task.preflight': ['complete-task', 'active', 'checks', undefined, ['review-ledger', 'manual-validation', 'post-review-commit', 'platform-sync-preflight']],
     'complete-task.completed': ['complete-task', 'completed', 'gate', undefined, undefined],
     'create-pr.completed': ['create-pr', 'active', 'gate', undefined, undefined],
     'create-task.completed': ['create-task', 'active', 'gate', undefined, undefined],

--- a/tests/unit/core/task-orchestration.test.ts
+++ b/tests/unit/core/task-orchestration.test.ts
@@ -104,19 +104,50 @@ test('route requires the latest review to bind the latest artifact structurally'
   });
 });
 
-test('route fails closed before commit when manual validation or ledger work remains', () => {
+test('route allows commit when manual validation remains (complete-task gate owns the pending items)', () => {
   const manual = approvedCodeFixture(1);
-  assert.equal(
-    routeOrchestration('TASK-20260101-000001', { repoRoot: manual.root }).error?.code,
-    'ORCHESTRATION_MANUAL_VALIDATION_PENDING'
-  );
+  const routed = routeOrchestration('TASK-20260101-000001', { repoRoot: manual.root });
+  assert.equal(routed.error, null);
+  assert.deepEqual(routed.next, {
+    action: 'commit', role: 'executor', stage: 'commit', round: 1, artifact: 'commit'
+  });
+});
 
+test('route fails closed before commit when code review ledger work remains', () => {
   const ledger = approvedCodeFixture();
   fs.appendFileSync(path.join(ledger.taskDir, 'task.md'), '\n## Review Disagreement Ledger\n\n| id | stage | round | severity | status | evidence |\n|----|-------|-------|----------|--------|----------|\n| CD-1 | code | 1 | blocker | open | review-code.md#CD-1 |\n');
   assert.equal(
     routeOrchestration('TASK-20260101-000001', { repoRoot: ledger.root }).error?.code,
     'ORCHESTRATION_LEDGER_BLOCKED'
   );
+});
+
+test('commit authorization is issued and the run completes even with pending manual validation', () => {
+  const f = approvedCodeFixture(1);
+  const now = () => '2026-01-01T00:00:00.000Z';
+  const begun = beginOrResumeOrchestration('TASK-20260101-000001', {
+    repoRoot: f.root, id: () => 'run-mv', now
+  });
+  assert.equal(begun.run?.commitAuthorization.issuedAt, null);
+
+  const prepared = prepareOrchestrationDelegation('TASK-20260101-000001', {
+    client: 'claude-code'
+  }, { repoRoot: f.root, id: () => 'receipt-mv', now, captureWorkspace: snapshot });
+  assert.equal(prepared.next?.stage, 'commit');
+  assert.equal(prepared.run?.pendingDelegation?.workspaceSnapshotScope, 'task');
+  assert.equal(prepared.run?.commitAuthorization.issuedAt, '2026-01-01T00:00:00.000Z');
+
+  assert.equal(activateOrchestrationDelegation('TASK-20260101-000001', {
+    nativeAgent: 'agent-infra-lifecycle-executor', childId: 'child-mv', parentId: 'parent-mv',
+    spawnMode: 'fresh', actualModel: 'gpt-5'
+  }, { repoRoot: f.root, now }).status, 'running');
+  assert.equal(completeCommitOrchestrationStage('TASK-20260101-000001', 'claude-code', { repoRoot: f.root }).status, 'running');
+  assert.equal(sealOrchestrationDelegation('TASK-20260101-000001', {
+    childId: 'child-mv', exitCode: 0, afterFingerprint: 'after', changedPaths: []
+  }, { repoRoot: f.root, now }).status, 'running');
+  assert.equal(advanceOrchestration('TASK-20260101-000001', { repoRoot: f.root, now }).status, 'completed');
+  assert.equal(readRun(f.taskDir)?.commitAuthorization.consumedAt, '2026-01-01T00:00:00.000Z');
+  assert.equal(readRun(f.taskDir)?.pendingDelegation, null);
 });
 
 test('commit authorization is issued at eligible prepare and the receipt reaches completed', () => {

--- a/tests/unit/core/verification-manual-validation.test.ts
+++ b/tests/unit/core/verification-manual-validation.test.ts
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { verifyInProcess } from '../../../lib/task/verification-engine.ts';
+
+// Branch matrix for the complete-task.preflight `manual-validation` check
+// (see plan-r5 改动二). The decision relies only on the latest review-code
+// artifact plus the append-only Activity Log, so the fixture is a bare task
+// directory with task.md and optional artifacts.
+
+const REVIEW_CODE_MV_1 = `# Code Review
+
+## 审查摘要
+
+- **总体结论**：通过
+- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：1
+`;
+
+function fixture(activityEntries: string[]) {
+  const taskDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verification-manual-validation-'));
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---
+id: TASK-20260101-000001
+---
+
+# Task
+
+## 活动日志
+
+${activityEntries.join('\n')}
+`);
+  return taskDir;
+}
+
+function check(taskDir: string) {
+  return verifyInProcess({
+    mode: 'check',
+    skillName: 'complete-task',
+    taskDir,
+    artifactFile: undefined,
+    checks: ['manual-validation'],
+    repositoryRoot: process.cwd()
+  });
+}
+
+test('manual-validation check passes when no review-code artifact exists', () => {
+  const taskDir = fixture([]);
+  const result = check(taskDir);
+  assert.equal(result.status, 'pass');
+  assert.match(result.message, /No review-code artifact/);
+});
+
+test('manual-validation check passes when the latest review-code has zero pending items', () => {
+  const taskDir = fixture([]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1.replace('**人工校验**：1', '**人工校验**：0'));
+  const result = check(taskDir);
+  assert.equal(result.status, 'pass');
+  assert.match(result.message, /No pending manual validation items/);
+});
+
+test('manual-validation check fails when pending items exist without a manual-validation artifact', () => {
+  const taskDir = fixture([]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1);
+  const result = check(taskDir);
+  assert.equal(result.status, 'fail');
+  assert.match(result.message, /manual validation item\(s\) pending/);
+});
+
+test('manual-validation check fails when the artifact exists but completion is not recorded', () => {
+  const taskDir = fixture([
+    '- 2026-01-01 00:00:00+00:00 — **Review Code (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code.md'
+  ]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1);
+  fs.writeFileSync(path.join(taskDir, 'manual-validation.md'), '# Manual Validation\n');
+  const result = check(taskDir);
+  assert.equal(result.status, 'fail');
+  assert.match(result.message, /completion is not recorded/);
+});
+
+test('manual-validation check passes on the standard flow when completion follows the latest review-code', () => {
+  const taskDir = fixture([
+    '- 2026-01-01 00:00:00+00:00 — **Review Code (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code.md',
+    '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation.md; verified on staging'
+  ]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1);
+  fs.writeFileSync(path.join(taskDir, 'manual-validation.md'), '# Manual Validation\n');
+  const result = check(taskDir);
+  assert.equal(result.status, 'pass');
+  assert.match(result.message, /Manual validation completed → manual-validation\.md/);
+});
+
+test('manual-validation check fails when completion predates a newer review-code round', () => {
+  const taskDir = fixture([
+    '- 2026-01-01 00:00:00+00:00 — **Review Code (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code.md',
+    '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation.md; verified on staging',
+    '- 2026-01-01 00:00:00+00:00 — **Review Code (Round 2)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0, Manual-validation: 1 → review-code-r2.md'
+  ]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1);
+  fs.writeFileSync(path.join(taskDir, 'review-code-r2.md'), REVIEW_CODE_MV_1);
+  fs.writeFileSync(path.join(taskDir, 'manual-validation.md'), '# Manual Validation\n');
+  const result = check(taskDir);
+  assert.equal(result.status, 'fail');
+  assert.match(result.message, /Latest review-code \(round 2\) came after/);
+});
+
+test('manual-validation check fails closed when the latest review-code completion entry is missing', () => {
+  const taskDir = fixture([
+    '- 2026-01-01 00:00:00+00:00 — **Complete Manual Validation** by claude — Manual validation passed → manual-validation.md; verified on staging'
+  ]);
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), REVIEW_CODE_MV_1);
+  fs.writeFileSync(path.join(taskDir, 'manual-validation.md'), '# Manual Validation\n');
+  const result = check(taskDir);
+  assert.equal(result.status, 'fail');
+  assert.match(result.message, /completion entry is missing from the Activity Log/);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #777

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #777

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 `run-task` 在 review-code 含人工校验项时于 commit 前直接拦截所造成的流程死锁。真实环境校验通常依赖代码先提交并推送，但原流程要求先完成校验才允许提交，且 commit 后编排即结束，导致任务无法推进。

本变更保留人工校验的安全要求，同时把强制点移到 `complete-task`：编排可以先完成 commit/push，未决人工校验仍会在任务收尾前 fail closed。

## 📋 主要变更 / Brief Changelog

- 移除 orchestration route 对 commit 的 `ORCHESTRATION_MANUAL_VALIDATION_PENDING` 前置门禁，使含人工校验项的已批准实现仍可进入 commit。
- 为 `complete-task.preflight` 增加 `manual-validation` 检查，验证最新 review-code、canonical 校验产物和 Activity Log 时序，缺失或过期证据均 fail closed。
- 同步 `complete-task`、`complete-manual-validation` 运行时技能、双语模板与 verify 配置，明确人工校验在 commit 后、任务完成前承接。
- 增加编排、验证引擎、CLI、集成与端到端回归测试，覆盖无人工校验、待校验、已完成、过期及异常日志场景。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run build` 验证 TypeScript 编译与构建产物。
2. 运行 `npm test` 执行完整测试套件。
3. 运行 `git diff --check main...HEAD` 检查 diff 格式，并核对 `review-code-r2.md` 的 Approved 结论。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

最新验证：1957 passed，0 failed，3 skipped；TypeScript 构建与 `git diff --check` 通过。

## 📸 截图 / Screenshots

不适用；本次变更涉及内部生命周期编排、任务门禁与自动化测试，无可视化界面变化。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass（项目当前未配置 lint；TypeScript 构建与 `git diff --check` 已通过）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 采用已裁决的方案 C：`run-task` 在 commit 后正常完成，不新增 paused 或独立 manual-validation 编排阶段；任务级校验由 `complete-manual-validation` 与 `complete-task` 承接。
- 代码审查 Round 2 已通过：0 blocker、0 major、0 minor、0 manual-validation。
- 本 PR 不削弱人工校验要求；只有不存在待校验项，或最新人工校验证据覆盖最新 review-code 时，任务完成门禁才会放行。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查人工校验强制点从 commit route 迁移到 complete-task preflight 后的 fail-closed 语义、Activity Log 时序关联，以及现有 commit authorization / receipt 恢复路径是否保持不变。

Generated with AI assistance
