### PR TITLE
fix(watch-pr): 补全合并冲突检测与自愈


### DIFF
--- a/.agents/rules/pr-checks-commands.md
+++ b/.agents/rules/pr-checks-commands.md
@@ -1,6 +1,6 @@
-# PR required checks 平台意图
+# PR readiness 平台意图
 
-required checks 的筛选、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。SKILL/模型只负责失败分类、根因分析、最小修复和授权后的提交推送。
+required checks、PR mergeability、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。每次 inspect/poll 都在同一 PR head 快照上聚合，不跨 head 拼接事实。
 
 GitHub adapter 要求 `gh >= 2.16.0`。平台上下文会在任何 GitHub API、PR 或 checks 操作前检查该依赖；未选择 GitHub 平台时不探测也不依赖 `gh`。
 
@@ -13,7 +13,7 @@ agent-infra-internal platform-checks watch {task-id} \
   --interval-seconds 30 --deadline-seconds 1800
 ```
 
-结构化 `checks.state` 为 `passed|failed|pending|timed-out|cancelled|no-required`。`passed|no-required` 退出 0；确定失败/取消退出 1；pending、timeout 或网络阻塞退出 2。依赖缺失、版本过低和确定性平台错误直接返回其原始结构化错误，不执行兼容降级。
+结构化 `readiness.state` 为 `ready|conflicting|checks-failed|pending|timed-out|cancelled`，并携带 `headSha`。仅 `ready` 退出 0；`conflicting|checks-failed` 退出 1；其余或网络阻塞退出 2。`checks.state` 仍保留 check-only 诊断；依赖和确定性平台错误不降级。
 
 ## 定位失败 run/job
 

--- a/.agents/skills/watch-pr/SKILL.md
+++ b/.agents/skills/watch-pr/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: watch-pr
 description: >
-  监控 PR 的 required checks 并在失败时自愈。
-  当需要监控 PR 的 required checks 并在失败时自愈时使用。
+  监控 PR readiness，并在 required checks 失败或合并冲突时自愈。
+  当需要持续监控 PR 直到门禁通过且明确可合入时使用。
 ---
 
 # 监控 Pull Request
 
-在 `create-pr` 之后持续监控 PR 的 required CI checks：全绿则引导合入，required check 失败则自动拉日志、本地修复并推送、重新轮询；达修复上限或属非代码层/不可定位失败则停止并向用户求助。平台专属命令集中在 `.agents/rules/pr-checks-commands.md`，本技能正文保持平台无关。
+在 `create-pr` 之后持续监控同一 PR head 的 required checks 与 mergeability。只有 checks 通过且平台明确可合入才进入成功出口；check 失败走既有修复，合并冲突走受限 rebase 自愈，未知或无法安全闭环时 fail-closed。
 
 ## 行为边界 / 关键规则
 
-- 仅监控 + 自愈当前 PR 的 required checks；不做与失败 check 无关的改动。
+- 仅监控 + 自愈当前 PR 的 required checks 与文本合并冲突；不扩展到审批或其他仓库规则。
 - 自愈通过 Git workflow intent 发布修复，但**发布前必须本地跑通相关测试**；修复上限与代码层分类授权不变。
 - 求助出口是「产出后停止」语义：停止本轮、输出阻塞说明、等待用户主动触发，**不**中途提问。
 - 裸数字 / `NN` / `TASK-id` 入参一律按任务短号解析（见 `.agents/rules/task-short-id.md`）；PR 号只走 `--pr <number>` / PR URL / 省略（当前分支），不复用裸数字语法。
@@ -44,21 +44,21 @@ description: >
 - 场景 C（`--pr <number>` 或 PR URL）：直接取该 PR 号为 `{pr#}`；随后按「反查任务」确定 `{task-id}`。
 - 反查任务（场景 A / C）：通过任务上下文/任务查询取得与 `{pr#}` 唯一绑定的 active task。未命中时停止并提示先绑定 PR；typed checks intent 不建立第二套无任务状态机。
 
-### 2. 监控 required checks
+### 2. 监控 PR readiness
 
 执行此步骤前，先读取 `reference/monitor-and-heal.md` 与 `.agents/rules/pr-checks-commands.md`。
 
-进入本轮时初始化内存列表 `repairCommits=[]`。调用 `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`，按结构化 `checks.state` 分为「全绿」/「失败」/「挂起」，分别进入步骤 7、步骤 3 或步骤 4。
+进入本轮时初始化 `repairCommits=[]` 与 `rebaseAttempts=0`。调用 `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`，只按结构化 `readiness.state` 分流：`ready` 进入步骤 7，`conflicting` 或 `checks-failed` 进入步骤 3，`pending|timed-out|cancelled` 进入步骤 4。
 
-### 3. 失败自愈循环
+### 3. 自愈循环
 
 执行此步骤前，先读取 `reference/monitor-and-heal.md` 的「自愈决策树」与 `.agents/rules/pr-checks-commands.md` 的「解析失败 run id 并拉日志」。
 
-只对可定位代码层失败最小修复并测试；通过后依次调用 `git-workflow commit` 与 `git-workflow push`，仅记录远端复核成功的 SHA。达硬上限或 run 不可定位时转步骤 4。
+`checks-failed` 只对可定位代码层失败做最小修复和测试，再用既有 commit/push intent 发布。`conflicting` 严格执行 reference 的同仓库、干净工作树、head/base 身份、rebase、完整测试与 `git-workflow push-rebased` 精确 lease 流程；上限 2 次。仅记录远端复核成功的 SHA，随后重新监控新 head；任一安全检查失败转步骤 4。
 
 ### 4. 求助出口（产出后停止）
 
-当自愈达上限、失败属非代码层、run id 不可定位、或步骤 2 挂起超时时，停止本轮并向用户汇总：阻塞原因、已尝试的修复（含每次修复 commit）、相关失败 job 与 run/log 链接（报告结构见 `reference/monitor-and-heal.md` 的「求助报告模板」）。**不**渲染下一步命令，等待用户裁定。随后在任务锚定路径下执行步骤 5/6 记录本轮结果。
+当自愈达上限、失败属非代码层、run id 不可定位、readiness 未知/超时，或 rebase、测试、远端身份、精确 lease 任一无法闭环时，停止本轮并按 reference 汇总 PR head/base、冲突文件、远端事实、测试与尝试记录。**不**渲染下一步命令。随后在任务锚定路径下执行步骤 5/6。
 
 ### 5. 更新任务状态
 
@@ -77,7 +77,7 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 - **不改** `pr_status`（保持 `created`）与 `current_step`
 - **追加**到 `## 活动日志`（不要覆盖之前的记录；`{N}` = 本任务已有 Watch PR 条目数 + 1）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {全绿：all required checks green, repair commits: {k} [{sha 摘要}] / 阻塞：blocked: {简述}}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {成功：PR ready, repair commits: {k} [{sha 摘要}] / 阻塞：blocked: {简述}}
   ```
 
 ### 6. 完成校验
@@ -104,7 +104,7 @@ agent-infra-internal task-verify {task-id} watch-pr.completed --format text
 > 渲染下一步前先读取 `.agents/rules/next-step-output.md`，仅为已选场景调用统一 helper，并将 stdout 填入 `{next-step-commands}`。
 
 按场景输出：
-- 「全绿」+ 任务锚定：说明所有 required checks 已通过，并只按本轮是否产生修复 commit 渲染一个出口（`{task-ref}` 替换为短号）：
+- `ready` + 任务锚定：说明 required checks 已通过且当前 head 明确可合入，并只按本轮是否产生修复 commit 渲染一个出口（`{task-ref}` 替换为短号）：
 
   `repairCommits.length == 0`：
 
@@ -129,8 +129,8 @@ agent-infra-internal task-verify {task-id} watch-pr.completed --format text
 ## 完成检查清单
 
 - [ ] 解析出目标 PR（及可能的任务上下文）
-- [ ] 完成 required checks 监控，得到全绿 / 阻塞结论
-- [ ] 自愈仅限可定位的代码层失败，且推送前本地测试通过、未超修复上限
+- [ ] 完成 readiness 监控，只有 checks 通过且明确可合入才得到成功结论
+- [ ] check / rebase 自愈均通过本地测试和对应安全 intent，且未超修复上限
 - [ ] 任务锚定路径：更新了 task.md 并追加 Watch PR 的 Activity Log
 - [ ] 任务锚定路径：完成校验通过
 - [ ] 已通过统一 helper 渲染已选场景的下一步命令

--- a/.agents/skills/watch-pr/reference/monitor-and-heal.md
+++ b/.agents/skills/watch-pr/reference/monitor-and-heal.md
@@ -2,13 +2,14 @@
 
 `watch-pr` 步骤 2/3/4 的平台无关判定逻辑。具体平台命令（监控、解析失败 run、拉日志、读取 PR 号）见 `.agents/rules/pr-checks-commands.md`；本文件只描述与平台无关的分类与决策。
 
-## 结果分类
+## Readiness 分类
 
 按 `.agents/rules/pr-checks-commands.md` 的监控命令执行后，依其退出码归为三类：
 
-- 全部 required checks 通过 → 「全绿」（SKILL 步骤 7 全绿出口）。
-- 至少一个失败 / 出错 → 「失败」（SKILL 步骤 3 自愈）。
-- 仍有 pending 或达到总时长上限 → 「挂起」（SKILL 步骤 4 求助）。
+- `ready`：同一 head 的 required checks 通过且平台明确可合入 → SKILL 步骤 7。
+- `checks-failed`：至少一个 required check 失败或取消 → SKILL 步骤 3 的 CI 自愈。
+- `conflicting`：平台明确当前 head 与 base 冲突 → SKILL 步骤 3 的 rebase 自愈。
+- `pending|timed-out|cancelled`：mergeability/checks 未形成可靠成功事实 → SKILL 步骤 4。
 
 ## 自愈决策树
 
@@ -34,6 +35,23 @@ unknown: help
    - 将本次修复的 commit SHA 追加到当前运行的 `repairCommits`，修复计数 +1，回到 SKILL 步骤 2 重新监控；全绿时列表为空走 `complete-task`，非空走 `review-code`。
    - 绝不执行与失败无关的「顺手优化」；不放宽 / 跳过失败的断言来「修绿」。
 
+## 合并冲突自愈
+
+```text
+# conflict-heal-contract
+strategy: rebase
+remote-update: exact-lease
+unsafe: help
+```
+
+1. 仅当 PR、head 与 base repository 完全相同，当前分支等于 head ref，本地 HEAD 等于快照 head SHA，且工作树/暂存区干净时继续；否则求助。
+2. 找到与 PR repository 精确匹配的 remote，抓取 base ref，记录完整 `expectedBaseHead`，并确认远端 head 仍等于完整旧 SHA。
+3. 执行 `git rebase <expectedBaseHead>`。只处理 Git 报告的文本 unmerged paths；无法可靠解决时 `git rebase --abort`，记录冲突路径和双方 SHA 后求助。
+4. rebase 完成后运行项目 `test` skill 的完整验证。失败时不推送。
+5. 把 remote、branch、完整 `expectedOldHead`、`newHead`、baseBranch 和完整 `expectedBaseHead` 写入仓库外的临时 intent JSON，调用 `agent-infra-internal git-workflow push-rebased --input {intent.json}`。
+6. core 会复核干净状态、分支/HEAD、远端 head/base、ancestor、精确 `--force-with-lease` 与推送后远端 SHA。任一失败不得改用普通 force；重新取 PR 快照或求助。
+7. 推送成功后把新 SHA 加入 `repairCommits`，`rebaseAttempts += 1`，重新监控新 head。上限 2 次；最终 ready 且列表非空时只进入 `review-code` 出口。
+
 ## 求助报告模板
 
 进入求助出口时，向用户输出以下固定结构（不写入产物文件）：
@@ -41,7 +59,10 @@ unknown: help
 ```
 PR #{pr#} 监控阻塞，需人工介入。
 
-阻塞原因：{非代码层 / 达修复上限 / run 不可定位 / 轮询超时}
+阻塞原因：{非代码层 / 达修复上限 / run 不可定位 / readiness 未知 / rebase 或安全更新失败}
+PR head/base：{repository/ref/SHA}
+冲突与远端事实：{conflict paths / expected 与 actual head/base / rebase abort 状态}
+验证：{命令与失败摘要；未运行则说明原因}
 失败 check：{name}（workflow：{workflow}）
 失败 run / 日志：{run/job 链接}
 已尝试的修复（共 {k} 次）：

--- a/lib/git/workflow.ts
+++ b/lib/git/workflow.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 type CommandResult = { status: number | null; stdout: string; stderr: string };
 type GitRunner = (args: readonly string[], cwd: string) => CommandResult;
@@ -16,6 +18,10 @@ function run(runner: GitRunner, cwd: string, args: readonly string[]): CommandRe
 function value(runner: GitRunner, cwd: string, args: readonly string[], trim = true): string | null {
   const result = run(runner, cwd, args);
   return result.status === 0 ? (trim ? result.stdout.trim() : result.stdout.replace(/\n$/, '')) : null;
+}
+
+function cleanMessage(message: string): string {
+  return message.replace(/(https?:\/\/)[^\s/@:]+(?::[^\s/@]*)?@/gi, '$1***@').trim();
 }
 
 function inspectGitWorkflow(cwd: string, runner: GitRunner = defaultRunner, remoteInput?: { remote: string; refs: readonly string[] }) {
@@ -97,5 +103,63 @@ function pushGitRefs(input: { cwd: string; remote: string; refs: readonly string
   return { status: failures === 0 ? 'applied' as const : failures === operations.length ? 'failed' as const : 'degraded' as const, changed: failures < operations.length, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations, error: failures ? { code: 'GIT_PUSH_PARTIAL', message: `${failures} ref push operation(s) failed` } : null };
 }
 
-export { commitExplicitPaths, inspectGitWorkflow, pushGitRefs };
-export type { CommandResult, GitRunner };
+type PushRebasedInput = {
+  cwd: string;
+  remote: string;
+  branch: string;
+  expectedOldHead: string;
+  newHead: string;
+  baseBranch: string;
+  expectedBaseHead: string;
+};
+
+function pushRebasedBranch(input: PushRebasedInput, runner: GitRunner = defaultRunner) {
+  const sha = /^[0-9a-f]{40}$/i;
+  const refName = /^(?!-)(?!.*\.\.)(?!.*(?:^|\/)\.)(?!.*[~^:?*\[\\\s])(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+$/;
+  if (!input.remote || !refName.test(input.remote) || !refName.test(input.branch) || !refName.test(input.baseBranch) ||
+      !sha.test(input.expectedOldHead) || !sha.test(input.newHead) || !sha.test(input.expectedBaseHead)) {
+    return { status: 'failed' as const, changed: false, snapshot: null, operations: [], error: { code: 'GIT_REBASED_INPUT_INVALID', message: 'Remote, branches, and full 40-character SHAs are required' } };
+  }
+  const snapshot = inspectGitWorkflow(input.cwd, runner).snapshot;
+  if (!snapshot) return { status: 'failed' as const, changed: false, snapshot: null, operations: [], error: { code: 'GIT_INSPECT_FAILED', message: 'Unable to inspect Git repository' } };
+  if (snapshot.branch !== input.branch || snapshot.head !== input.newHead) {
+    return { status: 'failed' as const, changed: false, snapshot, operations: [], error: { code: 'GIT_LOCAL_IDENTITY_MISMATCH', message: 'Current branch or HEAD does not match the rebased intent' } };
+  }
+  const rebasePaths = ['rebase-merge', 'rebase-apply']
+    .map((name) => value(runner, input.cwd, ['rev-parse', '--git-path', name]))
+    .filter((candidate): candidate is string => Boolean(candidate));
+  if (snapshot.worktree.length > 0 || snapshot.staged.length > 0 ||
+      run(runner, input.cwd, ['rev-parse', '-q', '--verify', 'REBASE_HEAD']).status === 0 ||
+      rebasePaths.some((candidate) => fs.existsSync(path.isAbsolute(candidate) ? candidate : path.join(input.cwd, candidate)))) {
+    return { status: 'failed' as const, changed: false, snapshot, operations: [], error: { code: 'GIT_LOCAL_STATE_UNSAFE', message: 'Working tree must be clean with no rebase in progress' } };
+  }
+  const remoteRef = `refs/heads/${input.branch}`;
+  const baseRef = `refs/heads/${input.baseBranch}`;
+  const remoteHead = value(runner, input.cwd, ['ls-remote', '--exit-code', input.remote, remoteRef])?.split(/\s+/)[0] ?? null;
+  if (remoteHead !== input.expectedOldHead) {
+    return { status: 'failed' as const, changed: false, snapshot, operations: [], error: { code: 'GIT_REMOTE_HEAD_MISMATCH', message: `Expected remote head ${input.expectedOldHead}, received ${remoteHead ?? 'unavailable'}` } };
+  }
+  const baseHead = value(runner, input.cwd, ['ls-remote', '--exit-code', input.remote, baseRef])?.split(/\s+/)[0] ?? null;
+  if (baseHead !== input.expectedBaseHead) {
+    return { status: 'failed' as const, changed: false, snapshot, operations: [], error: { code: 'GIT_REMOTE_BASE_MISMATCH', message: `Expected base head ${input.expectedBaseHead}, received ${baseHead ?? 'unavailable'}` } };
+  }
+  if (run(runner, input.cwd, ['merge-base', '--is-ancestor', input.expectedBaseHead, input.newHead]).status !== 0) {
+    return { status: 'failed' as const, changed: false, snapshot, operations: [], error: { code: 'GIT_REBASED_ANCESTOR_MISMATCH', message: 'Rebased head does not contain the expected base head' } };
+  }
+  const pushed = run(runner, input.cwd, [
+    'push', `--force-with-lease=${remoteRef}:${input.expectedOldHead}`,
+    input.remote, `${input.newHead}:${remoteRef}`
+  ]);
+  if (pushed.status !== 0) {
+    const message = cleanMessage(pushed.stderr) || 'Rebased branch push was rejected';
+    return { status: 'failed' as const, changed: false, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'push-rebased', status: 'failed' as const, ref: input.branch, message }], error: { code: 'GIT_REBASED_PUSH_REJECTED', message } };
+  }
+  const verified = value(runner, input.cwd, ['ls-remote', '--exit-code', input.remote, remoteRef])?.split(/\s+/)[0] ?? null;
+  if (verified !== input.newHead) {
+    return { status: 'failed' as const, changed: true, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'push-rebased', status: 'failed' as const, ref: input.branch, message: 'Remote ref verification failed' }], error: { code: 'GIT_REBASED_VERIFY_FAILED', message: `Expected pushed head ${input.newHead}, received ${verified ?? 'unavailable'}` } };
+  }
+  return { status: 'applied' as const, changed: true, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'push-rebased', status: 'applied' as const, ref: input.branch }], error: null };
+}
+
+export { commitExplicitPaths, inspectGitWorkflow, pushGitRefs, pushRebasedBranch };
+export type { CommandResult, GitRunner, PushRebasedInput };

