### PR TITLE
feat(orchestration): 补齐模型证据并保持 Codex 失败关闭


### DIFF
--- a/.agents/hooks/lifecycle-delegation.js
+++ b/.agents/hooks/lifecycle-delegation.js
@@ -42,7 +42,7 @@ process.stdin.on('end', () => {
       '--native-agent', String(nativeAgent),
       '--child-id', String(event.child_id || event.agent_id || event.thread_id || ''),
       '--parent-id', String(event.parent_id || event.parent_session_id || event.session_id || ''),
-      '--spawn-mode', String(event.spawn_mode || 'fresh')
+      '--spawn-mode', String(event.spawn_mode || (client === 'claude-code' ? 'fresh' : ''))
     );
     if (event.model) args.push('--actual-model', String(event.model));
     if (event.model_fallback_reason) args.push('--fallback-reason', String(event.model_fallback_reason));

--- a/.agents/rules/lifecycle-orchestration.md
+++ b/.agents/rules/lifecycle-orchestration.md
@@ -14,7 +14,10 @@
 
 ## 模型策略
 
-reviewer 优先选择与上一 executor 不同的模型。若客户端只能使用同模型，必须记录 requested model、actual model 和降级原因；缺少降级理由时失败关闭。
+- 新 run 必须固化 executor/reviewer 模型；不同模型时 `sameModelReason` 为 null，同模型时必须说明隔离受限原因。重入不得静默改写策略。
+- route 按 role 返回 requested model，prepare 必须在工作区快照前精确匹配它；原生 spawn 必须显式使用该模型，不能继承会话默认值。
+- 原生 start 必须记录宿主观察到的 actual model。actual 与 requested 不同时必须另行记录 `modelFallbackReason`；它不能用同模型策略理由替代。
+- 缺少模型策略、实际模型或降级理由时失败关闭；旧 run 缺模型策略时稳定暂停。
 
 ## 稳定暂停条件
 

--- a/.agents/skills/run-task/SKILL.md
+++ b/.agents/skills/run-task/SKILL.md
@@ -7,14 +7,14 @@ description: >
 
 # 运行任务生命周期
 
-总控只编排，不直接执行任何阶段技能。执行前先读取 `.agents/rules/no-mid-flow-questions.md` 与 `.agents/rules/lifecycle-orchestration.md`。
+总控只编排，不直接执行任何阶段技能。执行前先读取 `.agents/rules/no-mid-flow-questions.md`、`.agents/rules/lifecycle-orchestration.md` 与 `reference/host-validation.md`。
 
-1. 解析任务引用并执行 `agent-infra-internal task-snapshot {task-id} --format text`。
-2. 调用 `agent-infra-internal task-orchestration {task-id} begin-or-resume`；若为 paused/completed，按结构化结果停止。
-3. 调用 `route` 并读取唯一 action、role、round 和 artifact；不得从审查文案自行推断。
-4. 调用 `agent-infra-internal task-orchestration {task-id} prepare --client {client}`；核心自动记录工作区基线。成功后用当前客户端的 fresh 原生子 Agent 启动指定 executor/reviewer，只传短任务引用、skill 名和最小交接摘要，不传 receipt identity，不继承总控历史。
+1. 解析任务引用及 `--executor-model <id>`、`--reviewer-model <id>`、可选 `--same-model-reason <text>`，并执行 `agent-infra-internal task-snapshot {task-id} --format text`。首次启动必须提供两种模型；仅同模型时要求理由。
+2. 调用 `agent-infra-internal task-orchestration {task-id} begin-or-resume` 并转发本次提供的模型参数；已有 run 可省略参数并使用持久化策略，重复提供时必须完全一致。若为 paused/completed，按结构化结果停止。
+3. 调用 `route` 并读取唯一 action、role、round、artifact 和 `requestedModel`；不得从审查文案或会话默认值自行推断。
+4. 调用 `agent-infra-internal task-orchestration {task-id} prepare --client {client} --requested-model {requestedModel}`；核心在记录工作区基线前校验模型。成功后用当前客户端的 fresh 原生子 Agent 启动指定 executor/reviewer，并显式覆盖为同一 `requestedModel`；只传短任务引用、skill 名和最小交接摘要，不传 receipt identity，不继承总控历史。
 5. 原生 start/stop hook 通过唯一 pending delegation 自动关联任务，并由核心计算工作区变化、封存 receipt；子 Agent 返回后调用 `advance`。只有 `running` 才重复步骤 3；`paused` 或 `completed` 立即停止。
-6. 每轮创建新 child；禁止 follow-up 复用 reviewer。任何 capability、hook、身份、模型降级、账本或 fingerprint 异常都调用 `pause` 并失败关闭。
+6. 每轮创建新 child；禁止 follow-up 复用 reviewer。原生 start 必须回传非空 actual model；actual 与 requested 不同时必须有宿主降级理由。任何 capability、hook、身份、模型证据、账本或 fingerprint 异常都调用 `pause` 并失败关闭。
 7. 完成或暂停后运行对应 typed verification，并把结构化 run 摘要、暂停原因或 commit 终点告知用户。
 
 ## 停止

--- a/.agents/skills/run-task/config/verify.json
+++ b/.agents/skills/run-task/config/verify.json
@@ -4,6 +4,7 @@
     "task-meta": {
       "required_fields": ["id", "status", "updated_at", "agent_infra_version", "current_step", "assigned_to"]
     },
-    "orchestration-state": {}
+    "orchestration-state": {},
+    "orchestration-evidence": {}
   }
 }

--- a/.agents/skills/run-task/reference/host-validation.md
+++ b/.agents/skills/run-task/reference/host-validation.md
@@ -1,0 +1,20 @@
+# 宿主契约验证
+
+发布支持某个客户端前，必须用真实宿主事件证明生命周期证据链；bridge 单测只证明字段映射，不能证明事件来自宿主。
+
+## 必须证明的字段
+
+- 客户端版本、启用的多代理能力、启动入口与信任边界。
+- 原始 start/stop 事件能稳定给出 event type、managed agent、parent/child identity、fresh spawn mode 和 actual model。
+- 显式 requested model 能传给 executor/reviewer；若宿主回退，事件能同时给出 actual model 与非空 fallback reason。
+- candidate checkout 与打包安装后的行为一致，且模型策略、receipt 与验证结果可从 `orchestration.json` 复核。
+
+## 验证顺序
+
+1. 在干净临时仓库记录客户端版本、feature 状态和启动命令。
+2. 分别启动 fresh executor 与 fresh reviewer，保存去敏后的原始 stdin 和结构化 run；不得补写宿主未产生的字段。
+3. 验证 requested/actual 一致路径与有理由的 fallback 路径，并确认缺字段会失败关闭。
+4. 对同一 commit 执行 candidate checkout 与 `npm pack` 安装验证，记录 tarball 哈希和结果。
+5. 仅把去敏摘要与非敏感 fixture 纳入版本库；token、绝对用户路径、transcript 内容和凭证必须删除或替换。
+
+任一字段无法从真实宿主稳定观察时，该客户端的 orchestration capability 保持 `unsupported`，并把缺口记录为人工验证项。

--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -70,3 +70,18 @@ jobs:
         run: |
           cd "$RUNNER_TEMP/agent-infra-smoke"
           ./node_modules/.bin/agent-infra sandbox --help
+
+      - name: Smoke - init includes orchestration contracts
+        shell: bash
+        run: |
+          set -euxo pipefail
+          SMOKE_DIR="$RUNNER_TEMP/agent-infra-smoke"
+          PROJECT_DIR="$SMOKE_DIR/project"
+          mkdir -p "$PROJECT_DIR"
+          cd "$PROJECT_DIR"
+          printf 'smokeproj\nsmokeorg\n\n\n\n\n' | "$SMOKE_DIR/node_modules/.bin/agent-infra" init
+          AGENT_INFRA_PACKAGE_ROOT="$SMOKE_DIR/node_modules/@fitlab-ai/agent-infra" \
+            node .agents/skills/update-agent-infra/scripts/sync-templates.js >/dev/null
+          test -f .agents/skills/run-task/reference/host-validation.md
+          test -f .agents/skills/run-task/config/verify.json
+          "$SMOKE_DIR/node_modules/.bin/agent-infra-internal" task-orchestration --help

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ The most-used lifecycle commands, in delivery order. The command prefix varies b
 | `code-task` → `review-code` | Implement and test, then run a structured code review |
 | `commit` → `create-pr` → `complete-task` | Commit, open a PR, and archive the task |
 
+Start a new orchestration run with explicit role models, for example: `$run-task 42 --executor-model <model-id> --reviewer-model <model-id>`. If both roles must use one model, also provide `--same-model-reason "<reason>"`. Re-entry may omit these flags because the run policy is persisted and immutable.
+
 See the full catalog — task status, release, security, and project-maintenance skills — in [Built-in AI Skills](./docs/en/skills.md).
 
 ## What You Get

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -180,6 +180,8 @@ ai agent-client configure
 | `code-task` → `review-code` | 实现并测试，再执行结构化代码审查 |
 | `commit` → `create-pr` → `complete-task` | 提交、创建 PR、归档任务 |
 
+首次启动总控时需显式指定角色模型，例如：`$run-task 42 --executor-model <model-id> --reviewer-model <model-id>`。若两个角色只能使用同一模型，还需提供 `--same-model-reason "<原因>"`。模型策略会持久化且不可静默改写，因此重入时可以省略这些参数。
+
 完整清单（任务状态、发布、安全、项目维护等 skill）见 [内置 AI Skills](./docs/zh-CN/skills.md)。
 
 ## 安装效果

