### PR TITLE
fix(completion): 完善外部 PR 交付任务的安全收尾流程


### DIFF
--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -14,6 +14,7 @@ description: >
 
 - 本命令更新任务元数据并物理移动任务目录
 - 除非强制执行，不要转移有未完成工作流步骤的任务
+- 入口接受可选 `--external-pr <N>`；仅用于外部交付候选歧义时的显式选择，不绕过身份或平台门禁
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
@@ -54,6 +55,16 @@ agent-infra-internal task-snapshot {task-id} --format text
 场景 A 为 active 任务的正常完成路径；场景 B `finalization-retry` 只重试归档后的 task 评论与终态门禁。
 
 ### 2. 验证完成前置条件（未满足则必须停止）
+
+先读取 `reference/external-delivery.md`，然后在 active 任务上调用：
+
+```bash
+agent-infra-internal platform-pr resolve-external {task-id} --agent {standard-agent-token} [--pr {external-pr}]
+```
+
+- `mode=external`：只以本次 typed result 的 `authorization` 和 `selected` 作为外部交付授权与绑定身份，继续本步骤的既有硬门禁。
+- `mode=normal`：走现有本地生命周期前置条件；历史 `pr_number` / `pr_status` 不构成外部授权。
+- `status=failed|blocked`：立即停止并展示稳定错误；`--force` 不得绕过。
 
 **门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR），以及 `task.md` frontmatter 的 `pr_status`（`pending` / `created` / `skipped`）。
 
@@ -126,7 +137,7 @@ Please complete the missing steps first, or use --force to override.
 
 如果存在有效的 `issue_number`，严格按以下顺序执行：
 
-1. 按 artifact catalog 顺序，对本地已有产物逐项调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {artifact} --agent {artifact-agent} --backfill`。
+1. 调用 `agent-infra-internal platform-comment backfill {task-id} --agent {standard-agent-token}`，由 core 仅按 completion canonical inventory 固定顺序补发产物并在全部成功后精确恢复目标历史告警。
 2. 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --requirements --fields`。
 3. 把业务摘要写入临时文件，并调用 `agent-infra-internal platform-comment sync {task-id} --kind summary --body-file {path} --agent {standard-agent-token}`。
 

--- a/.agents/skills/complete-task/reference/external-delivery.md
+++ b/.agents/skills/complete-task/reference/external-delivery.md
@@ -1,0 +1,17 @@
+# 外部 PR 交付
+
+本场景只适用于 completion canonical inventory 为空、实现实际由已合并的外部 PR 交付的 active 任务。
+
+## Typed 状态机
+
+调用 `agent-infra-internal platform-pr resolve-external {task-id} --agent {agent} [--pr {N}]`。core 先检查 completion inventory；非空时返回 `mode=normal`，且显式 `--pr` 会失败。空 inventory 必须有正整数 `issue_number`，否则返回 `EXTERNAL_DELIVERY_ISSUE_REQUIRED`。
+
+core 通过平台 adapter 读取 Issue 的权威 closing change requests，穷尽分页后只把 base 仓库匹配任务仓库且已经合并、身份字段完整的候选视为 eligible。唯一候选自动选择；多候选、身份冲突或证据缺失均 fail closed。`--pr` 只能从权威 closing eligible 集合中显式选择，不能绕过仓库、Issue、合并或身份校验。
+
+## 授权与持久审计
+
+当次调用只以 typed result 的 `mode=external`、`authorization` 和 `selected` 为机器分支依据。`pr_status: created` 只是现有 verifier 的兼容 shim，表示任务已绑定可验证的 PR；它既不表示 PR 由本任务创建，也不能单独授权跳过 lifecycle。
+
+成功绑定会原子写入 PR 字段并追加 `Bind External PR` Activity Log，记录授权来源、Issue、PR URL/编号、base/head repository/ref/SHA、合并时间和 merge commit。相同完整证据重试为 no-op；已有同号但缺审计签名时补写一次；编号或身份变化失败。不得调用 PR create 路径。
+
+外部模式仍须通过 review ledger、manual validation、post-review commit、平台同步、preflight 与终态校验。无 canonical review-code 时仅沿用 verifier 已定义的 N/A 规则；`--force` 不解除任何硬门禁。

--- a/lib/internal/platform-comment.ts
+++ b/lib/internal/platform-comment.ts
@@ -9,9 +9,11 @@ import {
 } from '../platform/issue-comments.ts';
 import type { CommentKind } from '../platform/issue-comments.ts';
 import type { PlatformResult } from '../platform/types.ts';
+import { backfillCompletionComments } from '../platform/completion-backfill.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-comment list --issue <N> [--cwd <path>]
        agent-infra-internal platform-comment owner <task-ref> [--cwd <path>]
