### PR TITLE
refactor(opencode): 迁移 OpenCode Agent Client Adapter


### DIFF
--- a/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -165,7 +165,15 @@ const AGENT_CLIENT_MANIFEST = [
       ".opencode/commands/"
     ],
     "merged": [],
-    "ejected": []
+    "ejected": [],
+    "customCommand": {
+      "target": ".opencode/commands/${skillName}.md",
+      "frontmatter": {
+        "agent": "general",
+        "subtask": false
+      },
+      "argumentsToken": "$ARGUMENTS"
+    }
   }
 ];
 const CUSTOM_TUI_CONTRACT = {
@@ -804,19 +812,30 @@ function generateClaudeCommand(skill, lang) {
   return `${lines.join('\n')}\n`;
 }
 
-function generateOpenCodeCommand(skill, lang) {
+function formatYamlScalarMetadata(key, value) {
+  if (typeof value === 'boolean') return [`${key}: ${String(value)}`];
+  if (/^[A-Za-z0-9_-]+$/.test(value)) return [`${key}: ${value}`];
+  return formatYamlMetadata(key, value);
+}
+
+function generateAgentClientCommand(skill, lang, descriptor) {
   const isZhCN = lang === 'zh-CN';
   const lines = [
     '---',
     ...formatYamlMetadata('description', skill.description),
-    'agent: general',
-    'subtask: false',
+    ...Object.entries(descriptor.frontmatter).flatMap(([key, value]) =>
+      formatYamlScalarMetadata(key, value)
+    ),
     '---',
     ''
   ];
 
-  if (skill.args) {
-    lines.push(isZhCN ? '参数：$ARGUMENTS' : 'Arguments: $ARGUMENTS');
+  if (skill.args && descriptor.argumentsToken) {
+    lines.push(
+      isZhCN
+        ? `参数：${descriptor.argumentsToken}`
+        : `Arguments: ${descriptor.argumentsToken}`
+    );
     lines.push('');
   }
 
@@ -1067,10 +1086,11 @@ function generateCustomCommands(
         report.custom.commands
       );
     }
-    if (enabledTUIs.has('opencode')) {
+    for (const adapter of AGENT_CLIENT_MANIFEST) {
+      if (!enabledTUIs.has(adapter.id) || !adapter.customCommand) continue;
       managedWriter(
-        `.opencode/commands/${skill.dirName}.md`,
-        generateOpenCodeCommand(skill, lang),
+        adapter.customCommand.target.replaceAll('${skillName}', skill.dirName),
+        generateAgentClientCommand(skill, lang, adapter.customCommand),
         report.custom.commands
       );
     }

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -55,6 +55,22 @@ runs the `agy` binary, and pre-seeds its settings, keybindings, and MCP configur
 under the [official configuration directory](https://antigravity.google/docs/cli/settings).
 Run `agy` inside a newly created container once to complete authentication.
 
+The OpenCode adapter installs `opencode-ai` through the shared Node/npm image
+layer and keeps each branch in one persistent volume at
+`/home/devuser/.local/share/opencode`. Inside that volume, OpenCode uses
+`XDG_CONFIG_HOME=.local/share/opencode/.xdg/config` and
+`XDG_STATE_HOME=.local/share/opencode/.xdg/state`; its normal data root remains
+`/home/devuser/.local/share`. On first creation, a legacy branch-local
+`opencode.json` is copied into the canonical XDG config only when that target
+does not exist. The host config contributes only missing string `model` and
+`small_model` values. The host `XDG_DATA_HOME/opencode/auth.json` file is the
+only live credential mount, and it is optional for version/help smoke checks.
+
+Disabling or uninstalling OpenCode removes only adapter-managed project assets
+and selection state. It does not delete the host XDG directories, legacy
+config, branch runtime volume, user-authored commands, or other non-managed
+runtime data. Re-enable the adapter to reuse that preserved state.
+
 Disabling a client never deletes its host credentials, configuration, or
 history. `sandbox show` lists only currently selected tools, even when disabled
 client state remains on the host. Host state is considered for deletion only by
@@ -221,7 +237,7 @@ target.
 | `.ssh/*` | Host SSH material is protected and is not imported through the default sandbox. |
 | `.gnupg/*` | GPG private material is managed by `gpg-agent`. |
 | `.claude/*`, `.codex/*`, `.gemini/*` | AI tool credentials use dedicated bind mounts. |
-| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode credentials and data use dedicated bind mounts. |
+| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode host data stays outside dotfiles; only `auth.json` uses its dedicated live mount. |
 | `.host-shell-config/*` | agent-infra managed shell and Git configuration. |
 | `.gitconfig`, `.gitignore_global`, `.stCommitMsg`, `.bash_aliases` | agent-infra symlinks these to `.host-shell-config/`, including `safe.directory` and GPG sync state. |
 | `README.md` | agent-infra scaffolds a discoverability README at the dotfiles root on first create; the link hook ignores it so `$HOME/README.md` is not shadowed. |

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -52,6 +52,19 @@ Antigravity adapter 使用[官方安装器](https://antigravity.google/docs/cli/
 下预置 settings、keybindings 与 MCP 配置。新建容器后需在容器内运行一次
 `agy` 完成认证。
 
+OpenCode adapter 通过共享的 Node/npm 镜像层安装 `opencode-ai`，并把每个分支的
+状态保存在 `/home/devuser/.local/share/opencode` 单一持久卷中。卷内的
+`XDG_CONFIG_HOME` 为 `.local/share/opencode/.xdg/config`，`XDG_STATE_HOME`
+为 `.local/share/opencode/.xdg/state`，常规数据根目录仍为
+`/home/devuser/.local/share`。首次创建时，只有 canonical XDG 配置不存在，
+才会把分支旧版 `opencode.json` 复制过去；宿主配置只补齐缺失的字符串
+`model` 与 `small_model`。唯一实时凭证 mount 是宿主
+`XDG_DATA_HOME/opencode/auth.json`，version/help 的无认证 smoke 不要求该文件存在。
+
+禁用或卸载 OpenCode 只会移除 adapter 管理的项目资产与选择状态，不会删除宿主
+XDG 目录、旧配置、分支运行时卷、用户自建 command 或其他非托管运行时数据；
+重新启用 adapter 后会继续复用这些保留状态。
+
 禁用客户端绝不会删除其宿主凭证、配置或历史。即使宿主仍保留已禁用客户端
 的状态，`sandbox show` 也只展示当前选中的工具。只有显式执行
 `sandbox rm`、`sandbox prune` 等清理命令时，才会考虑删除宿主状态。
@@ -186,7 +199,7 @@ dotfiles 树解引用到
 | `.ssh/*` | host SSH 材料受保护，不会通过默认沙箱导入。 |
 | `.gnupg/*` | GPG 私钥由 `gpg-agent` 管理。 |
 | `.claude/*`, `.codex/*`, `.gemini/*` | AI 工具凭证使用专用 bind mount。 |
-| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode 凭证和数据使用专用 bind mount。 |
+| `.config/opencode/*`, `.local/share/opencode/*` | OpenCode 宿主数据不走 dotfiles；只有 `auth.json` 使用独立实时 mount。 |
 | `.host-shell-config/*` | agent-infra 管理的 shell 和 Git 配置。 |
 | `.gitconfig`, `.gitignore_global`, `.stCommitMsg`, `.bash_aliases` | agent-infra 将这些路径软链到 `.host-shell-config/`，包含 `safe.directory` 和 GPG 同步状态。 |
 | `README.md` | agent-infra 会在 dotfiles 根目录 scaffold 一份发现性 README；link hook 会忽略它，避免遮蔽 `$HOME/README.md`。 |

--- a/lib/agent-clients/adapter.ts
+++ b/lib/agent-clients/adapter.ts
@@ -50,12 +50,19 @@ type AgentClientSeedCommand = Readonly<{
   target: string;
 }>;
 
+type AgentClientCustomCommandDescriptor = Readonly<{
+  target: string;
+  frontmatter: Readonly<Record<string, string | boolean>>;
+  argumentsToken?: string;
+}>;
+
 type AgentClientProjectDescriptor = Readonly<{
   ownedPathPrefixes: readonly string[];
   managed: readonly string[];
   merged: readonly string[];
   ejected: readonly string[];
   seedCommands: readonly AgentClientSeedCommand[];
+  customCommand?: AgentClientCustomCommandDescriptor;
 }>;
 
 type AgentClientAdapter = Readonly<{
@@ -81,6 +88,7 @@ type AgentClientManifestEntry = Readonly<{
   managed: readonly string[];
   merged: readonly string[];
   ejected: readonly string[];
+  customCommand?: AgentClientCustomCommandDescriptor;
 }>;
 
 const PROJECT_ASSET_CATEGORIES = ['managed', 'merged', 'ejected'] as const;
@@ -394,6 +402,50 @@ function defineAgentClientAdapter(
     });
   });
 
+  let customCommand: AgentClientCustomCommandDescriptor | undefined;
+  if (candidate.project.customCommand !== undefined) {
+    const descriptor = candidate.project.customCommand;
+    const placeholders = typeof descriptor?.target === 'string'
+      ? [...descriptor.target.matchAll(/\$\{([^}]+)\}/g)].map((match) => match[1])
+      : [];
+    const targetProbe = typeof descriptor?.target === 'string'
+      ? descriptor.target.replaceAll('${skillName}', 'skill')
+      : '';
+    const frontmatter = descriptor?.frontmatter;
+    if (
+      !descriptor
+      || typeof descriptor !== 'object'
+      || placeholders.length !== 1
+      || placeholders[0] !== 'skillName'
+      || targetProbe.includes('${')
+      || !isProjectRelativeLiteral(targetProbe)
+      || !paths.some((prefix) => targetProbe.startsWith(prefix))
+      || !frontmatter
+      || typeof frontmatter !== 'object'
+      || Array.isArray(frontmatter)
+      || Object.values(frontmatter).some((value) =>
+        typeof value !== 'string' && typeof value !== 'boolean'
+      )
+      || (
+        descriptor.argumentsToken !== undefined
+        && (
+          typeof descriptor.argumentsToken !== 'string'
+          || descriptor.argumentsToken === ''
+          || /[\r\n]/.test(descriptor.argumentsToken)
+        )
+      )
+    ) {
+      throw new Error(`Agent Client '${candidate.id}' has an invalid custom command`);
+    }
+    customCommand = Object.freeze({
+      target: descriptor.target,
+      frontmatter: Object.freeze({ ...frontmatter }),
+      ...(descriptor.argumentsToken === undefined
+        ? {}
+        : { argumentsToken: descriptor.argumentsToken })
+    });
+  }
+
   if (!candidate.sandbox || typeof candidate.sandbox.createTool !== 'function') {
     throw new Error(`Agent Client '${candidate.id}' requires a sandbox descriptor`);
   }
@@ -515,7 +567,8 @@ function defineAgentClientAdapter(
     project: Object.freeze({
       ownedPathPrefixes: Object.freeze(paths),
       ...projectAssets,
-      seedCommands: Object.freeze(seedCommands)
+      seedCommands: Object.freeze(seedCommands),
+      ...(customCommand === undefined ? {} : { customCommand })
     }),
     sandbox: Object.freeze({ createTool, aliases, hooks, recoveryChecks })
   });
@@ -525,6 +578,7 @@ export { defineAgentClientAdapter };
 export type {
   AgentClientAdapter,
   AgentClientCapabilities,
+  AgentClientCustomCommandDescriptor,
   AgentClientDelegationEvidence,
   AgentClientManifestEntry,
   AgentClientModelSelectionContext,

--- a/lib/agent-clients/adapters/opencode-sandbox.ts
+++ b/lib/agent-clients/adapters/opencode-sandbox.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type {
+  AgentClientSandboxHook,
+  AgentClientSandboxRecoveryCheck
+} from '../../sandbox/tool-types.ts';
+
+type JsonObject = Record<string, unknown>;
+
+function readJsonObject(filePath: string): JsonObject | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as JsonObject
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveXdgRoot(value: string | undefined, fallback: string): string {
+  return typeof value === 'string' && value !== '' && path.isAbsolute(value)
+    ? value
+    : fallback;
+}
+
+function ensureOpenCodeSandboxState(
+  toolDir: string,
+  hostHome: string,
+  hostEnv: Readonly<NodeJS.ProcessEnv> = {}
+): void {
+  const canonicalConfigDir = path.join(toolDir, '.xdg', 'config', 'opencode');
+  const canonicalStateDir = path.join(toolDir, '.xdg', 'state', 'opencode');
+  const canonicalConfigPath = path.join(canonicalConfigDir, 'opencode.json');
+  const legacyConfigPath = path.join(toolDir, 'opencode.json');
+  fs.mkdirSync(canonicalConfigDir, { recursive: true });
+  fs.mkdirSync(canonicalStateDir, { recursive: true });
+
+  if (!fs.existsSync(canonicalConfigPath) && fs.existsSync(legacyConfigPath)) {
+    fs.copyFileSync(legacyConfigPath, canonicalConfigPath, fs.constants.COPYFILE_EXCL);
+  }
+
+  const hostConfigRoot = resolveXdgRoot(
+    hostEnv.XDG_CONFIG_HOME,
+    path.join(hostHome, '.config')
+  );
+  const hostConfig = readJsonObject(
+    path.join(hostConfigRoot, 'opencode', 'opencode.json')
+  );
+  if (!hostConfig) {
+    return;
+  }
+
+  let sandboxConfig: JsonObject = {};
+  if (fs.existsSync(canonicalConfigPath)) {
+    const existing = readJsonObject(canonicalConfigPath);
+    if (!existing) {
+      return;
+    }
+    sandboxConfig = existing;
+  }
+
+  let changed = false;
+  for (const key of ['model', 'small_model']) {
+    if (Object.hasOwn(sandboxConfig, key)) {
+      continue;
+    }
+    const value = hostConfig[key];
+    if (typeof value === 'string' && value !== '') {
+      sandboxConfig[key] = value;
+      changed = true;
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(canonicalConfigPath, JSON.stringify(sandboxConfig, null, 2), 'utf8');
+  }
+}
+
+const opencodeBeforeContainerCreateHook: AgentClientSandboxHook = {
+  id: 'opencode-before-container-create',
+  phase: 'before-container-create',
+  async run(context) {
+    const create = context.create;
+    const entry = create?.resolvedTools.find(({ tool }) => tool.id === 'opencode');
+    if (!create || !entry) {
+      return {
+        status: 'fatal',
+        message: 'OpenCode sandbox hook requires its resolved tool state.'
+      };
+    }
+    ensureOpenCodeSandboxState(entry.dir, create.hostHome, create.hostEnv);
+    return { status: 'ready' };
+  }
+};
+
+const opencodeRecoveryChecks: readonly AgentClientSandboxRecoveryCheck[] = [
+  {
+    id: 'command-available',
+    probe: { script: 'command -v "$1"', args: ['opencode'] },
+    finding: {
+      repairKind: 'hard-failure',
+      message: 'OpenCode is not available on PATH inside the sandbox.'
+    }
+  },
+  {
+    id: 'config-writable',
+    probe: {
+      script: 'probe="$1/.agent-infra-opencode-config-$$"; trap \'rm -f -- "$probe"\' EXIT; : > "$probe"',
+      args: ['/home/devuser/.local/share/opencode/.xdg/config/opencode']
+    },
+    finding: {
+      repairKind: 'permissions',
+      message: 'OpenCode config directory is not writable by devuser.',
+      path: '/home/devuser/.local/share/opencode/.xdg/config/opencode'
+    }
+  },
+  {
+    id: 'state-writable',
+    probe: {
+      script: 'probe="$1/.agent-infra-opencode-state-$$"; trap \'rm -f -- "$probe"\' EXIT; : > "$probe"',
+      args: ['/home/devuser/.local/share/opencode/.xdg/state/opencode']
+    },
+    finding: {
+      repairKind: 'permissions',
+      message: 'OpenCode state directory is not writable by devuser.',
+      path: '/home/devuser/.local/share/opencode/.xdg/state/opencode'
+    }
+  }
+];
+
+export {
+  ensureOpenCodeSandboxState,
+  opencodeBeforeContainerCreateHook,
+  opencodeRecoveryChecks
+};

--- a/lib/agent-clients/adapters/opencode.ts
+++ b/lib/agent-clients/adapters/opencode.ts
@@ -1,5 +1,9 @@
 import { defineAgentClientAdapter } from '../adapter.ts';
 import { hostJoin } from '../../sandbox/engines/wsl2-paths.ts';
+import {
+  opencodeBeforeContainerCreateHook,
+  opencodeRecoveryChecks
+} from './opencode-sandbox.ts';
 
 const YOLO_PERMISSION = '{"*":"allow","read":"allow","bash":"allow","edit":"allow","webfetch":"allow","external_directory":"allow","doom_loop":"allow"}';
 
@@ -37,7 +41,12 @@ const opencodeAdapter = defineAgentClientAdapter({
         'zh-CN': '.opencode/commands/update-agent-infra.zh-CN.md'
       },
       target: '.opencode/commands/update-agent-infra.md'
-    }]
+    }],
+    customCommand: {
+      target: '.opencode/commands/${skillName}.md',
+      frontmatter: { agent: 'general', subtask: false },
+      argumentsToken: '$ARGUMENTS'
+    }
   },
   sandbox: {
     createTool: ({ home }) => ({
@@ -49,7 +58,9 @@ const opencodeAdapter = defineAgentClientAdapter({
       versionCmd: 'opencode --version',
       setupHint: 'Configure OpenCode credentials inside the container before first use.',
       envVars: {
-        OPENCODE_CONFIG: '/home/devuser/.local/share/opencode/opencode.json'
+        XDG_DATA_HOME: '/home/devuser/.local/share',
+        XDG_CONFIG_HOME: '/home/devuser/.local/share/opencode/.xdg/config',
+        XDG_STATE_HOME: '/home/devuser/.local/share/opencode/.xdg/state'
       },
       hostLiveMounts: [
         {
@@ -68,7 +79,8 @@ const opencodeAdapter = defineAgentClientAdapter({
         command: `OPENCODE_PERMISSION='${YOLO_PERMISSION}' opencode; tput ed`
       }
     ],
-    hooks: []
+    hooks: [opencodeBeforeContainerCreateHook],
+    recoveryChecks: opencodeRecoveryChecks
   }
 });
 

--- a/lib/agent-clients/registry.ts
+++ b/lib/agent-clients/registry.ts
@@ -135,7 +135,15 @@ function createAgentClientManifest(): readonly AgentClientManifestEntry[] {
       ownedPathPrefixes: Object.freeze([...adapter.project.ownedPathPrefixes]),
       managed: Object.freeze([...adapter.project.managed]),
       merged: Object.freeze([...adapter.project.merged]),
-      ejected: Object.freeze([...adapter.project.ejected])
+      ejected: Object.freeze([...adapter.project.ejected]),
+      ...(adapter.project.customCommand === undefined
+        ? {}
+        : {
+          customCommand: Object.freeze({
+            ...adapter.project.customCommand,
+            frontmatter: Object.freeze({ ...adapter.project.customCommand.frontmatter })
+          })
+        })
     }))
   );
 }

