### PR TITLE
fix(create-task): 创建任务时提取可观察验收标准


### DIFF
--- a/.agents/skills/create-task/reference/context-capture.md
+++ b/.agents/skills/create-task/reference/context-capture.md
@@ -18,6 +18,40 @@
 
 缺失类别保持为空，不推导补齐。相同信息去重，但不得丢失来源或状态语义。
 
+## 可观察验收提取
+
+以下语言无关契约是可观察验收信息的稳定捕获边界：
+
+```text
+# observable-acceptance-contract
+sources: current-request,necessary-prior-discussion
+scan-entire-visible-context: true
+recognize-without-acceptance-label: true
+components: observable-input,action,expected-result
+combine-distributed-evidence: true
+preserve-source-state: true
+missing-components: preserve-as-gaps
+agent-inference-as-confirmed: false
+destination: task-input.acceptance-criteria
+scenario-explicit: capture-supported-components
+scenario-distributed: combine-supported-components
+scenario-insufficient: preserve-supported-components-and-gaps
+```
+
+执行顺序：
+
+1. 扫描当前请求及必要前序讨论的完整可见上下文；即使用户没有使用“验收标准”标签，也要识别其中的可观察信息。
+2. 找出可观察输入、用户或系统执行的动作以及预期结果。这些组成可以分散在不同轮次。
+3. 将描述同一行为且有上下文证据的组成合并为自足条目，并保留每项信息的来源和确认状态。
+4. 未表达的组成保持为缺口；不得补造阈值、场景、动作或结果，也不得把 Agent 推导标记为用户已确认。
+5. 将条目写入 `## 任务输入 / ### 验收标准`。如果上下文没有提供可观察标准，该分类保持为空，真实的待确认信息继续保留在既有分类中。
+
+边界样例：
+
+- **单轮显式信息**：当前请求同时给出输入、动作和结果时，捕获全部有证据的组成并注明来自当前请求。
+- **跨轮分散信息**：当前请求描述动作、必要前序讨论提供输入或结果时，只合并属于同一行为的组成，并分别保留来源状态。
+- **信息不足**：用户只说“应该更快”但没有可观察条件或阈值时，不得编造性能目标；保留已表达的关注点和缺口，无法形成标准则让验收分类为空。
+
 ## 安全与压缩
 
 - 排除密钥、Token、凭据和与任务无关的个人信息。

--- a/templates/.agents/skills/create-task/reference/context-capture.en.md
+++ b/templates/.agents/skills/create-task/reference/context-capture.en.md
@@ -18,6 +18,40 @@ Faithfully condense existing information into task.md under `## Task Input`:
 
 Leave missing categories empty rather than inferring content. Deduplicate repeated information without losing its source or state.
 
+## Observable Acceptance Extraction
+
+The following language-neutral contract is the stable boundary for capturing observable acceptance information:
+
+```text
+# observable-acceptance-contract
+sources: current-request,necessary-prior-discussion
+scan-entire-visible-context: true
+recognize-without-acceptance-label: true
+components: observable-input,action,expected-result
+combine-distributed-evidence: true
+preserve-source-state: true
+missing-components: preserve-as-gaps
+agent-inference-as-confirmed: false
+destination: task-input.acceptance-criteria
+scenario-explicit: capture-supported-components
+scenario-distributed: combine-supported-components
+scenario-insufficient: preserve-supported-components-and-gaps
+```
+
+Execution order:
+
+1. Scan the complete visible context of the current request and necessary prior discussion. Recognize observable information even when the user did not label it as acceptance criteria.
+2. Identify observable inputs, user or system actions, and expected results. These components may be distributed across turns.
+3. Combine supported components that describe the same behavior into a self-contained item, preserving the source and confirmation state of each piece of information.
+4. Preserve unexpressed components as gaps. Do not invent thresholds, scenarios, actions, or results, and do not mark agent inference as user-confirmed information.
+5. Write the items under `## Task Input / ### Acceptance Criteria`. If the context provides no observable criterion, leave that category empty and retain genuine unknowns in the existing categories.
+
+Boundary examples:
+
+- **Single-turn explicit information**: when the current request provides an input, action, and result, capture every supported component and identify the current request as its source.
+- **Distributed information**: when the current request describes an action and necessary prior discussion provides an input or result, combine only components for the same behavior and preserve their source states separately.
+- **Insufficient information**: when the user only says that something "should be faster" without an observable condition or threshold, do not invent a performance target; preserve the stated concern and gaps, leaving the acceptance category empty when no criterion can be formed.
+
 ## Safety and Compression
 
 - Exclude secrets, tokens, credentials, and unrelated personal information.