--- a/lib/internal/git-workflow.ts
+++ b/lib/internal/git-workflow.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { commitExplicitPaths, inspectGitWorkflow, pushGitRefs } from '../git/workflow.ts';
+import { commitExplicitPaths, inspectGitWorkflow, pushGitRefs, pushRebasedBranch } from '../git/workflow.ts';
 import { compareReviewTrees, snapshotReview } from '../git/review-snapshot.ts';
 import { resolvePostReviewGlobs } from '../task/review-fingerprint.ts';
 
@@ -23,6 +23,10 @@ function gitWorkflow(args: string[] = []): void {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
     result = input ? pushGitRefs({ cwd: cwd ?? process.cwd(), ...input }) : { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
+  } else if (action === 'push-rebased') {
+    const inputIndex = rest.indexOf('--input');
+    const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
+    result = input ? pushRebasedBranch({ cwd: cwd ?? process.cwd(), ...input }) : { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
   } else if (action === 'snapshot' || action === 'compare-trees') {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;

--- a/lib/internal/platform-checks.ts
+++ b/lib/internal/platform-checks.ts
@@ -2,9 +2,9 @@ import path from 'node:path';
 
 import {
   fetchPlatformCheckLogs,
-  inspectRequiredChecks,
+  inspectPullRequestReadiness,
   resolvePlatformCheckRun,
-  watchPlatformChecks
+  watchPullRequestReadiness
 } from '../platform/pr-checks.ts';
 import type { ChecksResult } from '../platform/pr-checks.ts';
 
@@ -70,7 +70,7 @@ async function platformChecks(args: string[] = []): Promise<void> {
   };
   const unexpected = Object.keys(values).find((name) => !allowed[operation]!.includes(name));
   if (unexpected) { fail(`${operation} does not accept --${unexpected}`); return; }
-  if (operation === 'inspect') { finish(inspectRequiredChecks(taskRef, { cwd })); return; }
+  if (operation === 'inspect') { finish(inspectPullRequestReadiness(taskRef, { cwd })); return; }
   if (operation === 'resolve-run') {
     if (!values.checkName) { fail('resolve-run requires --check-name'); return; }
     finish(resolvePlatformCheckRun(taskRef, { cwd, checkName: values.checkName, detailsUrl: values.detailsUrl }));
@@ -91,7 +91,7 @@ async function platformChecks(args: string[] = []): Promise<void> {
   process.once('SIGINT', abort);
   process.once('SIGTERM', abort);
   try {
-    finish(await watchPlatformChecks(taskRef, { cwd, intervalSeconds, deadlineSeconds, signal: controller.signal }));
+    finish(await watchPullRequestReadiness(taskRef, { cwd, intervalSeconds, deadlineSeconds, signal: controller.signal }));
   } finally {
     process.removeListener('SIGINT', abort);
     process.removeListener('SIGTERM', abort);

--- a/lib/platform/adapters.ts
+++ b/lib/platform/adapters.ts
@@ -6,6 +6,11 @@ type PlatformAdapterContext = {
   client?: unknown;
 };
 
+type PlatformMergeability = {
+  state: 'mergeable' | 'conflicting' | 'unknown';
+  detail: string | null;
+};
+
 type PlatformChangeRequestSnapshot = {
   repository: string;
   number: number;
@@ -22,6 +27,7 @@ type PlatformChangeRequestSnapshot = {
   labels: string[];
   assignees: string[];
   milestone: string | null;
+  mergeability?: PlatformMergeability;
 };
 
 type PlatformCheckSnapshot = {
@@ -185,5 +191,6 @@ export type {
   PlatformChangeRequestSnapshot,
   PlatformCheckSnapshot,
   PlatformInspectionResult,
+  PlatformMergeability,
   RequiredChecksInspectionContext
 };

--- a/lib/platform/pr-checks.ts
+++ b/lib/platform/pr-checks.ts
@@ -19,10 +19,13 @@ type CheckBucket = 'pass' | 'fail' | 'pending' | 'cancel';
 type CheckState = 'passed' | 'failed' | 'pending' | 'timed-out' | 'cancelled' | 'no-required';
 type CheckSnapshot = PlatformCheckSnapshot;
 type ChecksSnapshot = { state: Exclude<CheckState, 'timed-out'>; required: CheckSnapshot[] };
+type ReadinessState = 'ready' | 'conflicting' | 'checks-failed' | 'pending' | 'timed-out' | 'cancelled';
+type ReadinessSnapshot = { state: ReadinessState; headSha: string };
 type RunCandidate = { id: number; name: string; headSha: string; jobId?: number | null };
 type ChecksResult = PlatformResult & {
   pullRequest: PullRequestSnapshot | null;
   checks: { state: CheckState; required: CheckSnapshot[] };
+  readiness?: ReadinessSnapshot;
   resolution?: { status: 'resolved' | 'missing' | 'ambiguous'; runId: number | null; jobId: number | null };
   logs?: { runId: number; jobId?: number; text: string };
 };
@@ -37,25 +40,15 @@ function classifyRequiredChecks(required: CheckSnapshot[]): ChecksSnapshot {
   return { state: 'passed', required };
 }
 
-async function watchRequiredChecks(options: {
-  inspect: () => Promise<ChecksSnapshot>;
-  intervalMs: number;
-  deadlineMs: number;
-  now?: () => number;
-  sleep?: (delayMs: number) => Promise<void>;
-  signal?: AbortSignal;
-}): Promise<{ state: CheckState; required: CheckSnapshot[] }> {
-  const now = options.now || (() => performance.now());
-  const sleep = options.sleep || ((delay) => new Promise<void>((resolve) => setTimeout(resolve, delay)));
-  const started = now();
-  while (true) {
-    if (options.signal?.aborted) return { state: 'cancelled', required: [] };
-    const snapshot = await options.inspect();
-    if (snapshot.state !== 'pending') return snapshot;
-    const elapsed = now() - started;
-    if (elapsed >= options.deadlineMs) return { state: 'timed-out', required: snapshot.required };
-    await sleep(Math.min(options.intervalMs, options.deadlineMs - elapsed));
-  }
+function classifyPullRequestReadiness(input: {
+  headSha: string;
+  mergeability: 'mergeable' | 'conflicting' | 'unknown';
+  checks: ChecksSnapshot;
+}): ReadinessSnapshot {
+  if (input.mergeability === 'conflicting') return { state: 'conflicting', headSha: input.headSha };
+  if (input.checks.state === 'failed' || input.checks.state === 'cancelled') return { state: 'checks-failed', headSha: input.headSha };
+  if (input.mergeability === 'unknown' || input.checks.state === 'pending') return { state: 'pending', headSha: input.headSha };
+  return { state: 'ready', headSha: input.headSha };
 }
 
 function parseRunJobIdentity(detailsUrl: string): { runId: number; jobId: number | null } | null {
@@ -143,6 +136,13 @@ function resolvedTask(taskRef: string, options: InspectionOptions) {
 function inspectRequiredChecks(taskRef: string, options: InspectionOptions = {}): ChecksResult {
   const base = resolvedTask(taskRef, options);
   if (!base.ok) return base.output;
+  return inspectChecksForResolvedTask(base, options);
+}
+
+function inspectChecksForResolvedTask(
+  base: Extract<ReturnType<typeof resolvedTask>, { ok: true }>,
+  options: InspectionOptions
+): ChecksResult {
   const repository = base.context.platform.repository!;
   const inspected = inspectPlatformRequiredChecks(base.context.platform.type, {
     cwd: base.resolved.repoRoot,
@@ -179,36 +179,62 @@ function inspectRequiredChecks(taskRef: string, options: InspectionOptions = {})
   });
 }
 
-async function watchPlatformChecks(taskRef: string, options: InspectionOptions & {
+function inspectPullRequestReadiness(taskRef: string, options: InspectionOptions = {}): ChecksResult {
+  const base = resolvedTask(taskRef, options);
+  if (!base.ok) return base.output;
+  const checked = inspectChecksForResolvedTask(base, options);
+  const classifiedCodes = new Set(['REQUIRED_CHECKS_PENDING', 'REQUIRED_CHECKS_FAILED', 'REQUIRED_CHECKS_CANCELLED']);
+  if (checked.error && !classifiedCodes.has(checked.error.code)) return checked;
+  const readiness = classifyPullRequestReadiness({
+    headSha: base.pullRequest.head.sha,
+    mergeability: base.pullRequest.mergeability?.state ?? 'unknown',
+    checks: checked.checks as ChecksSnapshot
+  });
+  const status = readiness.state === 'ready' ? 'no-op'
+    : readiness.state === 'conflicting' || readiness.state === 'checks-failed' ? 'failed' : 'blocked';
+  return checksResult(status, {
+    ...checked,
+    status,
+    changed: false,
+    readiness,
+    error: status === 'no-op' ? null : {
+      code: readiness.state === 'conflicting' ? 'PR_MERGE_CONFLICT'
+        : readiness.state === 'checks-failed' ? 'REQUIRED_CHECKS_FAILED' : 'PR_READINESS_PENDING',
+      message: `Pull request readiness is ${readiness.state}`,
+      retryable: readiness.state === 'pending'
+    }
+  });
+}
+
+async function watchPullRequestReadiness(taskRef: string, options: InspectionOptions & {
   intervalSeconds: number;
   deadlineSeconds: number;
   signal?: AbortSignal;
   now?: () => number;
   sleep?: (delayMs: number) => Promise<void>;
 }): Promise<ChecksResult> {
+  const now = options.now || (() => performance.now());
+  const sleep = options.sleep || ((delay: number) => new Promise<void>((resolve) => setTimeout(resolve, delay)));
+  const started = now();
   let last: ChecksResult | null = null;
-  const watched = await watchRequiredChecks({
-    intervalMs: options.intervalSeconds * 1000,
-    deadlineMs: options.deadlineSeconds * 1000,
-    signal: options.signal,
-    now: options.now,
-    sleep: options.sleep,
-    inspect: async () => {
-      last = inspectRequiredChecks(taskRef, options);
-      if (last.checks.state === 'pending' && last.error?.code === 'REQUIRED_CHECKS_PENDING') return last.checks as ChecksSnapshot;
-      return last.checks as ChecksSnapshot;
-    }
-  });
-  if (!last) return checksResult('blocked', { checks: watched, error: { code: 'REQUIRED_CHECKS_UNAVAILABLE', message: 'No checks snapshot was produced', retryable: true } });
-  const snapshot = last as ChecksResult;
-  if (watched.state === 'timed-out' || watched.state === 'cancelled') return checksResult('blocked', {
-    ...snapshot,
-    status: 'blocked',
-    changed: false,
-    checks: watched,
-    error: { code: watched.state === 'timed-out' ? 'REQUIRED_CHECKS_TIMEOUT' : 'REQUIRED_CHECKS_CANCELLED', message: `Required checks ${watched.state}`, retryable: watched.state === 'timed-out' }
-  });
-  return { ...snapshot, checks: watched };
+  while (true) {
+    if (options.signal?.aborted) return checksResult('blocked', {
+      ...last,
+      status: 'blocked', changed: false,
+      readiness: { state: 'cancelled', headSha: last?.pullRequest?.head.sha ?? '' },
+      error: { code: 'PR_READINESS_CANCELLED', message: 'Pull request readiness watch was cancelled', retryable: false }
+    });
+    last = inspectPullRequestReadiness(taskRef, options);
+    if (last.readiness?.state !== 'pending' || last.error?.code !== 'PR_READINESS_PENDING') return last;
+    const elapsed = now() - started;
+    if (elapsed >= options.deadlineSeconds * 1000) return checksResult('blocked', {
+      ...last,
+      status: 'blocked', changed: false,
+      readiness: { state: 'timed-out', headSha: last.pullRequest?.head.sha ?? '' },
+      error: { code: 'PR_READINESS_TIMEOUT', message: 'Pull request readiness watch timed out', retryable: true }
+    });
+    await sleep(Math.min(options.intervalSeconds * 1000, options.deadlineSeconds * 1000 - elapsed));
+  }
 }
 
 function resolvePlatformCheckRun(taskRef: string, options: SharedOptions & { checkName: string; detailsUrl?: string }): ChecksResult {
@@ -262,14 +288,15 @@ function fetchPlatformCheckLogs(taskRef: string, options: SharedOptions & { run:
 }
 
 export {
+  classifyPullRequestReadiness,
   classifyRequiredChecks,
   fetchCheckLogText,
   fetchPlatformCheckLogs,
   inspectRequiredChecks,
+  inspectPullRequestReadiness,
   parseRunJobIdentity,
   resolvePlatformCheckRun,
   resolveRunCandidate,
-  watchPlatformChecks,
-  watchRequiredChecks
+  watchPullRequestReadiness
 };
-export type { CheckBucket, CheckSnapshot, ChecksResult, ChecksSnapshot, CheckState, RunCandidate };
+export type { CheckBucket, CheckSnapshot, ChecksResult, ChecksSnapshot, CheckState, ReadinessSnapshot, ReadinessState, RunCandidate };

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -68,6 +68,8 @@ type RemotePullRequest = {
   labels?: Array<string | { name?: string }>;
   assignees?: Array<{ login?: string }>;
   milestone?: { title?: string } | null;
+  mergeable?: boolean | null;
+  mergeable_state?: string | null;
 };
 
 type ClosingPullRequestNode = {
@@ -134,6 +136,12 @@ function normalizePullRequest(remote: RemotePullRequest, repository: string): Pu
   const baseRepository = remote.base?.repo?.full_name;
   if (!Number.isInteger(number) || number <= 0 || !remote.node_id || !remote.html_url ||
       !remote.head?.ref || !remote.head.sha || !headRepository || !remote.base?.ref || !baseRepository) return null;
+  const mergeabilityDetail = remote.mergeable_state?.trim().toLowerCase() || null;
+  const mergeability = remote.mergeable === false
+    ? { state: 'conflicting' as const, detail: mergeabilityDetail }
+    : remote.mergeable === true && mergeabilityDetail !== 'dirty'
+      ? { state: 'mergeable' as const, detail: mergeabilityDetail }
+      : { state: 'unknown' as const, detail: mergeabilityDetail };
   return {
     repository,
     number,
@@ -149,7 +157,8 @@ function normalizePullRequest(remote: RemotePullRequest, repository: string): Pu
     mergeCommitSha: remote.merge_commit_sha || null,
     labels: (remote.labels || []).map((label) => typeof label === 'string' ? label : label.name || '').filter(Boolean).sort(),
     assignees: (remote.assignees || []).map((assignee) => assignee.login || '').filter(Boolean).sort(),
-    milestone: remote.milestone?.title || null
+    milestone: remote.milestone?.title || null,
+    mergeability
   };
 }
 

--- a/templates/.agents/rules/pr-checks-commands.en.md
+++ b/templates/.agents/rules/pr-checks-commands.en.md
@@ -1,6 +1,6 @@
-# Required-checks Platform Intents
+# PR Readiness Platform Intents
 
-Typed intents own required-only selection, polling deadlines, run/job resolution, and log retrieval. The skill/model owns failure classification, root-cause analysis, minimum fixes, tests, and authorized commit/push actions.
+Typed intents own required-check selection, PR mergeability, polling deadlines, run/job resolution, and logs. Every inspect/poll aggregates facts from one PR head snapshot; facts are never mixed across heads.
 
 ```bash
 agent-infra-internal platform-checks inspect {task-id}
@@ -15,4 +15,4 @@ agent-infra-internal platform-checks logs {task-id} \
   --run {run-id} [--job {job-id}]
 ```
 
-`checks.state` is `passed|failed|pending|timed-out|cancelled|no-required`. Green/no-required exits 0; definite failure/cancellation exits 1; pending, timeout, or network blocking exits 2. Each platform adapter validates its own dependencies before operations and preserves dependency or deterministic platform errors without compatibility degradation. Run resolution prefers a validated details URL and otherwise requires one exact PR-head/check-name match. Platform intents never edit business code or push.
+`readiness.state` is `ready|conflicting|checks-failed|pending|timed-out|cancelled` and carries `headSha`. Only `ready` exits 0; conflicting/check failures exit 1; all other readiness or network blocking exits 2. `checks.state` remains available as check-only diagnostics. Adapter dependency and deterministic platform errors are preserved without degradation. Platform intents never edit business code or push.

--- a/templates/.agents/rules/pr-checks-commands.github.en.md
+++ b/templates/.agents/rules/pr-checks-commands.github.en.md
@@ -1,4 +1,4 @@
-# Required-checks Platform Intents
+# GitHub PR Readiness Intents
 
 The GitHub adapter requires `gh >= 2.16.0`. Platform context checks this dependency before any GitHub API, PR, or checks operation. Projects that do not select GitHub neither probe nor depend on `gh`.
 
@@ -15,4 +15,4 @@ agent-infra-internal platform-checks logs {task-id} \
   --run {run-id} [--job {job-id}]
 ```
 
-The core owns required-only selection, deadlines, exact run/job resolution, and faithful logs. Green/no-required exits 0; definite failure exits 1; pending, timeout, or network blocking exits 2. Missing dependencies, unsupported versions, and deterministic platform failures preserve their structured errors without compatibility degradation. The skill/model still owns diagnosis, fixes, tests, and authorized commit/push actions.
+The adapter normalizes REST `mergeable=false` to `conflicting`, null/missing to `unknown`, and true to `mergeable`; `mergeable=true` plus diagnostic `dirty` is contradictory and becomes `unknown`. Other diagnostics such as `blocked` do not override REST true. Core combines that fact with required checks for one `headSha`: only `ready` exits 0, `conflicting|checks-failed` exit 1, and pending/timeout/cancel/network blocking exit 2. Dependency and deterministic platform errors are preserved without degradation.

--- a/templates/.agents/rules/pr-checks-commands.github.zh-CN.md
+++ b/templates/.agents/rules/pr-checks-commands.github.zh-CN.md
@@ -1,4 +1,4 @@
-# PR required checks 平台意图
+# GitHub PR readiness 平台意图
 
 required checks 的筛选、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。SKILL/模型只负责失败分类、根因分析、最小修复和授权后的提交推送。
 
@@ -13,7 +13,7 @@ agent-infra-internal platform-checks watch {task-id} \
   --interval-seconds 30 --deadline-seconds 1800
 ```
 
-结构化 `checks.state` 为 `passed|failed|pending|timed-out|cancelled|no-required`。`passed|no-required` 退出 0；确定失败/取消退出 1；pending、timeout 或网络阻塞退出 2。依赖缺失、版本过低和确定性平台错误直接返回其原始结构化错误，不执行兼容降级。
+adapter 把 REST `mergeable=false` 规范化为 `conflicting`，null/缺失为 `unknown`，true 为 `mergeable`；true 与诊断 `dirty` 矛盾时降为 `unknown`。`blocked` 等其他诊断不覆盖 REST true。core 在同一 `headSha` 上与 required checks 聚合：仅 `ready` 退出 0，`conflicting|checks-failed` 退出 1，pending/timeout/cancel/网络阻塞退出 2。依赖与确定性平台错误不降级。
 
 ## 定位失败 run/job
 

--- a/templates/.agents/rules/pr-checks-commands.zh-CN.md
+++ b/templates/.agents/rules/pr-checks-commands.zh-CN.md
@@ -1,6 +1,6 @@
-# PR required checks 平台意图
+# PR readiness 平台意图
 
-required checks 的筛选、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。SKILL/模型只负责失败分类、根因分析、最小修复和授权后的提交推送。
+required checks、PR mergeability、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。每次 inspect/poll 都在同一 PR head 快照上聚合，不跨 head 拼接事实。
 
 ## 快照与监控
 
@@ -11,7 +11,7 @@ agent-infra-internal platform-checks watch {task-id} \
   --interval-seconds 30 --deadline-seconds 1800
 ```
 
-结构化 `checks.state` 为 `passed|failed|pending|timed-out|cancelled|no-required`。`passed|no-required` 退出 0；确定失败/取消退出 1；pending、timeout 或网络阻塞退出 2。平台 adapter 必须在操作前验证自身依赖；依赖或确定性平台错误直接透传，不执行兼容降级。
+结构化 `readiness.state` 为 `ready|conflicting|checks-failed|pending|timed-out|cancelled`，并携带 `headSha`。仅 `ready` 退出 0；`conflicting|checks-failed` 退出 1；其余或网络阻塞退出 2。`checks.state` 仍保留 check-only 诊断；平台 adapter 的依赖和确定性错误不降级。
 
 ## 定位失败 run/job
 

--- a/templates/.agents/skills/watch-pr/SKILL.en.md
+++ b/templates/.agents/skills/watch-pr/SKILL.en.md
@@ -1,17 +1,17 @@
 ---
 name: watch-pr
 description: >
-  Watch a PR's required checks and self-heal on failure.
-  Use when you need to monitor a PR's required checks and auto-recover on failure.
+  Watch PR readiness and self-heal required-check failures or merge conflicts.
+  Use when a PR must be monitored until checks pass and it is explicitly mergeable.
 ---
 
 # Watch Pull Request
 
-After `create-pr`, continuously watch the PR's required CI checks: when everything is green, guide toward merge; when a required check fails, pull the logs, fix and push locally, then re-poll; when the fix attempt limit is reached or the failure is non-code / unlocatable, stop and ask the user for help. Platform-specific commands live in `.agents/rules/pr-checks-commands.md`; this skill body stays platform-agnostic.
+After `create-pr`, continuously watch required checks and mergeability for the same PR head. Only passed checks plus explicit mergeability may reach success; check failures use the existing repair path, conflicts use constrained rebase healing, and unknown or unsafe states fail closed.
 
 ## Behavior Boundaries / Key Rules
 
-- Only watch + self-heal the current PR's required checks; make no changes unrelated to the failing check.
+- Only self-heal the current PR's required checks and text merge conflicts; do not add approval or repository-rule readiness dimensions.
 - Self-heal publishes through Git workflow intents, but **affected tests must pass first**; the attempt cap and code-layer authorization remain unchanged.
 - The help exit is "produce-then-stop": end this round, output the blocker explanation, and wait for the user to trigger the next step — **never** ask mid-flow.
 - Bare numbers / `NN` / `TASK-id` arguments are always resolved as task short ids (see `.agents/rules/task-short-id.md`); a PR number is passed only via `--pr <number>` / a PR URL / omission (current branch), never reusing the bare-number syntax.
@@ -44,21 +44,21 @@ Resolve the target PR number `{pr#}` and an optional `{task-id}` via these deter
 - Scenario C (`--pr <number>` or a PR URL): use that PR number directly as `{pr#}`; then determine `{task-id}` via "Reverse-lookup task".
 - Reverse-lookup task (scenarios A / C): use task context/query capabilities to find the unique active task bound to `{pr#}`. If none exists, stop and request binding first; the typed checks intent does not create a second taskless state machine.
 
-### 2. Watch Required Checks
+### 2. Watch PR Readiness
 
 Before running this step, read `reference/monitor-and-heal.md` and `.agents/rules/pr-checks-commands.md`.
 
-Initialize the in-memory list `repairCommits=[]` for this run. Run `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`, then route its structured `checks.state` to the all-green, failure, or pending path.
+Initialize `repairCommits=[]` and `rebaseAttempts=0`. Run `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`, then route only by `readiness.state`: `ready` to step 7, `conflicting|checks-failed` to step 3, and `pending|timed-out|cancelled` to step 4.
 
-### 3. Failure Self-Heal Loop
+### 3. Self-Heal Loop
 
 Before running this step, read the "Self-Heal Decision Tree" of `reference/monitor-and-heal.md` and "Resolve a Failing Run id and Pull Logs" of `.agents/rules/pr-checks-commands.md`.
 
-For a locatable code-layer failure, make the minimum fix and run relevant tests. Then call `git-workflow commit` and `git-workflow push`; append only a remotely verified SHA to `repairCommits`.
+For `checks-failed`, minimally fix a locatable code-layer failure, test, and publish through the existing commit/push intents. For `conflicting`, follow the reference's same-repository, clean-tree, head/base identity, rebase, full-test, and `git-workflow push-rebased` exact-lease flow, capped at two attempts. Append only remotely verified SHAs, then watch the new head again; any failed safety check goes to step 4.
 
 ### 4. Help Exit (Produce-Then-Stop)
 
-When self-heal hits the cap, the failure is non-code, the run id is unlocatable, or step 2 times out while pending, stop this round and summarize for the user: the blocker, the fixes attempted (including each fix commit), and the relevant failing job and run/log links (report shape in the "Help report template" of `reference/monitor-and-heal.md`). Do **not** render a next-step command; wait for the user. Then, on the task-anchored path, run steps 5/6 to record this round's outcome.
+When healing hits a cap, a check failure is non-code/unlocatable, readiness stays unknown, or rebase, tests, remote identity, or exact lease cannot close safely, stop and report the PR head/base, conflict paths, remote facts, tests, and attempts using the reference template. Do **not** render a next-step command. Then run steps 5/6 on the task-anchored path.
 
 ### 5. Update Task State
 
@@ -77,7 +77,7 @@ Update `.agents/workspace/active/{task-id}/task.md`:
 - **Do not change** `pr_status` (keep `created`) or `current_step`
 - **Append** to `## Activity Log` (do not overwrite prior entries; `{N}` = number of existing Watch PR entries for this task + 1):
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {green: all required checks green, repair commits: {k} [{SHA summary}] / blocked: blocked: {summary}}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {success: PR ready, repair commits: {k} [{SHA summary}] / blocked: blocked: {summary}}
   ```
 
 ### 6. Verification Gate
@@ -104,7 +104,7 @@ Keep the gate output in your reply as the verification evidence. Without current
 > Before rendering next steps, read `.agents/rules/next-step-output.md`, invoke the shared helper only for the selected scenario, and insert its stdout at `{next-step-commands}`.
 
 Output per scenario:
-- "All green" + task-anchored: state that all required checks passed, then render exactly one exit based on whether this run created repair commits (`{task-ref}` becomes the short id):
+- `ready` + task-anchored: state that required checks passed and the current head is explicitly mergeable, then render exactly one exit based on whether this run created repair commits (`{task-ref}` becomes the short id):
 
   `repairCommits.length == 0`:
 
@@ -129,8 +129,8 @@ Populate `{next-step-commands}` for this scenario by running `agent-infra-intern
 ## Completion Checklist
 
 - [ ] Resolved the target PR (and any task context)
-- [ ] Completed required-checks watching with an all-green / blocked conclusion
-- [ ] Self-heal limited to locatable code-layer failures, with local tests passing before push and within the fix cap
+- [ ] Completed readiness watching; success requires passed checks and explicit mergeability
+- [ ] Check/rebase healing passed local tests and its safety intent within the attempt cap
 - [ ] Task-anchored path: updated task.md and appended the Watch PR Activity Log entry
 - [ ] Task-anchored path: verification gate passed
 - [ ] Rendered the selected next-step commands through the shared helper

--- a/templates/.agents/skills/watch-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/watch-pr/SKILL.zh-CN.md
@@ -1,17 +1,17 @@
 ---
 name: watch-pr
 description: >
-  监控 PR 的 required checks 并在失败时自愈。
-  当需要监控 PR 的 required checks 并在失败时自愈时使用。
+  监控 PR readiness，并在 required checks 失败或合并冲突时自愈。
+  当需要持续监控 PR 直到门禁通过且明确可合入时使用。
 ---
 
 # 监控 Pull Request
 
-在 `create-pr` 之后持续监控 PR 的 required CI checks：全绿则引导合入，required check 失败则自动拉日志、本地修复并推送、重新轮询；达修复上限或属非代码层/不可定位失败则停止并向用户求助。平台专属命令集中在 `.agents/rules/pr-checks-commands.md`，本技能正文保持平台无关。
+在 `create-pr` 之后持续监控同一 PR head 的 required checks 与 mergeability。只有 checks 通过且平台明确可合入才进入成功出口；check 失败走既有修复，合并冲突走受限 rebase 自愈，未知或无法安全闭环时 fail-closed。
 
 ## 行为边界 / 关键规则
 
-- 仅监控 + 自愈当前 PR 的 required checks；不做与失败 check 无关的改动。
+- 仅监控 + 自愈当前 PR 的 required checks 与文本合并冲突；不扩展到审批或其他仓库规则。
 - 自愈通过 Git workflow intent 发布修复，但**发布前必须本地跑通相关测试**；修复上限与代码层分类授权不变。
 - 求助出口是「产出后停止」语义：停止本轮、输出阻塞说明、等待用户主动触发，**不**中途提问。
 - 裸数字 / `NN` / `TASK-id` 入参一律按任务短号解析（见 `.agents/rules/task-short-id.md`）；PR 号只走 `--pr <number>` / PR URL / 省略（当前分支），不复用裸数字语法。
@@ -44,21 +44,21 @@ description: >
 - 场景 C（`--pr <number>` 或 PR URL）：直接取该 PR 号为 `{pr#}`；随后按「反查任务」确定 `{task-id}`。
 - 反查任务（场景 A / C）：通过任务上下文/任务查询取得与 `{pr#}` 唯一绑定的 active task。未命中时停止并提示先绑定 PR；typed checks intent 不建立第二套无任务状态机。
 
-### 2. 监控 required checks
+### 2. 监控 PR readiness
 
 执行此步骤前，先读取 `reference/monitor-and-heal.md` 与 `.agents/rules/pr-checks-commands.md`。
 
-进入本轮时初始化内存列表 `repairCommits=[]`。调用 `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`，按结构化 `checks.state` 分为「全绿」/「失败」/「挂起」，分别进入步骤 7、步骤 3 或步骤 4。
+进入本轮时初始化 `repairCommits=[]` 与 `rebaseAttempts=0`。调用 `agent-infra-internal platform-checks watch {task-id} --interval-seconds 30 --deadline-seconds 1800`，只按结构化 `readiness.state` 分流：`ready` 进入步骤 7，`conflicting` 或 `checks-failed` 进入步骤 3，`pending|timed-out|cancelled` 进入步骤 4。
 
-### 3. 失败自愈循环
+### 3. 自愈循环
 
 执行此步骤前，先读取 `reference/monitor-and-heal.md` 的「自愈决策树」与 `.agents/rules/pr-checks-commands.md` 的「解析失败 run id 并拉日志」。
 
-只对可定位代码层失败最小修复并测试；通过后依次调用 `git-workflow commit` 与 `git-workflow push`，仅记录远端复核成功的 SHA。达硬上限或 run 不可定位时转步骤 4。
+`checks-failed` 只对可定位代码层失败做最小修复和测试，再用既有 commit/push intent 发布。`conflicting` 严格执行 reference 的同仓库、干净工作树、head/base 身份、rebase、完整测试与 `git-workflow push-rebased` 精确 lease 流程；上限 2 次。仅记录远端复核成功的 SHA，随后重新监控新 head；任一安全检查失败转步骤 4。
 
 ### 4. 求助出口（产出后停止）
 
-当自愈达上限、失败属非代码层、run id 不可定位、或步骤 2 挂起超时时，停止本轮并向用户汇总：阻塞原因、已尝试的修复（含每次修复 commit）、相关失败 job 与 run/log 链接（报告结构见 `reference/monitor-and-heal.md` 的「求助报告模板」）。**不**渲染下一步命令，等待用户裁定。随后在任务锚定路径下执行步骤 5/6 记录本轮结果。
+当自愈达上限、失败属非代码层、run id 不可定位、readiness 未知/超时，或 rebase、测试、远端身份、精确 lease 任一无法闭环时，停止本轮并按 reference 汇总 PR head/base、冲突文件、远端事实、测试与尝试记录。**不**渲染下一步命令。随后在任务锚定路径下执行步骤 5/6。
 
 ### 5. 更新任务状态
 
@@ -77,7 +77,7 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 - **不改** `pr_status`（保持 `created`）与 `current_step`
 - **追加**到 `## 活动日志`（不要覆盖之前的记录；`{N}` = 本任务已有 Watch PR 条目数 + 1）：
   ```
-  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {全绿：all required checks green, repair commits: {k} [{sha 摘要}] / 阻塞：blocked: {简述}}
+  - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Watch PR (Round {N})** by {agent} — {成功：PR ready, repair commits: {k} [{sha 摘要}] / 阻塞：blocked: {简述}}
   ```
 
 ### 6. 完成校验
@@ -104,7 +104,7 @@ agent-infra-internal task-verify {task-id} watch-pr.completed --format text
 > 渲染下一步前先读取 `.agents/rules/next-step-output.md`，仅为已选场景调用统一 helper，并将 stdout 填入 `{next-step-commands}`。
 
 按场景输出：
-- 「全绿」+ 任务锚定：说明所有 required checks 已通过，并只按本轮是否产生修复 commit 渲染一个出口（`{task-ref}` 替换为短号）：
+- `ready` + 任务锚定：说明 required checks 已通过且当前 head 明确可合入，并只按本轮是否产生修复 commit 渲染一个出口（`{task-ref}` 替换为短号）：
 
   `repairCommits.length == 0`：
 
@@ -129,8 +129,8 @@ agent-infra-internal task-verify {task-id} watch-pr.completed --format text
 ## 完成检查清单
 
 - [ ] 解析出目标 PR（及可能的任务上下文）
-- [ ] 完成 required checks 监控，得到全绿 / 阻塞结论
-- [ ] 自愈仅限可定位的代码层失败，且推送前本地测试通过、未超修复上限
+- [ ] 完成 readiness 监控，只有 checks 通过且明确可合入才得到成功结论
+- [ ] check / rebase 自愈均通过本地测试和对应安全 intent，且未超修复上限
 - [ ] 任务锚定路径：更新了 task.md 并追加 Watch PR 的 Activity Log
 - [ ] 任务锚定路径：完成校验通过
 - [ ] 已通过统一 helper 渲染已选场景的下一步命令

--- a/templates/.agents/skills/watch-pr/reference/monitor-and-heal.en.md
+++ b/templates/.agents/skills/watch-pr/reference/monitor-and-heal.en.md
@@ -2,13 +2,14 @@
 
 Platform-agnostic decision logic for `watch-pr` steps 2/3/4. The concrete platform commands (watch, resolve a failing run, pull logs, read the PR number) live in `.agents/rules/pr-checks-commands.md`; this file only describes platform-independent classification and decisions.
 
-## Outcome Classification
+## Readiness Classification
 
-After running the watch command from `.agents/rules/pr-checks-commands.md`, classify by its exit code into three buckets:
+After the watch command, route by structured `readiness.state`:
 
-- All required checks passed → "all green" (SKILL step 7 green exit).
-- At least one failed / errored → "failure" (SKILL step 3 self-heal).
-- Still pending or the overall time cap was reached → "pending" (SKILL step 4 help exit).
+- `ready`: required checks passed and the same head is explicitly mergeable → SKILL step 7.
+- `checks-failed`: a required check failed or was cancelled → CI healing in SKILL step 3.
+- `conflicting`: the platform explicitly reports a head/base conflict → rebase healing in SKILL step 3.
+- `pending|timed-out|cancelled`: no reliable success fact exists → SKILL step 4.
 
 ## Self-Heal Decision Tree
 
@@ -34,6 +35,23 @@ For each failing check, decide "self-heal" vs "ask for help" in this order:
    - Append the fix commit SHA to this run's `repairCommits`, increment the fix count, and return to SKILL step 2. When checks turn green, an empty list routes to `complete-task`; a non-empty list routes to `review-code`.
    - Never make unrelated "drive-by" optimizations; never loosen / skip the failing assertion to "make it green".
 
+## Merge-Conflict Healing
+
+```text
+# conflict-heal-contract
+strategy: rebase
+remote-update: exact-lease
+unsafe: help
+```
+
+1. Continue only when the PR, head, and base repositories match; the current branch equals the head ref; local HEAD equals the snapshot head SHA; and the worktree/index are clean.
+2. Select a remote that exactly matches the PR repository, fetch the base ref, record the full `expectedBaseHead`, and confirm the remote head still equals the full old SHA.
+3. Run `git rebase <expectedBaseHead>`. Handle only Git-reported text unmerged paths. If resolution is unsafe, run `git rebase --abort`, record paths and both SHAs, and use help.
+4. After rebase, run the project `test` skill's full validation. Never push a failing result.
+5. Write remote, branch, full `expectedOldHead`, `newHead`, baseBranch, and full `expectedBaseHead` to a temporary intent outside the repository; call `agent-infra-internal git-workflow push-rebased --input {intent.json}`.
+6. Core verifies clean state, branch/HEAD, remote head/base, ancestry, exact `--force-with-lease`, and the post-push SHA. Never fall back to generic force; refresh the PR snapshot or use help.
+7. On success, append the new SHA to `repairCommits`, increment `rebaseAttempts`, and watch the new head. Cap at two attempts; a final ready state with repairs routes only to `review-code`.
+
 ## Help Report Template
 
 When entering the help exit, output the following fixed structure to the user (not written to any artifact file):
@@ -41,7 +59,10 @@ When entering the help exit, output the following fixed structure to the user (n
 ```
 PR #{pr#} monitoring is blocked; manual intervention needed.
 
-Blocker: {non-code layer / fix cap reached / run unlocatable / poll timeout}
+Blocker: {non-code layer / cap reached / run unlocatable / readiness unknown / unsafe rebase or update}
+PR head/base: {repository/ref/SHA}
+Conflict and remote facts: {paths / expected and actual head/base / rebase abort state}
+Validation: {command and failure summary, or why it did not run}
 Failing check: {name} (workflow: {workflow})
 Failing run / logs: {run/job link}
 Fixes attempted ({k} total):

--- a/templates/.agents/skills/watch-pr/reference/monitor-and-heal.zh-CN.md
+++ b/templates/.agents/skills/watch-pr/reference/monitor-and-heal.zh-CN.md
@@ -2,13 +2,14 @@
 
 `watch-pr` 步骤 2/3/4 的平台无关判定逻辑。具体平台命令（监控、解析失败 run、拉日志、读取 PR 号）见 `.agents/rules/pr-checks-commands.md`；本文件只描述与平台无关的分类与决策。
 
-## 结果分类
+## Readiness 分类
 
 按 `.agents/rules/pr-checks-commands.md` 的监控命令执行后，依其退出码归为三类：
 
-- 全部 required checks 通过 → 「全绿」（SKILL 步骤 7 全绿出口）。
-- 至少一个失败 / 出错 → 「失败」（SKILL 步骤 3 自愈）。
-- 仍有 pending 或达到总时长上限 → 「挂起」（SKILL 步骤 4 求助）。
+- `ready`：同一 head 的 required checks 通过且平台明确可合入 → SKILL 步骤 7。
+- `checks-failed`：至少一个 required check 失败或取消 → SKILL 步骤 3 的 CI 自愈。
+- `conflicting`：平台明确当前 head 与 base 冲突 → SKILL 步骤 3 的 rebase 自愈。
+- `pending|timed-out|cancelled`：mergeability/checks 未形成可靠成功事实 → SKILL 步骤 4。
 
 ## 自愈决策树
 
@@ -34,6 +35,23 @@ unknown: help
    - 将本次修复的 commit SHA 追加到当前运行的 `repairCommits`，修复计数 +1，回到 SKILL 步骤 2 重新监控；全绿时列表为空走 `complete-task`，非空走 `review-code`。
    - 绝不执行与失败无关的「顺手优化」；不放宽 / 跳过失败的断言来「修绿」。
 
+## 合并冲突自愈
+
+```text
+# conflict-heal-contract
+strategy: rebase
+remote-update: exact-lease
+unsafe: help
+```
+
+1. 仅当 PR、head 与 base repository 完全相同，当前分支等于 head ref，本地 HEAD 等于快照 head SHA，且工作树/暂存区干净时继续；否则求助。
+2. 找到与 PR repository 精确匹配的 remote，抓取 base ref，记录完整 `expectedBaseHead`，并确认远端 head 仍等于完整旧 SHA。
+3. 执行 `git rebase <expectedBaseHead>`。只处理 Git 报告的文本 unmerged paths；无法可靠解决时 `git rebase --abort`，记录冲突路径和双方 SHA 后求助。
+4. rebase 完成后运行项目 `test` skill 的完整验证。失败时不推送。
+5. 把 remote、branch、完整 `expectedOldHead`、`newHead`、baseBranch 和完整 `expectedBaseHead` 写入仓库外的临时 intent JSON，调用 `agent-infra-internal git-workflow push-rebased --input {intent.json}`。
+6. core 会复核干净状态、分支/HEAD、远端 head/base、ancestor、精确 `--force-with-lease` 与推送后远端 SHA。任一失败不得改用普通 force；重新取 PR 快照或求助。
+7. 推送成功后把新 SHA 加入 `repairCommits`，`rebaseAttempts += 1`，重新监控新 head。上限 2 次；最终 ready 且列表非空时只进入 `review-code` 出口。
+
 ## 求助报告模板
 
 进入求助出口时，向用户输出以下固定结构（不写入产物文件）：
@@ -41,7 +59,10 @@ unknown: help
 ```
 PR #{pr#} 监控阻塞，需人工介入。
 
-阻塞原因：{非代码层 / 达修复上限 / run 不可定位 / 轮询超时}
+阻塞原因：{非代码层 / 达修复上限 / run 不可定位 / readiness 未知 / rebase 或安全更新失败}
+PR head/base：{repository/ref/SHA}
+冲突与远端事实：{conflict paths / expected 与 actual head/base / rebase abort 状态}
+验证：{命令与失败摘要；未运行则说明原因}
 失败 check：{name}（workflow：{workflow}）
 失败 run / 日志：{run/job 链接}
 已尝试的修复（共 {k} 次）：

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -105,6 +105,8 @@ if (args[0] === "api" && args[1] && /repos\/[^/]+\/[^/]+\/pulls\/\d+$/.test(args
     title: "Fixture PR",
     body: "Fixture body",
     draft: false,
+    mergeable: true,
+    mergeable_state: "clean",
     head: { ref: "fixture-head", sha, repo: { full_name: repository } },
     base: { ref: "main", repo: { full_name: repository } },
     ...stored

--- a/tests/integration/cli/git-workflow.test.ts
+++ b/tests/integration/cli/git-workflow.test.ts
@@ -44,3 +44,37 @@ test('git-workflow CLI commits explicit paths and verifies remote refs', () => {
     fs.rmSync(remote, { recursive: true, force: true });
   }
 });
+
+test('git-workflow push-rebased updates a rewritten branch with an exact old-head lease', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'git-workflow-rebase-cli-'));
+  const remote = fs.mkdtempSync(path.join(os.tmpdir(), 'git-workflow-rebase-remote-'));
+  try {
+    execFileSync('git', ['init', '-q', '--bare'], { cwd: remote });
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: root });
+    execFileSync('git', ['remote', 'add', 'origin', remote], { cwd: root });
+    fs.writeFileSync(path.join(root, 'base.txt'), 'base\n');
+    execFileSync('git', ['add', 'base.txt'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+    execFileSync('git', ['push', '-q', 'origin', 'main'], { cwd: root });
+    const baseHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    execFileSync('git', ['switch', '-qc', 'feature'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'feature.txt'), 'one\n');
+    execFileSync('git', ['add', 'feature.txt'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'feature one'], { cwd: root });
+    execFileSync('git', ['push', '-q', 'origin', 'feature'], { cwd: root });
+    const oldHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    execFileSync('git', ['commit', '--amend', '-qm', 'feature rewritten'], { cwd: root });
+    const newHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    const input = path.join(remote, 'push-rebased.json');
+    fs.writeFileSync(input, JSON.stringify({ remote: 'origin', branch: 'feature', expectedOldHead: oldHead, newHead, baseBranch: 'main', expectedBaseHead: baseHead }));
+    const pushed = run(root, ['push-rebased', '--input', input]);
+    assert.equal(pushed.status, 0, `${pushed.stderr}\n${pushed.stdout}`);
+    assert.equal(JSON.parse(pushed.stdout).status, 'applied');
+    assert.equal(execFileSync('git', ['ls-remote', 'origin', 'refs/heads/feature'], { cwd: root, encoding: 'utf8' }).split(/\s/)[0], newHead);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(remote, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/cli/platform-checks.test.ts
+++ b/tests/integration/cli/platform-checks.test.ts
@@ -21,7 +21,7 @@ test('platform-checks CLI advertises inspect, watch, run resolution and logs', (
   }
 });
 
-test('platform-checks inspect returns only the structured required-check terminal state', () => {
+test('platform-checks inspect returns ready only when checks pass and the PR is mergeable', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-checks-cli-'));
   try {
     execFileSync('git', ['init', '-q'], { cwd: root });
@@ -43,7 +43,54 @@ test('platform-checks inspect returns only the structured required-check termina
     assert.equal(output.status, 0, `${output.stderr}\n${output.stdout}`);
     const parsed = JSON.parse(output.stdout);
     assert.equal(parsed.checks.state, 'passed');
+    assert.equal(parsed.readiness.state, 'ready');
     assert.deepEqual(parsed.checks.required.map((check: { name: string }) => check.name), ['build']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('platform-checks inspect fails closed for conflicting, unknown, and contradictory mergeability', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-readiness-cli-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:fitlab-ai/agent-infra.git'], { cwd: root });
+    const taskId = 'TASK-20260101-000001';
+    const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+    fs.mkdirSync(taskDir, { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), '{"platform":{"type":"github"}}');
+    fs.writeFileSync(path.join(taskDir, 'task.md'), ['---', `id: ${taskId}`, 'status: active', 'pr_number: 5', '---', ''].join('\n'));
+    const fake = path.join(root, 'fake-gh.cjs');
+    const checks = path.join(root, 'checks.json');
+    const pr = path.join(root, 'pr.json');
+    fs.copyFileSync(filePath('tests/fixtures/validate-artifact/fake-gh.js'), fake);
+    fs.writeFileSync(checks, JSON.stringify([{ name: 'build', bucket: 'pass' }]));
+    const cases = [
+      { value: { mergeable: false, mergeable_state: 'dirty' }, exit: 1, state: 'conflicting' },
+      { value: { mergeable: null, mergeable_state: 'unknown' }, exit: 2, state: 'pending' },
+      { value: { mergeable: true, mergeable_state: 'dirty' }, exit: 2, state: 'pending' }
+    ];
+    for (const scenario of cases) {
+      fs.writeFileSync(pr, JSON.stringify(scenario.value));
+      const output = run(['inspect', taskId], { cwd: root, env: {
+        AGENT_INFRA_GH_BIN: process.execPath,
+        AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([fake]),
+        GH_FAKE_CHECKS_PATH: checks,
+        GH_FAKE_PR_PATH: pr
+      } });
+      assert.equal(output.status, scenario.exit, `${output.stderr}\n${output.stdout}`);
+      assert.equal(JSON.parse(output.stdout).readiness.state, scenario.state);
+    }
+    fs.writeFileSync(pr, JSON.stringify({ mergeable: true, mergeable_state: 'clean' }));
+    fs.writeFileSync(checks, JSON.stringify([{ name: 'build', bucket: 'fail' }]));
+    const failed = run(['inspect', taskId], { cwd: root, env: {
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([fake]),
+      GH_FAKE_CHECKS_PATH: checks,
+      GH_FAKE_PR_PATH: pr
+    } });
+    assert.equal(failed.status, 1, `${failed.stderr}\n${failed.stdout}`);
+    assert.equal(JSON.parse(failed.stdout).readiness.state, 'checks-failed');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/git/workflow.test.ts
+++ b/tests/unit/git/workflow.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { commitExplicitPaths, inspectGitWorkflow, pushGitRefs } from '../../../lib/git/workflow.ts';
+import { commitExplicitPaths, inspectGitWorkflow, pushGitRefs, pushRebasedBranch } from '../../../lib/git/workflow.ts';
 
 function fixture(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'git-workflow-'));
@@ -62,4 +62,87 @@ test('inspect and push expose recoverable per-ref outcomes', () => {
   assert.equal(result.operations.length, 2);
   assert.deepEqual(calls.filter((call) => call[0] === 'push'), [['push', 'origin', 'main']]);
   assert.deepEqual(calls.filter((call) => call[0] === 'ls-remote'), [['ls-remote', '--exit-code', 'origin', 'refs/heads/main']]);
+});
+
+test('pushRebasedBranch uses an exact lease after validating local and remote identities', () => {
+  const oldHead = 'a'.repeat(40);
+  const newHead = 'b'.repeat(40);
+  const baseHead = 'c'.repeat(40);
+  const calls: string[][] = [];
+  let remoteHead = oldHead;
+  const result = pushRebasedBranch({
+    cwd: '/repo', remote: 'origin', branch: 'feature', expectedOldHead: oldHead,
+    newHead, baseBranch: 'main', expectedBaseHead: baseHead
+  }, (args: readonly string[]) => {
+    calls.push([...args]);
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return { status: 0, stdout: `${newHead}\n`, stderr: '' };
+    if (args[0] === 'branch') return { status: 0, stdout: 'feature\n', stderr: '' };
+    if (args[0] === 'status') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'rev-parse' && args[1] === '--git-path') return { status: 0, stdout: '/repo/.git/rebase-merge\n', stderr: '' };
+    if (args[0] === 'ls-remote') {
+      const sha = args.at(-1) === 'refs/heads/main' ? baseHead : remoteHead;
+      return { status: 0, stdout: `${sha}\t${args.at(-1)}\n`, stderr: '' };
+    }
+    if (args[0] === 'merge-base') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'push') { remoteHead = newHead; return { status: 0, stdout: '', stderr: '' }; }
+    return { status: 1, stdout: '', stderr: 'unexpected' };
+  });
+  assert.equal(result.status, 'applied');
+  assert.deepEqual(calls.find((call) => call[0] === 'push'), [
+    'push', `--force-with-lease=refs/heads/feature:${oldHead}`, 'origin', `${newHead}:refs/heads/feature`
+  ]);
+});
+
+test('pushRebasedBranch rejects stale remote facts without pushing', () => {
+  const oldHead = 'a'.repeat(40);
+  const newHead = 'b'.repeat(40);
+  const baseHead = 'c'.repeat(40);
+  const calls: string[][] = [];
+  const result = pushRebasedBranch({
+    cwd: '/repo', remote: 'origin', branch: 'feature', expectedOldHead: oldHead,
+    newHead, baseBranch: 'main', expectedBaseHead: baseHead
+  }, (args: readonly string[]) => {
+    calls.push([...args]);
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return { status: 0, stdout: `${newHead}\n`, stderr: '' };
+    if (args[0] === 'branch') return { status: 0, stdout: 'feature\n', stderr: '' };
+    if (args[0] === 'status') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'rev-parse' && args[1] === '--git-path') return { status: 0, stdout: '/repo/.git/rebase-merge\n', stderr: '' };
+    if (args[0] === 'ls-remote') return { status: 0, stdout: `${'d'.repeat(40)}\t${args.at(-1)}\n`, stderr: '' };
+    return { status: 1, stdout: '', stderr: '' };
+  });
+  assert.equal(result.error?.code, 'GIT_REMOTE_HEAD_MISMATCH');
+  assert.equal(calls.some((call) => call[0] === 'push'), false);
+});
+
+test('pushRebasedBranch fails closed at every local, base, ancestry, push, and verification boundary', () => {
+  const oldHead = 'a'.repeat(40);
+  const newHead = 'b'.repeat(40);
+  const baseHead = 'c'.repeat(40);
+  const input = { cwd: '/repo', remote: 'origin', branch: 'feature', expectedOldHead: oldHead, newHead, baseBranch: 'main', expectedBaseHead: baseHead };
+  assert.equal(pushRebasedBranch({ ...input, newHead: 'short' }).error?.code, 'GIT_REBASED_INPUT_INVALID');
+
+  const runCase = (stage: 'dirty' | 'identity' | 'base' | 'ancestor' | 'push' | 'verify') => {
+    return pushRebasedBranch(input, (args: readonly string[]) => {
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return { status: 0, stdout: `${stage === 'identity' ? oldHead : newHead}\n`, stderr: '' };
+    if (args[0] === 'branch') return { status: 0, stdout: 'feature\n', stderr: '' };
+    if (args[0] === 'status') return { status: 0, stdout: stage === 'dirty' ? '?? local.txt\n' : '', stderr: '' };
+    if (args[0] === 'rev-parse') return { status: 1, stdout: '', stderr: '' };
+    if (args[0] === 'ls-remote') {
+      const isBase = args.at(-1) === 'refs/heads/main';
+      const value = isBase ? stage === 'base' ? 'd'.repeat(40) : baseHead
+        : oldHead;
+      return { status: 0, stdout: `${value}\t${args.at(-1)}\n`, stderr: '' };
+    }
+    if (args[0] === 'merge-base') return { status: stage === 'ancestor' ? 1 : 0, stdout: '', stderr: '' };
+    if (args[0] === 'push') return { status: stage === 'push' ? 1 : 0, stdout: '', stderr: stage === 'push' ? 'rejected' : '' };
+    return { status: 1, stdout: '', stderr: '' };
+    });
+  };
+
+  assert.equal(runCase('dirty').error?.code, 'GIT_LOCAL_STATE_UNSAFE');
+  assert.equal(runCase('identity').error?.code, 'GIT_LOCAL_IDENTITY_MISMATCH');
+  assert.equal(runCase('base').error?.code, 'GIT_REMOTE_BASE_MISMATCH');
+  assert.equal(runCase('ancestor').error?.code, 'GIT_REBASED_ANCESTOR_MISMATCH');
+  assert.equal(runCase('push').error?.code, 'GIT_REBASED_PUSH_REJECTED');
+  assert.equal(runCase('verify').error?.code, 'GIT_REBASED_VERIFY_FAILED');
 });

--- a/tests/unit/platform/pr-checks.test.ts
+++ b/tests/unit/platform/pr-checks.test.ts
@@ -1,12 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import {
+  classifyPullRequestReadiness,
   classifyRequiredChecks,
   fetchCheckLogText,
   parseRunJobIdentity,
   resolveRunCandidate,
-  watchRequiredChecks
+  watchPullRequestReadiness
 } from '../../../lib/platform/pr-checks.ts';
 import type { GitHubClient } from '../../../lib/platform/github-client.ts';
 
@@ -18,17 +23,74 @@ test('required checks classify terminal and non-terminal states', () => {
   assert.equal(classifyRequiredChecks([{ name: 'build', bucket: 'cancel' }]).state, 'cancelled');
 });
 
-test('required checks watcher uses an injected monotonic deadline', async () => {
-  let now = 0;
-  const output = await watchRequiredChecks({
-    inspect: async () => ({ state: 'pending', required: [{ name: 'build', bucket: 'pending' }] }),
-    intervalMs: 10,
-    deadlineMs: 20,
-    now: () => now,
-    sleep: async (delay) => { now += delay; }
+test('PR readiness watcher reaches injected deadline and preserves the observed head', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-readiness-watch-'));
+  const taskId = 'TASK-20260101-000001';
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:o/r.git'], { cwd: root });
+    const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+    fs.mkdirSync(taskDir, { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), '{"platform":{"type":"github"}}');
+    fs.writeFileSync(path.join(taskDir, 'task.md'), ['---', `id: ${taskId}`, 'status: active', 'pr_number: 5', '---', ''].join('\n'));
+    const client = {
+      version() { return { ok: true as const, value: '2.16.0' }; },
+      json(args: string[]) {
+        const joined = args.join(' ');
+        if (args[1] === 'user') return { ok: true as const, value: { login: 'codex' } };
+        if (args[0] === 'api' && args[1] === 'repos/o/r') return { ok: true as const, value: { full_name: 'o/r', fork: false, permissions: { push: true } } };
+        if (args[0] === 'api' && args[1] === 'repos/o/r/pulls/5') return { ok: true as const, value: {
+          number: 5, node_id: 'PR_5', html_url: 'https://github.com/o/r/pull/5', state: 'open',
+          head: { ref: 'feature', sha: 'a'.repeat(40), repo: { full_name: 'o/r' } },
+          base: { ref: 'main', sha: 'b'.repeat(40), repo: { full_name: 'o/r' } },
+          mergeable: null
+        } };
+        if (args[0] === 'pr' && args[1] === 'checks') return { ok: true as const, value: [{ name: 'build', bucket: 'pass' }] };
+        return { ok: false as const, error: { code: 'PLATFORM_REQUEST_FAILED', message: joined, retryable: false } };
+      },
+      text() { return { ok: true as const, value: '' }; }
+    } as unknown as GitHubClient;
+    let now = 0;
+    const output = await watchPullRequestReadiness(taskId, {
+      cwd: root, client, intervalSeconds: 0.01, deadlineSeconds: 0.02,
+      now: () => now,
+      sleep: async (delay) => { now += delay; }
+    });
+    assert.equal(output.status, 'blocked');
+    assert.deepEqual(output.readiness, { state: 'timed-out', headSha: 'a'.repeat(40) });
+    assert.equal(output.error?.code, 'PR_READINESS_TIMEOUT');
+    assert.equal(now, 20);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('PR readiness watcher returns a cancelled terminal state for an aborted signal', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const output = await watchPullRequestReadiness('TASK-20260101-000001', {
+    intervalSeconds: 1, deadlineSeconds: 1, signal: controller.signal
   });
-  assert.equal(output.state, 'timed-out');
-  assert.equal(now, 20);
+  assert.equal(output.status, 'blocked');
+  assert.deepEqual(output.readiness, { state: 'cancelled', headSha: '' });
+  assert.equal(output.error?.code, 'PR_READINESS_CANCELLED');
+});
+
+test('PR readiness requires both terminal checks and explicit mergeability for one head', () => {
+  const checks = { state: 'passed' as const, required: [{ name: 'build', bucket: 'pass' as const }] };
+  assert.deepEqual(classifyPullRequestReadiness({ headSha: 'a'.repeat(40), mergeability: 'conflicting', checks }), {
+    state: 'conflicting', headSha: 'a'.repeat(40)
+  });
+  assert.deepEqual(classifyPullRequestReadiness({ headSha: 'b'.repeat(40), mergeability: 'unknown', checks }), {
+    state: 'pending', headSha: 'b'.repeat(40)
+  });
+  assert.deepEqual(classifyPullRequestReadiness({ headSha: 'c'.repeat(40), mergeability: 'mergeable', checks }), {
+    state: 'ready', headSha: 'c'.repeat(40)
+  });
+  assert.equal(classifyPullRequestReadiness({
+    headSha: 'd'.repeat(40), mergeability: 'mergeable',
+    checks: { state: 'failed', required: [{ name: 'build', bucket: 'fail' }] }
+  }).state, 'checks-failed');
 });
 
 test('run identity prefers validated details URLs and exact unique fallback', () => {

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -37,7 +37,8 @@ test('PR identity normalization retains canonical remote facts', () => {
     head: { repository: 'o/r', ref: 'feature', sha: 'sha-7' },
     base: { repository: 'o/r', ref: 'main', sha: 'base-7' },
     mergedAt: null, mergeCommitSha: null,
-    labels: ['type: feature'], assignees: ['codex'], milestone: '1.0.0'
+    labels: ['type: feature'], assignees: ['codex'], milestone: '1.0.0',
+    mergeability: { state: 'unknown', detail: null }
   });
 });
 
@@ -48,6 +49,24 @@ test('PR identity normalization retains authoritative merge facts', () => {
   assert.equal(normalized?.base.sha, 'base-8');
   assert.equal(normalized?.mergedAt, '2026-07-25T00:00:00Z');
   assert.equal(normalized?.mergeCommitSha, 'merge-8');
+});
+
+test('PR mergeability normalization fails closed on missing and contradictory facts', () => {
+  assert.deepEqual(normalizePullRequest({ ...remote(9), mergeable: false, mergeable_state: ' DIRTY ' }, 'o/r')?.mergeability, {
+    state: 'conflicting', detail: 'dirty'
+  });
+  assert.deepEqual(normalizePullRequest({ ...remote(9), mergeable: true, mergeable_state: 'dirty' }, 'o/r')?.mergeability, {
+    state: 'unknown', detail: 'dirty'
+  });
+  assert.deepEqual(normalizePullRequest({ ...remote(9), mergeable: true, mergeable_state: 'BLOCKED' }, 'o/r')?.mergeability, {
+    state: 'mergeable', detail: 'blocked'
+  });
+  assert.deepEqual(normalizePullRequest({ ...remote(9), mergeable: null }, 'o/r')?.mergeability, {
+    state: 'unknown', detail: null
+  });
+  assert.deepEqual(normalizePullRequest(remote(9), 'o/r')?.mergeability, {
+    state: 'unknown', detail: null
+  });
 });
 
 function prByNumberFixture() {

--- a/tests/unit/templates/generic-template-contracts.test.ts
+++ b/tests/unit/templates/generic-template-contracts.test.ts
@@ -186,6 +186,20 @@ test("watch-pr templates declare a language-neutral self-heal test command contr
   assert.deepEqual(contracts, [expected, expected]);
 });
 
+test("watch-pr templates declare a language-neutral conflict-heal contract", () => {
+  const contracts = ["en", "zh-CN"].map((language) => contractEntries(
+    read(`templates/.agents/skills/watch-pr/reference/monitor-and-heal.${language}.md`),
+    "conflict-heal-contract"
+  ));
+
+  const expected = {
+    strategy: "rebase",
+    "remote-update": "exact-lease",
+    unsafe: "help"
+  };
+  assert.deepEqual(contracts, [expected, expected]);
+});
+
 test("milestone initialization follows SemVer precedence and preserves wide numeric fields", onPlatforms("linux", "darwin"), () => {
   const cases = [
     {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #787

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that doesn't need an issue

Closes #787

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

收紧 `watch-pr` 的成功条件：只有同一 PR head 的 required checks 通过且平台明确判定可合入时才返回 ready。存在合并冲突时进入受限 rebase 自愈；无法安全闭环时 fail-closed。

Tighten `watch-pr` readiness so success requires both passing required checks and explicit mergeability for the same PR head. Conflicts enter a guarded rebase flow, while uncertain or unsafe states fail closed.

## 📋 主要变更 / Brief Changelog

- 聚合 required checks 与 mergeability，输出绑定 head SHA 的结构化 readiness 状态。
- 新增受同仓库、分支身份、干净工作区、base/head SHA 与精确 lease 保护的 rebase push intent。
- 更新 `watch-pr` 双语技能与平台规则，并补充 deadline、取消、冲突及远端竞态测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run test:smoke` 与 `npm run test:core`。
3. 运行 `npm test`，确认完整构建与测试通过。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

结果：2082 tests，2079 passed，3 skipped，0 failed。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 仅解决 Issue #787，不包含无关变更。
- [x] Commit 具备有意义的 Conventional Commit 主题与正文。
- [x] 已完成自我审查与独立代码审查。
- [x] 已编写必要的单元和集成测试。
- [x] 类型检查、构建与完整测试通过。
- [x] 已同步更新运行时与双语模板文档。
- [x] 已考虑兼容性：保留 check-only inspect helper，删除无调用方的旧 watcher。

## 📋 附加信息 / Additional Notes

- 合并冲突修复只允许同仓库文本冲突，并使用 `--force-with-lease` 的精确旧 SHA 保护远端更新。
- 任一本地身份、远端 head/base、祖先关系、测试或推送后复核不一致都会停止自动修复。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 readiness 的同 head 聚合语义，以及 `push-rebased` 在远端竞态下是否始终 fail-closed。

Generated with AI assistance