+       agent-infra-internal platform-comment backfill <task-ref> --agent <agent> [--cwd <path>]
        agent-infra-internal platform-comment sync <task-ref> --kind <kind> --agent <agent> [--artifact <file>] [--body-file <path|->] [--status-label <label>] [--backfill] [--cwd <path>]
 `;
 
@@ -53,7 +55,7 @@ function readBodyFile(value: string, cwd: string): string {
 function platformComment(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['list', 'owner', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || !['list', 'owner', 'backfill', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }
   const hasTaskRef = operation !== 'list';
   const taskRef = hasTaskRef ? args[1] : undefined;
   if (hasTaskRef && (!taskRef || taskRef.startsWith('--'))) { fail(`${operation} requires a task ref`); return; }
@@ -72,6 +74,16 @@ function platformComment(args: string[] = []): void {
     const unexpected = Object.keys(parsed.values).find((key) => key !== 'cwd');
     if (unexpected) { fail(`owner does not accept '--${unexpected}'`); return; }
     finish(checkPlatformCommentOwner(taskRef!, { cwd }));
+    return;
+  }
+  if (operation === 'backfill') {
+    const unexpected = Object.keys(parsed.values).find((key) => !['cwd', 'agent'].includes(key));
+    if (unexpected) { fail(`backfill does not accept '--${unexpected}'`); return; }
+    const agent = parsed.values.agent;
+    if (typeof agent !== 'string' || !agent) { fail('backfill requires --agent'); return; }
+    const normalizedAgent = normalizeAgentToken(agent);
+    if (!normalizedAgent) { fail(`invalid --agent '${agent}': ${AGENT_USAGE_HINT}`); return; }
+    finish(backfillCompletionComments(taskRef!, { cwd, agent: normalizedAgent }));
     return;
   }
   const kind = parsed.values.kind;

--- a/lib/internal/platform-pr.ts
+++ b/lib/internal/platform-pr.ts
@@ -6,6 +6,7 @@ import {
   bindPlatformPullRequest,
   createPlatformPullRequest,
   inspectPlatformPullRequest,
+  resolveExternalPullRequest,
   syncPlatformPullRequest
 } from '../platform/pull-requests.ts';
 import type { PullRequestResult } from '../platform/pull-requests.ts';
@@ -13,6 +14,7 @@ import { summaryContext, syncPullRequestSummary } from '../platform/pr-summary.t
 import type { PlatformResult } from '../platform/types.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-pr inspect <task-ref> [--cwd <path>]
+       agent-infra-internal platform-pr resolve-external <task-ref> --agent <agent> [--pr <N>] [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr create <task-ref> --agent <agent> --base <branch> --head <branch> --title-file <path|-> --body-file <path|-> [--draft] [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr bind <task-ref> --pr <N> --agent <agent> [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr sync <task-ref> --agent <agent> [--metadata] [--closing-issue] [--dry-run] [--cwd <path>]
@@ -62,7 +64,7 @@ function readFile(value: string, cwd: string): string {
 function platformPr(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'create', 'bind', 'sync', 'summary-context', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || !['inspect', 'resolve-external', 'create', 'bind', 'sync', 'summary-context', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }
   const taskRef = args[1];
   if (!taskRef || taskRef.startsWith('--')) { fail(`${operation} requires a task ref`); return; }
   const parsed = parse(args, 2);
@@ -71,6 +73,7 @@ function platformPr(args: string[] = []): void {
   const cwd = path.resolve(typeof values.cwd === 'string' ? values.cwd : process.cwd());
   const allowed: Record<string, string[]> = {
     inspect: ['cwd'],
+    'resolve-external': ['cwd', 'agent', 'pr', 'dryRun'],
     create: ['cwd', 'agent', 'base', 'head', 'titleFile', 'bodyFile', 'draft', 'dryRun'],
     bind: ['cwd', 'agent', 'pr', 'dryRun'],
     sync: ['cwd', 'agent', 'metadata', 'closingIssue', 'dryRun'],
@@ -85,6 +88,12 @@ function platformPr(args: string[] = []): void {
   const agent = normalizeAgentToken(values.agent);
   if (!agent) { fail(`invalid --agent '${values.agent}': ${AGENT_USAGE_HINT}`); return; }
   values.agent = agent;
+  if (operation === 'resolve-external') {
+    const pr = values.pr === undefined ? undefined : Number(values.pr);
+    if (pr !== undefined && (!Number.isInteger(pr) || pr <= 0)) { fail('resolve-external requires a positive --pr'); return; }
+    finish(resolveExternalPullRequest(taskRef, { cwd, agent: values.agent, pr, dryRun: values.dryRun === true }));
+    return;
+  }
   if (operation === 'bind') {
     const pr = Number(values.pr);
     if (!Number.isInteger(pr) || pr <= 0) { fail('bind requires a positive --pr'); return; }

--- a/lib/platform/adapters.ts
+++ b/lib/platform/adapters.ts
@@ -45,6 +45,11 @@ type ChangeRequestInspectionContext = PlatformAdapterContext & {
   number: number;
 };
 
+type IssueClosingChangeRequestsContext = PlatformAdapterContext & {
+  repository: string;
+  issueNumber: number;
+};
+
 type RequiredChecksInspectionContext = ChangeRequestInspectionContext & {
   headSha: string;
 };
@@ -65,6 +70,9 @@ type PlatformAdapter = {
   inspectChangeRequest?(
     context: ChangeRequestInspectionContext
   ): PlatformInspectionResult<PlatformChangeRequestSnapshot>;
+  inspectIssueClosingChangeRequests?(
+    context: IssueClosingChangeRequestsContext
+  ): PlatformInspectionResult<PlatformChangeRequestSnapshot[]>;
   inspectRequiredChecks?(
     context: RequiredChecksInspectionContext
   ): PlatformInspectionResult<PlatformCheckSnapshot[]>;
@@ -88,7 +96,7 @@ function registerPlatformCapabilities(
   type: string,
   capabilities: Pick<
     PlatformAdapter,
-    'inspectChangeRequest' | 'inspectRequiredChecks' | 'resolveChangeRequestGitEvidence'
+    'inspectChangeRequest' | 'inspectIssueClosingChangeRequests' | 'inspectRequiredChecks' | 'resolveChangeRequestGitEvidence'
   >
 ): void {
   const adapter = adapters.get(type);
@@ -98,12 +106,22 @@ function registerPlatformCapabilities(
 
 function hasPlatformCapability(
   type: string | null,
-  capability: 'change-request' | 'required-checks' | 'change-request-git-evidence'
+  capability: 'change-request' | 'issue-closing-change-requests' | 'required-checks' | 'change-request-git-evidence'
 ): boolean {
   const adapter = getPlatformAdapter(type);
   if (capability === 'change-request') return typeof adapter?.inspectChangeRequest === 'function';
+  if (capability === 'issue-closing-change-requests') return typeof adapter?.inspectIssueClosingChangeRequests === 'function';
   if (capability === 'required-checks') return typeof adapter?.inspectRequiredChecks === 'function';
   return typeof adapter?.resolveChangeRequestGitEvidence === 'function';
+}
+
+function inspectPlatformIssueClosingChangeRequests(
+  type: string | null,
+  context: IssueClosingChangeRequestsContext
+): PlatformInspectionResult<PlatformChangeRequestSnapshot[]> {
+  const adapter = getPlatformAdapter(type);
+  return adapter?.inspectIssueClosingChangeRequests?.(context) ??
+    unsupported(type, 'issue closing change-request inspection');
 }
 
 function unsupported<T>(type: string | null, capability: string): PlatformInspectionResult<T> {
@@ -150,6 +168,7 @@ export {
   getPlatformAdapter,
   hasPlatformCapability,
   inspectPlatformChangeRequest,
+  inspectPlatformIssueClosingChangeRequests,
   inspectPlatformRequiredChecks,
   listPlatformAdapters,
   registerPlatformAdapter,
@@ -159,6 +178,7 @@ export {
 export type {
   ChangeRequestGitEvidenceContext,
   ChangeRequestInspectionContext,
+  IssueClosingChangeRequestsContext,
   PlatformAdapter,
   PlatformAdapterContext,
   PlatformChangeRequestGitEvidenceSpec,

--- a/lib/platform/completion-backfill.ts
+++ b/lib/platform/completion-backfill.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { COMPLETION_BACKFILL_FAMILIES, inspectCompletionArtifacts } from '../task/finalization-artifacts.ts';
+import { parseArtifactName } from '../task/artifact-lifecycle.ts';
+import { parseTaskFrontmatter } from '../task/frontmatter.ts';
+import { resolveTaskRef } from '../task/resolve-ref.ts';
+import { getOpenWorkflowWarnings } from '../task/workflow-warnings.ts';
+import { applyWorkflowWarningIntent } from '../task/workflow-warning-intents.ts';
+import { captureTaskWriteMetadata } from '../task/write.ts';
+import { syncPlatformComment } from './issue-comments.ts';
+import type { GitHubClient } from './github-client.ts';
+import { platformResult } from './types.ts';
+import type { PlatformOperation, PlatformResult } from './types.ts';
+
+type CompletionBackfillOptions = { agent: string; cwd?: string; client?: GitHubClient };
+type CompletionBackfillResult = PlatformResult & {
+  artifacts: Array<{ artifact: string; status: PlatformResult['status'] }>;
+  warnings: Array<{ id: string; status: string }>;
+};
+
+function result(
+  base: PlatformResult,
+  artifacts: CompletionBackfillResult['artifacts'],
+  warnings: CompletionBackfillResult['warnings']
+): CompletionBackfillResult {
+  return { ...base, artifacts, warnings };
+}
+
+function excludedPrReview(taskDir: string, message: string): string | null {
+  const names = [...message.matchAll(/(?:^|[^A-Za-z0-9_-])(pr-review(?:-r[1-9]\d*)?\.md)(?=$|[^A-Za-z0-9_.-])/g)]
+    .map((match) => match[1]!);
+  if (names.length !== 1) return null;
+  const parsed = parseArtifactName(names[0]!);
+  if (!parsed || parsed.family !== 'pr-review') return null;
+  const artifactPath = path.join(taskDir, parsed.name);
+  try {
+    const stat = fs.lstatSync(artifactPath);
+    return stat.isFile() && !stat.isSymbolicLink() ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function backfillCompletionComments(
+  taskRef: string,
+  options: CompletionBackfillOptions
+): CompletionBackfillResult {
+  const resolved = resolveTaskRef(taskRef, options.cwd ? { repoRoot: options.cwd } : {});
+  if (!resolved.ok) return result(platformResult('failed', {
+    error: { code: resolved.code, message: resolved.message, retryable: false }
+  }), [], []);
+  const inventory = inspectCompletionArtifacts(resolved.taskId, { repoRoot: resolved.repoRoot });
+  if (inventory.status === 'failed') return result(platformResult('failed', {
+    error: {
+      code: inventory.error?.code || 'ARTIFACT_TOPOLOGY_CONFLICT',
+      message: inventory.error?.message || 'Completion artifact inventory failed',
+      retryable: false
+    }
+  }), [], []);
+  const initialContent = fs.readFileSync(resolved.taskMdPath, 'utf8');
+  const issueNumber = Number(parseTaskFrontmatter(initialContent).issue_number);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) return result(platformResult('no-op', {
+    error: { code: 'ISSUE_NOT_LINKED', message: 'Task has no valid issue_number', retryable: false }
+  }), [], []);
+
+  const artifacts: CompletionBackfillResult['artifacts'] = [];
+  const operations: PlatformOperation[] = [];
+  let latest = platformResult('no-op', { error: null });
+  for (const artifact of inventory.artifacts) {
+    latest = syncPlatformComment(resolved.taskId, {
+      kind: 'artifact',
+      artifact: artifact.name,
+      agent: options.agent,
+      backfill: true,
+      cwd: resolved.repoRoot,
+      client: options.client
+    });
+    operations.push(...latest.operations.map((operation) => ({
+      ...operation,
+      name: `${artifact.name}:${operation.name}`
+    })));
+    artifacts.push({ artifact: artifact.name, status: latest.status });
+    if (latest.status === 'failed' || latest.status === 'blocked') return result({ ...latest, operations }, artifacts, []);
+    if (latest.error) return result(platformResult(latest.error.retryable ? 'blocked' : 'failed', {
+      platform: latest.platform,
+      resource: latest.resource,
+      capabilities: latest.capabilities,
+      operations,
+      error: latest.error
+    }), artifacts, []);
+  }
+
+  const matching = getOpenWorkflowWarnings(initialContent).flatMap((warning) => {
+    if (warning.step !== 'complete-task' || warning.code !== 'COMMENT_SYNC_FAILED' || warning.target !== 'artifact') return [];
+    const excluded = excludedPrReview(resolved.taskDir, warning.message);
+    return excluded ? [{ warning, excluded }] : [];
+  });
+  const warnings: CompletionBackfillResult['warnings'] = [];
+  let metadata: ReturnType<typeof captureTaskWriteMetadata> | null = null;
+  for (const { warning, excluded } of matching) {
+    metadata ??= captureTaskWriteMetadata();
+    const resolution = [
+      `excluded=${excluded}`,
+      `completionFamilies=${COMPLETION_BACKFILL_FAMILIES.join(',')}`,
+      `synchronized=${inventory.artifacts.map((artifact) => artifact.name).join(',') || 'none'}`,
+      `completedAt=${metadata.timestamp}`
+    ].join('; ');
+    const updated = applyWorkflowWarningIntent({
+      kind: 'set-status', taskRef: resolved.taskId, id: warning.id, status: 'resolved', resolution
+    }, { repoRoot: resolved.repoRoot, metadataProvider: () => metadata! });
+    if (updated.status === 'failed') return result(platformResult('failed', {
+      platform: latest.platform,
+      resource: latest.resource,
+      capabilities: latest.capabilities,
+      operations,
+      changed: artifacts.some((item) => item.status === 'applied'),
+      error: { code: updated.error?.code || 'WARNING_UPDATE_FAILED', message: updated.error?.message || 'Unable to resolve workflow warning', retryable: false }
+    }), artifacts, warnings);
+    warnings.push({ id: warning.id, status: updated.status });
+  }
+  const changed = artifacts.some((item) => item.status === 'applied') || warnings.some((item) => item.status === 'applied');
+  return result(platformResult(changed ? 'applied' : 'no-op', {
+    platform: latest.platform,
+    resource: latest.resource,
+    capabilities: latest.capabilities,
+    changed,
+    operations,
+    error: null
+  }), artifacts, warnings);
+}
+
+export { backfillCompletionComments };
+export type { CompletionBackfillOptions, CompletionBackfillResult };

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -7,6 +7,7 @@ import { extractSection } from '../task/sections.ts';
 import { captureTaskWriteMetadata, writeTask } from '../task/write.ts';
 import {
   inspectPlatformChangeRequest,
+  inspectPlatformIssueClosingChangeRequests,
   registerPlatformCapabilities
 } from './adapters.ts';
 import type { PlatformChangeRequestSnapshot } from './adapters.ts';
@@ -17,6 +18,7 @@ import { inspectPlatformIssue } from './issues.ts';
 import { planPullRequestMetadata } from './pull-request-metadata.ts';
 import { platformResult } from './types.ts';
 import type { PlatformOperation, PlatformResult } from './types.ts';
+import { inspectCompletionArtifacts } from '../task/finalization-artifacts.ts';
 
 type PullRequestSnapshot = PlatformChangeRequestSnapshot;
 
@@ -37,6 +39,18 @@ type CreateOptions = SharedOptions & {
 };
 type BindOptions = SharedOptions & { agent: string; pr: number; dryRun?: boolean };
 type SyncOptions = SharedOptions & { agent: string; metadata?: boolean; closingIssue?: boolean; dryRun?: boolean };
+type ResolveExternalOptions = SharedOptions & { agent: string; pr?: number; dryRun?: boolean };
+type ExternalPullRequestSelection =
+  | { status: 'normal'; candidates: PullRequestSnapshot[]; eligible: [] }
+  | { status: 'selected'; source: 'unique' | 'explicit'; selected: PullRequestSnapshot; candidates: PullRequestSnapshot[]; eligible: PullRequestSnapshot[] }
+  | { status: 'failed'; code: string; message: string; candidates: PullRequestSnapshot[]; eligible: PullRequestSnapshot[] };
+type ExternalPullRequestResult = PullRequestResult & {
+  mode: 'normal' | 'external' | null;
+  authorization: 'unique' | 'explicit' | null;
+  candidates: PullRequestSnapshot[];
+  eligible: PullRequestSnapshot[];
+  selected: PullRequestSnapshot | null;
+};
 
 type RemotePullRequest = {
   number?: number;
@@ -56,6 +70,34 @@ type RemotePullRequest = {
   milestone?: { title?: string } | null;
 };
 
+type ClosingPullRequestNode = {
+  number?: number;
+  id?: string;
+  url?: string;
+  state?: string;
+  title?: string;
+  body?: string | null;
+  isDraft?: boolean;
+  headRefName?: string;
+  headRefOid?: string;
+  headRepository?: { nameWithOwner?: string } | null;
+  baseRefName?: string;
+  baseRefOid?: string;
+  baseRepository?: { nameWithOwner?: string } | null;
+  mergedAt?: string | null;
+  mergeCommit?: { oid?: string } | null;
+  labels?: { nodes?: Array<{ name?: string }> };
+  assignees?: { nodes?: Array<{ login?: string }> };
+  milestone?: { title?: string } | null;
+};
+
+type ClosingPullRequestPage = {
+  data?: { repository?: { issue?: { closedByPullRequestsReferences?: {
+    nodes?: ClosingPullRequestNode[];
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  } } } };
+};
+
 function result(
   status: PlatformResult['status'],
   taskId: string | null,
@@ -67,6 +109,21 @@ function result(
     ...platformResult(status),
     task: { id: taskId, issueNumber, prNumber },
     pullRequest: null,
+    ...overrides
+  };
+}
+
+function externalResult(
+  base: PullRequestResult,
+  overrides: Partial<ExternalPullRequestResult> = {}
+): ExternalPullRequestResult {
+  return {
+    ...base,
+    mode: null,
+    authorization: null,
+    candidates: [],
+    eligible: [],
+    selected: null,
     ...overrides
   };
 }
@@ -94,6 +151,146 @@ function normalizePullRequest(remote: RemotePullRequest, repository: string): Pu
     assignees: (remote.assignees || []).map((assignee) => assignee.login || '').filter(Boolean).sort(),
     milestone: remote.milestone?.title || null
   };
+}
+
+function normalizeClosingPullRequest(node: ClosingPullRequestNode, repository: string): PullRequestSnapshot | null {
+  return normalizePullRequest({
+    number: node.number,
+    node_id: node.id,
+    html_url: node.url,
+    state: node.state === 'OPEN' ? 'open' : 'closed',
+    title: node.title,
+    body: node.body,
+    draft: node.isDraft,
+    head: { ref: node.headRefName, sha: node.headRefOid, repo: node.headRepository ? { full_name: node.headRepository.nameWithOwner } : null },
+    base: { ref: node.baseRefName, sha: node.baseRefOid, repo: node.baseRepository ? { full_name: node.baseRepository.nameWithOwner } : null },
+    merged_at: node.mergedAt,
+    merge_commit_sha: node.mergeCommit?.oid,
+    labels: node.labels?.nodes,
+    assignees: node.assignees?.nodes,
+    milestone: node.milestone
+  }, repository);
+}
+
+function repositoryKey(repository: string): string {
+  return repository.trim().toLowerCase();
+}
+
+function identitySignature(pullRequest: PullRequestSnapshot): string {
+  return [
+    pullRequest.repository, pullRequest.number, pullRequest.nodeId, pullRequest.url,
+    pullRequest.head.repository, pullRequest.head.ref, pullRequest.head.sha,
+    pullRequest.base.repository, pullRequest.base.ref, pullRequest.base.sha,
+    pullRequest.mergedAt || '', pullRequest.mergeCommitSha || ''
+  ].join('|');
+}
+
+function hasCompleteExternalIdentity(pullRequest: PullRequestSnapshot): boolean {
+  const required = [
+    pullRequest.repository, pullRequest.nodeId, pullRequest.url,
+    pullRequest.head.repository, pullRequest.head.ref, pullRequest.head.sha,
+    pullRequest.base.repository, pullRequest.base.ref, pullRequest.base.sha
+  ];
+  return Number.isInteger(pullRequest.number) && pullRequest.number > 0 &&
+    required.every((value) => Boolean(value?.trim())) &&
+    Boolean(pullRequest.mergedAt) === Boolean(pullRequest.mergeCommitSha);
+}
+
+function selectExternalPullRequest(
+  candidates: PullRequestSnapshot[],
+  repository: string,
+  existingPrNumber: number | null,
+  explicitPrNumber: number | null
+): ExternalPullRequestSelection {
+  const invalid = candidates.find((candidate) => !hasCompleteExternalIdentity(candidate));
+  if (invalid) return {
+    status: 'failed', code: 'PR_IDENTITY_INVALID',
+    message: `Closing PR #${invalid.number} lacks required identity`, candidates, eligible: []
+  };
+  const byNumber = new Map<number, string>();
+  for (const candidate of candidates) {
+    const signature = identitySignature(candidate);
+    const prior = byNumber.get(candidate.number);
+    if (prior && prior !== signature) return {
+      status: 'failed', code: 'PR_IDENTITY_INVALID',
+      message: `Closing PR #${candidate.number} has conflicting identities`, candidates, eligible: []
+    };
+    byNumber.set(candidate.number, signature);
+  }
+  const unique = candidates.filter((candidate, index) =>
+    candidates.findIndex((other) => other.number === candidate.number) === index
+  );
+  const wantedRepository = repositoryKey(repository);
+  const eligible = unique.filter((candidate) =>
+    repositoryKey(candidate.repository) === wantedRepository &&
+    repositoryKey(candidate.base.repository) === wantedRepository &&
+    Boolean(candidate.mergedAt && candidate.mergeCommitSha)
+  );
+  if (explicitPrNumber !== null) {
+    const selected = unique.find((candidate) => candidate.number === explicitPrNumber);
+    if (!selected) return { status: 'failed', code: 'PR_NOT_FOUND', message: `PR #${explicitPrNumber} is not a closing PR`, candidates, eligible };
+    if (!eligible.some((candidate) => candidate.number === explicitPrNumber)) {
+      return { status: 'failed', code: 'PR_IDENTITY_INVALID', message: `PR #${explicitPrNumber} is not an eligible merged PR`, candidates, eligible };
+    }
+    if (existingPrNumber !== null && existingPrNumber !== explicitPrNumber) {
+      return { status: 'failed', code: 'PR_BIND_CONFLICT', message: `Task is already bound to PR #${existingPrNumber}`, candidates, eligible };
+    }
+    return { status: 'selected', source: 'explicit', selected, candidates, eligible };
+  }
+  if (existingPrNumber !== null && eligible.length === 1 && existingPrNumber !== eligible[0]!.number) {
+    return { status: 'failed', code: 'PR_BIND_CONFLICT', message: `Task is already bound to PR #${existingPrNumber}`, candidates, eligible };
+  }
+  if (eligible.length === 0) return { status: 'normal', candidates, eligible: [] };
+  if (eligible.length > 1) return {
+    status: 'failed', code: 'PR_IDENTITY_AMBIGUOUS',
+    message: 'Multiple eligible merged closing pull requests were found', candidates, eligible
+  };
+  return { status: 'selected', source: 'unique', selected: eligible[0]!, candidates, eligible };
+}
+
+const CLOSING_PULL_REQUESTS_QUERY = `query($owner:String!,$name:String!,$issue:Int!,$cursor:String){repository(owner:$owner,name:$name){issue(number:$issue){closedByPullRequestsReferences(first:100,after:$cursor){nodes{number id url state title body isDraft headRefName headRefOid headRepository{nameWithOwner} baseRefName baseRefOid baseRepository{nameWithOwner} mergedAt mergeCommit{oid} labels(first:100){nodes{name}} assignees(first:100){nodes{login}} milestone{title}} pageInfo{hasNextPage endCursor}}}}}`;
+
+function inspectGitHubIssueClosingChangeRequests(
+  client: GitHubClient,
+  repository: string,
+  issueNumber: number,
+  cwd: string
+) {
+  const [owner, name] = repository.split('/');
+  if (!owner || !name || !Number.isInteger(issueNumber) || issueNumber <= 0) return {
+    ok: false as const,
+    error: { code: 'PR_IDENTITY_INVALID', message: 'Repository or Issue identity is invalid', retryable: false }
+  };
+  const candidates: PullRequestSnapshot[] = [];
+  let cursor: string | null = null;
+  for (;;) {
+    const args = [
+      'api', 'graphql', '-f', `query=${CLOSING_PULL_REQUESTS_QUERY}`,
+      '-F', `owner=${owner}`, '-F', `name=${name}`, '-F', `issue=${issueNumber}`
+    ];
+    if (cursor) args.push('-F', `cursor=${cursor}`);
+    const response = client.json<ClosingPullRequestPage>(args, { cwd });
+    if (!response.ok) return response;
+    const connection = response.value?.data?.repository?.issue?.closedByPullRequestsReferences;
+    if (!connection || !Array.isArray(connection.nodes) || !connection.pageInfo) return {
+      ok: false as const,
+      error: { code: 'PR_IDENTITY_INVALID', message: 'Closing pull request response is incomplete', retryable: false }
+    };
+    for (const node of connection.nodes) {
+      const normalized = normalizeClosingPullRequest(node, repository);
+      if (!normalized) return {
+        ok: false as const,
+        error: { code: 'PR_IDENTITY_INVALID', message: 'Closing pull request identity is incomplete', retryable: false }
+      };
+      candidates.push(normalized);
+    }
+    if (!connection.pageInfo.hasNextPage) return { ok: true as const, value: candidates };
+    if (!connection.pageInfo.endCursor || connection.pageInfo.endCursor === cursor) return {
+      ok: false as const,
+      error: { code: 'PR_IDENTITY_INVALID', message: 'Closing pull request pagination cursor is invalid', retryable: false }
+    };
+    cursor = connection.pageInfo.endCursor;
+  }
 }
 
 function expectedHead(repository: string, head: string): { repository: string; ref: string } {
@@ -246,6 +443,11 @@ registerPlatformCapabilities('github', {
   inspectChangeRequest({ client, repository, number, cwd }) {
     return inspectGitHubPullRequest((client as GitHubClient | undefined) || createGitHubClient(), repository, number, cwd);
   },
+  inspectIssueClosingChangeRequests({ client, repository, issueNumber, cwd }) {
+    return inspectGitHubIssueClosingChangeRequests(
+      (client as GitHubClient | undefined) || createGitHubClient(), repository, issueNumber, cwd
+    );
+  },
   resolveChangeRequestGitEvidence(context) {
     return resolveGitHubChangeRequestGitEvidence(context);
   }
@@ -396,6 +598,146 @@ function bindPlatformPullRequest(taskRef: string, options: BindOptions): PullReq
   });
 }
 