--- a/lib/run/tui.ts
+++ b/lib/run/tui.ts
@@ -1,9 +1,16 @@
 import { renderAgentClientInvocation } from '../agent-clients/invocation.ts';
 import { getAgentClientAdapter } from '../agent-clients/registry.ts';
+import type { AgentClientId } from '../agent-clients/types.ts';
 
 export type TuiName = 'claude' | 'codex' | 'antigravity' | 'opencode';
 
 const TUI_NAMES = new Set(['claude', 'codex', 'antigravity', 'opencode']);
+const TUI_AGENT_CLIENT_IDS: Readonly<Record<TuiName, AgentClientId>> = Object.freeze({
+  claude: 'claude-code',
+  codex: 'codex',
+  antigravity: 'antigravity-cli',
+  opencode: 'opencode'
+});
 
 export type CommandConfig = {
   defaultTui?: unknown;
@@ -29,14 +36,10 @@ export function selectTui(
 }
 
 export function renderPrompt(params: { tui: TuiName; skill: string; args: string[] }): string {
-  const suffix = [params.skill, ...params.args].join(' ').trim();
-  if (params.tui === 'codex') {
-    return renderAgentClientInvocation(getAgentClientAdapter('codex').invocation, {
-      skillName: params.skill,
-      args: params.args
-    });
-  }
-  return `/${suffix}`;
+  return renderAgentClientInvocation(
+    getAgentClientAdapter(TUI_AGENT_CLIENT_IDS[params.tui]).invocation,
+    { skillName: params.skill, args: params.args }
+  );
 }
 
 export function buildTuiCommand(tui: TuiName, prompt: string): [string, string[]] {

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -990,44 +990,6 @@ export function ensureClaudeSettings(toolDir: string, hostHomeDir?: string): voi
   }
 }
 