--- a/lib/internal/task-orchestration.ts
+++ b/lib/internal/task-orchestration.ts
@@ -43,7 +43,8 @@ function taskOrchestration(args: string[] = []): void {
   for (let index = 2; index < args.length; index += 1) {
     const flag = args[index]!;
     if (![
-      '--max-steps', '--client', '--requested-model', '--parent-id', '--before-fingerprint',
+      '--max-steps', '--executor-model', '--reviewer-model', '--same-model-reason',
+      '--client', '--requested-model', '--parent-id', '--before-fingerprint',
       '--native-agent', '--child-id', '--spawn-mode', '--actual-model', '--fallback-reason',
       '--exit-code', '--after-fingerprint', '--changed-paths', '--code', '--message', '--recoverable', '--agent'
     ].includes(flag)) {
@@ -69,7 +70,21 @@ function taskOrchestration(args: string[] = []): void {
     if (maxSteps !== undefined && (!Number.isInteger(maxSteps) || maxSteps < 1)) {
       usageFailure('--max-steps must be a positive integer'); return;
     }
-    result = beginOrResumeOrchestration(taskRef!, { maxSteps });
+    const hasExecutorModel = values['--executor-model'] !== undefined;
+    const hasReviewerModel = values['--reviewer-model'] !== undefined;
+    const hasSameModelReason = values['--same-model-reason'] !== undefined;
+    if (hasExecutorModel !== hasReviewerModel || (hasSameModelReason && !hasExecutorModel)) {
+      usageFailure("model policy options require both '--executor-model' and '--reviewer-model'");
+      return;
+    }
+    result = beginOrResumeOrchestration(taskRef!, {
+      maxSteps,
+      modelPolicy: hasExecutorModel ? {
+        executor: values['--executor-model']!,
+        reviewer: values['--reviewer-model']!,
+        sameModelReason: values['--same-model-reason'] ?? null
+      } : undefined
+    });
   } else if (intent === 'route') {
     result = routeOrchestration(taskRef!);
   } else if (intent === 'status') {

--- a/lib/task/delegation-receipts.ts
+++ b/lib/task/delegation-receipts.ts
@@ -51,7 +51,7 @@ function fail(code: string, message: string): ReceiptFailure {
 }
 
 function prepareDelegation(
-  input: Omit<DelegationReceipt, 'id' | 'actualModel' | 'modelFallbackReason' | 'parentId' | 'childId' | 'spawnMode' | 'agent' | 'status' | 'afterFingerprint' | 'changedPaths' | 'createdAt' | 'activatedAt' | 'sealedAt' | 'consumedAt'>,
+  input: Omit<DelegationReceipt, 'id' | 'requestedModel' | 'actualModel' | 'modelFallbackReason' | 'parentId' | 'childId' | 'spawnMode' | 'agent' | 'status' | 'afterFingerprint' | 'changedPaths' | 'createdAt' | 'activatedAt' | 'sealedAt' | 'consumedAt'> & Readonly<{ requestedModel: string }>,
   options: { id?: () => string; now?: () => string } = {}
 ): DelegationReceipt {
   return Object.freeze({
@@ -93,8 +93,11 @@ function activateDelegation(
     return fail('DELEGATION_IDENTITY_INVALID', 'native parent/child identity does not match the prepared delegation');
   }
   if (event.spawnMode !== 'fresh') return fail('DELEGATION_FORK_FORBIDDEN', `spawn mode '${event.spawnMode}' is not fresh`);
-  const actualModel = event.actualModel ?? null;
-  if (actualModel && receipt.requestedModel && actualModel !== receipt.requestedModel && !event.modelFallbackReason) {
+  const actualModel = event.actualModel;
+  if (!actualModel || actualModel.trim() !== actualModel) {
+    return fail('DELEGATION_MODEL_IDENTITY_MISSING', 'native start event must provide a non-empty actual model identity');
+  }
+  if (actualModel !== receipt.requestedModel && (!event.modelFallbackReason || event.modelFallbackReason.trim() === '')) {
     return fail('DELEGATION_MODEL_FALLBACK_UNRECORDED', 'actual model differs from requested model without a fallback reason');
   }
   return { ok: true, receipt: Object.freeze({

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -21,6 +21,11 @@ import type { AgentClientId } from '../agent-clients/types.ts';
 import { captureWorkspaceSnapshot, diffWorkspaceSnapshots } from './workspace-snapshot.ts';
 
 type OrchestrationStatus = 'running' | 'paused' | 'completed';
+type OrchestrationModelPolicy = Readonly<{
+  executor: string;
+  reviewer: string;
+  sameModelReason: string | null;
+}>;
 type OrchestrationRun = Readonly<{
   schemaVersion: 1;
   taskId: string;
@@ -29,6 +34,7 @@ type OrchestrationRun = Readonly<{
   nextStage: DelegationStage | null;
   stepCount: number;
   maxSteps: number;
+  modelPolicy?: OrchestrationModelPolicy;
   baseline: string;
   pendingDelegation: DelegationReceipt | null;
   receipts: readonly DelegationReceipt[];
@@ -43,6 +49,7 @@ type OrchestrationNext = Readonly<{
   stage: DelegationStage;
   round: number;
   artifact: string;
+  requestedModel: string | null;
 }>;
 type OrchestrationResult = Readonly<{
   status: OrchestrationStatus | 'failed';
@@ -57,6 +64,7 @@ type OrchestrationOptions = {
   id?: () => string;
   now?: () => string;
   maxSteps?: number;
+  modelPolicy?: OrchestrationModelPolicy;
   captureWorkspace?: (repoRoot: string, taskId: string | null) => string;
   diffWorkspace?: (repoRoot: string, before: string, after: string) => string[];
 };
@@ -89,11 +97,57 @@ function failed(code: string, message: string, taskId: string | null = null): Or
   return { status: 'failed', changed: false, taskId, run: null, next: null, error: { code, message } };
 }
 
+function validModel(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.trim() === value;
+}
+
+function validateModelPolicy(policy: OrchestrationModelPolicy | undefined): Readonly<{ code: string; message: string }> | null {
+  if (!policy || !validModel(policy.executor) || !validModel(policy.reviewer)) {
+    return { code: 'ORCHESTRATION_MODEL_POLICY_REQUIRED', message: 'executor and reviewer model identities are required' };
+  }
+  if (policy.executor === policy.reviewer) {
+    if (!validModel(policy.sameModelReason)) {
+      return { code: 'ORCHESTRATION_MODEL_SEPARATION_REQUIRED', message: 'using the same executor and reviewer model requires a reason' };
+    }
+  } else if (policy.sameModelReason !== null) {
+    return { code: 'ORCHESTRATION_MODEL_POLICY_INVALID', message: 'same-model reason must be null when executor and reviewer models differ' };
+  }
+  return null;
+}
+
+function sameModelPolicy(left: OrchestrationModelPolicy, right: OrchestrationModelPolicy): boolean {
+  return left.executor === right.executor
+    && left.reviewer === right.reviewer
+    && left.sameModelReason === right.sameModelReason;
+}
+
 function beginOrResumeOrchestration(taskRef: string, options: OrchestrationOptions = {}): OrchestrationResult {
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return failed(resolved.code, resolved.message, resolved.taskId);
   const existing = readRun(resolved.taskDir);
   if (existing) {
+    if (!existing.modelPolicy && existing.status !== 'completed') {
+      if (existing.status === 'paused' && existing.pause?.code === 'ORCHESTRATION_MODEL_EVIDENCE_MISSING') {
+        return { status: 'paused', changed: false, taskId: resolved.taskId, run: existing, next: null, error: null };
+      }
+      const paused = withUpdatedRun(existing, {
+        status: 'paused',
+        pause: {
+          code: 'ORCHESTRATION_MODEL_EVIDENCE_MISSING',
+          message: 'existing orchestration run has no persisted model policy',
+          recoverable: false
+        }
+      });
+      saveRun(resolved.taskDir, paused);
+      return { status: 'paused', changed: true, taskId: resolved.taskId, run: paused, next: null, error: null };
+    }
+    if (options.modelPolicy) {
+      const policyError = validateModelPolicy(options.modelPolicy);
+      if (policyError) return failed(policyError.code, policyError.message, resolved.taskId);
+      if (!existing.modelPolicy || !sameModelPolicy(existing.modelPolicy, options.modelPolicy)) {
+        return failed('ORCHESTRATION_MODEL_POLICY_MISMATCH', 'provided model policy does not match the persisted run policy', resolved.taskId);
+      }
+    }
     if (existing.status === 'paused' && existing.pause?.recoverable && existing.pendingDelegation === null) {
       const resumed = withUpdatedRun(existing, { status: 'running', pause: null });
       saveRun(resolved.taskDir, resumed);
@@ -101,6 +155,8 @@ function beginOrResumeOrchestration(taskRef: string, options: OrchestrationOptio
     }
     return { status: existing.status, changed: false, taskId: resolved.taskId, run: existing, next: null, error: null };
   }
+  const policyError = validateModelPolicy(options.modelPolicy);
+  if (policyError) return failed(policyError.code, policyError.message, resolved.taskId);
   const now = (options.now ?? (() => new Date().toISOString()))();
   const run: OrchestrationRun = {
     schemaVersion: 1,
@@ -110,6 +166,7 @@ function beginOrResumeOrchestration(taskRef: string, options: OrchestrationOptio
     nextStage: null,
     stepCount: 0,
     maxSteps: options.maxSteps ?? 24,
+    modelPolicy: options.modelPolicy!,
     baseline: '',
     pendingDelegation: null,
     receipts: [],
@@ -150,7 +207,7 @@ function latestReviewApproved(taskDir: string, family: 'review-analysis' | 'revi
   return parsed.ok && parsed.summary.verdict === 'Approved' && parsed.summary.counts !== null;
 }
 
-function routeFromFacts(taskDir: string): OrchestrationNext | null {
+function routeFromFacts(taskDir: string): Omit<OrchestrationNext, 'requestedModel'> | null {
   const analysisRound = highestRound(taskDir, 'analysis');
   const analysisReviewRound = highestRound(taskDir, 'review-analysis');
   const planRound = highestRound(taskDir, 'plan');
@@ -210,8 +267,13 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
   } catch (error) {
     return failed('ORCHESTRATION_TASK_INVALID', error instanceof Error ? error.message : String(error), resolved.taskId);
   }
-  const next = routeFromFacts(resolved.taskDir);
-  if (!next) return failed('ORCHESTRATION_ROUTE_UNKNOWN', 'cannot determine a unique lifecycle action', resolved.taskId);
+  const routed = routeFromFacts(resolved.taskDir);
+  if (!routed) return failed('ORCHESTRATION_ROUTE_UNKNOWN', 'cannot determine a unique lifecycle action', resolved.taskId);
+  const run = readRun(resolved.taskDir);
+  const next: OrchestrationNext = {
+    ...routed,
+    requestedModel: run?.modelPolicy?.[routed.role] ?? null
+  };
   if (next.stage === 'commit') {
     const reviewRound = highestRound(resolved.taskDir, 'review-code');
     const review = parseReviewSummary(fs.readFileSync(
@@ -231,7 +293,7 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
       return failed('ORCHESTRATION_LEDGER_BLOCKED', 'code review ledger has unresolved findings or human decisions', resolved.taskId);
     }
   }
-  return { status: 'running', changed: false, taskId: resolved.taskId, run: readRun(resolved.taskDir), next, error: null };
+  return { status: 'running', changed: false, taskId: resolved.taskId, run, next, error: null };
 }
 
 function statusOrchestration(taskRef: string, options: OrchestrationOptions = {}): OrchestrationResult {
@@ -257,6 +319,7 @@ function prepareOrchestrationDelegation(
   }
   const run = readRun(resolved.taskDir);
   if (!run || run.status !== 'running') return failed('ORCHESTRATION_RUN_NOT_RUNNING', 'a running orchestration is required', resolved.taskId);
+  if (!run.modelPolicy) return failed('ORCHESTRATION_MODEL_EVIDENCE_MISSING', 'running orchestration has no persisted model policy', resolved.taskId);
   if (run.pendingDelegation) return failed('ORCHESTRATION_DELEGATION_BUSY', 'the run already has a pending delegation', resolved.taskId);
   const repositoryPending = (['claude-code', 'codex'] as AgentClientId[])
     .flatMap((client) => matchingDelegations(client, () => true, options));
@@ -267,6 +330,13 @@ function prepareOrchestrationDelegation(
   const routed = routeOrchestration(taskRef, options);
   if (!routed.next) return routed;
   const next = routed.next;
+  if (!validModel(input.requestedModel)) {
+    return failed('ORCHESTRATION_REQUESTED_MODEL_REQUIRED', 'prepare requires the exact requested model identity', resolved.taskId);
+  }
+  const expectedModel = run.modelPolicy[next.role];
+  if (input.requestedModel !== expectedModel) {
+    return failed('ORCHESTRATION_REQUESTED_MODEL_MISMATCH', `requested model does not match the persisted ${next.role} model`, resolved.taskId);
+  }
   let beforeFingerprint: string;
   try {
     beforeFingerprint = (options.captureWorkspace ?? captureWorkspaceSnapshot)(resolved.repoRoot, resolved.taskId);
@@ -281,7 +351,7 @@ function prepareOrchestrationDelegation(
     round: next.round,
     artifact: next.artifact,
     client: input.client,
-    requestedModel: input.requestedModel ?? null,
+    requestedModel: input.requestedModel,
     workspaceSnapshotScope: 'task',
     beforeFingerprint
   }, { id: options.id, now: options.now });
@@ -542,4 +612,4 @@ export {
   statusOrchestration,
   validateOrchestrationStage
 };
-export type { OrchestrationNext, OrchestrationResult, OrchestrationRun, OrchestrationStatus };
+export type { OrchestrationModelPolicy, OrchestrationNext, OrchestrationResult, OrchestrationRun, OrchestrationStatus };

--- a/lib/task/verification-checks.ts
+++ b/lib/task/verification-checks.ts
@@ -1,6 +1,6 @@
 const LOCAL_VERIFICATION_CHECKS = [
   'task-meta', 'artifact', 'implementation-input', 'activity-log', 'completion-checklist',
-  'orchestration-state'
+  'orchestration-state', 'orchestration-evidence'
 ] as const;
 
 function isLocalVerificationCheck(value: string): value is typeof LOCAL_VERIFICATION_CHECKS[number] {

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -122,6 +122,8 @@ function runCheck(type: any, context: any, shared: any): any {
       return checkPostReviewCommit(context);
     case "orchestration-state":
       return checkOrchestrationState(context);
+    case "orchestration-evidence":
+      return checkOrchestrationEvidence(context);
     default: {
       const adapter = PLATFORM_ADAPTERS[type];
       if (!adapter) {
@@ -161,6 +163,69 @@ function checkOrchestrationState({ taskDir }: any): any {
     return failResult('orchestration-state', 'Paused run has a sealed delegation that could still advance');
   }
   return passResult('orchestration-state', `Orchestration run is safely ${run.status}`);
+}
+
+function exactText(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.trim() === value;
+}
+
+function checkOrchestrationEvidence({ taskDir }: any): any {
+  const file = path.join(taskDir, 'orchestration.json');
+  const stat = safeStat(file);
+  if (!stat?.isFile()) return failResult('orchestration-evidence', 'orchestration.json is missing');
+  let run: any;
+  try {
+    run = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    return failResult('orchestration-evidence', `Invalid orchestration.json: ${String(error)}`);
+  }
+  const policy = run.modelPolicy;
+  if (!policy || !exactText(policy.executor) || !exactText(policy.reviewer)) {
+    return failResult('orchestration-evidence', 'Run model policy requires exact executor and reviewer identities');
+  }
+  if (policy.executor === policy.reviewer) {
+    if (!exactText(policy.sameModelReason)) {
+      return failResult('orchestration-evidence', 'Shared executor/reviewer model requires a persisted reason');
+    }
+  } else if (policy.sameModelReason !== null) {
+    return failResult('orchestration-evidence', 'Distinct executor/reviewer models require a null same-model reason');
+  }
+  if (!Array.isArray(run.receipts)) {
+    return failResult('orchestration-evidence', 'Run receipts must be an array');
+  }
+  if (run.status === 'completed' && (
+    run.receipts.length === 0
+    || run.receipts.at(-1)?.stage !== 'commit'
+    || run.receipts.at(-1)?.status !== 'consumed'
+  )) {
+    return failResult('orchestration-evidence', 'Completed run requires a final consumed commit receipt');
+  }
+  if (run.pendingDelegation && !['prepared', 'activated', 'stage-completed'].includes(run.pendingDelegation.status)) {
+    return failResult('orchestration-evidence', `Pending receipt has unsafe status '${run.pendingDelegation.status}'`);
+  }
+  const receipts = [...run.receipts, ...(run.pendingDelegation ? [run.pendingDelegation] : [])];
+  for (const receipt of receipts) {
+    const expectedModel = policy[receipt.role];
+    if (!expectedModel || receipt.requestedModel !== expectedModel) {
+      return failResult('orchestration-evidence', `Receipt '${receipt.id ?? '(unknown)'}' requested model does not match its role policy`);
+    }
+    const activated = ['activated', 'stage-completed', 'sealed', 'consumed'].includes(receipt.status);
+    if (activated) {
+      if (!exactText(receipt.actualModel)) {
+        return failResult('orchestration-evidence', `Receipt '${receipt.id ?? '(unknown)'}' has no host-observed actual model`);
+      }
+      if (!exactText(receipt.parentId) || !exactText(receipt.childId) || receipt.parentId === receipt.childId || receipt.spawnMode !== 'fresh') {
+        return failResult('orchestration-evidence', `Receipt '${receipt.id ?? '(unknown)'}' has invalid fresh delegation identity`);
+      }
+      if (receipt.actualModel !== receipt.requestedModel && !exactText(receipt.modelFallbackReason)) {
+        return failResult('orchestration-evidence', `Receipt '${receipt.id ?? '(unknown)'}' model fallback is not justified`);
+      }
+    }
+  }
+  if (run.receipts.some((receipt: any) => receipt.status !== 'consumed')) {
+    return failResult('orchestration-evidence', 'Historical receipts must be consumed');
+  }
+  return passResult('orchestration-evidence', 'Persisted orchestration model and delegation evidence is internally consistent');
 }
 
 // === Check Functions ===

--- a/lib/task/verification.ts
+++ b/lib/task/verification.ts
@@ -72,8 +72,8 @@ const VERIFICATION_CATALOG: Readonly<Record<VerificationEvent, VerificationSpec>
   'import-dependabot.completed': gate('import-dependabot', 'active'),
   'import-issue.completed': gate('import-issue', 'active'),
   'watch-pr.completed': gate('watch-pr', 'active'),
-  'run-task.paused': { skill: 'run-task', expectedState: 'active', mode: 'checks', checks: ['orchestration-state'] },
-  'run-task.completed': { skill: 'run-task', expectedState: 'active', mode: 'checks', checks: ['orchestration-state'] }
+  'run-task.paused': { skill: 'run-task', expectedState: 'active', mode: 'checks', checks: ['orchestration-state', 'orchestration-evidence'] },
+  'run-task.completed': { skill: 'run-task', expectedState: 'active', mode: 'checks', checks: ['orchestration-state', 'orchestration-evidence'] }
 };
 
 function failure(request: { taskRef: string; event: string; artifact?: string }, code: string, message: string, extra: Partial<TaskVerificationResult> = {}): TaskVerificationResult {

--- a/templates/.agents/hooks/lifecycle-delegation.js
+++ b/templates/.agents/hooks/lifecycle-delegation.js
@@ -42,7 +42,7 @@ process.stdin.on('end', () => {
       '--native-agent', String(nativeAgent),
       '--child-id', String(event.child_id || event.agent_id || event.thread_id || ''),
       '--parent-id', String(event.parent_id || event.parent_session_id || event.session_id || ''),
-      '--spawn-mode', String(event.spawn_mode || 'fresh')
+      '--spawn-mode', String(event.spawn_mode || (client === 'claude-code' ? 'fresh' : ''))
     );
     if (event.model) args.push('--actual-model', String(event.model));
     if (event.model_fallback_reason) args.push('--fallback-reason', String(event.model_fallback_reason));

--- a/templates/.agents/rules/lifecycle-orchestration.en.md
+++ b/templates/.agents/rules/lifecycle-orchestration.en.md
@@ -14,7 +14,10 @@
 
 ## Model Policy
 
-Prefer a reviewer model different from the preceding executor. Same-model fallback must record requested model, actual model, and reason; an unrecorded fallback fails closed.
+- A new run persists executor/reviewer models. Distinct models require a null `sameModelReason`; using one model for both roles requires an isolation-limit reason. Re-entry must not silently rewrite the policy.
+- Route resolves the requested model by role, prepare matches it before a workspace snapshot, and native spawn explicitly uses it instead of inheriting session defaults.
+- Native start records the host-observed actual model. A requested/actual mismatch separately requires `modelFallbackReason`; the same-model policy reason cannot substitute for it.
+- Missing model policy, actual model, or fallback reason fails closed. A legacy run without model policy pauses stably.
 
 ## Stable Pause Conditions
 

--- a/templates/.agents/rules/lifecycle-orchestration.zh-CN.md
+++ b/templates/.agents/rules/lifecycle-orchestration.zh-CN.md
@@ -14,7 +14,10 @@
 
 ## 模型策略
 
-reviewer 优先选择与上一 executor 不同的模型。若客户端只能使用同模型，必须记录 requested model、actual model 和降级原因；缺少降级理由时失败关闭。
+- 新 run 必须固化 executor/reviewer 模型；不同模型时 `sameModelReason` 为 null，同模型时必须说明隔离受限原因。重入不得静默改写策略。
+- route 按 role 返回 requested model，prepare 必须在工作区快照前精确匹配它；原生 spawn 必须显式使用该模型，不能继承会话默认值。
+- 原生 start 必须记录宿主观察到的 actual model。actual 与 requested 不同时必须另行记录 `modelFallbackReason`；它不能用同模型策略理由替代。
+- 缺少模型策略、实际模型或降级理由时失败关闭；旧 run 缺模型策略时稳定暂停。
 
 ## 稳定暂停条件
 

--- a/templates/.agents/skills/run-task/SKILL.en.md
+++ b/templates/.agents/skills/run-task/SKILL.en.md
@@ -7,14 +7,14 @@ description: >
 
 # Run Task Lifecycle
 
-The orchestrator delegates only and never executes a stage skill itself. First read `.agents/rules/no-mid-flow-questions.md` and `.agents/rules/lifecycle-orchestration.md`.
+The orchestrator delegates only and never executes a stage skill itself. First read `.agents/rules/no-mid-flow-questions.md`, `.agents/rules/lifecycle-orchestration.md`, and `reference/host-validation.md`.
 
-1. Resolve the task and run `agent-infra-internal task-snapshot {task-id} --format text`.
-2. Run `agent-infra-internal task-orchestration {task-id} begin-or-resume`; stop on structured paused/completed results.
-3. Run `route` and use its single action, role, round, and artifact. Never infer routing from review prose.
-4. Run `agent-infra-internal task-orchestration {task-id} prepare --client {client}` so core records the workspace baseline, then start the specified executor/reviewer with the current client's fresh native subagent mechanism. Pass only the short task reference, skill name, and minimal handoff; never pass receipt identity or inherit orchestrator history.
+1. Resolve the task plus `--executor-model <id>`, `--reviewer-model <id>`, and optional `--same-model-reason <text>`, then run `agent-infra-internal task-snapshot {task-id} --format text`. A new run requires both models; only same-model use requires a reason.
+2. Run `agent-infra-internal task-orchestration {task-id} begin-or-resume`, forwarding model arguments supplied on this entry. An existing run may omit them and reuse persisted policy; repeated values must match exactly. Stop on structured paused/completed results.
+3. Run `route` and use its single action, role, round, artifact, and `requestedModel`. Never infer routing or model identity from review prose or session defaults.
+4. Run `agent-infra-internal task-orchestration {task-id} prepare --client {client} --requested-model {requestedModel}` so core validates the model before recording the workspace baseline. Start the specified executor/reviewer with the current client's fresh native subagent mechanism and explicitly override it to the same `requestedModel`. Pass only the short task reference, skill name, and minimal handoff; never pass receipt identity or inherit orchestrator history.
 5. Native start/stop hooks correlate the unique pending delegation and let core compute workspace changes and seal the receipt. After the child returns, run `advance`. Repeat step 3 only for `running`; stop immediately for `paused` or `completed`.
-6. Create a new child every round and never follow up with an old reviewer. Capability, hook, identity, model fallback, ledger, or fingerprint failures must call `pause` and fail closed.
+6. Create a new child every round and never follow up with an old reviewer. Native start must report a non-empty actual model, and a requested/actual mismatch requires a host fallback reason. Capability, hook, identity, model-evidence, ledger, or fingerprint failures must call `pause` and fail closed.
 7. On pause or completion, run the matching typed verification and report the structured run summary, pause reason, or commit endpoint.
 
 ## Stop

--- a/templates/.agents/skills/run-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/run-task/SKILL.zh-CN.md
@@ -7,14 +7,14 @@ description: >
 
 # 运行任务生命周期
 
-总控只编排，不直接执行任何阶段技能。执行前先读取 `.agents/rules/no-mid-flow-questions.md` 与 `.agents/rules/lifecycle-orchestration.md`。
+总控只编排，不直接执行任何阶段技能。执行前先读取 `.agents/rules/no-mid-flow-questions.md`、`.agents/rules/lifecycle-orchestration.md` 与 `reference/host-validation.md`。
 
-1. 解析任务引用并执行 `agent-infra-internal task-snapshot {task-id} --format text`。
-2. 调用 `agent-infra-internal task-orchestration {task-id} begin-or-resume`；若为 paused/completed，按结构化结果停止。
-3. 调用 `route` 并读取唯一 action、role、round 和 artifact；不得从审查文案自行推断。
-4. 调用 `agent-infra-internal task-orchestration {task-id} prepare --client {client}`；核心自动记录工作区基线。成功后用当前客户端的 fresh 原生子 Agent 启动指定 executor/reviewer，只传短任务引用、skill 名和最小交接摘要，不传 receipt identity，不继承总控历史。
+1. 解析任务引用及 `--executor-model <id>`、`--reviewer-model <id>`、可选 `--same-model-reason <text>`，并执行 `agent-infra-internal task-snapshot {task-id} --format text`。首次启动必须提供两种模型；仅同模型时要求理由。
+2. 调用 `agent-infra-internal task-orchestration {task-id} begin-or-resume` 并转发本次提供的模型参数；已有 run 可省略参数并使用持久化策略，重复提供时必须完全一致。若为 paused/completed，按结构化结果停止。
+3. 调用 `route` 并读取唯一 action、role、round、artifact 和 `requestedModel`；不得从审查文案或会话默认值自行推断。
+4. 调用 `agent-infra-internal task-orchestration {task-id} prepare --client {client} --requested-model {requestedModel}`；核心在记录工作区基线前校验模型。成功后用当前客户端的 fresh 原生子 Agent 启动指定 executor/reviewer，并显式覆盖为同一 `requestedModel`；只传短任务引用、skill 名和最小交接摘要，不传 receipt identity，不继承总控历史。
 5. 原生 start/stop hook 通过唯一 pending delegation 自动关联任务，并由核心计算工作区变化、封存 receipt；子 Agent 返回后调用 `advance`。只有 `running` 才重复步骤 3；`paused` 或 `completed` 立即停止。
-6. 每轮创建新 child；禁止 follow-up 复用 reviewer。任何 capability、hook、身份、模型降级、账本或 fingerprint 异常都调用 `pause` 并失败关闭。
+6. 每轮创建新 child；禁止 follow-up 复用 reviewer。原生 start 必须回传非空 actual model；actual 与 requested 不同时必须有宿主降级理由。任何 capability、hook、身份、模型证据、账本或 fingerprint 异常都调用 `pause` 并失败关闭。
 7. 完成或暂停后运行对应 typed verification，并把结构化 run 摘要、暂停原因或 commit 终点告知用户。
 
 ## 停止

--- a/templates/.agents/skills/run-task/config/verify.en.json
+++ b/templates/.agents/skills/run-task/config/verify.en.json
@@ -4,6 +4,7 @@
     "task-meta": {
       "required_fields": ["id", "status", "updated_at", "agent_infra_version", "current_step", "assigned_to"]
     },
-    "orchestration-state": {}
+    "orchestration-state": {},
+    "orchestration-evidence": {}
   }
 }

--- a/templates/.agents/skills/run-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/run-task/config/verify.zh-CN.json
@@ -4,6 +4,7 @@
     "task-meta": {
       "required_fields": ["id", "status", "updated_at", "agent_infra_version", "current_step", "assigned_to"]
     },
-    "orchestration-state": {}
+    "orchestration-state": {},
+    "orchestration-evidence": {}
   }
 }

--- a/templates/.agents/skills/run-task/reference/host-validation.en.md
+++ b/templates/.agents/skills/run-task/reference/host-validation.en.md
@@ -1,0 +1,20 @@
+# Host Contract Validation
+
+Before publishing support for a client, prove the lifecycle evidence chain with real host events. Bridge tests prove field mapping only; they do not prove host provenance.
+
+## Required Evidence
+
+- Client version, enabled multi-agent capability, launch surface, and trust boundary.
+- Raw start/stop events stably provide event type, managed agent, parent/child identity, fresh spawn mode, and actual model.
+- The explicit requested model reaches each executor/reviewer. A host fallback reports both the actual model and a non-empty fallback reason.
+- Candidate-checkout and packed-install behavior match, with model policy, receipts, and verification results auditable in `orchestration.json`.
+
+## Validation Sequence
+
+1. Record client version, feature state, and launch command in a clean temporary repository.
+2. Start a fresh executor and reviewer, retaining redacted raw stdin and the structured run. Never synthesize a field the host did not emit.
+3. Validate requested/actual match and justified-fallback paths, plus fail-closed behavior for missing fields.
+4. Validate the same commit from a candidate checkout and an `npm pack` install; record the tarball hash and results.
+5. Commit only redacted summaries and non-sensitive fixtures. Remove or replace tokens, user-specific absolute paths, transcript content, and credentials.
+
+If any required field cannot be observed reliably from the real host, keep that client's orchestration capability `unsupported` and record the gap as manual validation.

--- a/templates/.agents/skills/run-task/reference/host-validation.zh-CN.md
+++ b/templates/.agents/skills/run-task/reference/host-validation.zh-CN.md
@@ -1,0 +1,20 @@
+# 宿主契约验证
+
+发布支持某个客户端前，必须用真实宿主事件证明生命周期证据链；bridge 单测只证明字段映射，不能证明事件来自宿主。
+
+## 必须证明的字段
+
+- 客户端版本、启用的多代理能力、启动入口与信任边界。
+- 原始 start/stop 事件能稳定给出 event type、managed agent、parent/child identity、fresh spawn mode 和 actual model。
+- 显式 requested model 能传给 executor/reviewer；若宿主回退，事件能同时给出 actual model 与非空 fallback reason。
+- candidate checkout 与打包安装后的行为一致，且模型策略、receipt 与验证结果可从 `orchestration.json` 复核。
+
+## 验证顺序
+
+1. 在干净临时仓库记录客户端版本、feature 状态和启动命令。
+2. 分别启动 fresh executor 与 fresh reviewer，保存去敏后的原始 stdin 和结构化 run；不得补写宿主未产生的字段。
+3. 验证 requested/actual 一致路径与有理由的 fallback 路径，并确认缺字段会失败关闭。
+4. 对同一 commit 执行 candidate checkout 与 `npm pack` 安装验证，记录 tarball 哈希和结果。
+5. 仅把去敏摘要与非敏感 fixture 纳入版本库；token、绝对用户路径、transcript 内容和凭证必须删除或替换。
+
+任一字段无法从真实宿主稳定观察时，该客户端的 orchestration capability 保持 `unsupported`，并把缺口记录为人工验证项。

--- a/tests/integration/cli/orchestration-hooks.test.ts
+++ b/tests/integration/cli/orchestration-hooks.test.ts
@@ -128,6 +128,22 @@ test('lifecycle hook prefers the repository-local CLI independently of cwd', () 
   });
 });
 
+test('lifecycle hook forwards the exact host-observed model and fallback reason', () => {
+  const fixture = createHookFixture('missing');
+  const payload = JSON.parse(fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'));
+  payload.model = 'host-model-v2';
+  payload.model_fallback_reason = 'requested model was temporarily unavailable';
+
+  const result = run(JSON.stringify(payload), fixture);
+
+  assert.equal(result.status, 0, result.stderr);
+  const args = JSON.parse(result.stdout).args as string[];
+  assert.deepEqual(args.slice(-4), [
+    '--actual-model', 'host-model-v2',
+    '--fallback-reason', 'requested model was temporarily unavailable'
+  ]);
+});
+
 test('lifecycle hook fails closed when the repository-local CLI fails', () => {
   const fixture = createHookFixture('broken');
 

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -213,11 +213,15 @@ test('completed event validates orchestration provenance before writing task sta
     'node', [INTERNAL_CLI_PATH, 'task-orchestration', f.id, ...args],
     { cwd: f.root, encoding: 'utf8' }
   );
-  assert.equal(orchestrate(['begin-or-resume']).status, 0);
-  assert.equal(orchestrate(['prepare', '--client', 'claude-code']).status, 0);
+  assert.equal(orchestrate([
+    'begin-or-resume', '--executor-model', 'executor-model', '--reviewer-model', 'reviewer-model'
+  ]).status, 0);
+  assert.equal(orchestrate([
+    'prepare', '--client', 'claude-code', '--requested-model', 'reviewer-model'
+  ]).status, 0);
   assert.equal(orchestrate([
     'hook-start', '--native-agent', 'agent-infra-lifecycle-reviewer', '--child-id', 'child-1',
-    '--parent-id', 'parent-1', '--spawn-mode', 'fresh'
+    '--parent-id', 'parent-1', '--spawn-mode', 'fresh', '--actual-model', 'reviewer-model'
   ]).status, 0);
 
   const before = fs.readFileSync(f.file);

--- a/tests/integration/cli/task-orchestration.test.ts
+++ b/tests/integration/cli/task-orchestration.test.ts
@@ -27,12 +27,16 @@ function run(root: string, args: string[]) {
 
 test('task-orchestration begins idempotently and exposes a structured route', () => {
   const f = fixture();
-  const begin = run(f.root, [f.id, 'begin-or-resume', '--max-steps', '8']);
+  const begin = run(f.root, [f.id, 'begin-or-resume', '--max-steps', '8',
+    '--executor-model', 'executor-model', '--reviewer-model', 'reviewer-model']);
   assert.equal(begin.status, 0, begin.stderr);
   const begun = JSON.parse(begin.stdout);
   assert.equal(begun.status, 'running');
   assert.equal(begun.changed, true);
   assert.equal(begun.run.maxSteps, 8);
+  assert.deepEqual(begun.run.modelPolicy, {
+    executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: null
+  });
   assert.equal(fs.existsSync(path.join(f.dir, 'orchestration.json')), true);
 
   const second = run(f.root, [f.id, 'begin-or-resume']);
@@ -42,7 +46,8 @@ test('task-orchestration begins idempotently and exposes a structured route', ()
   const route = run(f.root, [f.id, 'route']);
   assert.equal(route.status, 0, route.stderr);
   assert.deepEqual(JSON.parse(route.stdout).next, {
-    action: 'analyze-task', role: 'executor', stage: 'analysis', round: 1, artifact: 'analysis.md'
+    action: 'analyze-task', role: 'executor', stage: 'analysis', round: 1,
+    artifact: 'analysis.md', requestedModel: 'executor-model'
   });
 });
 
@@ -54,14 +59,41 @@ test('task-orchestration rejects duplicate and unknown options without writing s
   assert.equal(fs.existsSync(path.join(f.dir, 'orchestration.json')), false);
 });
 
-test('task-orchestration prepare derives the workspace baseline without model-supplied identity', () => {
+test('task-orchestration rejects partial model policy options before core state changes', () => {
   const f = fixture();
-  assert.equal(run(f.root, [f.id, 'begin-or-resume']).status, 0);
+  const first = run(f.root, [f.id, 'begin-or-resume', '--executor-model', 'executor-model']);
+  assert.equal(first.status, 2);
+  assert.equal(JSON.parse(first.stdout).error.code, 'ORCHESTRATION_PAYLOAD_INVALID');
+  assert.equal(fs.existsSync(path.join(f.dir, 'orchestration.json')), false);
 
-  const prepared = run(f.root, [f.id, 'prepare', '--client', 'claude-code']);
+  assert.equal(run(f.root, [f.id, 'begin-or-resume', '--executor-model', 'executor-model',
+    '--reviewer-model', 'reviewer-model']).status, 0);
+  const runPath = path.join(f.dir, 'orchestration.json');
+  const before = fs.readFileSync(runPath);
+  const reentry = run(f.root, [f.id, 'begin-or-resume', '--reviewer-model', 'reviewer-model']);
+  assert.equal(reentry.status, 2);
+  assert.equal(JSON.parse(reentry.stdout).error.code, 'ORCHESTRATION_PAYLOAD_INVALID');
+  assert.deepEqual(fs.readFileSync(runPath), before);
+});
+
+test('task-orchestration prepare derives the workspace baseline with the persisted role model', () => {
+  const f = fixture();
+  assert.equal(run(f.root, [f.id, 'begin-or-resume', '--executor-model', 'executor-model',
+    '--reviewer-model', 'reviewer-model']).status, 0);
+
+  const prepared = run(f.root, [f.id, 'prepare', '--client', 'claude-code',
+    '--requested-model', 'executor-model']);
   assert.equal(prepared.status, 0, prepared.stderr);
   const result = JSON.parse(prepared.stdout);
   assert.equal(result.run.pendingDelegation.parentId, null);
   assert.equal(result.run.pendingDelegation.workspaceSnapshotScope, 'task');
   assert.match(result.run.pendingDelegation.beforeFingerprint, /^[0-9a-f]{40,64}$/);
+});
+
+test('task-orchestration begin fails closed when model policy is omitted', () => {
+  const f = fixture();
+  const result = run(f.root, [f.id, 'begin-or-resume']);
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).error.code, 'ORCHESTRATION_MODEL_POLICY_REQUIRED');
+  assert.equal(fs.existsSync(path.join(f.dir, 'orchestration.json')), false);
 });

--- a/tests/unit/cli/task-verification.test.ts
+++ b/tests/unit/cli/task-verification.test.ts
@@ -57,8 +57,8 @@ test('verification catalog is a closed mapping of all business events', () => {
     'import-dependabot.completed': ['import-dependabot', 'active', 'gate', undefined, undefined],
     'import-issue.completed': ['import-issue', 'active', 'gate', undefined, undefined],
     'watch-pr.completed': ['watch-pr', 'active', 'gate', undefined, undefined],
-    'run-task.paused': ['run-task', 'active', 'checks', undefined, ['orchestration-state']],
-    'run-task.completed': ['run-task', 'active', 'checks', undefined, ['orchestration-state']]
+    'run-task.paused': ['run-task', 'active', 'checks', undefined, ['orchestration-state', 'orchestration-evidence']],
+    'run-task.completed': ['run-task', 'active', 'checks', undefined, ['orchestration-state', 'orchestration-evidence']]
   } as const;
   for (const event of EXPECTED_EVENTS) {
     const spec = VERIFICATION_CATALOG[event];
@@ -95,4 +95,116 @@ test('unknown events fail with a stable orchestration error', () => {
   const f = fixture();
   const unknown = verifyTaskEvent({ taskRef: f.taskId, event: 'unknown.completed' }, { repoRoot: f.root });
   assert.equal(unknown.error?.code, 'VERIFY_EVENT_UNKNOWN');
+});
+
+test('run-task verification accepts complete model evidence and rejects missing host identity', () => {
+  const f = fixture();
+  const configDir = path.join(f.root, '.agents', 'skills', 'run-task', 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'verify.json'), JSON.stringify({
+    skill: 'run-task',
+    checks: { 'orchestration-state': {}, 'orchestration-evidence': {} }
+  }));
+  const receipt = {
+    id: 'receipt-1', taskId: f.taskId, runId: 'run-1', role: 'executor',
+    stage: 'commit', round: 1, artifact: 'commit', client: 'claude-code',
+    requestedModel: 'executor-model', actualModel: 'executor-model', modelFallbackReason: null,
+    parentId: 'parent-1', childId: 'child-1', spawnMode: 'fresh', agent: 'claude-code',
+    status: 'consumed', beforeFingerprint: 'before', afterFingerprint: 'after', changedPaths: [],
+    createdAt: '2026-01-01T00:00:00.000Z', activatedAt: '2026-01-01T00:00:01.000Z',
+    sealedAt: '2026-01-01T00:00:02.000Z', consumedAt: '2026-01-01T00:00:03.000Z'
+  };
+  const run = {
+    schemaVersion: 1, taskId: f.taskId, runId: 'run-1', status: 'completed', nextStage: null,
+    stepCount: 1, maxSteps: 24, baseline: '',
+    modelPolicy: { executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: null },
+    pendingDelegation: null, receipts: [receipt], pause: null,
+    commitAuthorization: { issuedAt: '2026-01-01T00:00:00.000Z', consumedAt: '2026-01-01T00:00:03.000Z' },
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:03.000Z'
+  };
+  const runPath = path.join(f.taskDir, 'orchestration.json');
+  fs.writeFileSync(runPath, `${JSON.stringify(run, null, 2)}\n`);
+
+  const valid = verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.completed' }, { repoRoot: f.root });
+  assert.equal(valid.status, 'pass');
+  assert.equal(valid.invocations.length, 2);
+
+  fs.writeFileSync(runPath, `${JSON.stringify({ ...run, receipts: [{ ...receipt, actualModel: null }] }, null, 2)}\n`);
+  const invalid = verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.completed' }, { repoRoot: f.root });
+  assert.equal(invalid.status, 'fail');
+  assert.equal(invalid.invocations.length, 2);
+
+  fs.writeFileSync(runPath, `${JSON.stringify({ ...run, modelPolicy: undefined }, null, 2)}\n`);
+  assert.equal(
+    verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.completed' }, { repoRoot: f.root }).status,
+    'fail'
+  );
+
+  fs.writeFileSync(runPath, `${JSON.stringify({
+    ...run,
+    modelPolicy: { executor: 'shared-model', reviewer: 'shared-model', sameModelReason: null },
+    receipts: [{ ...receipt, requestedModel: 'shared-model', actualModel: 'shared-model' }]
+  }, null, 2)}\n`);
+  assert.equal(
+    verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.completed' }, { repoRoot: f.root }).status,
+    'fail'
+  );
+
+  fs.writeFileSync(runPath, `${JSON.stringify({
+    ...run,
+    modelPolicy: {
+      executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: 'not applicable'
+    }
+  }, null, 2)}\n`);
+  assert.equal(
+    verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.completed' }, { repoRoot: f.root }).status,
+    'fail'
+  );
+});
+
+test('run-task verification accepts a clean unsupported pause and rejects unsafe pending evidence', () => {
+  const f = fixture();
+  const configDir = path.join(f.root, '.agents', 'skills', 'run-task', 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'verify.json'), JSON.stringify({
+    skill: 'run-task', checks: { 'orchestration-state': {}, 'orchestration-evidence': {} }
+  }));
+  const paused = {
+    schemaVersion: 1, taskId: f.taskId, runId: 'run-1', status: 'paused', nextStage: null,
+    stepCount: 0, maxSteps: 24, baseline: '',
+    modelPolicy: { executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: null },
+    pendingDelegation: null, receipts: [],
+    pause: { code: 'ORCHESTRATION_CLIENT_UNSUPPORTED', message: 'client unsupported', recoverable: false },
+    commitAuthorization: { issuedAt: null, consumedAt: null },
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z'
+  };
+  const runPath = path.join(f.taskDir, 'orchestration.json');
+  fs.writeFileSync(runPath, `${JSON.stringify(paused, null, 2)}\n`);
+  assert.equal(
+    verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.paused' }, { repoRoot: f.root }).status,
+    'pass'
+  );
+
+  fs.writeFileSync(runPath, `${JSON.stringify({
+    ...paused,
+    pendingDelegation: {
+      id: 'receipt-1', taskId: f.taskId, runId: 'run-1', role: 'executor', stage: 'analysis',
+      round: 1, artifact: 'analysis.md', client: 'claude-code', requestedModel: 'executor-model',
+      actualModel: null, modelFallbackReason: null, parentId: 'parent', childId: 'child',
+      spawnMode: 'fresh', agent: null, status: 'activated', beforeFingerprint: 'before',
+      afterFingerprint: null, changedPaths: [], createdAt: '2026-01-01T00:00:00.000Z',
+      activatedAt: '2026-01-01T00:00:01.000Z', sealedAt: null, consumedAt: null
+    }
+  }, null, 2)}\n`);
+  const missingModel = verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.paused' }, { repoRoot: f.root });
+  assert.equal(missingModel.status, 'fail');
+  assert.equal(missingModel.invocations.length, 2);
+
+  const sealed = JSON.parse(fs.readFileSync(runPath, 'utf8'));
+  sealed.pendingDelegation.status = 'sealed';
+  sealed.pendingDelegation.actualModel = 'executor-model';
+  fs.writeFileSync(runPath, `${JSON.stringify(sealed, null, 2)}\n`);
+  const sealedResult = verifyTaskEvent({ taskRef: f.taskId, event: 'run-task.paused' }, { repoRoot: f.root });
+  assert.equal(sealedResult.status, 'fail');
+  assert.equal(sealedResult.invocations.length, 1);
 });

--- a/tests/unit/core/delegation-receipts.test.ts
+++ b/tests/unit/core/delegation-receipts.test.ts
@@ -67,10 +67,25 @@ test('managed identities fail closed while unrelated subagents are ignored', () 
   }).code, 'DELEGATION_ROLE_MISMATCH');
 });
 
+test('activation requires host-observed model identity and records justified fallback', () => {
+  const prepared = prepareDelegation(input, { id: () => 'delegation-model' });
+  const event = {
+    nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-model',
+    parentId: 'parent-model', spawnMode: 'fresh'
+  };
+
+  assert.equal(activateDelegation(prepared, event).code, 'DELEGATION_MODEL_IDENTITY_MISSING');
+  assert.equal(activateDelegation(prepared, { ...event, actualModel: 'fallback-model' }).code, 'DELEGATION_MODEL_FALLBACK_UNRECORDED');
+  assert.equal(activateDelegation(prepared, {
+    ...event, actualModel: 'fallback-model', modelFallbackReason: 'requested model unavailable'
+  }).ok, true);
+});
+
 test('reviewer write gate rejects shared, non-allowlisted task, and cross-task paths', () => {
   const prepared = prepareDelegation(input, { id: () => 'delegation-3' });
   const activated = activateDelegation(prepared, {
-    nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-3', parentId: 'parent-1', spawnMode: 'fresh'
+    nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-3', parentId: 'parent-1',
+    spawnMode: 'fresh', actualModel: 'review-model'
   });
   assert.equal(activated.ok, true);
   if (!activated.ok) return;

--- a/tests/unit/core/task-orchestration.test.ts
+++ b/tests/unit/core/task-orchestration.test.ts
@@ -8,7 +8,7 @@ import {
   activateMatchingOrchestrationDelegation,
   activateOrchestrationDelegation,
   advanceOrchestration,
-  beginOrResumeOrchestration,
+  beginOrResumeOrchestration as beginOrResumeOrchestrationRaw,
   completeCommitOrchestrationStage,
   completeOrchestrationStage,
   pauseOrchestration,
@@ -20,6 +20,14 @@ import {
 } from '../../../lib/task/orchestration.ts';
 
 const snapshot = () => 'before-tree';
+const modelPolicy = { executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: null } as const;
+
+function beginOrResumeOrchestration(
+  taskRef: string,
+  options: Parameters<typeof beginOrResumeOrchestrationRaw>[1] = {}
+) {
+  return beginOrResumeOrchestrationRaw(taskRef, { modelPolicy, ...options });
+}
 
 function fixture(step: string) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchestration-'));
@@ -50,6 +58,73 @@ test('begin is persistent and idempotent for a running task', () => {
   const second = beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
   assert.equal(second.changed, false);
   assert.equal(second.run?.runId, 'run-1');
+  assert.deepEqual(second.run?.modelPolicy, modelPolicy);
+});
+
+test('begin requires a complete run-level model policy and justified same-model use', () => {
+  const missing = fixture('requirement-analysis');
+  const missingResult = beginOrResumeOrchestrationRaw('TASK-20260101-000001', { repoRoot: missing.root });
+  assert.equal(missingResult.error?.code, 'ORCHESTRATION_MODEL_POLICY_REQUIRED');
+  assert.equal(fs.existsSync(path.join(missing.taskDir, 'orchestration.json')), false);
+
+  const unjustified = fixture('requirement-analysis');
+  const unjustifiedResult = beginOrResumeOrchestrationRaw('TASK-20260101-000001', {
+    repoRoot: unjustified.root,
+    modelPolicy: { executor: 'shared-model', reviewer: 'shared-model', sameModelReason: null }
+  });
+  assert.equal(unjustifiedResult.error?.code, 'ORCHESTRATION_MODEL_SEPARATION_REQUIRED');
+
+  const irrelevantReason = fixture('requirement-analysis');
+  const irrelevantReasonResult = beginOrResumeOrchestrationRaw('TASK-20260101-000001', {
+    repoRoot: irrelevantReason.root,
+    modelPolicy: { executor: 'executor-model', reviewer: 'reviewer-model', sameModelReason: 'not applicable' }
+  });
+  assert.equal(irrelevantReasonResult.error?.code, 'ORCHESTRATION_MODEL_POLICY_INVALID');
+
+  const justified = fixture('requirement-analysis');
+  const justifiedResult = beginOrResumeOrchestrationRaw('TASK-20260101-000001', {
+    repoRoot: justified.root,
+    modelPolicy: { executor: 'shared-model', reviewer: 'shared-model', sameModelReason: 'host exposes one eligible model' }
+  });
+  assert.equal(justifiedResult.status, 'running');
+});
+
+test('resume rejects policy changes and pauses legacy runs without model evidence', () => {
+  const mismatch = fixture('requirement-analysis');
+  beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: mismatch.root });
+  const mismatchResult = beginOrResumeOrchestrationRaw('TASK-20260101-000001', {
+    repoRoot: mismatch.root,
+    modelPolicy: { executor: 'other-model', reviewer: 'reviewer-model', sameModelReason: null }
+  });
+  assert.equal(mismatchResult.error?.code, 'ORCHESTRATION_MODEL_POLICY_MISMATCH');
+
+  const legacy = fixture('requirement-analysis');
+  beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: legacy.root });
+  const runPath = path.join(legacy.taskDir, 'orchestration.json');
+  const persisted = JSON.parse(fs.readFileSync(runPath, 'utf8'));
+  delete persisted.modelPolicy;
+  fs.writeFileSync(runPath, `${JSON.stringify(persisted, null, 2)}\n`);
+  const resumed = beginOrResumeOrchestrationRaw('TASK-20260101-000001', { repoRoot: legacy.root });
+  assert.equal(resumed.status, 'paused');
+  assert.equal(resumed.run?.pause?.code, 'ORCHESTRATION_MODEL_EVIDENCE_MISSING');
+  const repeated = beginOrResumeOrchestrationRaw('TASK-20260101-000001', { repoRoot: legacy.root });
+  assert.equal(repeated.changed, false);
+});
+
+test('prepare validates requested model before capturing workspace state', () => {
+  const f = fixture('requirement-analysis');
+  beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
+  let captures = 0;
+  const captureWorkspace = () => { captures += 1; return 'snapshot'; };
+  const missing = prepareOrchestrationDelegation('TASK-20260101-000001', {
+    client: 'claude-code'
+  }, { repoRoot: f.root, captureWorkspace });
+  assert.equal(missing.error?.code, 'ORCHESTRATION_REQUESTED_MODEL_REQUIRED');
+  const mismatch = prepareOrchestrationDelegation('TASK-20260101-000001', {
+    client: 'claude-code', requestedModel: 'wrong-model'
+  }, { repoRoot: f.root, captureWorkspace });
+  assert.equal(mismatch.error?.code, 'ORCHESTRATION_REQUESTED_MODEL_MISMATCH');
+  assert.equal(captures, 0);
 });
 
 test('prepare fails closed for clients without orchestration capability', () => {
@@ -75,13 +150,13 @@ test('prepare fails closed for Codex when native lifecycle events are not observ
 test('route selects one fresh role from existing lifecycle facts', () => {
   const analysis = fixture('requirement-analysis');
   assert.deepEqual(routeOrchestration('TASK-20260101-000001', { repoRoot: analysis.root }).next, {
-    action: 'analyze-task', role: 'executor', stage: 'analysis', round: 1, artifact: 'analysis.md'
+    action: 'analyze-task', role: 'executor', stage: 'analysis', round: 1, artifact: 'analysis.md', requestedModel: null
   });
 
   const review = fixture('requirement-analysis-review');
   fs.writeFileSync(path.join(review.taskDir, 'analysis.md'), '# Analysis\n');
   assert.deepEqual(routeOrchestration('TASK-20260101-000001', { repoRoot: review.root }).next, {
-    action: 'review-analysis', role: 'reviewer', stage: 'review-analysis', round: 1, artifact: 'review-analysis.md'
+    action: 'review-analysis', role: 'reviewer', stage: 'review-analysis', round: 1, artifact: 'review-analysis.md', requestedModel: null
   });
 
   const code = fixture('technical-design-review');
@@ -90,7 +165,7 @@ test('route selects one fresh role from existing lifecycle facts', () => {
   fs.writeFileSync(path.join(code.taskDir, 'plan.md'), '# Plan\n');
   fs.writeFileSync(path.join(code.taskDir, 'review-plan.md'), '# Plan Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
   assert.deepEqual(routeOrchestration('TASK-20260101-000001', { repoRoot: code.root }).next, {
-    action: 'code-task', role: 'executor', stage: 'code', round: 1, artifact: 'code.md'
+    action: 'code-task', role: 'executor', stage: 'code', round: 1, artifact: 'code.md', requestedModel: null
   });
 });
 
@@ -100,7 +175,7 @@ test('route requires the latest review to bind the latest artifact structurally'
   fs.utimesSync(path.join(f.taskDir, 'review-code.md'), new Date(), new Date());
 
   assert.deepEqual(routeOrchestration('TASK-20260101-000001', { repoRoot: f.root }).next, {
-    action: 'review-code', role: 'reviewer', stage: 'review-code', round: 2, artifact: 'review-code-r2.md'
+    action: 'review-code', role: 'reviewer', stage: 'review-code', round: 2, artifact: 'review-code-r2.md', requestedModel: null
   });
 });
 
@@ -128,7 +203,7 @@ test('commit authorization is issued at eligible prepare and the receipt reaches
   assert.equal(begun.run?.commitAuthorization.issuedAt, null);
 
   const prepared = prepareOrchestrationDelegation('TASK-20260101-000001', {
-    client: 'claude-code'
+    client: 'claude-code', requestedModel: 'executor-model'
   }, { repoRoot: f.root, id: () => 'receipt-1', now, captureWorkspace: snapshot });
   assert.equal(prepared.next?.stage, 'commit');
   assert.equal(prepared.run?.pendingDelegation?.workspaceSnapshotScope, 'task');
@@ -136,7 +211,7 @@ test('commit authorization is issued at eligible prepare and the receipt reaches
 
   assert.equal(activateOrchestrationDelegation('TASK-20260101-000001', {
     nativeAgent: 'agent-infra-lifecycle-executor', childId: 'child-1', parentId: 'parent-1',
-    spawnMode: 'fresh', actualModel: 'gpt-5'
+    spawnMode: 'fresh', actualModel: 'executor-model'
   }, { repoRoot: f.root, now }).status, 'running');
   assert.equal(completeCommitOrchestrationStage('TASK-20260101-000001', 'claude-code', { repoRoot: f.root }).status, 'running');
   assert.equal(sealOrchestrationDelegation('TASK-20260101-000001', {
@@ -149,13 +224,13 @@ test('commit authorization is issued at eligible prepare and the receipt reaches
 test('native start binds the unique prepared delegation without task identity', () => {
   const f = fixture('requirement-analysis');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'executor-model' }, {
     repoRoot: f.root, captureWorkspace: snapshot
   });
 
   const started = activateMatchingOrchestrationDelegation('claude-code', {
     nativeAgent: 'agent-infra-lifecycle-executor', childId: 'child-native',
-    parentId: 'parent-session', spawnMode: 'fresh'
+    parentId: 'parent-session', spawnMode: 'fresh', actualModel: 'executor-model'
   }, { repoRoot: f.root });
 
   assert.equal(started.status, 'running');
@@ -167,13 +242,13 @@ test('native start binds the unique prepared delegation without task identity', 
 test('managed native hook mismatches persist a recoverable pause', () => {
   const f = fixture('requirement-analysis');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'executor-model' }, {
     repoRoot: f.root, captureWorkspace: snapshot
   });
 
   const started = activateMatchingOrchestrationDelegation('claude-code', {
     nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'wrong-role',
-    parentId: 'parent-session', spawnMode: 'fresh'
+    parentId: 'parent-session', spawnMode: 'fresh', actualModel: 'executor-model'
   }, { repoRoot: f.root });
 
   assert.equal(started.status, 'paused');
@@ -183,7 +258,7 @@ test('managed native hook mismatches persist a recoverable pause', () => {
 test('repository pending guard includes paused runs that retain a delegation', () => {
   const f = fixture('requirement-analysis');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'executor-model' }, {
     repoRoot: f.root, captureWorkspace: snapshot
   });
   pauseOrchestration('TASK-20260101-000001', 'HOOK_FAILED', 'hook failed', true, { repoRoot: f.root });
@@ -196,7 +271,7 @@ test('repository pending guard includes paused runs that retain a delegation', (
   );
   beginOrResumeOrchestration('TASK-20260101-000002', { repoRoot: f.root });
 
-  const prepared = prepareOrchestrationDelegation('TASK-20260101-000002', { client: 'claude-code' }, {
+  const prepared = prepareOrchestrationDelegation('TASK-20260101-000002', { client: 'claude-code', requestedModel: 'executor-model' }, {
     repoRoot: f.root, captureWorkspace: snapshot
   });
 
@@ -213,12 +288,12 @@ test('native stop derives the workspace delta before sealing the unique delegati
   };
   fs.writeFileSync(path.join(f.taskDir, 'analysis.md'), '# Analysis\n');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'reviewer-model' }, {
     repoRoot: f.root, captureWorkspace
   });
   activateMatchingOrchestrationDelegation('claude-code', {
     nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-stop',
-    parentId: 'parent-session', spawnMode: 'fresh'
+    parentId: 'parent-session', spawnMode: 'fresh', actualModel: 'reviewer-model'
   }, { repoRoot: f.root });
   completeOrchestrationStage('TASK-20260101-000001', {
     stage: 'review-analysis', round: 1, artifact: 'review-analysis.md', agent: 'claude-code'
@@ -251,7 +326,7 @@ test('native stop preserves legacy snapshot scope for an old pending receipt', (
   };
   fs.writeFileSync(path.join(f.taskDir, 'analysis.md'), '# Analysis\n');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'reviewer-model' }, {
     repoRoot: f.root, captureWorkspace
   });
   const runPath = path.join(f.taskDir, 'orchestration.json');
@@ -260,7 +335,7 @@ test('native stop preserves legacy snapshot scope for an old pending receipt', (
   fs.writeFileSync(runPath, `${JSON.stringify(persisted, null, 2)}\n`);
   activateMatchingOrchestrationDelegation('claude-code', {
     nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-legacy',
-    parentId: 'parent-session', spawnMode: 'fresh'
+    parentId: 'parent-session', spawnMode: 'fresh', actualModel: 'reviewer-model'
   }, { repoRoot: f.root });
   completeOrchestrationStage('TASK-20260101-000001', {
     stage: 'review-analysis', round: 1, artifact: 'review-analysis.md', agent: 'claude-code'
@@ -283,12 +358,12 @@ test('reviewer snapshot shape mismatch fails closed to a recoverable pause', () 
   const f = fixture('requirement-analysis-review');
   fs.writeFileSync(path.join(f.taskDir, 'analysis.md'), '# Analysis\n');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
-  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code' }, {
+  prepareOrchestrationDelegation('TASK-20260101-000001', { client: 'claude-code', requestedModel: 'reviewer-model' }, {
     repoRoot: f.root, captureWorkspace: snapshot
   });
   activateMatchingOrchestrationDelegation('claude-code', {
     nativeAgent: 'agent-infra-lifecycle-reviewer', childId: 'child-rollback',
-    parentId: 'parent-session', spawnMode: 'fresh'
+    parentId: 'parent-session', spawnMode: 'fresh', actualModel: 'reviewer-model'
   }, { repoRoot: f.root });
   completeOrchestrationStage('TASK-20260101-000001', {
     stage: 'review-analysis', round: 1, artifact: 'review-analysis.md', agent: 'claude-code'

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -190,6 +190,19 @@ test("SKILL.md reference paths point to existing files", () => {
   });
 });
 
+test("run-task verification configs expose the same ordered local checks", () => {
+  const files = [
+    ".agents/skills/run-task/config/verify.json",
+    "templates/.agents/skills/run-task/config/verify.en.json",
+    "templates/.agents/skills/run-task/config/verify.zh-CN.json"
+  ];
+  const checks = files.map((relativePath) => Object.keys(JSON.parse(read(relativePath)).checks));
+  const baseline = checks[0]!;
+  assert.deepEqual(checks[1], baseline);
+  assert.deepEqual(checks[2], baseline);
+  assert.equal(new Set(baseline).size, baseline.length);
+});
+
 test("local entropy-check defines review checklist and report template sections", () => {
   const skill = read(".agents/skills/entropy-check/SKILL.md");
   const checklist = read(".agents/skills/entropy-check/reference/checklist.md");


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #768

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #768

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

在不放宽现有隔离与来源门禁的前提下，补齐生命周期编排中的 requested model、actual model 与 fallback 证据。真实 Codex 宿主目前仍未暴露足以机械验证的原生生命周期事件，因此本变更不会强行恢复 Codex orchestration，而是继续保持 unsupported 和零副作用失败关闭。

同时固化 executor/reviewer 的运行级模型策略，让 route、prepare、原生 start receipt 与 typed verification 使用同一组可审计事实；旧 run 缺少模型证据时稳定暂停，不静默迁移或继承会话默认值。

## 📋 主要变更 / Brief Changelog

- 为 orchestration run 持久化不可变的 executor/reviewer 模型策略，校验同模型理由、重入一致性以及 CLI 参数原子性。
- route 返回角色 requested model，prepare 在工作区快照前精确匹配；原生 start 必须记录 actual model，发生 fallback 时必须提供宿主理由。
- 新增 `orchestration-evidence` typed verification，覆盖缺失策略、模型错配、不完整 receipt、旧 run 暂停和 unsupported 干净暂停。
- 同步 run-task 技能、规则、双语模板、README、候选包 smoke 和真实宿主验证指南。
- 扩展单元与集成测试，覆盖模型策略、receipt、hook、CLI、verification 和模板一致性。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck` 验证 TypeScript 测试与 JavaScript 检查配置。
2. 运行 `npm test` 构建项目并执行完整测试套件。
3. 运行 `git diff --check main...HEAD` 检查提交差异格式。
4. 核对 `review-code-r2.md` 的 Approved 结论及 reviewed snapshot tree。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

最新验证：1953 passed，0 failed，3 skipped；TypeScript typecheck、项目构建和 `git diff --check` 通过。

## 📸 截图 / Screenshots

不适用；本次变更涉及内部生命周期编排、证据门禁、技能文档与自动化测试，无可视化界面变化。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass（项目当前未配置 lint；TypeScript typecheck、构建与 `git diff --check` 已通过）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- Codex orchestration 继续声明为 unsupported；普通 fresh subagent 能力不受影响。
- 旧 orchestration run 缺少 model policy 时稳定暂停，不回填无法证明的历史事实。
- 人工校验处置：
  1. 真实 Claude Code SubagentStart 的 actual model 仍待人工确认。
  2. 候选包完整 `run-task` 到安全 commit 的成功链：**维护者决定本次无需验证**；这是范围豁免，不代表已验证通过。
  3. 发布后 registry 包复核：待发布后执行；范围为精确版本/发布物身份、隔离安装、init/模板契约和 Codex unsupported 零副作用失败关闭，不包含第 2 项已豁免的完整成功链。
- 代码审查 Round 2 已通过：0 blocker、0 major、0 minor；当前仍待执行第 1 项和缩减范围后的第 3 项。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查模型策略在 begin/resume/route/prepare/start/verification 各层的一致性、actual/requested mismatch 的 fallback 证据，以及 Codex unsupported 与旧 run 稳定暂停是否保持零副作用失败关闭。

Generated with AI assistance