+function externalEvidenceNote(
+  issueNumber: number,
+  source: 'unique' | 'explicit',
+  pullRequest: PullRequestSnapshot
+): string {
+  return [
+    `authorization=${source}`,
+    externalIdentityEvidenceNote(issueNumber, pullRequest)
+  ].join('; ');
+}
+
+function externalIdentityEvidenceNote(
+  issueNumber: number,
+  pullRequest: PullRequestSnapshot
+): string {
+  return [
+    `issue=#${issueNumber}`,
+    `pr=#${pullRequest.number}`,
+    `url=${pullRequest.url}`,
+    `base=${pullRequest.base.repository}:${pullRequest.base.ref}@${pullRequest.base.sha}`,
+    `head=${pullRequest.head.repository}:${pullRequest.head.ref}@${pullRequest.head.sha}`,
+    `mergedAt=${pullRequest.mergedAt}`,
+    `mergeCommitSha=${pullRequest.mergeCommitSha}`
+  ].join('; ');
+}
+
+function resolveExternalPullRequest(taskRef: string, options: ResolveExternalOptions): ExternalPullRequestResult {
+  const base = resolvedContext(taskRef, options);
+  if (!base.ok) return externalResult(base.output);
+  const inventory = inspectCompletionArtifacts(base.resolved.taskId, { repoRoot: base.resolved.repoRoot });
+  if (inventory.status === 'failed') return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    error: { code: inventory.error?.code || 'ARTIFACT_TOPOLOGY_CONFLICT', message: inventory.error?.message || 'Completion artifact inventory failed', retryable: false }
+  }));
+  if (inventory.artifacts.length > 0) {
+    if (options.pr !== undefined) return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform,
+      capabilities: base.context.capabilities,
+      error: { code: 'EXTERNAL_DELIVERY_NOT_APPLICABLE', message: 'External PR selection is only valid when the completion inventory is empty', retryable: false }
+    }), { mode: 'normal' });
+    return externalResult(result('no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform,
+      capabilities: base.context.capabilities,
+      operations: [{ name: 'external-pr:inventory', status: 'no-op', reasonCode: 'CANONICAL_ARTIFACTS_PRESENT' }],
+      error: null
+    }), { mode: 'normal' });
+  }
+  if (!base.issueNumber) return externalResult(result('failed', base.resolved.taskId, null, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    error: { code: 'EXTERNAL_DELIVERY_ISSUE_REQUIRED', message: 'External delivery requires a valid issue_number', retryable: false }
+  }));
+  const inspected = inspectPlatformIssueClosingChangeRequests(base.context.platform.type, {
+    cwd: base.resolved.repoRoot,
+    repository: base.context.platform.repository!,
+    issueNumber: base.issueNumber,
+    client: base.client
+  });
+  if (!inspected.ok || !inspected.value) {
+    const error = inspected.error || { code: 'PR_IDENTITY_INVALID', message: 'Closing PR inspection returned no candidates', retryable: false };
+    return externalResult(result(error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform, capabilities: base.context.capabilities, error
+    }));
+  }
+  const selected = selectExternalPullRequest(
+    inspected.value,
+    base.context.platform.repository!,
+    base.prNumber,
+    options.pr ?? null
+  );
+  if (selected.status === 'normal') return externalResult(result('no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    operations: [{ name: 'external-pr:select', status: 'no-op', reasonCode: 'NO_ELIGIBLE_CANDIDATE' }],
+    error: null
+  }), { mode: 'normal', candidates: selected.candidates, eligible: selected.eligible });
+  if (selected.status === 'failed') return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    error: { code: selected.code, message: selected.message, retryable: false }
+  }), { candidates: selected.candidates, eligible: selected.eligible });
+
+  const note = externalEvidenceNote(base.issueNumber, selected.source, selected.selected);
+  const identityNote = externalIdentityEvidenceNote(base.issueNumber, selected.selected);
+  const activityEntry = `**Bind External PR** by ${options.agent} — ${note}`;
+  const auditLines = base.content.split(/\r?\n/).filter((line) => line.includes('**Bind External PR**'));
+  const alreadyAudited = auditLines.some((line) => line.endsWith(identityNote));
+  if (auditLines.length > 0 && !alreadyAudited) return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    pullRequest: selected.selected,
+    error: { code: 'PR_BIND_CONFLICT', message: 'Existing external PR audit evidence conflicts with the selected identity', retryable: false }
+  }), { candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
+  if (alreadyAudited && base.prNumber !== selected.selected.number) return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    pullRequest: selected.selected,
+    error: { code: 'PR_BIND_CONFLICT', message: 'External PR audit evidence does not match the task binding', retryable: false }
+  }), { candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
+  if (base.prNumber === selected.selected.number && alreadyAudited) {
+    return externalResult(result('no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform,
+      capabilities: base.context.capabilities,
+      resource: { kind: 'pull-request', number: selected.selected.number },
+      pullRequest: selected.selected,
+      operations: [{ name: 'task:bind-external-pr', status: 'no-op', reasonCode: 'EVIDENCE_ALREADY_RECORDED' }],
+      error: null
+    }), { mode: 'external', authorization: selected.source, candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
+  }
+  const metadata = captureTaskWriteMetadata();
+  const write = writeTask({
+    taskRef: base.resolved.taskId,
+    expectedState: 'active',
+    dryRun: options.dryRun,
+    mutations: [
+      { kind: 'frontmatter', set: { pr_number: selected.selected.number, pr_status: 'created', assigned_to: options.agent } },
+      { kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: '活动日志', body: appendActivity(
+        base.content, `- ${metadata.timestamp} — ${activityEntry}`
+      ) }
+    ]
+  }, { repoRoot: base.resolved.repoRoot, metadataProvider: () => metadata });
+  if (write.status === 'failed') return externalResult(result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    pullRequest: selected.selected,
+    error: { code: write.error.code, message: write.error.message, retryable: false }
+  }), { candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
+  const operationStatus = options.dryRun ? 'planned' : write.status === 'applied' ? 'applied' : 'no-op';
+  return externalResult(result(operationStatus, base.resolved.taskId, base.issueNumber, options.dryRun ? base.prNumber : selected.selected.number, {
+    changed: !options.dryRun && write.changed,
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    resource: { kind: 'pull-request', number: selected.selected.number },
+    pullRequest: selected.selected,
+    operations: [{ name: 'task:bind-external-pr', status: operationStatus, reasonCode: null }],
+    error: null
+  }), { mode: 'external', authorization: selected.source, candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
+}
+
 function createPlatformPullRequest(taskRef: string, options: CreateOptions): PullRequestResult {
   const base = resolvedContext(taskRef, options);
   if (!base.ok) return base.output;
@@ -524,11 +866,14 @@ export {
   bindPlatformPullRequest,
   createPlatformPullRequest,
   inspectGitHubPullRequest,
+  inspectGitHubIssueClosingChangeRequests,
   inspectPlatformPullRequest,
   inspectPlatformPullRequestByNumber,
   normalizePullRequest,
   resolveGitHubChangeRequestGitEvidence,
+  resolveExternalPullRequest,
+  selectExternalPullRequest,
   selectPullRequest,
   syncPlatformPullRequest
 };
-export type { BindOptions, CreateOptions, PullRequestResult, PullRequestSnapshot, SyncOptions };
+export type { BindOptions, CreateOptions, ExternalPullRequestResult, ExternalPullRequestSelection, PullRequestResult, PullRequestSnapshot, ResolveExternalOptions, SyncOptions };

--- a/lib/task/finalization-artifacts.ts
+++ b/lib/task/finalization-artifacts.ts
@@ -1,0 +1,58 @@
+import {
+  assertWritableInventory,
+  inspectTaskArtifacts
+} from './artifact-lifecycle.ts';
+import type {
+  ArtifactError,
+  ArtifactFamily,
+  ArtifactIdentity,
+  InspectOptions
+} from './artifact-lifecycle.ts';
+
+const COMPLETION_BACKFILL_FAMILIES = [
+  'analysis',
+  'review-analysis',
+  'plan',
+  'review-plan',
+  'code',
+  'review-code',
+  'manual-validation'
+] as const satisfies readonly ArtifactFamily[];
+
+type CompletionArtifactResult = {
+  status: 'ready' | 'failed';
+  changed: false;
+  taskId: string | null;
+  taskDir: string | null;
+  artifacts: readonly ArtifactIdentity[];
+  error: ArtifactError | null;
+};
+
+function inspectCompletionArtifacts(
+  taskRef: string,
+  options: InspectOptions = {}
+): CompletionArtifactResult {
+  const artifacts: ArtifactIdentity[] = [];
+  let taskId: string | null = null;
+  let taskDir: string | null = null;
+  for (const family of COMPLETION_BACKFILL_FAMILIES) {
+    const inventory = inspectTaskArtifacts(taskRef, family, options);
+    taskId = inventory.taskId ?? taskId;
+    taskDir = inventory.taskDir ?? taskDir;
+    if (inventory.status === 'failed') {
+      return { status: 'failed', changed: false, taskId, taskDir, artifacts: [], error: inventory.error };
+    }
+    const writableError = assertWritableInventory(inventory);
+    const brokenReference = inventory.diagnostics.find((item) => item.code === 'BROKEN_REFERENCE');
+    const error = writableError ?? (brokenReference ? {
+      code: 'ARTIFACT_REFERENCE_INVALID' as const,
+      message: brokenReference.message
+    } : null);
+    if (error) return { status: 'failed', changed: false, taskId, taskDir, artifacts: [], error };
+    artifacts.push(...inventory.artifacts);
+  }
+  return { status: 'ready', changed: false, taskId, taskDir, artifacts, error: null };
+}
+
+export { COMPLETION_BACKFILL_FAMILIES, inspectCompletionArtifacts };
+export type { CompletionArtifactResult };

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -14,6 +14,7 @@ description: >
 
 - This command updates task metadata AND physically moves the task directory
 - Do not move a task that has incomplete workflow steps unless forced
+- The entry point accepts optional `--external-pr <N>` only to select among ambiguous external-delivery candidates; it never bypasses identity or platform gates
 
 Version stamp rule: when creating or updating `task.md` frontmatter, read `.agents/rules/version-stamp.md` first and write or refresh `agent_infra_version`.
 
@@ -55,6 +56,16 @@ If not found in `active/`, check `blocked/` and `completed/`:
 Scenario A is the normal active-task path. Scenario B `finalization-retry` retries only the archived task comment and terminal gate.
 
 ### 2. Verify Completion Prerequisites (Failure Must Stop)
+
+Read `reference/external-delivery.md`, then run for the active task:
+
+```bash
+agent-infra-internal platform-pr resolve-external {task-id} --agent {standard-agent-token} [--pr {external-pr}]
+```
+
+- `mode=external`: only this invocation's typed `authorization` and `selected` fields authorize and identify external delivery; continue through every existing hard gate below.
+- `mode=normal`: use the existing local lifecycle prerequisites; historical `pr_number` / `pr_status` values do not authorize external delivery.
+- `status=failed|blocked`: stop immediately and show the stable error; `--force` cannot bypass it.
 
 **Gate read (project-level PR flow policy)**: Before running this step, read `.agents/.airc.json`'s `prFlow` field (three states: field absent = recommend PR by default, skipping allowed; `"required"` = PR mandatory; `"disabled"` = no PR flow), and `pr_status` from `task.md` frontmatter (`pending` / `created` / `skipped`).
 
@@ -127,7 +138,7 @@ Check whether task.md has a valid `issue_number`. If it does not, skip this step
 
 When an `issue_number` exists, execute in this exact order:
 
-1. In artifact-catalog order, run `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {artifact} --agent {artifact-agent} --backfill` for every local artifact.
+1. Run `agent-infra-internal platform-comment backfill {task-id} --agent {standard-agent-token}` so core publishes only the completion canonical inventory in fixed order and resolves matching historical warnings only after full success.
 2. Run `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --requirements --fields`.
 3. Write the business summary to a temporary file and run `agent-infra-internal platform-comment sync {task-id} --kind summary --body-file {path} --agent {standard-agent-token}`.
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -14,6 +14,7 @@ description: >
 
 - 本命令更新任务元数据并物理移动任务目录
 - 除非强制执行，不要转移有未完成工作流步骤的任务
+- 入口接受可选 `--external-pr <N>`；仅用于外部交付候选歧义时的显式选择，不绕过身份或平台门禁
 
 版本戳规则：创建或更新 `task.md` frontmatter 时，先读取 `.agents/rules/version-stamp.md`，并写入或刷新 `agent_infra_version`。
 
@@ -54,6 +55,16 @@ agent-infra-internal task-snapshot {task-id} --format text
 场景 A 为 active 任务的正常完成路径；场景 B `finalization-retry` 只重试归档后的 task 评论与终态门禁。
 
 ### 2. 验证完成前置条件（未满足则必须停止）
+
+先读取 `reference/external-delivery.md`，然后在 active 任务上调用：
+
+```bash
+agent-infra-internal platform-pr resolve-external {task-id} --agent {standard-agent-token} [--pr {external-pr}]
+```
+
+- `mode=external`：只以本次 typed result 的 `authorization` 和 `selected` 作为外部交付授权与绑定身份，继续本步骤的既有硬门禁。
+- `mode=normal`：走现有本地生命周期前置条件；历史 `pr_number` / `pr_status` 不构成外部授权。
+- `status=failed|blocked`：立即停止并展示稳定错误；`--force` 不得绕过。
 
 **门控读取（项目级 PR 流程策略）**：在执行本步骤前，读取 `.agents/.airc.json` 的 `prFlow` 字段（三态：字段缺省 = 默认推荐 PR、允许跳过；`"required"` = 强制 PR；`"disabled"` = 强制无 PR），以及 `task.md` frontmatter 的 `pr_status`（`pending` / `created` / `skipped`）。
 
@@ -126,7 +137,7 @@ Please complete the missing steps first, or use --force to override.
 
 如果存在有效的 `issue_number`，严格按以下顺序执行：
 
-1. 按 artifact catalog 顺序，对本地已有产物逐项调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {artifact} --agent {artifact-agent} --backfill`。
+1. 调用 `agent-infra-internal platform-comment backfill {task-id} --agent {standard-agent-token}`，由 core 仅按 completion canonical inventory 固定顺序补发产物并在全部成功后精确恢复目标历史告警。
 2. 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --requirements --fields`。
 3. 把业务摘要写入临时文件，并调用 `agent-infra-internal platform-comment sync {task-id} --kind summary --body-file {path} --agent {standard-agent-token}`。
 

--- a/templates/.agents/skills/complete-task/reference/external-delivery.en.md
+++ b/templates/.agents/skills/complete-task/reference/external-delivery.en.md
@@ -1,0 +1,17 @@
+# External PR Delivery
+
+This scenario applies only to an active task whose completion canonical inventory is empty because an already-merged external PR delivered the implementation.
+
+## Typed State Machine
+
+Run `agent-infra-internal platform-pr resolve-external {task-id} --agent {agent} [--pr {N}]`. Core checks the completion inventory first. A non-empty inventory returns `mode=normal`, and supplying `--pr` then fails. An empty inventory requires a positive `issue_number`; otherwise core returns `EXTERNAL_DELIVERY_ISSUE_REQUIRED`.
+
+The platform adapter supplies authoritative Issue closing change requests across all pages. Only candidates with a matching base repository, complete identity, and merge evidence are eligible. One candidate is selected automatically; ambiguity, conflicts, and missing evidence fail closed. `--pr` may only select an authoritative eligible closing candidate and cannot bypass repository, Issue, merge, or identity validation.
+
+## Authorization and Persistent Audit
+
+Only the current typed result's `mode=external`, `authorization`, and `selected` fields control the machine branch. `pr_status: created` is a compatibility shim for existing verifiers: it means a verifiable PR is bound, not that this task created it, and it cannot authorize lifecycle skipping by itself.
+
+A successful bind atomically writes PR fields and appends a `Bind External PR` Activity Log entry containing the authorization source, Issue, PR URL/number, base/head repository/ref/SHA, merge time, and merge commit. Replaying identical complete evidence is a no-op; an existing same-number binding without the signature adds it once; number or identity changes fail. The PR create path must never run.
+
+External mode still passes review-ledger, manual-validation, post-review-commit, platform-sync, preflight, and terminal gates. Without a canonical review-code artifact, only existing verifier N/A rules apply. `--force` does not disable any hard gate.

--- a/templates/.agents/skills/complete-task/reference/external-delivery.zh-CN.md
+++ b/templates/.agents/skills/complete-task/reference/external-delivery.zh-CN.md
@@ -1,0 +1,17 @@
+# 外部 PR 交付
+
+本场景只适用于 completion canonical inventory 为空、实现实际由已合并的外部 PR 交付的 active 任务。
+
+## Typed 状态机
+
+调用 `agent-infra-internal platform-pr resolve-external {task-id} --agent {agent} [--pr {N}]`。core 先检查 completion inventory；非空时返回 `mode=normal`，且显式 `--pr` 会失败。空 inventory 必须有正整数 `issue_number`，否则返回 `EXTERNAL_DELIVERY_ISSUE_REQUIRED`。
+
+core 通过平台 adapter 读取 Issue 的权威 closing change requests，穷尽分页后只把 base 仓库匹配任务仓库且已经合并、身份字段完整的候选视为 eligible。唯一候选自动选择；多候选、身份冲突或证据缺失均 fail closed。`--pr` 只能从权威 closing eligible 集合中显式选择，不能绕过仓库、Issue、合并或身份校验。
+
+## 授权与持久审计
+
+当次调用只以 typed result 的 `mode=external`、`authorization` 和 `selected` 为机器分支依据。`pr_status: created` 只是现有 verifier 的兼容 shim，表示任务已绑定可验证的 PR；它既不表示 PR 由本任务创建，也不能单独授权跳过 lifecycle。
+
+成功绑定会原子写入 PR 字段并追加 `Bind External PR` Activity Log，记录授权来源、Issue、PR URL/编号、base/head repository/ref/SHA、合并时间和 merge commit。相同完整证据重试为 no-op；已有同号但缺审计签名时补写一次；编号或身份变化失败。不得调用 PR create 路径。
+
+外部模式仍须通过 review ledger、manual validation、post-review commit、平台同步、preflight 与终态校验。无 canonical review-code 时仅沿用 verifier 已定义的 N/A 规则；`--force` 不解除任何硬门禁。

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -206,6 +206,21 @@ if (args[0] === "api" && args[1] && /repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(arg
 }
 
 if (args[0] === "api" && args[1] === "graphql") {
+  if (process.env.GH_FAKE_CLOSING_PRS_PATH && args.some((arg) => arg.includes("closedByPullRequestsReferences"))) {
+    const pages = readJson("GH_FAKE_CLOSING_PRS_PATH") || [];
+    const cursorArgument = args.find((arg) => arg.startsWith("cursor="));
+    const cursor = cursorArgument ? cursorArgument.slice("cursor=".length) : null;
+    const pageIndex = cursor === null
+      ? 0
+      : Math.max(0, pages.findIndex((page) => page.previousCursor === cursor));
+    const page = pages[pageIndex] || { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } };
+    process.stdout.write(JSON.stringify({
+      data: { repository: { issue: { closedByPullRequestsReferences: {
+        nodes: page.nodes || [], pageInfo: page.pageInfo || { hasNextPage: false, endCursor: null }
+      } } } }
+    }));
+    process.exit(0);
+  }
   if (process.env.GH_FAKE_ISSUE_FIELDS_FAIL) {
     console.error(process.env.GH_FAKE_ISSUE_FIELDS_FAIL);
     process.exit(1);

--- a/tests/integration/cli/complete-task-preflight.test.ts
+++ b/tests/integration/cli/complete-task-preflight.test.ts
@@ -103,6 +103,20 @@ test('platform-sync-preflight is a distinct typed verification result', () => {
   }
 });
 
+test('preflight keeps review and manual-validation checks inactive when only pr-review evidence exists', () => {
+  const f = fixture();
+  try {
+    fs.writeFileSync(path.join(f.activeDir, 'pr-review.md'), '# External PR review\n');
+    const result = run(f.root, ['task-verify', TASK_ID, 'complete-task.preflight', '--format', 'json']);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const payload = JSON.parse(result.stdout);
+    assert.match(payload.invocations[1].payload.message, /No review-code artifact/);
+    assert.equal(payload.invocations[2].status, 'pass');
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
 test('preflight success permits one archive and releases the short id', () => {
   const f = fixture();
   try {

--- a/tests/integration/cli/platform-comment.test.ts
+++ b/tests/integration/cli/platform-comment.test.ts
@@ -32,6 +32,12 @@ function fixture() {
   return { root, taskId, commentsPath, env };
 }
 
+function runComment(args: string[], f: ReturnType<typeof fixture>) {
+  return spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'platform-comment', ...args], {
+    cwd: f.root, env: f.env, encoding: 'utf8'
+  });
+}
+
 test('platform internal commands expose stable JSON and idempotent task comment sync', () => {
   const f = fixture();
   const context = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'platform-context', 'resolve'], {
@@ -58,4 +64,77 @@ test('platform internal commands reject invalid payloads with exit code 1', () =
   });
   assert.equal(result.status, 1);
   assert.equal(JSON.parse(result.stdout).error.code, 'COMMENT_PAYLOAD_INVALID');
+});
+
+test('platform-comment backfill syncs only completion artifacts and resolves only matching excluded pr-review warnings', () => {
+  const f = fixture();
+  try {
+    const taskMd = path.join(f.root, '.agents', 'workspace', 'active', f.taskId, 'task.md');
+    fs.writeFileSync(taskMd, [
+      '---', `id: ${f.taskId}`, 'type: feature', 'status: active', 'issue_number: 7', '---', '',
+      '# Task', '', '## Workflow Warnings', '',
+      '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+      '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+      "| WW-1 | 2026-08-07 09:00:00+08:00 | complete-task | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | artifact | COMMENT_PAYLOAD_INVALID: unsupported artifact 'pr-review.md' | retry |  |  |",
+      "| WW-2 | 2026-08-07 09:01:00+08:00 | issue-sync | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | artifact | unsupported artifact 'pr-review.md' | retry |  |  |",
+      '', '## Activity Log', ''
+    ].join('\n'));
+    const taskDir = path.dirname(taskMd);
+    for (const name of ['analysis.md', 'plan.md', 'code.md', 'pr-review.md']) {
+      fs.writeFileSync(path.join(taskDir, name), `# ${name}\n`);
+    }
+
+    const result = runComment(['backfill', f.taskId, '--agent', 'codex'], f);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const output = JSON.parse(result.stdout);
+    assert.deepEqual(output.artifacts.map((item: { artifact: string }) => item.artifact), ['analysis.md', 'plan.md', 'code.md']);
+    const comments = JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')) as Array<{ body: string }>;
+    assert.equal(comments.length, 3);
+    const updated = fs.readFileSync(taskMd, 'utf8');
+    assert.match(updated, /\| WW-1 \|[^\n]+\| resolved \|/);
+    assert.match(updated, /\| WW-2 \|[^\n]+\| open \|/);
+
+    const replay = runComment(['backfill', f.taskId, '--agent', 'codex'], f);
+    assert.equal(replay.status, 0, replay.stderr || replay.stdout);
+    assert.equal(JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')).length, 3);
+
+    const direct = runComment(['sync', f.taskId, '--kind', 'artifact', '--artifact', 'pr-review.md', '--agent', 'codex'], f);
+    assert.equal(direct.status, 0, direct.stderr || direct.stdout);
+    assert.equal(JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')).length, 4);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('platform-comment backfill leaves warnings open when an artifact comment fails', () => {
+  const f = fixture();
+  try {
+    const taskMd = path.join(f.root, '.agents', 'workspace', 'active', f.taskId, 'task.md');
+    fs.writeFileSync(taskMd, [
+      '---', `id: ${f.taskId}`, 'type: feature', 'status: active', 'issue_number: 7', '---', '',
+      '# Task', '', '## Workflow Warnings', '',
+      '| id | time | step | severity | code | status | target | message | action | resolved_at | resolution |',
+      '|----|------|------|----------|------|--------|--------|---------|--------|-------------|------------|',
+      "| WW-1 | 2026-08-07 09:00:00+08:00 | complete-task | ACTION_REQUIRED | COMMENT_SYNC_FAILED | open | artifact | unsupported artifact 'pr-review.md' | retry |  |  |",
+      '', '## Activity Log', ''
+    ].join('\n'));
+    const taskDir = path.dirname(taskMd);
+    fs.writeFileSync(path.join(taskDir, 'analysis.md'), '# analysis\n');
+    fs.writeFileSync(path.join(taskDir, 'pr-review.md'), '# review\n');
+    const counter = path.join(f.root, 'failure-count.txt');
+    fs.writeFileSync(counter, '3');
+    const env = {
+      ...f.env,
+      GH_FAKE_TRANSIENT_FAIL_MATCHER: '/issues/7/comments',
+      GH_FAKE_TRANSIENT_FAIL_COUNTER_FILE: counter,
+      AGENT_INFRA_PLATFORM_RETRY_DELAYS_MS: '0'
+    };
+    const failed = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'platform-comment', 'backfill', f.taskId, '--agent', 'codex'], {
+      cwd: f.root, env, encoding: 'utf8'
+    });
+    assert.equal(failed.status, 2, failed.stderr || failed.stdout);
+    assert.match(fs.readFileSync(taskMd, 'utf8'), /\| WW-1 \|[^\n]+\| open \|/);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
 });

--- a/tests/integration/cli/platform-pr.test.ts
+++ b/tests/integration/cli/platform-pr.test.ts
@@ -16,8 +16,99 @@ function run(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } 
 test('platform-pr CLI advertises all PR and summary intents', () => {
   const output = run(['--help']);
   assert.equal(output.status, 0);
-  for (const operation of ['inspect', 'create', 'bind', 'sync', 'summary-context', 'summary-sync']) {
+  for (const operation of ['inspect', 'resolve-external', 'create', 'bind', 'sync', 'summary-context', 'summary-sync']) {
     assert.match(output.stdout, new RegExp(`platform-pr ${operation}`));
+  }
+});
+
+function externalFixture(taskContent: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-pr-external-'));
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:fitlab-ai/agent-infra.git'], { cwd: root });
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), '{"platform":{"type":"github"}}');
+  fs.writeFileSync(path.join(taskDir, 'task.md'), taskContent.replaceAll('{task-id}', taskId));
+  const closing = path.join(root, 'closing.json');
+  const calls = path.join(root, 'calls.jsonl');
+  const fake = path.join(root, 'fake-gh.cjs');
+  fs.copyFileSync(filePath('tests/fixtures/validate-artifact/fake-gh.js'), fake);
+  const candidate = {
+    number: 771, id: 'PR_771', url: 'https://github.com/fitlab-ai/agent-infra/pull/771',
+    state: 'MERGED', title: 'Community fix', body: '', isDraft: false,
+    headRefName: 'community-fix', headRefOid: 'a'.repeat(40), headRepository: { nameWithOwner: 'contributor/agent-infra' },
+    baseRefName: 'main', baseRefOid: 'b'.repeat(40), baseRepository: { nameWithOwner: 'fitlab-ai/agent-infra' },
+    mergedAt: '2026-08-07T01:00:00Z', mergeCommit: { oid: 'c'.repeat(40) },
+    labels: { nodes: [] }, assignees: { nodes: [] }, milestone: null
+  };
+  fs.writeFileSync(closing, JSON.stringify([
+    { nodes: [], pageInfo: { hasNextPage: true, endCursor: 'page-2' } },
+    { previousCursor: 'page-2', nodes: [candidate], pageInfo: { hasNextPage: false, endCursor: null } }
+  ]));
+  const env = {
+    AGENT_INFRA_GH_BIN: process.execPath,
+    AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([fake]),
+    GH_FAKE_CLOSING_PRS_PATH: closing,
+    GH_FAKE_ARGS_PATH: calls
+  };
+  return { root, taskId, taskDir, calls, env };
+}
+
+test('platform-pr resolve-external preserves normal tasks and fails explicitly when an empty inventory lacks an Issue', () => {
+  const withArtifact = externalFixture('---\nid: {task-id}\nstatus: active\n---\n\n# Task\n\n## Activity Log\n');
+  try {
+    fs.writeFileSync(path.join(withArtifact.taskDir, 'analysis.md'), '# analysis\n');
+    const normal = run(['resolve-external', withArtifact.taskId, '--agent', 'codex'], { cwd: withArtifact.root, env: withArtifact.env });
+    assert.equal(normal.status, 0, normal.stderr || normal.stdout);
+    assert.equal(JSON.parse(normal.stdout).mode, 'normal');
+    const calls = fs.readFileSync(withArtifact.calls, 'utf8').trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line) as string[]);
+    assert.equal(calls.some((call) => call.some((arg) => arg.includes('closedByPullRequestsReferences'))), false);
+  } finally {
+    fs.rmSync(withArtifact.root, { recursive: true, force: true });
+  }
+
+  const withoutIssue = externalFixture('---\nid: {task-id}\nstatus: active\n---\n\n# Task\n\n## Activity Log\n');
+  try {
+    const failed = run(['resolve-external', withoutIssue.taskId, '--agent', 'codex'], { cwd: withoutIssue.root, env: withoutIssue.env });
+    assert.equal(failed.status, 1);
+    assert.equal(JSON.parse(failed.stdout).error.code, 'EXTERNAL_DELIVERY_ISSUE_REQUIRED');
+  } finally {
+    fs.rmSync(withoutIssue.root, { recursive: true, force: true });
+  }
+});
+
+test('platform-pr resolve-external paginates, binds one merged fork PR, audits evidence, and replays idempotently', () => {
+  const f = externalFixture('---\nid: {task-id}\nstatus: active\nissue_number: 767\n---\n\n# Task\n\n## Activity Log\n');
+  try {
+    const args = ['resolve-external', f.taskId, '--agent', 'codex'];
+    const first = run(args, { cwd: f.root, env: f.env });
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+    const firstResult = JSON.parse(first.stdout);
+    assert.equal(firstResult.mode, 'external');
+    assert.equal(firstResult.authorization, 'unique');
+    assert.equal(firstResult.selected.number, 771);
+    const content = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+    assert.match(content, /^pr_number: 771$/m);
+    assert.equal((content.match(/\*\*Bind External PR\*\*/g) || []).length, 1);
+
+    const replay = run(['resolve-external', f.taskId, '--agent', 'claude'], { cwd: f.root, env: f.env });
+    assert.equal(replay.status, 0, replay.stderr || replay.stdout);
+    assert.equal(JSON.parse(replay.stdout).status, 'no-op');
+    const replayContent = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+    assert.equal((replayContent.match(/\*\*Bind External PR\*\*/g) || []).length, 1);
+
+    const explicitReplay = run(['resolve-external', f.taskId, '--agent', 'codex', '--pr', '771'], { cwd: f.root, env: f.env });
+    assert.equal(explicitReplay.status, 0, explicitReplay.stderr || explicitReplay.stdout);
+    assert.equal(JSON.parse(explicitReplay.stdout).status, 'no-op');
+    const explicitReplayContent = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+    assert.equal((explicitReplayContent.match(/\*\*Bind External PR\*\*/g) || []).length, 1);
+
+    const calls = fs.readFileSync(f.calls, 'utf8').trim().split(/\r?\n/).map((line) => JSON.parse(line) as string[]);
+    assert.equal(calls.filter((call) => call.some((arg) => arg.includes('closedByPullRequestsReferences'))).length, 6);
+    assert.equal(calls.some((call) => call.includes('POST') && call.some((arg) => /\/pulls$/.test(arg))), false);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
   }
 });
 
@@ -69,6 +160,7 @@ test('platform-pr CLI rejects incomplete and conflicting payloads before I/O', (
   for (const args of [
     ['create', 'TASK-1', '--agent', 'codex'],
     ['bind', 'TASK-1', '--agent', 'codex', '--pr', 'x'],
+    ['resolve-external', 'TASK-1', '--agent', 'codex', '--pr', 'x'],
     ['sync', 'TASK-1', '--agent', 'codex'],
     ['summary-sync', 'TASK-1', '--agent', 'codex']
   ]) {

--- a/tests/unit/platform/adapters.test.ts
+++ b/tests/unit/platform/adapters.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   hasPlatformCapability,
   inspectPlatformChangeRequest,
+  inspectPlatformIssueClosingChangeRequests,
   inspectPlatformRequiredChecks,
   registerPlatformAdapter,
   resolvePlatformChangeRequestGitEvidence
@@ -40,6 +41,9 @@ test('registered platform adapters provide normalized change-request and require
         }
       };
     },
+    inspectIssueClosingChangeRequests() {
+      return { ok: true, value: [] };
+    },
     inspectRequiredChecks() {
       return {
         ok: true,
@@ -67,6 +71,7 @@ test('registered platform adapters provide normalized change-request and require
   });
 
   assert.equal(hasPlatformCapability('custom-inspection-test', 'change-request'), true);
+  assert.equal(hasPlatformCapability('custom-inspection-test', 'issue-closing-change-requests'), true);
   assert.equal(hasPlatformCapability('custom-inspection-test', 'required-checks'), true);
   assert.equal(hasPlatformCapability('custom-inspection-test', 'change-request-git-evidence'), true);
   assert.equal(inspectPlatformChangeRequest('custom-inspection-test', {
@@ -98,6 +103,9 @@ test('registered platform adapters provide normalized change-request and require
       number: 42
     }).value!
   }).value?.reviewedHeadRef, 'refs/changes/42/head');
+  assert.deepEqual(inspectPlatformIssueClosingChangeRequests('custom-inspection-test', {
+    cwd: process.cwd(), repository: 'acme/widgets', issueNumber: 7
+  }).value, []);
 });
 
 test('missing inspection capabilities return an explicit unsupported result', () => {
@@ -111,6 +119,7 @@ test('missing inspection capabilities return an explicit unsupported result', ()
   });
 
   assert.equal(hasPlatformCapability('context-only-test', 'change-request'), false);
+  assert.equal(hasPlatformCapability('context-only-test', 'issue-closing-change-requests'), false);
   assert.equal(hasPlatformCapability('context-only-test', 'required-checks'), false);
   assert.equal(hasPlatformCapability('context-only-test', 'change-request-git-evidence'), false);
   assert.equal(inspectPlatformChangeRequest('context-only-test', {
@@ -145,5 +154,8 @@ test('missing inspection capabilities return an explicit unsupported result', ()
       assignees: [],
       milestone: null
     }
+  }).error?.code, 'PLATFORM_CAPABILITY_UNSUPPORTED');
+  assert.equal(inspectPlatformIssueClosingChangeRequests('context-only-test', {
+    cwd: process.cwd(), repository: 'acme/widgets', issueNumber: 7
   }).error?.code, 'PLATFORM_CAPABILITY_UNSUPPORTED');
 });

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -7,8 +7,10 @@ import { spawnSync } from 'node:child_process';
 
 import {
   inspectPlatformPullRequestByNumber,
+  inspectGitHubIssueClosingChangeRequests,
   normalizePullRequest,
   resolveGitHubChangeRequestGitEvidence,
+  selectExternalPullRequest,
   selectPullRequest
 } from '../../../lib/platform/pull-requests.ts';
 import type { GitHubClient } from '../../../lib/platform/github-client.ts';
@@ -94,6 +96,73 @@ test('PR selection fails closed for zero or multiple exact head/base matches', (
   });
   assert.equal(selectPullRequest([], 'o/r', 'feature', 'main').status, 'missing');
   assert.equal(selectPullRequest([remote(1), remote(2)], 'o/r', 'feature', 'main').status, 'ambiguous');
+});
+
+test('external PR selection filters before uniqueness and accepts a merged fork PR', () => {
+  const merged = normalizePullRequest({
+    ...remote(7), state: 'closed', merged_at: '2026-07-25T00:00:00Z', merge_commit_sha: 'merge-7',
+    head: { ...remote(7).head, repo: { full_name: 'contributor/r' } }
+  }, 'o/r')!;
+  const unmerged = normalizePullRequest(remote(8), 'o/r')!;
+  const otherRepository = { ...merged, number: 9, nodeId: 'PR_9', base: { ...merged.base, repository: 'other/r' } };
+  const result = selectExternalPullRequest([unmerged, otherRepository, merged], 'O/R', null, null);
+  assert.equal(result.status, 'selected');
+  if (result.status !== 'selected') throw new Error('expected selected result');
+  assert.equal(result.source, 'unique');
+  assert.equal(result.selected?.number, 7);
+  assert.deepEqual(result.eligible.map((item) => item.number), [7]);
+});
+
+test('external PR selection fails closed for ambiguity, explicit mismatch, binding conflict, and identity conflict', () => {
+  const first = normalizePullRequest({
+    ...remote(7), state: 'closed', merged_at: '2026-07-25T00:00:00Z', merge_commit_sha: 'merge-7'
+  }, 'o/r')!;
+  const second = { ...first, number: 8, nodeId: 'PR_8', url: 'https://github.com/o/r/pull/8' };
+  const codes = [
+    selectExternalPullRequest([first, second], 'o/r', null, null),
+    selectExternalPullRequest([first], 'o/r', null, 8),
+    selectExternalPullRequest([first], 'o/r', 8, 7),
+    selectExternalPullRequest([first, { ...first, head: { ...first.head, sha: 'different' } }], 'o/r', null, null)
+  ].map((result) => result.status === 'failed' ? result.code : null);
+  assert.deepEqual(codes, ['PR_IDENTITY_AMBIGUOUS', 'PR_NOT_FOUND', 'PR_BIND_CONFLICT', 'PR_IDENTITY_INVALID']);
+});
+
+test('GitHub closing PR inspection exhausts cursor pagination and fails closed on incomplete identities', () => {
+  const nodes = [7, 8].map((number) => ({
+    number, id: `PR_${number}`, url: `https://github.com/o/r/pull/${number}`, state: 'MERGED',
+    title: 'Merged', body: '', isDraft: false,
+    headRefName: `feature-${number}`, headRefOid: `head-${number}`, headRepository: { nameWithOwner: 'fork/r' },
+    baseRefName: 'main', baseRefOid: `base-${number}`, baseRepository: { nameWithOwner: 'o/r' },
+    mergedAt: '2026-07-25T00:00:00Z', mergeCommit: { oid: `merge-${number}` },
+    labels: { nodes: [] }, assignees: { nodes: [] }, milestone: null
+  }));
+  let calls = 0;
+  const client = {
+    json(args: string[]) {
+      calls += 1;
+      const second = args.includes('cursor=next');
+      return { ok: true, value: { data: { repository: { issue: { closedByPullRequestsReferences: {
+        nodes: [second ? nodes[1] : nodes[0]],
+        pageInfo: second ? { hasNextPage: false, endCursor: null } : { hasNextPage: true, endCursor: 'next' }
+      } } } } } };
+    }
+  } as unknown as GitHubClient;
+  const inspected = inspectGitHubIssueClosingChangeRequests(client, 'o/r', 7, process.cwd());
+  assert.equal(inspected.ok, true);
+  assert.equal(calls, 2);
+  assert.deepEqual(inspected.ok ? inspected.value.map((item) => item.number) : [], [7, 8]);
+
+  const invalidClient = {
+    json() {
+      return { ok: true, value: { data: { repository: { issue: { closedByPullRequestsReferences: {
+        nodes: [{ ...nodes[0], headRefOid: undefined }], pageInfo: { hasNextPage: false, endCursor: null }
+      } } } } } };
+    }
+  } as unknown as GitHubClient;
+  const invalid = inspectGitHubIssueClosingChangeRequests(invalidClient, 'o/r', 7, process.cwd());
+  assert.equal(invalid.ok, false);
+  if (invalid.ok) throw new Error('expected invalid identity');
+  assert.equal(invalid.error.code, 'PR_IDENTITY_INVALID');
 });
 
 test('GitHub evidence prefers an exact upstream remote', () => {

--- a/tests/unit/task/finalization-artifacts.test.ts
+++ b/tests/unit/task/finalization-artifacts.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  COMPLETION_BACKFILL_FAMILIES,
+  inspectCompletionArtifacts
+} from '../../../lib/task/finalization-artifacts.ts';
+
+function fixture() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'finalization-artifacts-'));
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(repoRoot, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\nstatus: active\n---\n`);
+  return { repoRoot, taskId, taskDir };
+}
+
+test('completion inventory returns only canonical lifecycle artifacts in stable family and round order', () => {
+  const f = fixture();
+  try {
+    for (const name of [
+      'code.md', 'analysis-r2.md', 'plan.md', 'analysis.md',
+      'manual-validation.md', 'pr-review.md', 'pr-review-r2.md'
+    ]) fs.writeFileSync(path.join(f.taskDir, name), '# artifact\n');
+
+    const result = inspectCompletionArtifacts(f.taskId, { repoRoot: f.repoRoot });
+    assert.equal(result.status, 'ready');
+    assert.deepEqual(COMPLETION_BACKFILL_FAMILIES, [
+      'analysis', 'review-analysis', 'plan', 'review-plan',
+      'code', 'review-code', 'manual-validation'
+    ]);
+    assert.deepEqual(result.artifacts.map((artifact) => artifact.name), [
+      'analysis.md', 'analysis-r2.md', 'plan.md', 'code.md', 'manual-validation.md'
+    ]);
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('completion inventory distinguishes an empty inventory from blocking topology diagnostics', () => {
+  const f = fixture();
+  try {
+    assert.deepEqual(inspectCompletionArtifacts(f.taskId, { repoRoot: f.repoRoot }).artifacts, []);
+    fs.writeFileSync(path.join(f.taskDir, 'analysis-r2.md'), '# gap\n');
+    const result = inspectCompletionArtifacts(f.taskId, { repoRoot: f.repoRoot });
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error?.code, 'ARTIFACT_TOPOLOGY_CONFLICT');
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1426,18 +1426,28 @@ test("complete-task splits active preflight checks from completed-state checks",
 test("complete-task docs keep remote preflight before lifecycle and terminal sync after it", () => {
   skillDocPaths("complete-task").forEach((relativePath) => {
     const content = read(relativePath);
-    const artifactSync = content.indexOf("platform-comment sync {task-id} --kind artifact");
+    const externalResolve = content.indexOf("platform-pr resolve-external {task-id}");
+    const artifactSync = content.indexOf("platform-comment backfill {task-id}");
     const preflight = content.indexOf("task-verify {task-id} complete-task.preflight");
     const lifecycle = content.indexOf("task-lifecycle {task-id} complete");
     const taskSync = content.indexOf("platform-comment sync {task-id} --kind task");
     const completedGate = content.indexOf("task-verify {task-id} complete-task.completed");
 
-    assert.ok(artifactSync >= 0 && artifactSync < preflight, `${relativePath} should backfill artifacts before preflight`);
+    assert.ok(externalResolve >= 0 && externalResolve < artifactSync, `${relativePath} should resolve external delivery before platform backfill`);
+    assert.ok(artifactSync >= 0 && artifactSync < preflight, `${relativePath} should backfill completion artifacts before preflight`);
     assert.ok(preflight < lifecycle, `${relativePath} should run preflight before lifecycle completion`);
     assert.ok(lifecycle < taskSync, `${relativePath} should sync the terminal task comment after lifecycle completion`);
     assert.ok(taskSync < completedGate, `${relativePath} should run the completed gate after terminal task sync`);
     assert.ok(content.includes("finalization-retry"), `${relativePath} should define the retry branch identifier`);
   });
+});
+
+test("complete-task external delivery references are present in runtime and bilingual templates", () => {
+  for (const relativePath of [
+    ".agents/skills/complete-task/reference/external-delivery.md",
+    "templates/.agents/skills/complete-task/reference/external-delivery.zh-CN.md",
+    "templates/.agents/skills/complete-task/reference/external-delivery.en.md"
+  ]) assert.ok(read(relativePath).length > 0, `${relativePath} should exist`);
 });
 
 test("import-issue checklists include the task comment sync step", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #792

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #792

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [x] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

完善 `complete-task` 对“本地任务由外部社区 PR 完成交付”场景的支持。维护者现在可以基于 Issue 的 closing association 安全复用已合并 PR，在身份不完整、候选歧义或既有绑定冲突时稳定失败，并避免创建重复 PR。

同时把完成阶段的产物补发范围收敛到 canonical lifecycle artifacts，排除 `pr-review*.md`，并在成功重试后精确恢复历史误报告警，不放宽既有审查、人工验证、提交和平台同步门禁。

## 📋 主要变更 / Brief Changelog

- 新增 Issue closing PR 的 GraphQL 分页查询、完整身份归一、eligible 候选选择和外部绑定审计。
- 新增 completion canonical artifact inventory 与批量评论补发，严格排除 `pr-review` 产物族。
- 为 `complete-task` 接入外部交付解析、历史 warning 精确恢复和双语 reference 文档。
- 增加 typed core、CLI、模板和幂等回归测试，包括自动绑定后显式同号重放。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck` 验证 TypeScript 与 JavaScript 类型检查。
2. 运行 `npm run test:core` 验证核心单元与集成测试。
3. 运行 `npm test` 完成构建并执行完整测试套件。
4. 运行 `git diff --check origin/main...HEAD` 检查 PR 差异格式。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

最新验证：完整测试 2044 passed、0 failed、3 skipped（2047 tests）；core 1735 passed、0 failed、2 skipped（1737 tests）；类型检查、构建和差异检查均通过。

## 📸 截图 / Screenshots

不适用；本次变更涉及任务完成编排、平台身份校验和自动化测试，无可视化界面变化。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [ ] 代码检查通过 / Lint checks pass（项目当前未配置 lint；类型检查、构建和差异检查已通过）
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail（无破坏性变更）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

- 外部绑定仅接受任务仓库中、base 仓库匹配且已合并的 closing PR；零候选走普通路径，多候选和身份冲突均 fail closed。
- 审计持久格式仍记录授权来源，幂等键仅使用稳定 PR 身份，因此 `unique` 与 `explicit` 同号重放均收敛为 no-op。
- 代码审查 Round 2 已通过：0 blocker、0 major、0 minor、0 manual-validation。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 closing PR 身份完整性与分页边界、唯一/显式候选选择的 fail-closed 行为、审计重放幂等性，以及 completion inventory 对 `pr-review` 的排除和 warning 恢复条件。

Generated with AI assistance