-export function ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void {
-  if (!hostHomeDir) {
-    return;
-  }
-
-  const hostConfigPath = path.join(hostHomeDir, '.config', 'opencode', 'opencode.json');
-  const hostJson = readHostJsonSafe(hostConfigPath);
-  if (!hostJson) {
-    return;
-  }
-
-  const sandboxConfigPath = path.join(toolDir, 'opencode.json');
-  let sandboxJson: JsonObject = {};
-  if (fs.existsSync(sandboxConfigPath)) {
-    const existing = readHostJsonSafe(sandboxConfigPath);
-    if (!existing) {
-      return;
-    }
-    sandboxJson = existing;
-  }
-  let changed = false;
-  for (const key of ['model', 'small_model']) {
-    if (Object.hasOwn(sandboxJson, key)) {
-      continue;
-    }
-    const value = hostJson[key];
-    if (typeof value !== 'string' || value === '') {
-      continue;
-    }
-    sandboxJson[key] = value;
-    changed = true;
-  }
-
-  if (changed) {
-    fs.writeFileSync(sandboxConfigPath, JSON.stringify(sandboxJson, null, 2), 'utf8');
-  }
-}
-
 export function sandboxAliasesPath(home: string): string {
   return hostJoin(home, '.agent-infra', 'aliases', 'sandbox.sh');
 }