--- a/templates/.agents/skills/create-task/reference/context-capture.zh-CN.md
+++ b/templates/.agents/skills/create-task/reference/context-capture.zh-CN.md
@@ -18,6 +18,40 @@
 
 缺失类别保持为空，不推导补齐。相同信息去重，但不得丢失来源或状态语义。
 
+## 可观察验收提取
+
+以下语言无关契约是可观察验收信息的稳定捕获边界：
+
+```text
+# observable-acceptance-contract
+sources: current-request,necessary-prior-discussion
+scan-entire-visible-context: true
+recognize-without-acceptance-label: true
+components: observable-input,action,expected-result
+combine-distributed-evidence: true
+preserve-source-state: true
+missing-components: preserve-as-gaps
+agent-inference-as-confirmed: false
+destination: task-input.acceptance-criteria
+scenario-explicit: capture-supported-components
+scenario-distributed: combine-supported-components
+scenario-insufficient: preserve-supported-components-and-gaps
+```
+
+执行顺序：
+
+1. 扫描当前请求及必要前序讨论的完整可见上下文；即使用户没有使用“验收标准”标签，也要识别其中的可观察信息。
+2. 找出可观察输入、用户或系统执行的动作以及预期结果。这些组成可以分散在不同轮次。
+3. 将描述同一行为且有上下文证据的组成合并为自足条目，并保留每项信息的来源和确认状态。
+4. 未表达的组成保持为缺口；不得补造阈值、场景、动作或结果，也不得把 Agent 推导标记为用户已确认。
+5. 将条目写入 `## 任务输入 / ### 验收标准`。如果上下文没有提供可观察标准，该分类保持为空，真实的待确认信息继续保留在既有分类中。
+
+边界样例：
+
+- **单轮显式信息**：当前请求同时给出输入、动作和结果时，捕获全部有证据的组成并注明来自当前请求。
+- **跨轮分散信息**：当前请求描述动作、必要前序讨论提供输入或结果时，只合并属于同一行为的组成，并分别保留来源状态。
+- **信息不足**：用户只说“应该更快”但没有可观察条件或阈值时，不得编造性能目标；保留已表达的关注点和缺口，无法形成标准则让验收分类为空。
+
 ## 安全与压缩
 
 - 排除密钥、Token、凭据和与任务无关的个人信息。

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1625,6 +1625,55 @@ test("task templates expose the same structured task-input contract", () => {
   );
 });
 