@@ -1531,6 +1493,7 @@ export async function create(args: string[]): Promise<void> {
                 plan: capabilityPlan,
                 create: {
                   hostHome: effectiveConfig.home,
+                  hostEnv: { ...process.env },
                   resolvedTools: effectiveResolvedTools
                 }
               },
@@ -1552,11 +1515,6 @@ export async function create(args: string[]): Promise<void> {
               // prepareClaudeCredentials wrote OAuth credentials or confirmed
               // provider/API settings are enough for Claude Code. If no usable
               // auth was present, the claude-code entry was removed above.
-            }
-            const opencodeEntry = effectiveResolvedTools.find(({ tool }) => tool.id === 'opencode');
-            if (opencodeEntry) {
-              // The TUI reads <toolDir>/opencode.json via OPENCODE_CONFIG pinned in tools.js.
-              ensureOpenCodeModelInheritance(opencodeEntry.dir, effectiveConfig.home);
             }
             const toolVolumes = effectiveResolvedTools.flatMap(({ tool, dir }) =>
               tool.tmpfs ? [] : ['-v', volumeArg(engine, dir, tool.containerMount)]

--- a/lib/sandbox/tool-types.ts
+++ b/lib/sandbox/tool-types.ts
@@ -64,6 +64,7 @@ type SandboxResolvedToolState = Readonly<{
 
 type SandboxHookCreateContext = Readonly<{
   hostHome: string;
+  hostEnv?: Readonly<NodeJS.ProcessEnv>;
   resolvedTools: readonly SandboxResolvedToolState[];
 }>;
 

--- a/scripts/build-inline.js
+++ b/scripts/build-inline.js
@@ -55,6 +55,17 @@ function validateManifest(manifest, registry) {
   }
   for (const entry of manifest) {
     const arrayFields = ['ownedPathPrefixes', 'managed', 'merged', 'ejected'];
+    const customCommand = entry.customCommand;
+    const expectedKeys = [
+      'displayName',
+      'ejected',
+      'id',
+      'invocation',
+      'managed',
+      'merged',
+      'ownedPathPrefixes',
+      ...(customCommand === undefined ? [] : ['customCommand'])
+    ].sort().join(',');
     if (
       typeof entry.id !== 'string'
       || typeof entry.displayName !== 'string'
@@ -65,8 +76,31 @@ function validateManifest(manifest, registry) {
         !Array.isArray(entry[field])
         || entry[field].some((value) => typeof value !== 'string')
       )
-      || Object.keys(entry).sort().join(',')
-        !== 'displayName,ejected,id,invocation,managed,merged,ownedPathPrefixes'
+      || (
+        customCommand !== undefined
+        && (
+          typeof customCommand !== 'object'
+          || customCommand === null
+          || typeof customCommand.target !== 'string'
+          || typeof customCommand.frontmatter !== 'object'
+          || customCommand.frontmatter === null
+          || Array.isArray(customCommand.frontmatter)
+          || Object.values(customCommand.frontmatter).some((value) =>
+            typeof value !== 'string' && typeof value !== 'boolean'
+          )
+          || (
+            customCommand.argumentsToken !== undefined
+            && typeof customCommand.argumentsToken !== 'string'
+          )
+          || Object.keys(customCommand).sort().join(',')
+            !== [
+              'frontmatter',
+              'target',
+              ...(customCommand.argumentsToken === undefined ? [] : ['argumentsToken'])
+            ].sort().join(',')
+        )
+      )
+      || Object.keys(entry).sort().join(',') !== expectedKeys
     ) {
       throw new Error(`Invalid Agent Client manifest entry '${String(entry?.id)}'`);
     }

--- a/src/sync-templates.js
+++ b/src/sync-templates.js
@@ -655,19 +655,30 @@ function generateClaudeCommand(skill, lang) {
   return `${lines.join('\n')}\n`;
 }
 
-function generateOpenCodeCommand(skill, lang) {
+function formatYamlScalarMetadata(key, value) {
+  if (typeof value === 'boolean') return [`${key}: ${String(value)}`];
+  if (/^[A-Za-z0-9_-]+$/.test(value)) return [`${key}: ${value}`];
+  return formatYamlMetadata(key, value);
+}
+
+function generateAgentClientCommand(skill, lang, descriptor) {
   const isZhCN = lang === 'zh-CN';
   const lines = [
     '---',
     ...formatYamlMetadata('description', skill.description),
-    'agent: general',
-    'subtask: false',
+    ...Object.entries(descriptor.frontmatter).flatMap(([key, value]) =>
+      formatYamlScalarMetadata(key, value)
+    ),
     '---',
     ''
   ];
 
-  if (skill.args) {
-    lines.push(isZhCN ? '参数：$ARGUMENTS' : 'Arguments: $ARGUMENTS');
+  if (skill.args && descriptor.argumentsToken) {
+    lines.push(
+      isZhCN
+        ? `参数：${descriptor.argumentsToken}`
+        : `Arguments: ${descriptor.argumentsToken}`
+    );
     lines.push('');
   }
 
@@ -918,10 +929,11 @@ function generateCustomCommands(
         report.custom.commands
       );
     }
-    if (enabledTUIs.has('opencode')) {
+    for (const adapter of AGENT_CLIENT_MANIFEST) {
+      if (!enabledTUIs.has(adapter.id) || !adapter.customCommand) continue;
       managedWriter(
-        `.opencode/commands/${skill.dirName}.md`,
-        generateOpenCodeCommand(skill, lang),
+        adapter.customCommand.target.replaceAll('${skillName}', skill.dirName),
+        generateAgentClientCommand(skill, lang, adapter.customCommand),
         report.custom.commands
       );
     }

--- a/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
+++ b/templates/.agents/skills/update-agent-infra/scripts/sync-templates.js
@@ -165,7 +165,15 @@ const AGENT_CLIENT_MANIFEST = [
       ".opencode/commands/"
     ],
     "merged": [],
-    "ejected": []
+    "ejected": [],
+    "customCommand": {
+      "target": ".opencode/commands/${skillName}.md",
+      "frontmatter": {
+        "agent": "general",
+        "subtask": false
+      },
+      "argumentsToken": "$ARGUMENTS"
+    }
   }
 ];
 const CUSTOM_TUI_CONTRACT = {
@@ -804,19 +812,30 @@ function generateClaudeCommand(skill, lang) {
   return `${lines.join('\n')}\n`;
 }
 
-function generateOpenCodeCommand(skill, lang) {
+function formatYamlScalarMetadata(key, value) {
+  if (typeof value === 'boolean') return [`${key}: ${String(value)}`];
+  if (/^[A-Za-z0-9_-]+$/.test(value)) return [`${key}: ${value}`];
+  return formatYamlMetadata(key, value);
+}
+
+function generateAgentClientCommand(skill, lang, descriptor) {
   const isZhCN = lang === 'zh-CN';
   const lines = [
     '---',
     ...formatYamlMetadata('description', skill.description),
-    'agent: general',
-    'subtask: false',
+    ...Object.entries(descriptor.frontmatter).flatMap(([key, value]) =>
+      formatYamlScalarMetadata(key, value)
+    ),
     '---',
     ''
   ];
 
-  if (skill.args) {
-    lines.push(isZhCN ? '参数：$ARGUMENTS' : 'Arguments: $ARGUMENTS');
+  if (skill.args && descriptor.argumentsToken) {
+    lines.push(
+      isZhCN
+        ? `参数：${descriptor.argumentsToken}`
+        : `Arguments: ${descriptor.argumentsToken}`
+    );
     lines.push('');
   }
 
@@ -1067,10 +1086,11 @@ function generateCustomCommands(
         report.custom.commands
       );
     }
-    if (enabledTUIs.has('opencode')) {
+    for (const adapter of AGENT_CLIENT_MANIFEST) {
+      if (!enabledTUIs.has(adapter.id) || !adapter.customCommand) continue;
       managedWriter(
-        `.opencode/commands/${skill.dirName}.md`,
-        generateOpenCodeCommand(skill, lang),
+        adapter.customCommand.target.replaceAll('${skillName}', skill.dirName),
+        generateAgentClientCommand(skill, lang, adapter.customCommand),
         report.custom.commands
       );
     }

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -50,7 +50,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-dockerfile.test.ts
+++ b/tests/integration/cli/sandbox-dockerfile.test.ts
@@ -52,7 +52,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-dotfiles.test.ts
+++ b/tests/integration/cli/sandbox-dotfiles.test.ts
@@ -53,7 +53,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-engine.test.ts
+++ b/tests/integration/cli/sandbox-engine.test.ts
@@ -54,7 +54,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-git-config.test.ts
+++ b/tests/integration/cli/sandbox-git-config.test.ts
@@ -41,7 +41,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-gpg.test.ts
+++ b/tests/integration/cli/sandbox-gpg.test.ts
@@ -47,7 +47,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-inheritance.test.ts
+++ b/tests/integration/cli/sandbox-inheritance.test.ts
@@ -36,6 +36,9 @@ type ExecFn = (cmd: string, args: string[], options?: CommandOptions) => string 
 type EngineExecFn = (engine: string, cmd: string, args: string[], options?: CommandOptions) => string | Buffer | void;
 type RunSafeFn = (cmd: string, args: string[]) => string;
 type EngineRunSafeFn = (engine: string, cmd: string, args: string[]) => string;
+type OpenCodeSandboxModule = {
+  ensureOpenCodeSandboxState(toolDir: string, hostHome: string, hostEnv?: Readonly<NodeJS.ProcessEnv>): void;
+};
 type SandboxCreateModule = {
   create(args: string[]): Promise<void>;
   buildContainerEnvFile(tools: ResolvedToolFixture[], engine: string, runSafe?: EngineRunSafeFn, options?: CommandOptions): EnvFileResult;
@@ -45,7 +48,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string, containerCodexDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;
@@ -1223,8 +1225,8 @@ test("ensureCodexModelInheritance skips an unreadable host catalog file", onPlat
   }
 });
 
-test("ensureOpenCodeModelInheritance creates config with host model fields", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState creates config with host model fields", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-model-"));
 
@@ -1238,8 +1240,8 @@ test("ensureOpenCodeModelInheritance creates config with host model fields", asy
       }),
       "utf8"
     );
-    sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome);
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "opencode.json"), "utf8"));
+    opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json"), "utf8"));
     assert.equal(data.model, "anthropic/claude-opus-4-7");
     assert.equal(data.small_model, "openai/gpt-5.5-mini");
   } finally {
@@ -1248,8 +1250,8 @@ test("ensureOpenCodeModelInheritance creates config with host model fields", asy
   }
 });
 
-test("ensureOpenCodeModelInheritance preserves existing sandbox model fields", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState preserves existing sandbox model fields", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-keep-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-keep-"));
 
@@ -1271,8 +1273,8 @@ test("ensureOpenCodeModelInheritance preserves existing sandbox model fields", a
       }),
       "utf8"
     );
-    sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome);
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "opencode.json"), "utf8"));
+    opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json"), "utf8"));
     assert.equal(data.model, "openai/gpt-5.5");
     assert.equal(data.small_model, "anthropic/claude-sonnet-4-5");
   } finally {
@@ -1281,8 +1283,8 @@ test("ensureOpenCodeModelInheritance preserves existing sandbox model fields", a
   }
 });
 
-test("ensureOpenCodeModelInheritance inherits small model when host model is missing", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState inherits small model when host model is missing", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-small-model-only-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-small-model-only-"));
 
@@ -1293,8 +1295,8 @@ test("ensureOpenCodeModelInheritance inherits small model when host model is mis
       JSON.stringify({ small_model: "openai/gpt-5.5-mini" }),
       "utf8"
     );
-    sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome);
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, "opencode.json"), "utf8"));
+    opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json"), "utf8"));
     assert.equal(Object.hasOwn(data, "model"), false);
     assert.equal(data.small_model, "openai/gpt-5.5-mini");
   } finally {
@@ -1303,24 +1305,24 @@ test("ensureOpenCodeModelInheritance inherits small model when host model is mis
   }
 });
 