+test("create-task context capture exposes a structured observable-acceptance contract", () => {
+  const variants = [
+    ".agents/skills/create-task/reference/context-capture.md",
+    "templates/.agents/skills/create-task/reference/context-capture.zh-CN.md",
+    "templates/.agents/skills/create-task/reference/context-capture.en.md"
+  ];
+  const expectedEntries: Record<string, string> = {
+    sources: "current-request,necessary-prior-discussion",
+    "scan-entire-visible-context": "true",
+    "recognize-without-acceptance-label": "true",
+    components: "observable-input,action,expected-result",
+    "combine-distributed-evidence": "true",
+    "preserve-source-state": "true",
+    "missing-components": "preserve-as-gaps",
+    "agent-inference-as-confirmed": "false",
+    destination: "task-input.acceptance-criteria",
+    "scenario-explicit": "capture-supported-components",
+    "scenario-distributed": "combine-supported-components",
+    "scenario-insufficient": "preserve-supported-components-and-gaps"
+  };
+  const contracts: string[] = [];
+
+  variants.forEach((relativePath) => {
+    const content = read(relativePath);
+    const block = content.match(/```[a-z]*\n# observable-acceptance-contract\n([\s\S]*?)\n```/m)?.[1];
+    assert.ok(block, `${relativePath} should declare a fenced observable-acceptance contract`);
+
+    const entries: Record<string, string> = {};
+    block!.split("\n").forEach((line) => {
+      const match = line.match(/^([a-z][a-z-]*):[ \t]*(.*)$/);
+      if (match?.[1] !== undefined) entries[match[1]] = match[2] ?? "";
+    });
+
+    Object.entries(expectedEntries).forEach(([key, value]) => {
+      assert.equal(entries[key], value, `${relativePath} contract should declare ${key}: ${value}`);
+    });
+    contracts.push(block!.trim());
+  });
+
+  contracts.forEach((block) => {
+    assert.equal(block, contracts[0], "observable-acceptance contract should be byte-identical across variants");
+  });
+  assert.equal(
+    read(".agents/skills/create-task/reference/context-capture.md"),
+    read("templates/.agents/skills/create-task/reference/context-capture.zh-CN.md"),
+    "deployed context-capture reference should match its zh-CN template"
+  );
+});
+
 test("import-issue step 1 declares a structured title-derivation contract", () => {
   // Structural guard for the CC-prefix stripping rule (Issue #494). The assertable
   // object is a fenced, language-neutral contract block parsed by key (not prose


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #784

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that does not need an issue

Closes #784

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update

## 📝 变更目的 / Purpose of the Change

修复 `create-task` 与后续需求分析之间的验收信息断层。在任务创建时扫描当前请求与必要前序讨论，捕获用户已经表达的可观察输入、动作和预期结果，同时保留来源状态与真实缺口，避免后续分析因会话上下文丢失而重复询问。

Fix the acceptance-information gap between `create-task` and downstream analysis. Capture observable inputs, actions, and expected results from the current request and necessary prior discussion while preserving source state and genuine gaps.

## 📋 主要变更 / Brief Changelog

- 为 `create-task` 上下文捕获 reference 增加语言无关的可观察验收契约。
- 在英文、中文模板中同步执行顺序与单轮、跨轮、信息不足三类边界样例。
- 增加结构测试，验证契约键值、三变体一致性及部署副本一致性。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run `node --experimental-strip-types --no-warnings --test tests/unit/templates/skills.test.ts`.
3. Run the smoke, core, and full test suites recorded in the implementation report.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：目标测试 68/68 通过；smoke 1090/1090 通过；core 1858 通过、2 跳过；完整测试 2168 通过、3 跳过；TypeScript 类型检查与 `git diff --check` 通过。

## 📸 截图 / Screenshots

不适用；本次变更仅涉及 Skill reference 文档与结构测试。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 GitHub Issue / A corresponding GitHub Issue exists
- [x] PR 只解决一个 Issue / This PR addresses one issue
- [x] Commit 具有有意义的主题和正文 / The commit has a meaningful subject and body
- [x] 代码遵循项目规范并完成独立审查 / Code follows project conventions and independent review is complete
- [x] 已编写必要的单元测试 / Necessary unit tests were added
- [x] TypeScript 类型检查和完整测试通过 / Type checks and the full test suite pass
- [x] 已更新英文与中文文档 / English and Chinese documentation is updated
- [x] 已考虑向后兼容性 / Backward compatibility was considered

## 📋 附加信息 / Additional Notes

### ⚠️ 待人工校验 / Manual Validation Required

- 在真实 AI 客户端会话中分别走查单轮显式、跨轮分散和信息不足三类 `create-task` 输入，确认生成的 `task.md` 能合并有证据信息、保留来源状态，并且不会编造缺失的性能阈值或验收目标。

最新代码审查结论：Approved，0 blocker、0 major、0 minor；上述 1 项真实会话验证待维护者完成。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 `scan-entire-visible-context` 是否始终受 `sources` 边界约束、跨轮证据合并是否保持来源状态，以及结构测试是否避免绑定自然语言措辞。

Generated with AI assistance