-test("ensureOpenCodeModelInheritance skips missing host model fields", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState skips missing host model fields", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-missing-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-missing-"));
 
   try {
     fs.mkdirSync(path.join(hostHome, ".config", "opencode"), { recursive: true });
     fs.writeFileSync(path.join(hostHome, ".config", "opencode", "opencode.json"), JSON.stringify({ theme: "dark" }), "utf8");
-    sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome);
-    assert.equal(fs.existsSync(path.join(tmpDir, "opencode.json")), false);
+    opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome);
+    assert.equal(fs.existsSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json")), false);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(hostHome, { recursive: true, force: true });
   }
 });
 
-test("ensureOpenCodeModelInheritance skips empty host model fields", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState skips empty host model fields", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-empty-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-empty-"));
 
@@ -1331,32 +1333,32 @@ test("ensureOpenCodeModelInheritance skips empty host model fields", async () =>
       JSON.stringify({ model: "", small_model: "" }),
       "utf8"
     );
-    sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome);
-    assert.equal(fs.existsSync(path.join(tmpDir, "opencode.json")), false);
+    opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome);
+    assert.equal(fs.existsSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json")), false);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(hostHome, { recursive: true, force: true });
   }
 });
 
-test("ensureOpenCodeModelInheritance ignores malformed host json", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState ignores malformed host json", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-malformed-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-malformed-"));
 
   try {
     fs.mkdirSync(path.join(hostHome, ".config", "opencode"), { recursive: true });
     fs.writeFileSync(path.join(hostHome, ".config", "opencode", "opencode.json"), "{", "utf8");
-    assert.doesNotThrow(() => sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome));
-    assert.equal(fs.existsSync(path.join(tmpDir, "opencode.json")), false);
+    assert.doesNotThrow(() => opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome));
+    assert.equal(fs.existsSync(path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json")), false);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(hostHome, { recursive: true, force: true });
   }
 });
 
-test("ensureOpenCodeModelInheritance leaves malformed sandbox config alone", async () => {
-  const sandboxCreate = await loadFreshEsm<SandboxCreateModule>("lib/sandbox/commands/create.js");
+test("ensureOpenCodeSandboxState leaves malformed sandbox config alone", async () => {
+  const opencodeSandbox = await loadFreshEsm<OpenCodeSandboxModule>("lib/agent-clients/adapters/opencode-sandbox.js");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-model-malformed-sandbox-"));
   const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-opencode-host-valid-for-malformed-sandbox-"));
 
@@ -1367,9 +1369,10 @@ test("ensureOpenCodeModelInheritance leaves malformed sandbox config alone", asy
       JSON.stringify({ model: "anthropic/claude-opus-4-7" }),
       "utf8"
     );
-    const configPath = path.join(tmpDir, "opencode.json");
-    fs.writeFileSync(configPath, "{", "utf8");
-    assert.doesNotThrow(() => sandboxCreate.ensureOpenCodeModelInheritance(tmpDir, hostHome));
+    const legacyConfigPath = path.join(tmpDir, "opencode.json");
+    const configPath = path.join(tmpDir, ".xdg", "config", "opencode", "opencode.json");
+    fs.writeFileSync(legacyConfigPath, "{", "utf8");
+    assert.doesNotThrow(() => opencodeSandbox.ensureOpenCodeSandboxState(tmpDir, hostHome));
     assert.equal(fs.readFileSync(configPath, "utf8"), "{");
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/integration/cli/sandbox-shell.test.ts
+++ b/tests/integration/cli/sandbox-shell.test.ts
@@ -45,7 +45,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;

--- a/tests/integration/cli/sandbox-tools.test.ts
+++ b/tests/integration/cli/sandbox-tools.test.ts
@@ -47,7 +47,6 @@ type SandboxCreateModule = {
   ensureClaudeSettings(toolDir: string, hostHomeDir?: string): void;
   ensureCodexModelInheritance(toolDir: string, hostHomeDir?: string): void;
   ensureCodexWorkspaceTrust(toolDir: string): void;
-  ensureOpenCodeModelInheritance(toolDir: string, hostHomeDir?: string): void;
   buildImage(config: Record<string, unknown>, tools: Array<Record<string, unknown>>, dockerfilePath: string, imageSignature: string, deps?: Record<string, unknown>): void;
   commandErrorMessage(error: unknown): string;
   hostHasGpgKeys(home: string, execFn?: ExecFn): boolean;
@@ -903,7 +902,7 @@ test("claude-code tool pins CLAUDE_CONFIG_DIR so $HOME/.claude.json preseed reac
   assert.equal(tool.envVars?.CLAUDE_CONFIG_DIR, "/home/devuser/.claude");
 });
 
-test("opencode tool pins OPENCODE_CONFIG to the sandbox config file", async () => {
+test("opencode tool pins XDG roots inside its sandbox volume", async () => {
   const sandboxTools = await loadFreshEsm<typeof import("../../../lib/sandbox/tools.ts")>("lib/sandbox/tools.js");
   const tools = sandboxTools.resolveTools({
     home: "/home/host-user",
@@ -914,10 +913,11 @@ test("opencode tool pins OPENCODE_CONFIG to the sandbox config file", async () =
   assert.equal(tools.length, 1);
   const tool = required(tools[0]);
   assert.equal(tool.containerMount, "/home/devuser/.local/share/opencode");
-  assert.equal(
-    tool.envVars?.OPENCODE_CONFIG,
-    "/home/devuser/.local/share/opencode/opencode.json"
-  );
+  assert.deepEqual(tool.envVars, {
+    XDG_DATA_HOME: "/home/devuser/.local/share",
+    XDG_CONFIG_HOME: "/home/devuser/.local/share/opencode/.xdg/config",
+    XDG_STATE_HOME: "/home/devuser/.local/share/opencode/.xdg/state"
+  });
 });
 
 test("antigravity-cli tool preseeds keybindings and MCP config without host settings", async () => {

--- a/tests/integration/core/agent-client-workflow-matrix.test.ts
+++ b/tests/integration/core/agent-client-workflow-matrix.test.ts
@@ -13,10 +13,10 @@ import { filePath } from '../../helpers.ts';
 import { loadFreshEsm } from '../../helpers/esm.ts';
 import type { SyncTemplatesModule } from '../../helpers/esm.ts';
 
-function stateFor(mask: number): AgentClientState {
+function stateFor(enabledMask: number, installMask: number): AgentClientState {
   return Object.fromEntries(AGENT_CLIENT_IDS.map((id, index) => [id, {
-    enabled: (mask & (1 << index)) !== 0,
-    installInSandbox: index % 2 === 0
+    enabled: (enabledMask & (1 << index)) !== 0,
+    installInSandbox: (installMask & (1 << index)) !== 0
   }])) as AgentClientState;
 }
 
@@ -29,7 +29,8 @@ test('all 16 project integration combinations stay equivalent across core and st
   for (let mask = 0; mask < 16; mask += 1) {
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), `agent-client-mask-${mask}-`));
     try {
-      const state = stateFor(mask);
+      const installMask = ((mask << 1) | (mask >> 3)) & 0b1111;
+      const state = stateFor(mask, installMask);
       const config = {
         project: 'demo',
         org: 'acme',

--- a/tests/unit/core/agent-client-architecture.test.ts
+++ b/tests/unit/core/agent-client-architecture.test.ts
@@ -102,7 +102,7 @@ test('generic Agent Client core contains no client-specific ID literals', () => 
   }
 });
 
-test('generic sandbox lifecycle contains no Codex-specific ID literals', () => {
+test('generic sandbox lifecycle contains no migrated client-specific ID literals', () => {
   const candidates = [
     filePath('lib/sandbox/commands/create.ts'),
     filePath('lib/sandbox/recovery.ts')
@@ -119,7 +119,7 @@ test('generic sandbox lifecycle contains no Codex-specific ID literals', () => {
       const displayPath = path.relative(filePath('.'), candidate).replace(/\\/g, '/');
       const sourceFile = project.program.getSourceFile(candidate);
       assert.ok(sourceFile, `expected ${displayPath} in the TypeScript program`);
-      return findClientIdLiterals(sourceFile, displayPath, ['codex']);
+      return findClientIdLiterals(sourceFile, displayPath, ['codex', 'opencode']);
     });
 
     assert.deepEqual(

--- a/tests/unit/core/agent-client-registry.test.ts
+++ b/tests/unit/core/agent-client-registry.test.ts
@@ -100,7 +100,8 @@ function adapterInput(
       managed: ['.codex/hooks.json'],
       merged: [],
       ejected: [],
-      seedCommands: []
+      seedCommands: [],
+      customCommand: undefined
     },
     sandbox: {
       createTool: () => ({
@@ -209,6 +210,44 @@ test('adapter definitions validate their closed contract without mutating input'
 
   for (const invalid of invalidInputs) {
     assert.throws(() => defineAgentClientAdapter(invalid as AgentClientAdapter));
+  }
+});
+
+test('adapter custom commands validate paths, placeholders, metadata, and immutability', () => {
+  const adapter = defineAgentClientAdapter(adapterInput({
+    project: {
+      ...adapterInput().project,
+      customCommand: {
+        target: '.codex/commands/${skillName}.md',
+        frontmatter: { agent: 'general', subtask: false },
+        argumentsToken: '$ARGUMENTS'
+      }
+    }
+  }));
+
+  assert.deepEqual(adapter.project.customCommand, {
+    target: '.codex/commands/${skillName}.md',
+    frontmatter: { agent: 'general', subtask: false },
+    argumentsToken: '$ARGUMENTS'
+  });
+  assert.ok(Object.isFrozen(adapter.project.customCommand));
+  assert.ok(Object.isFrozen(adapter.project.customCommand?.frontmatter));
+
+  const invalidDescriptors = [
+    { target: '../${skillName}.md', frontmatter: {} },
+    { target: '.codex/commands/static.md', frontmatter: {} },
+    { target: '.codex/${skillName}/${skillName}.md', frontmatter: {} },
+    { target: '.codex/commands/${unknown}.md', frontmatter: {} },
+    { target: '.codex/commands/${skillName}.md', frontmatter: { nested: {} } },
+    { target: '.codex/commands/${skillName}.md', frontmatter: {}, argumentsToken: '' }
+  ];
+  for (const customCommand of invalidDescriptors) {
+    assert.throws(() => defineAgentClientAdapter(adapterInput({
+      project: {
+        ...adapterInput().project,
+        customCommand: customCommand as never
+      }
+    })), /invalid custom command/);
   }
 });
 
@@ -383,7 +422,12 @@ test('registry exposes the exact built-in project asset matrix', () => {
             'zh-CN': '.opencode/commands/update-agent-infra.zh-CN.md'
           },
           target: '.opencode/commands/update-agent-infra.md'
-        }]
+        }],
+        customCommand: {
+          target: '.opencode/commands/${skillName}.md',
+          frontmatter: { agent: 'general', subtask: false },
+          argumentsToken: '$ARGUMENTS'
+        }
       }
     }
   );
@@ -504,6 +548,12 @@ test('manifest projects invocation and remains deeply frozen', () => {
   );
   assert.ok(Object.isFrozen(manifest));
   assert.ok(manifest.every((entry) => Object.isFrozen(entry)));
+  assert.deepEqual(manifest.find(({ id }) => id === 'opencode')?.customCommand, {
+    target: '.opencode/commands/${skillName}.md',
+    frontmatter: { agent: 'general', subtask: false },
+    argumentsToken: '$ARGUMENTS'
+  });
+  assert.ok(Object.isFrozen(manifest.find(({ id }) => id === 'opencode')?.customCommand));
 });
 
 test('registry queries preserve canonical order and keep enabled separate from sandbox install state', () => {
@@ -624,12 +674,25 @@ test('manifest is a fresh frozen JSON-safe projection of registry metadata', () 
   for (const entry of first) {
     assert.deepEqual(
       Object.keys(entry),
-      ['id', 'displayName', 'invocation', 'ownedPathPrefixes', 'managed', 'merged', 'ejected']
+      [
+        'id',
+        'displayName',
+        'invocation',
+        'ownedPathPrefixes',
+        'managed',
+        'merged',
+        'ejected',
+        ...(entry.customCommand === undefined ? [] : ['customCommand'])
+      ]
     );
     assert.ok(Object.isFrozen(entry));
     assert.ok(Object.isFrozen(entry.ownedPathPrefixes));
     assert.ok(Object.isFrozen(entry.managed));
     assert.ok(Object.isFrozen(entry.merged));
     assert.ok(Object.isFrozen(entry.ejected));
+    if (entry.customCommand) {
+      assert.ok(Object.isFrozen(entry.customCommand));
+      assert.ok(Object.isFrozen(entry.customCommand.frontmatter));
+    }
   }
 });

--- a/tests/unit/core/opencode-agent-client.test.ts
+++ b/tests/unit/core/opencode-agent-client.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { getAgentClientAdapter } from '../../../lib/agent-clients/registry.ts';
+
+function hookContext(home: string, toolDir: string, hostEnv: NodeJS.ProcessEnv = {}) {
+  return {
+    signal: AbortSignal.timeout(5_000),
+    async runCommand() { return { stdout: '' }; },
+    create: {
+      hostHome: home,
+      hostEnv,
+      resolvedTools: [{
+        tool: getAgentClientAdapter('opencode').sandbox.createTool({ home, project: 'demo' }),
+        dir: toolDir
+      }]
+    }
+  };
+}
+
+test('OpenCode adapter declares its single-volume XDG, install, credential, and recovery contract', () => {
+  const adapter = getAgentClientAdapter('opencode');
+  const tool = adapter.sandbox.createTool({ home: '/host/home', project: 'demo' });
+
+  assert.deepEqual(tool.install, { type: 'npm', cmd: 'opencode-ai' });
+  assert.equal(tool.containerMount, '/home/devuser/.local/share/opencode');
+  assert.deepEqual(tool.envVars, {
+    XDG_DATA_HOME: '/home/devuser/.local/share',
+    XDG_CONFIG_HOME: '/home/devuser/.local/share/opencode/.xdg/config',
+    XDG_STATE_HOME: '/home/devuser/.local/share/opencode/.xdg/state'
+  });
+  assert.deepEqual(tool.hostLiveMounts, [{
+    hostPath: '/host/home/.local/share/opencode/auth.json',
+    containerSubpath: 'auth.json'
+  }]);
+  assert.deepEqual(
+    adapter.sandbox.hooks.map(({ id, phase }) => ({ id, phase })),
+    [{ id: 'opencode-before-container-create', phase: 'before-container-create' }]
+  );
+  assert.deepEqual(
+    adapter.sandbox.recoveryChecks?.map(({ id }) => id),
+    ['command-available', 'config-writable', 'state-writable']
+  );
+});
+
+test('OpenCode hook uses host XDG config and fills only missing model strings', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-adapter-'));
+  const home = path.join(root, 'home');
+  const toolDir = path.join(root, 'tool');
+  const configHome = path.join(root, 'xdg-config');
+  fs.mkdirSync(path.join(configHome, 'opencode'), { recursive: true });
+  fs.mkdirSync(toolDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(configHome, 'opencode', 'opencode.json'),
+    JSON.stringify({ model: 'provider/main', small_model: 'provider/small', token: 'secret' })
+  );
+  fs.writeFileSync(path.join(toolDir, 'opencode.json'), JSON.stringify({ model: 'legacy/main' }));
+
+  const hook = getAgentClientAdapter('opencode').sandbox.hooks[0];
+  assert.ok(hook);
+  const result = await hook.run(hookContext(home, toolDir, { XDG_CONFIG_HOME: configHome }));
+
+  assert.equal(result.status, 'ready');
+  const canonical = path.join(toolDir, '.xdg', 'config', 'opencode', 'opencode.json');
+  assert.deepEqual(JSON.parse(fs.readFileSync(canonical, 'utf8')), {
+    model: 'legacy/main',
+    small_model: 'provider/small'
+  });
+  assert.ok(fs.existsSync(path.join(toolDir, 'opencode.json')));
+});
+
+test('OpenCode hook preserves canonical config and safely ignores invalid host inputs', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-adapter-invalid-'));
+  const home = path.join(root, 'home');
+  const toolDir = path.join(root, 'tool');
+  const canonical = path.join(toolDir, '.xdg', 'config', 'opencode', 'opencode.json');
+  fs.mkdirSync(path.dirname(canonical), { recursive: true });
+  fs.writeFileSync(canonical, JSON.stringify({ model: 'sandbox/main' }));
+  fs.mkdirSync(path.join(home, '.config', 'opencode'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.config', 'opencode', 'opencode.json'), '{ invalid');
+
+  const hook = getAgentClientAdapter('opencode').sandbox.hooks[0];
+  assert.ok(hook);
+  await hook.run(hookContext(home, toolDir, { XDG_CONFIG_HOME: 'relative/path' }));
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(canonical, 'utf8')), { model: 'sandbox/main' });
+  assert.ok(fs.statSync(path.join(toolDir, '.xdg', 'state', 'opencode')).isDirectory());
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #670

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that does not need an issue

Closes #670

## 📋 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 🔧 重构 / Refactoring
- [x] 🚀 功能增强 / Feature enhancement

## 📝 变更目的 / Purpose of the Change

将 OpenCode 的 command 生成、skill 调用、XDG 配置与状态目录、npm 安装、凭证挂载和恢复检查迁移到统一 Agent Client adapter。该改动消除 sandbox 通用层中的 OpenCode 专有分支，同时保持独立启用、禁用、卸载以及用户运行时数据保留语义。

Migrate OpenCode command generation, skill invocation, XDG configuration and state paths, npm installation, credential mounting, and recovery checks into the unified Agent Client adapter. This removes OpenCode-specific branches from the generic sandbox layer while preserving independent enablement, disablement, uninstall behavior, and user runtime data.

## 📋 主要变更 / Brief Changelog

- 新增 JSON-safe custom command descriptor，并通过 registry manifest 驱动同步与 TUI 调用。
- 将 OpenCode XDG 迁移、模型继承和恢复探针收敛到 adapter-local hook。
- 覆盖 16 种客户端生命周期组合、静态契约及 XDG 行为，并更新中英文沙箱文档。
- Add a JSON-safe custom command descriptor that drives registry manifests, synchronization, and TUI invocation.
- Move OpenCode XDG migration, model inheritance, and recovery probes into an adapter-local hook.
- Cover all 16 client lifecycle combinations, static contracts, and XDG behavior; update English and Chinese sandbox documentation.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm test` to build the project and execute the full test suite.
2. Run the focused OpenCode, sandbox inheritance, sandbox tools, and lifecycle matrix tests.
3. Review the adapter manifest projection and generated template copies for consistency.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Full suite: 2161 passed, 3 skipped, 0 failed. Focused regression: 94 passed, 0 failed. TypeScript checks and `git diff --check` passed.

## 📸 截图 / Screenshots

Not applicable; this change affects CLI and sandbox internals.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / A GitHub issue exists for this change
- [x] 本 PR 只解决一个 Issue / This PR addresses one issue
- [x] 每个 commit 都有有意义的主题行和描述 / Each commit has a meaningful subject and body
- [x] 代码遵循项目规范并已完成自我审查 / Code follows project conventions and was reviewed
- [x] 已编写必要的单元测试 / Necessary unit tests were added
- [x] TypeScript checks and unit tests pass
- [x] 已更新相应的中英文文档 / Corresponding English and Chinese documentation was updated
- [x] 已考虑向后兼容性 / Backward compatibility was considered

## 📋 附加信息 / Additional Notes

### ⚠️ 待人工校验 / Manual Validation Required

- 在可用 Docker 或 OrbStack 的真实宿主环境创建启用 OpenCode 的沙箱，确认共享 npm 层安装与 `opencode --version` 正常。
- 验证容器内 canonical XDG 配置发现、config/state 可写 recovery probes、可选 `auth.json` 单文件 live mount，以及重复 create/disable/enable/uninstall 后用户运行时数据保留。
- This validation requires a real sandbox engine and cannot be completed by the automated test environment.

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 custom command descriptor 的 owned-path 边界、adapter-local XDG 迁移的非破坏语义，以及宿主环境仅限 before-create hook 的隔离边界。

Generated with AI assistance
