### PR TITLE
fix(review-pr): 补齐活动日志配对并精简摘要


### DIFF
--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -86,4 +86,6 @@
 - **延迟补写（本技能创建 task.md，开始时无文件可写）**——开始执行前先在内存记录 `started_at`，最后写活动日志时**一次性补两条**（started 行用 `started_at`、done 行用完成时间）：
   `create-task`、`import-issue`、`import-codescan`、`import-dependabot`。
 
+- **宿主解析后写入**——`review-pr` 只有在唯一任务宿主、canonical round 与被审 head 确定后才通过 `task-activity pr-review-start` 写 started；成功以 `pr-review-complete` 闭合，已知未发布的受控失败或 head 漂移以 `pr-review-terminate` 写 `aborted` / `superseded` 终态。同一 task/round/head/terminal payload 重放为 no-op；一次性检视不写任务日志。
+
 **例外**：`check-task` 等只读巡检类、不代表实质工作推进的技能不写 started。无 task.md 上下文的纯操作（如无关联任务的 `commit`）同样跳过。

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -55,13 +55,32 @@ agent-infra-internal pr-review-grade resolve-host --pr {pr-number} [--cwd <path>
 
 `resolve-host` 输出 `HostResolution`（`unique` / `ambiguous` / `none`），按以下策略分流：
 
-- **唯一宿主**：绑定 `{task-id}`，用 artifact 枚举确定 `analysis*`/`plan*`/`code*`/`review-*`/`pr-review*` 的存在性（进入步骤 2）。
+- **唯一宿主**：绑定 `{task-id}`，调用 `task-activity pr-review-inspect` 取得 canonical round、prepared/open 状态和最近成功审查身份，再按下述恢复规则开始本轮（进入步骤 2）。
 - **多宿主歧义**：`resolve-host` 返回 `ambiguous`，`decide` 会拒绝分类（fail closed）。立即停止并提示人工指定唯一宿主；不进入证据分类。
 - **无宿主**：默认阻塞，要求先建立 Issue/task 关联（给出关联指引），不自动创建/导入 Issue。仅当用户显式选择「仅一次性检视」时，过程文件写入 `.agents/workspace/reviews/{pr-number}/`（`recoverable: false`）。
 
+任务锚定路径在宿主与远端 head 确定后执行：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-inspect
+```
+
+- `prepared`：复用该 artifact；`open` 且 head 未变：对同一 artifact/head 重放 start（no-op）并恢复该轮。
+- `open` 且 head 已变：先把旧 artifact 的正式 Review 状态写为 `superseded`，再用旧 artifact/head 执行 terminate；随后使用 inspect 返回的 next round。
+- 无 prepared/open：按 `reference/report-template.md` 创建 next artifact 骨架，先写状态核对、身份信息、被审 head 与 `正式 Review 状态: pending`。
+
+在上述分流完成后、步骤 2 证据分级开始前写 started：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-start --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha}
+```
+
+一次性路径不调用 `task-activity`。任意 started 后、正式 Review 明确尚未发布的受控失败，都先把 artifact 状态写为 `aborted`，再以同一 artifact/head 调用 `pr-review-terminate --outcome aborted --reason <single-line>`；发布结果不确定时保持 open，不臆断 aborted。
+
 ### 2. 单次 decide：证据枚举 + 场景分类 + 风险分级 + 模式选择
 
-把宿主、artifact 存在性、head 状态与六个纯证据风险因素写入输入 JSON，调用一次：
+把宿主、artifact 存在性、head 状态与六个纯证据风险因素写入输入 JSON。prior review 只使用 inspect 返回的最高 `applied` / `no-op` artifact；pending/aborted/superseded/failed 只参与 round 连续性，不作为既有结论。调用一次：
 
 ```bash
 agent-infra-internal pr-review-grade decide --input-file {decide-input.json} [--cwd <path>]
@@ -71,7 +90,7 @@ agent-infra-internal pr-review-grade decide --input-file {decide-input.json} [--
 
 ### 3. 生成 `pr-review-rN.md`
 
-按 `reference/report-template.md` 生成本轮产物。`reconstruct`（或 `audit` 证据不足）时，在行级 finding 之前先写「重建上下文」段（需求边界 / 架构选择 / 影响面 / 验证覆盖，见 `reference/evidence-grading.md`）。frontmatter 或首部记录 `recoverable: true|false`（一次性路径为 `false`）。
+按 `reference/report-template.md` 完成本轮产物；任务锚定路径保留步骤 1 已写入的身份/head/pending 状态，不重新分配 round。`reconstruct`（或 `audit` 证据不足）时，在行级 finding 之前先写「重建上下文」段（需求边界 / 架构选择 / 影响面 / 验证覆盖，见 `reference/evidence-grading.md`）。frontmatter 或首部记录 `recoverable: true|false`（一次性路径为 `false`）。完成最终问题清单后，一次性冻结 `{verdict, blockers, major, minor}`；正式 Review 正文与步骤 6 的 complete payload 必须直接复用该对象，不从报告文案反向统计。
 
 ### 4. 同步 Issue artifact 评论（任务锚定路径）
 
@@ -99,18 +118,27 @@ agent-infra-internal platform-pr-review publish --pr {pr-number} --scope {taskId
   --commit {head-sha} --event {COMMENT|APPROVE|REQUEST_CHANGES} --body-file {review-body.md} [--dry-run] [--cwd <path>]
 ```
 
-`publish` 由 core 生成并校验 marker（首行），按 marker + commit 幂等（重放 no-op；marker 命中但 commit 不一致稳定失败）。head 漂移则停止并转入新轮次（重新执行步骤 1，轮次 `{round}+1`）。
+`publish` 由 core 生成并校验 marker（首行），按 marker + commit 幂等（重放 no-op；marker 命中但 commit 不一致稳定失败）。head 漂移时，先把旧 artifact 状态写为 `superseded`，再闭合旧轮：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-terminate --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha} \
+  --outcome superseded --reason "head changed before publish"
+```
+
+闭合成功后重新执行步骤 1，进入下一 canonical round；不得先写新轮 started。若 publish 调用的远端结果不确定，保留 open 并在重试时依赖 marker + commit 恢复。
 
 ### 6. 回写发布结果与任务状态
 
-- **任务锚定路径**：把 Review ID/URL 写入 `pr-review-rN.md`「发布结果」段，并追加活动日志：
+- **任务锚定路径**：publish 返回 `applied` / `no-op` 后，把 Review ID/URL 与同名正式 Review 状态写入 `pr-review-rN.md`「发布结果」段，再以步骤 3 冻结的同一组 verdict/counts 闭合活动日志：
 
   ```bash
-  agent-infra-internal task-activity {task-id} append --step "Review PR (Round {round})" --agent {agent} \
-    --note "receipt {receipt} · Review URL {review-url}" --artifact {pr-review-artifact}
+  agent-infra-internal task-activity {task-id} pr-review-complete --agent {agent} \
+    --artifact {pr-review-artifact} --head {head-sha} --verdict {approved|changes-requested|commented} \
+    --blockers {blockers} --major {major} --minor {minor}
   ```
 
-  `task-activity` 经 `writeTask` 原子完成 Activity Log 追加、`## 审查反馈` 链接与版本戳刷新；不改 `current_step`。
+  `task-activity` 由 typed payload 生成 `Verdict: <结论>, blockers: N, major: N, minor: N → {pr-review-artifact}`，并经 `writeTask` 原子完成 Activity Log、`## 审查反馈` 链接与版本戳刷新；不改 `current_step`，也不把 receipt/head/Review URL 写入 NOTE。
 
 - **一次性路径（无任务）**：Review ID/URL 只写 `pr-review-rN.md`「发布结果」段，不调用 `task-activity`。
 

--- a/.agents/skills/review-pr/reference/report-template.md
+++ b/.agents/skills/review-pr/reference/report-template.md
@@ -69,7 +69,7 @@
 
 ## 发布结果
 
-- **正式 Review 状态**：{applied / no-op / blocked / failed}
+- **正式 Review 状态**：{pending / applied / no-op / aborted / superseded / blocked / failed}
 - **Review ID**：{review-id 或 N/A}
 - **Review URL**：{review-url 或 N/A}
 - **Issue artifact 评论 URL**：{comment-url 或 N/A}

--- a/lib/internal/task-activity.ts
+++ b/lib/internal/task-activity.ts
@@ -1,13 +1,36 @@
-import { applyActivityAppendIntent } from '../task/activity-intent.ts';
-import type { ActivityAppendIntent } from '../task/activity-intent.ts';
+import {
+  applyPrReviewActivityIntent,
+  inspectPrReviewActivity
+} from '../task/activity-intent.ts';
+import type {
+  PrReviewActivityIntent,
+  PrReviewInspectIntent
+} from '../task/activity-intent.ts';
 
-const USAGE = `Usage: agent-infra-internal task-activity <task-ref> append --step <step> --agent <agent> --note <note> [--artifact <canonical.md>] [--dry-run]
+const USAGE = `Usage: agent-infra-internal task-activity <task-ref> pr-review-inspect
+       agent-infra-internal task-activity <task-ref> pr-review-start --agent <agent> --artifact <canonical.md> --head <40hex> [--dry-run]
+       agent-infra-internal task-activity <task-ref> pr-review-complete --agent <agent> --artifact <canonical.md> --head <40hex> --verdict <approved|changes-requested|commented> --blockers <N> --major <N> --minor <N> [--dry-run]
+       agent-infra-internal task-activity <task-ref> pr-review-terminate --agent <agent> --artifact <canonical.md> --head <40hex> --outcome <aborted|superseded> --reason <single-line> [--dry-run]
 `;
+
+const OPERATIONS = new Set(['pr-review-inspect', 'pr-review-start', 'pr-review-complete', 'pr-review-terminate']);
 const FLAGS: Record<string, string> = {
-  '--step': 'step',
   '--agent': 'agent',
-  '--note': 'note',
-  '--artifact': 'artifact'
+  '--artifact': 'artifact',
+  '--head': 'head',
+  '--verdict': 'verdict',
+  '--blockers': 'blockers',
+  '--major': 'major',
+  '--minor': 'minor',
+  '--outcome': 'outcome',
+  '--reason': 'reason'
+};
+const COMMON = ['agent', 'artifact', 'head'] as const;
+const ALLOWED: Record<string, ReadonlySet<string>> = {
+  'pr-review-inspect': new Set(['kind', 'taskRef']),
+  'pr-review-start': new Set(['kind', 'taskRef', 'agent', 'artifact', 'head', 'dryRun']),
+  'pr-review-complete': new Set(['kind', 'taskRef', 'agent', 'artifact', 'head', 'verdict', 'blockers', 'major', 'minor', 'dryRun']),
+  'pr-review-terminate': new Set(['kind', 'taskRef', 'agent', 'artifact', 'head', 'outcome', 'reason', 'dryRun'])
 };
 
 function usageFailure(message: string): void {
@@ -19,8 +42,8 @@ function usageFailure(message: string): void {
 function taskActivity(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
-  if (!taskRef || taskRef.startsWith('--') || !kind || kind !== 'append') {
-    usageFailure('task ref and the append intent are required');
+  if (!taskRef || taskRef.startsWith('--') || !kind || !OPERATIONS.has(kind)) {
+    usageFailure('task ref and a supported PR review intent are required');
     return;
   }
   const values: Record<string, unknown> = { kind, taskRef };
@@ -39,15 +62,28 @@ function taskActivity(args: string[] = []): void {
     const value = args[++index];
     if (value === undefined || value.startsWith('--')) { usageFailure(`option '${flag}' requires a value`); return; }
     seen.add(flag);
-    values[key] = value;
+    values[key] = ['blockers', 'major', 'minor'].includes(key) ? Number(value) : value;
   }
-  const allowed = new Set(['kind', 'taskRef', 'dryRun', 'step', 'agent', 'note', 'artifact']);
+
+  const allowed = ALLOWED[kind]!;
   const unexpected = Object.keys(values).find((key) => !allowed.has(key));
-  if (unexpected) { usageFailure(`append does not accept '${unexpected}'`); return; }
-  for (const key of ['step', 'agent', 'note']) {
-    if (values[key] === undefined) { usageFailure(`append requires '${key}'`); return; }
+  if (unexpected) { usageFailure(`${kind} does not accept '${unexpected}'`); return; }
+  if (kind === 'pr-review-inspect') {
+    const result = inspectPrReviewActivity(values as PrReviewInspectIntent);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (result.status === 'failed') process.exitCode = 1;
+    return;
   }
-  const result = applyActivityAppendIntent(values as ActivityAppendIntent);
+  for (const key of COMMON) {
+    if (values[key] === undefined) { usageFailure(`${kind} requires '${key}'`); return; }
+  }
+  const operationRequired = kind === 'pr-review-complete'
+    ? ['verdict', 'blockers', 'major', 'minor']
+    : kind === 'pr-review-terminate' ? ['outcome', 'reason'] : [];
+  for (const key of operationRequired) {
+    if (values[key] === undefined) { usageFailure(`${kind} requires '${key}'`); return; }
+  }
+  const result = applyPrReviewActivityIntent(values as PrReviewActivityIntent);
   process.stdout.write(`${JSON.stringify(result)}\n`);
   if (result.status === 'failed') process.exitCode = 1;
 }

--- a/lib/task/activity-intent.ts
+++ b/lib/task/activity-intent.ts
@@ -1,101 +1,368 @@
 import fs from 'node:fs';
-import path from 'node:path';
 
+import { normalizeAgentToken } from '../agent-clients/tokens.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
 import { locateActivityLog, appendActivityEntry } from './activity-log.ts';
-import { buildArtifactLinkSection, parseArtifactName } from './artifact-lifecycle.ts';
+import {
+  assertWritableInventory,
+  buildArtifactLinkSection,
+  inspectTaskArtifacts,
+  parseArtifactName
+} from './artifact-lifecycle.ts';
+import type { ArtifactIdentity } from './artifact-lifecycle.ts';
+import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
+import type { TaskExecutionLockOptions } from './task-execution-lock.ts';
 import { captureTaskWriteMetadata, writeTask } from './write.ts';
 import type { TaskMutation, TaskOperationSummary, TaskWriteOptions } from './write.ts';
 
-export type ActivityAppendIntent = {
-  kind: 'append';
+type PrReviewVerdict = 'approved' | 'changes-requested' | 'commented';
+type PrReviewOutcome = 'aborted' | 'superseded';
+type PrReviewArtifactStatus = 'pending' | 'applied' | 'no-op' | 'blocked' | 'failed' | 'aborted' | 'superseded';
+
+export type PrReviewInspectIntent = {
+  kind: 'pr-review-inspect';
   taskRef: string;
-  step: string;
+};
+
+export type PrReviewStartIntent = {
+  kind: 'pr-review-start';
+  taskRef: string;
   agent: string;
-  note: string;
-  artifact?: string;
+  artifact: string;
+  head: string;
   dryRun?: boolean;
 };
 
-export type ActivityIntentResult = {
+export type PrReviewCompleteIntent = {
+  kind: 'pr-review-complete';
+  taskRef: string;
+  agent: string;
+  artifact: string;
+  head: string;
+  verdict: PrReviewVerdict;
+  blockers: number;
+  major: number;
+  minor: number;
+  dryRun?: boolean;
+};
+
+export type PrReviewTerminateIntent = {
+  kind: 'pr-review-terminate';
+  taskRef: string;
+  agent: string;
+  artifact: string;
+  head: string;
+  outcome: PrReviewOutcome;
+  reason: string;
+  dryRun?: boolean;
+};
+
+export type PrReviewActivityIntent = PrReviewStartIntent | PrReviewCompleteIntent | PrReviewTerminateIntent;
+
+type PrReviewIdentity = {
+  round: number;
+  artifact: string;
+  head: string;
+  agent: string | null;
+  artifactStatus: PrReviewArtifactStatus;
+  note: string | null;
+};
+
+export type PrReviewActivitySnapshot = {
+  nextRound: number;
+  prepared: PrReviewIdentity | null;
+  open: PrReviewIdentity | null;
+  latestTerminal: PrReviewIdentity | null;
+  latestSuccessful: PrReviewIdentity | null;
+};
+
+export type PrReviewActivityResult = {
   status: 'planned' | 'applied' | 'no-op' | 'failed';
   changed: boolean;
-  intent: 'append';
+  intent: PrReviewActivityIntent['kind'];
   taskId: string | null;
   artifact: string | null;
   operations: readonly TaskOperationSummary[];
   error: { code: string; message: string } | null;
 };
 
-function failed(intent: ActivityAppendIntent, code: string, message: string, taskId: string | null = null): ActivityIntentResult {
+export type PrReviewInspectionResult = {
+  status: 'ready' | 'failed';
+  changed: false;
+  intent: 'pr-review-inspect';
+  taskId: string | null;
+  snapshot: PrReviewActivitySnapshot | null;
+  error: { code: string; message: string } | null;
+};
+
+type ActivityIntentOptions = TaskWriteOptions & { lockOptions?: TaskExecutionLockOptions };
+type ArtifactRecord = { identity: ArtifactIdentity; head: string; status: PrReviewArtifactStatus };
+type RoundState = ArtifactRecord & {
+  startedAgent: string | null;
+  terminalAgent: string | null;
+  terminalNote: string | null;
+};
+
+const HEAD_RE = /^[0-9a-f]{40}$/;
+const REVIEW_ACTION_RE = /^Review PR \(Round ([1-9]\d*)\)( \[started\])?$/;
+const VERDICTS: ReadonlySet<string> = new Set(['approved', 'changes-requested', 'commented']);
+const OUTCOMES: ReadonlySet<string> = new Set(['aborted', 'superseded']);
+const SUCCESS_STATUSES: ReadonlySet<PrReviewArtifactStatus> = new Set(['applied', 'no-op']);
+const ARTIFACT_STATUSES: ReadonlySet<string> = new Set([
+  'pending', 'applied', 'no-op', 'blocked', 'failed', 'aborted', 'superseded'
+]);
+
+function failed(
+  intent: PrReviewActivityIntent,
+  code: string,
+  message: string,
+  taskId: string | null = null
+): PrReviewActivityResult {
   return {
-    status: 'failed', changed: false, intent: 'append', taskId,
-    artifact: intent.artifact ?? null, operations: [], error: { code, message }
+    status: 'failed', changed: false, intent: intent.kind, taskId,
+    artifact: intent.artifact, operations: [], error: { code, message }
   };
 }
 
-function oneLine(value: string): string {
-  return value.replace(/\s*\r?\n\s*/g, ' ').trim();
+function inspectionFailed(code: string, message: string, taskId: string | null = null): PrReviewInspectionResult {
+  return {
+    status: 'failed', changed: false, intent: 'pr-review-inspect', taskId,
+    snapshot: null, error: { code, message }
+  };
 }
 
-/**
- * Append an Activity Log entry (and, optionally, a `## 审查反馈` artifact link)
- * to an active task via the atomic `writeTask` path. `current_step` is never
- * touched (PL-2): review-pr does not join the standard stage chain.
- */
-export function applyActivityAppendIntent(intent: ActivityAppendIntent, options: TaskWriteOptions = {}): ActivityIntentResult {
-  if (intent.kind !== 'append') return failed(intent, 'ACTIVITY_INTENT_INVALID', 'intent kind must be append');
-  const resolved = resolveTaskRef(intent.taskRef, { repoRoot: options.repoRoot });
-  if (!resolved.ok) return failed(intent, resolved.code, resolved.message, resolved.taskId);
-  if (resolved.state !== 'active') {
-    return failed(intent, 'TASK_STATE_MISMATCH', `task ${resolved.taskId} is ${resolved.state}, expected active`, resolved.taskId);
+function parseArtifactRecord(identity: ArtifactIdentity): ArtifactRecord | { code: string; message: string } {
+  let content: string;
+  try {
+    content = fs.readFileSync(identity.path, 'utf8');
+  } catch (error) {
+    return { code: 'ACTIVITY_ARTIFACT_READ_FAILED', message: error instanceof Error ? error.message : String(error) };
   }
-  const step = oneLine(intent.step);
-  const agent = oneLine(intent.agent);
-  const note = oneLine(intent.note);
-  if (!step || !agent || !note || /[\r\n]/.test(intent.step) || /[\r\n]/.test(intent.agent) || /[\r\n]/.test(intent.note)) {
-    return failed(intent, 'ACTIVITY_INTENT_INVALID', 'step, agent and note must be non-empty single-line values', resolved.taskId);
+  const heads = [...content.matchAll(/^- \*\*(?:被审 head SHA|Reviewed Head SHA)\*\*[:：]\s*([0-9a-f]{40})\s*$/gm)];
+  if (heads.length !== 1) {
+    return { code: 'ACTIVITY_ARTIFACT_INVALID', message: `${identity.name} must contain exactly one reviewed head SHA` };
   }
+  const statuses = [...content.matchAll(/^- \*\*(?:正式 Review 状态|Formal Review Status)\*\*[:：][ \t]*([a-z-]+)[^\r\n]*$/gm)];
+  const status = statuses[0]?.[1];
+  if (statuses.length !== 1 || !status || !ARTIFACT_STATUSES.has(status)) {
+    return { code: 'ACTIVITY_ARTIFACT_INVALID', message: `${identity.name} must contain exactly one supported formal review status` };
+  }
+  return { identity, head: heads[0]![1]!, status: status as PrReviewArtifactStatus };
+}
 
-  let artifact: ReturnType<typeof parseArtifactName> | null = null;
-  if (intent.artifact !== undefined) {
-    artifact = parseArtifactName(intent.artifact);
-    if (!artifact || artifact.family !== 'pr-review') {
-      return failed(intent, 'ACTIVITY_ARTIFACT_INVALID', `artifact '${intent.artifact}' is not a canonical pr-review artifact`, resolved.taskId);
-    }
+function toIdentity(state: RoundState, terminal = false): PrReviewIdentity {
+  return {
+    round: state.identity.round,
+    artifact: state.identity.name,
+    head: state.head,
+    agent: terminal ? state.terminalAgent : state.startedAgent,
+    artifactStatus: state.status,
+    note: terminal ? state.terminalNote : null
+  };
+}
+
+function readSnapshot(taskRef: string, repoRoot?: string):
+  | { ok: true; taskId: string; taskDir: string; taskMdPath: string; repoRoot: string; content: string; states: RoundState[]; snapshot: PrReviewActivitySnapshot }
+  | { ok: false; code: string; message: string; taskId: string | null } {
+  const resolved = resolveTaskRef(taskRef, { repoRoot });
+  if (!resolved.ok) return { ok: false, code: resolved.code, message: resolved.message, taskId: resolved.taskId };
+  if (resolved.state !== 'active') {
+    return { ok: false, code: 'TASK_STATE_MISMATCH', message: `task ${resolved.taskId} is ${resolved.state}, expected active`, taskId: resolved.taskId };
   }
+  const inventory = inspectTaskArtifacts(taskRef, 'pr-review', { repoRoot: resolved.repoRoot });
+  if (inventory.status === 'failed') {
+    return { ok: false, code: inventory.error?.code ?? 'ACTIVITY_ARTIFACT_INVALID', message: inventory.error?.message ?? 'artifact inspection failed', taskId: resolved.taskId };
+  }
+  const topology = assertWritableInventory(inventory);
+  if (topology) return { ok: false, code: topology.code, message: topology.message, taskId: resolved.taskId };
 
   let content: string;
   try {
     content = fs.readFileSync(resolved.taskMdPath, 'utf8');
   } catch (error) {
-    return failed(intent, 'TASK_READ_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
+    return { ok: false, code: 'TASK_READ_FAILED', message: error instanceof Error ? error.message : String(error), taskId: resolved.taskId };
   }
-  const section = locateActivityLog(content);
-  if (!section) {
-    return failed(intent, 'ACTIVITY_SECTION_MISSING', 'task has no unique Activity Log section', resolved.taskId);
+  const activity = locateActivityLog(content);
+  if (!activity) return { ok: false, code: 'ACTIVITY_SECTION_MISSING', message: 'task has no unique Activity Log section', taskId: resolved.taskId };
+
+  const knownRounds = new Set(inventory.artifacts.map((artifact) => artifact.round));
+  for (const entry of activity.entries) {
+    const match = REVIEW_ACTION_RE.exec(entry.step);
+    if (match && !knownRounds.has(Number(match[1]))) {
+      return { ok: false, code: 'ACTIVITY_STATE_CONFLICT', message: `Activity Log round ${match[1]} has no canonical pr-review artifact`, taskId: resolved.taskId };
+    }
+  }
+
+  const states: RoundState[] = [];
+  for (const identity of inventory.artifacts) {
+    const parsed = parseArtifactRecord(identity);
+    if ('code' in parsed) return { ok: false, ...parsed, taskId: resolved.taskId };
+    const base = `Review PR (Round ${identity.round})`;
+    const started = activity.entries.filter((entry) => entry.step === `${base} [started]`);
+    const terminal = activity.entries.filter((entry) => entry.step === base);
+    if (started.length > 1 || terminal.length > 1) {
+      return { ok: false, code: 'ACTIVITY_STATE_CONFLICT', message: `${base} has duplicate started or terminal rows`, taskId: resolved.taskId };
+    }
+    if (terminal.length === 1 && started.length === 0 && !terminal[0]!.note.startsWith('receipt ')) {
+      return { ok: false, code: 'ACTIVITY_STATE_CONFLICT', message: `${base} has a terminal row without a matching started row`, taskId: resolved.taskId };
+    }
+    if (terminal.length === 1) {
+      const note = terminal[0]!.note;
+      const terminalMatchesStatus =
+        (note.startsWith('Verdict: ') && SUCCESS_STATUSES.has(parsed.status))
+        || (note.startsWith('Outcome: Aborted, ') && parsed.status === 'aborted')
+        || (note.startsWith('Outcome: Superseded, ') && parsed.status === 'superseded')
+        || (note.startsWith('receipt ') && SUCCESS_STATUSES.has(parsed.status));
+      if (!terminalMatchesStatus) {
+        return { ok: false, code: 'ACTIVITY_STATE_CONFLICT', message: `${base} terminal note conflicts with artifact status ${parsed.status}`, taskId: resolved.taskId };
+      }
+    }
+    states.push({
+      ...parsed,
+      startedAgent: started[0]?.agent ?? null,
+      terminalAgent: terminal[0]?.agent ?? null,
+      terminalNote: terminal[0]?.note ?? null
+    });
+  }
+
+  const openStates = states.filter((state) => state.startedAgent !== null && state.terminalNote === null);
+  const preparedStates = states.filter((state) => state.status === 'pending' && state.startedAgent === null && state.terminalNote === null);
+  if (openStates.length > 1 || preparedStates.length > 1) {
+    return { ok: false, code: 'ACTIVITY_STATE_CONFLICT', message: 'multiple prepared or open PR review rounds exist', taskId: resolved.taskId };
+  }
+  const terminalStates = states.filter((state) => state.terminalNote !== null);
+  const successfulStates = states.filter((state) => SUCCESS_STATUSES.has(state.status));
+  const latestTerminal = terminalStates.at(-1) ?? null;
+  const latestSuccessful = successfulStates.at(-1) ?? null;
+  return {
+    ok: true,
+    taskId: resolved.taskId,
+    taskDir: resolved.taskDir,
+    taskMdPath: resolved.taskMdPath,
+    repoRoot: resolved.repoRoot,
+    content,
+    states,
+    snapshot: {
+      nextRound: inventory.next?.round ?? 1,
+      prepared: preparedStates[0] ? toIdentity(preparedStates[0]) : null,
+      open: openStates[0] ? toIdentity(openStates[0]) : null,
+      latestTerminal: latestTerminal ? toIdentity(latestTerminal, true) : null,
+      latestSuccessful: latestSuccessful ? toIdentity(latestSuccessful, true) : null
+    }
+  };
+}
+
+export function inspectPrReviewActivity(intent: PrReviewInspectIntent, options: Pick<ActivityIntentOptions, 'repoRoot'> = {}): PrReviewInspectionResult {
+  const state = readSnapshot(intent.taskRef, options.repoRoot);
+  if (!state.ok) return inspectionFailed(state.code, state.message, state.taskId);
+  return { status: 'ready', changed: false, intent: intent.kind, taskId: state.taskId, snapshot: state.snapshot, error: null };
+}
+
+function validateIntent(intent: PrReviewActivityIntent): { agent: string; artifact: { round: number; name: string } } | { code: string; message: string } {
+  const agent = normalizeAgentToken(intent.agent);
+  if (!agent) return { code: 'ACTIVITY_INTENT_INVALID', message: 'agent must be a supported collaborator token' };
+  const artifact = parseArtifactName(intent.artifact);
+  if (!artifact || artifact.family !== 'pr-review') {
+    return { code: 'ACTIVITY_ARTIFACT_INVALID', message: `artifact '${intent.artifact}' is not a canonical pr-review artifact` };
+  }
+  if (!HEAD_RE.test(intent.head)) return { code: 'ACTIVITY_INTENT_INVALID', message: 'head must be a lowercase 40-character SHA' };
+  if (intent.kind === 'pr-review-complete') {
+    if (!VERDICTS.has(intent.verdict)) return { code: 'ACTIVITY_INTENT_INVALID', message: 'verdict is invalid' };
+    if (![intent.blockers, intent.major, intent.minor].every((value) => Number.isSafeInteger(value) && value >= 0)) {
+      return { code: 'ACTIVITY_INTENT_INVALID', message: 'finding counts must be non-negative safe integers' };
+    }
+  }
+  if (intent.kind === 'pr-review-terminate') {
+    if (!OUTCOMES.has(intent.outcome)) return { code: 'ACTIVITY_INTENT_INVALID', message: 'outcome is invalid' };
+    if (!intent.reason.trim() || /[\r\n]/.test(intent.reason) || intent.reason !== intent.reason.trim()) {
+      return { code: 'ACTIVITY_INTENT_INVALID', message: 'reason must be a non-empty trimmed single-line value' };
+    }
+  }
+  return { agent, artifact };
+}
+
+function verdictLabel(verdict: PrReviewVerdict): string {
+  if (verdict === 'approved') return 'Approved';
+  if (verdict === 'changes-requested') return 'Changes Requested';
+  return 'Commented';
+}
+
+function outcomeLabel(outcome: PrReviewOutcome): string {
+  return outcome === 'aborted' ? 'Aborted' : 'Superseded';
+}
+
+function terminalNote(intent: PrReviewCompleteIntent | PrReviewTerminateIntent): string {
+  if (intent.kind === 'pr-review-complete') {
+    return `Verdict: ${verdictLabel(intent.verdict)}, blockers: ${intent.blockers}, major: ${intent.major}, minor: ${intent.minor} → ${intent.artifact}`;
+  }
+  return `Outcome: ${outcomeLabel(intent.outcome)}, reason: ${intent.reason} → ${intent.artifact}`;
+}
+
+function applyLocked(intent: PrReviewActivityIntent, normalizedAgent: string, options: ActivityIntentOptions): PrReviewActivityResult {
+  const state = readSnapshot(intent.taskRef, options.repoRoot);
+  if (!state.ok) return failed(intent, state.code, state.message, state.taskId);
+  const parsed = parseArtifactName(intent.artifact)!;
+  const roundState = state.states.find((item) => item.identity.name === parsed.name);
+  if (!roundState) return failed(intent, 'ACTIVITY_ARTIFACT_INVALID', `artifact '${intent.artifact}' is not landed`, state.taskId);
+  if (roundState.head !== intent.head) {
+    return failed(intent, 'ACTIVITY_IDENTITY_MISMATCH', `head does not match ${intent.artifact}`, state.taskId);
+  }
+  const base = `Review PR (Round ${parsed.round})`;
+  let step: string;
+  let note: string;
+  let linkArtifact = false;
+
+  if (intent.kind === 'pr-review-start') {
+    if (roundState.terminalNote !== null) {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${base} is already terminal`, state.taskId);
+    }
+    if (roundState.startedAgent !== null) {
+      return { status: 'no-op', changed: false, intent: intent.kind, taskId: state.taskId, artifact: intent.artifact, operations: [], error: null };
+    }
+    if (roundState.status !== 'pending') {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${intent.artifact} must be pending before start`, state.taskId);
+    }
+    if (state.snapshot.open && state.snapshot.open.artifact !== intent.artifact) {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `another PR review round is open: ${state.snapshot.open.artifact}`, state.taskId);
+    }
+    step = `${base} [started]`;
+    note = 'started';
+  } else {
+    note = terminalNote(intent);
+    if (roundState.terminalNote !== null) {
+      if (roundState.terminalNote === note) {
+        return { status: 'no-op', changed: false, intent: intent.kind, taskId: state.taskId, artifact: intent.artifact, operations: [], error: null };
+      }
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${base} has a different terminal payload`, state.taskId);
+    }
+    if (roundState.startedAgent === null) {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${base} has no matching started row`, state.taskId);
+    }
+    if (intent.kind === 'pr-review-complete' && !SUCCESS_STATUSES.has(roundState.status)) {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${intent.artifact} must be applied or no-op before completion`, state.taskId);
+    }
+    if (intent.kind === 'pr-review-terminate' && roundState.status !== intent.outcome) {
+      return failed(intent, 'ACTIVITY_STATE_CONFLICT', `${intent.artifact} status must match outcome ${intent.outcome}`, state.taskId);
+    }
+    step = base;
+    linkArtifact = true;
   }
 
   let metadata;
   try {
     metadata = (options.metadataProvider ?? captureTaskWriteMetadata)();
   } catch (error) {
-    return failed(intent, 'METADATA_CAPTURE_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
+    return failed(intent, 'METADATA_CAPTURE_FAILED', error instanceof Error ? error.message : String(error), state.taskId);
   }
-
-  const mutations: TaskMutation[] = [];
-  const activityBody = appendActivityEntry(section, { time: metadata.timestamp, step, agent, note });
-  mutations.push({ kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: section.heading, body: activityBody });
-  if (artifact) {
-    const link = buildArtifactLinkSection(content, {
-      ...artifact,
-      path: path.join(resolved.taskDir, artifact.name),
-      size: 0,
-      mtimeMs: 0
-    });
+  const section = locateActivityLog(state.content)!;
+  const mutations: TaskMutation[] = [{
+    kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: section.heading,
+    body: appendActivityEntry(section, { time: metadata.timestamp, step, agent: normalizedAgent, note })
+  }];
+  if (linkArtifact) {
+    const link = buildArtifactLinkSection(state.content, roundState.identity);
     mutations.push({ kind: 'section', aliases: link.aliases, heading: link.heading, body: link.body });
   }
-
   const writeResult = writeTask({
     taskRef: intent.taskRef,
     expectedState: 'active',
@@ -104,10 +371,10 @@ export function applyActivityAppendIntent(intent: ActivityAppendIntent, options:
   }, {
     ...options,
     taskLocation: {
-      repoRoot: resolved.repoRoot,
-      taskId: resolved.taskId,
-      taskMdPath: resolved.taskMdPath,
-      state: resolved.state
+      repoRoot: state.repoRoot,
+      taskId: state.taskId,
+      taskMdPath: state.taskMdPath,
+      state: 'active'
     },
     metadataProvider: () => metadata
   });
@@ -117,12 +384,34 @@ export function applyActivityAppendIntent(intent: ActivityAppendIntent, options:
   return {
     status: writeResult.status,
     changed: writeResult.changed,
-    intent: 'append',
+    intent: intent.kind,
     taskId: writeResult.taskId,
-    artifact: intent.artifact ?? null,
+    artifact: intent.artifact,
     operations: writeResult.operations,
     error: null
   };
 }
 
-export type { TaskWriteOptions } from './write.ts';
+export function applyPrReviewActivityIntent(intent: PrReviewActivityIntent, options: ActivityIntentOptions = {}): PrReviewActivityResult {
+  const validated = validateIntent(intent);
+  if ('code' in validated) return failed(intent, validated.code, validated.message);
+  const resolved = resolveTaskRef(intent.taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return failed(intent, resolved.code, resolved.message, resolved.taskId);
+  if (resolved.state !== 'active') {
+    return failed(intent, 'TASK_STATE_MISMATCH', `task ${resolved.taskId} is ${resolved.state}, expected active`, resolved.taskId);
+  }
+  try {
+    return withTaskExecutionLock(
+      resolved.repoRoot,
+      resolved.taskId,
+      `task-activity:${intent.kind}`,
+      () => applyLocked(intent, validated.agent, { ...options, repoRoot: resolved.repoRoot }),
+      options.lockOptions
+    );
+  } catch (error) {
+    if (error instanceof TaskExecutionLockError) return failed(intent, error.code, error.message, resolved.taskId);
+    return failed(intent, 'ACTIVITY_LOCK_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
+  }
+}
+
+export type { ActivityIntentOptions };

--- a/templates/.agents/rules/task-management.en.md
+++ b/templates/.agents/rules/task-management.en.md
@@ -83,4 +83,6 @@ The six internal commands (`task-event` / `task-lifecycle` / `platform-issue` / 
 - **Deferred form (the skill creates task.md, so there is no file to write to at the start)** — capture `started_at` in memory before running, then when writing the Activity Log at the end, **append both lines at once** (started line uses `started_at`, done line uses the completion time):
   `create-task`, `import-issue`, `import-codescan`, `import-dependabot`.
 
+- **After host resolution** — `review-pr` writes started through `task-activity pr-review-start` only after resolving the unique task host, canonical round, and reviewed head. Success closes through `pr-review-complete`; a controlled pre-publication failure or head drift closes through `pr-review-terminate` with an `aborted` / `superseded` terminal. Replaying the same task/round/head/terminal payload is a no-op; one-shot review never writes a task Activity Log.
+
 **Exceptions**: read-only inspection skills that do not represent real progress (e.g. `check-task`) do not write started. A bare operation with no task.md context (e.g. a `commit` not tied to a task) likewise skips it.

--- a/templates/.agents/rules/task-management.zh-CN.md
+++ b/templates/.agents/rules/task-management.zh-CN.md
@@ -86,4 +86,6 @@
 - **延迟补写（本技能创建 task.md，开始时无文件可写）**——开始执行前先在内存记录 `started_at`，最后写活动日志时**一次性补两条**（started 行用 `started_at`、done 行用完成时间）：
   `create-task`、`import-issue`、`import-codescan`、`import-dependabot`。
 
+- **宿主解析后写入**——`review-pr` 只有在唯一任务宿主、canonical round 与被审 head 确定后才通过 `task-activity pr-review-start` 写 started；成功以 `pr-review-complete` 闭合，已知未发布的受控失败或 head 漂移以 `pr-review-terminate` 写 `aborted` / `superseded` 终态。同一 task/round/head/terminal payload 重放为 no-op；一次性检视不写任务日志。
+
 **例外**：`check-task` 等只读巡检类、不代表实质工作推进的技能不写 started。无 task.md 上下文的纯操作（如无关联任务的 `commit`）同样跳过。

--- a/templates/.agents/skills/review-pr/SKILL.en.md
+++ b/templates/.agents/skills/review-pr/SKILL.en.md
@@ -55,13 +55,32 @@ agent-infra-internal pr-review-grade resolve-host --pr {pr-number} [--cwd <path>
 
 `resolve-host` returns a typed `HostResolution` (`unique` / `ambiguous` / `none`). Branch as follows:
 
-- **Unique host**: bind `{task-id}` and enumerate `analysis*`/`plan*`/`code*`/`review-*`/`pr-review*` presence (go to step 2).
+- **Unique host**: bind `{task-id}`, call `task-activity pr-review-inspect` to obtain the canonical round, prepared/open state, and latest successful review identity, then start this round using the recovery rules below (go to step 2).
 - **Ambiguous hosts**: `resolve-host` returns `ambiguous` and `decide` refuses to classify (fail closed). Stop and ask a human to pin the unique host; do not enter evidence classification.
 - **No host**: block by default and require linking an Issue/task first (show linking guidance); never auto-create/import an Issue. Only when the user explicitly chooses a "one-shot review" do process files land in `.agents/workspace/reviews/{pr-number}/` (`recoverable: false`).
 
+After the task-anchored path resolves the host and remote head, run:
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-inspect
+```
+
+- `prepared`: reuse that artifact; `open` with an unchanged head: replay start for the same artifact/head (a no-op) and resume the round.
+- `open` with a changed head: first set the old artifact Formal Review Status to `superseded`, then terminate it using the old artifact/head; continue with the next round returned by inspect.
+- No prepared/open round: create the next artifact skeleton from `reference/report-template.md`, initially recording the state check, identity, reviewed head, and `Formal Review Status: pending`.
+
+After this branch and before step 2 evidence grading, write started:
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-start --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha}
+```
+
+The one-shot path never calls `task-activity`. For a controlled failure after started where the formal Review is known not to have been published, first set the artifact status to `aborted`, then call `pr-review-terminate --outcome aborted --reason <single-line>` with the same artifact/head. If publication outcome is uncertain, leave the round open rather than guessing aborted.
+
 ### 2. Single decide: evidence enumeration + classification + risk + mode
 
-Write the host, artifact presence, head state, and the six pure-evidence risk factors to an input JSON, then call once:
+Write the host, artifact presence, head state, and the six pure-evidence risk factors to an input JSON. Use only the highest `applied` / `no-op` artifact returned by inspect as the prior review; pending/aborted/superseded/failed artifacts count only toward round continuity. Then call once:
 
 ```bash
 agent-infra-internal pr-review-grade decide --input-file {decide-input.json} [--cwd <path>]
@@ -71,7 +90,7 @@ Returns the full `DecisionRecord` (`scenario` / `freshness` / `alignment` / `ris
 
 ### 3. Generate `pr-review-rN.md`
 
-Generate this round's artifact per `reference/report-template.md`. In `reconstruct` mode (or `audit` with insufficient evidence), write a "Reconstruction Context" section (requirement boundary / architecture choices / impact surface / validation coverage, see `reference/evidence-grading.md`) before the line-level findings. Record `recoverable: true|false` in the frontmatter or header (the one-shot path sets `false`).
+Complete this round's artifact per `reference/report-template.md`; the task-anchored path preserves the identity/head/pending status written in step 1 and does not reallocate the round. In `reconstruct` mode (or `audit` with insufficient evidence), write a "Reconstruction Context" section (requirement boundary / architecture choices / impact surface / validation coverage, see `reference/evidence-grading.md`) before the line-level findings. Record `recoverable: true|false` in the frontmatter or header (the one-shot path sets `false`). After finalizing the findings list, freeze `{verdict, blockers, major, minor}` once; the formal Review body and step 6 complete payload must consume that same object directly, never recounting report prose.
 
 ### 4. Sync the Issue artifact comments (task-anchored path)
 
@@ -99,18 +118,27 @@ agent-infra-internal platform-pr-review publish --pr {pr-number} --scope {taskId
   --commit {head-sha} --event {COMMENT|APPROVE|REQUEST_CHANGES} --body-file {review-body.md} [--dry-run] [--cwd <path>]
 ```
 
-`publish` generates and validates the marker (first line) in core and is idempotent per marker + commit (replay is a no-op; marker hit on a different commit fails stably). On head drift, stop and start a new round (re-run step 1 with round `{round}+1`).
+`publish` generates and validates the marker (first line) in core and is idempotent per marker + commit (replay is a no-op; marker hit on a different commit fails stably). On head drift, first set the old artifact status to `superseded`, then close the old round:
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-terminate --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha} \
+  --outcome superseded --reason "head changed before publish"
+```
+
+After closure, re-run step 1 for the next canonical round; never start the new round first. If the remote outcome of `publish` is uncertain, keep the round open and recover through marker + commit idempotency on retry.
 
 ### 6. Write back the publication result and task state
 
-- **Task-anchored path**: write the Review ID/URL into the `pr-review-rN.md` "Publication Result" section and append the Activity Log entry:
+- **Task-anchored path**: after publish returns `applied` / `no-op`, write the Review ID/URL and matching Formal Review Status into the `pr-review-rN.md` "Publication Result" section, then close the Activity Log with the exact verdict/counts frozen in step 3:
 
   ```bash
-  agent-infra-internal task-activity {task-id} append --step "Review PR (Round {round})" --agent {agent} \
-    --note "receipt {receipt} · Review URL {review-url}" --artifact {pr-review-artifact}
+  agent-infra-internal task-activity {task-id} pr-review-complete --agent {agent} \
+    --artifact {pr-review-artifact} --head {head-sha} --verdict {approved|changes-requested|commented} \
+    --blockers {blockers} --major {major} --minor {minor}
   ```
 
-  `task-activity` atomically completes the Activity Log append, the `## Review Feedback` link, and the version-stamp refresh via `writeTask`; it never changes `current_step`.
+  `task-activity` generates `Verdict: <result>, blockers: N, major: N, minor: N → {pr-review-artifact}` from the typed payload and atomically writes the Activity Log, `## Review Feedback` link, and version stamp through `writeTask`. It never changes `current_step` or puts receipt/head/Review URL into the NOTE.
 
 - **One-shot path (no task)**: write the Review ID/URL only into the `pr-review-rN.md` "Publication Result" section; do not call `task-activity`.
 

--- a/templates/.agents/skills/review-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-pr/SKILL.zh-CN.md
@@ -55,13 +55,32 @@ agent-infra-internal pr-review-grade resolve-host --pr {pr-number} [--cwd <path>
 
 `resolve-host` 输出 `HostResolution`（`unique` / `ambiguous` / `none`），按以下策略分流：
 
-- **唯一宿主**：绑定 `{task-id}`，用 artifact 枚举确定 `analysis*`/`plan*`/`code*`/`review-*`/`pr-review*` 的存在性（进入步骤 2）。
+- **唯一宿主**：绑定 `{task-id}`，调用 `task-activity pr-review-inspect` 取得 canonical round、prepared/open 状态和最近成功审查身份，再按下述恢复规则开始本轮（进入步骤 2）。
 - **多宿主歧义**：`resolve-host` 返回 `ambiguous`，`decide` 会拒绝分类（fail closed）。立即停止并提示人工指定唯一宿主；不进入证据分类。
 - **无宿主**：默认阻塞，要求先建立 Issue/task 关联（给出关联指引），不自动创建/导入 Issue。仅当用户显式选择「仅一次性检视」时，过程文件写入 `.agents/workspace/reviews/{pr-number}/`（`recoverable: false`）。
 
+任务锚定路径在宿主与远端 head 确定后执行：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-inspect
+```
+
+- `prepared`：复用该 artifact；`open` 且 head 未变：对同一 artifact/head 重放 start（no-op）并恢复该轮。
+- `open` 且 head 已变：先把旧 artifact 的正式 Review 状态写为 `superseded`，再用旧 artifact/head 执行 terminate；随后使用 inspect 返回的 next round。
+- 无 prepared/open：按 `reference/report-template.md` 创建 next artifact 骨架，先写状态核对、身份信息、被审 head 与 `正式 Review 状态: pending`。
+
+在上述分流完成后、步骤 2 证据分级开始前写 started：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-start --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha}
+```
+
+一次性路径不调用 `task-activity`。任意 started 后、正式 Review 明确尚未发布的受控失败，都先把 artifact 状态写为 `aborted`，再以同一 artifact/head 调用 `pr-review-terminate --outcome aborted --reason <single-line>`；发布结果不确定时保持 open，不臆断 aborted。
+
 ### 2. 单次 decide：证据枚举 + 场景分类 + 风险分级 + 模式选择
 
-把宿主、artifact 存在性、head 状态与六个纯证据风险因素写入输入 JSON，调用一次：
+把宿主、artifact 存在性、head 状态与六个纯证据风险因素写入输入 JSON。prior review 只使用 inspect 返回的最高 `applied` / `no-op` artifact；pending/aborted/superseded/failed 只参与 round 连续性，不作为既有结论。调用一次：
 
 ```bash
 agent-infra-internal pr-review-grade decide --input-file {decide-input.json} [--cwd <path>]
@@ -71,7 +90,7 @@ agent-infra-internal pr-review-grade decide --input-file {decide-input.json} [--
 
 ### 3. 生成 `pr-review-rN.md`
 
-按 `reference/report-template.md` 生成本轮产物。`reconstruct`（或 `audit` 证据不足）时，在行级 finding 之前先写「重建上下文」段（需求边界 / 架构选择 / 影响面 / 验证覆盖，见 `reference/evidence-grading.md`）。frontmatter 或首部记录 `recoverable: true|false`（一次性路径为 `false`）。
+按 `reference/report-template.md` 完成本轮产物；任务锚定路径保留步骤 1 已写入的身份/head/pending 状态，不重新分配 round。`reconstruct`（或 `audit` 证据不足）时，在行级 finding 之前先写「重建上下文」段（需求边界 / 架构选择 / 影响面 / 验证覆盖，见 `reference/evidence-grading.md`）。frontmatter 或首部记录 `recoverable: true|false`（一次性路径为 `false`）。完成最终问题清单后，一次性冻结 `{verdict, blockers, major, minor}`；正式 Review 正文与步骤 6 的 complete payload 必须直接复用该对象，不从报告文案反向统计。
 
 ### 4. 同步 Issue artifact 评论（任务锚定路径）
 
@@ -99,18 +118,27 @@ agent-infra-internal platform-pr-review publish --pr {pr-number} --scope {taskId
   --commit {head-sha} --event {COMMENT|APPROVE|REQUEST_CHANGES} --body-file {review-body.md} [--dry-run] [--cwd <path>]
 ```
 
-`publish` 由 core 生成并校验 marker（首行），按 marker + commit 幂等（重放 no-op；marker 命中但 commit 不一致稳定失败）。head 漂移则停止并转入新轮次（重新执行步骤 1，轮次 `{round}+1`）。
+`publish` 由 core 生成并校验 marker（首行），按 marker + commit 幂等（重放 no-op；marker 命中但 commit 不一致稳定失败）。head 漂移时，先把旧 artifact 状态写为 `superseded`，再闭合旧轮：
+
+```bash
+agent-infra-internal task-activity {task-id} pr-review-terminate --agent {agent} \
+  --artifact {pr-review-artifact} --head {head-sha} \
+  --outcome superseded --reason "head changed before publish"
+```
+
+闭合成功后重新执行步骤 1，进入下一 canonical round；不得先写新轮 started。若 publish 调用的远端结果不确定，保留 open 并在重试时依赖 marker + commit 恢复。
 
 ### 6. 回写发布结果与任务状态
 
-- **任务锚定路径**：把 Review ID/URL 写入 `pr-review-rN.md`「发布结果」段，并追加活动日志：
+- **任务锚定路径**：publish 返回 `applied` / `no-op` 后，把 Review ID/URL 与同名正式 Review 状态写入 `pr-review-rN.md`「发布结果」段，再以步骤 3 冻结的同一组 verdict/counts 闭合活动日志：
 
   ```bash
-  agent-infra-internal task-activity {task-id} append --step "Review PR (Round {round})" --agent {agent} \
-    --note "receipt {receipt} · Review URL {review-url}" --artifact {pr-review-artifact}
+  agent-infra-internal task-activity {task-id} pr-review-complete --agent {agent} \
+    --artifact {pr-review-artifact} --head {head-sha} --verdict {approved|changes-requested|commented} \
+    --blockers {blockers} --major {major} --minor {minor}
   ```
 
-  `task-activity` 经 `writeTask` 原子完成 Activity Log 追加、`## 审查反馈` 链接与版本戳刷新；不改 `current_step`。
+  `task-activity` 由 typed payload 生成 `Verdict: <结论>, blockers: N, major: N, minor: N → {pr-review-artifact}`，并经 `writeTask` 原子完成 Activity Log、`## 审查反馈` 链接与版本戳刷新；不改 `current_step`，也不把 receipt/head/Review URL 写入 NOTE。
 
 - **一次性路径（无任务）**：Review ID/URL 只写 `pr-review-rN.md`「发布结果」段，不调用 `task-activity`。
 

--- a/templates/.agents/skills/review-pr/reference/report-template.en.md
+++ b/templates/.agents/skills/review-pr/reference/report-template.en.md
@@ -69,7 +69,7 @@ Land the following in order before the line-level findings, without impersonatin
 
 ## Publication Result
 
-- **Formal Review Status**: {applied / no-op / blocked / failed}
+- **Formal Review Status**: {pending / applied / no-op / aborted / superseded / blocked / failed}
 - **Review ID**: {review-id or N/A}
 - **Review URL**: {review-url or N/A}
 - **Issue Artifact Comment URL**: {comment-url or N/A}

--- a/templates/.agents/skills/review-pr/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-pr/reference/report-template.zh-CN.md
@@ -69,7 +69,7 @@
 
 ## 发布结果
 
-- **正式 Review 状态**：{applied / no-op / blocked / failed}
+- **正式 Review 状态**：{pending / applied / no-op / aborted / superseded / blocked / failed}
 - **Review ID**：{review-id 或 N/A}
 - **Review URL**：{review-url 或 N/A}
 - **Issue artifact 评论 URL**：{comment-url 或 N/A}

--- a/tests/integration/cli/task-log.test.ts
+++ b/tests/integration/cli/task-log.test.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { CLI_PATH } from '../../helpers.ts';
+import { CLI_PATH, INTERNAL_CLI_PATH } from '../../helpers.ts';
 
 const SCRIPT = path.resolve(process.cwd(), '.agents/scripts/task-short-id.js');
 
@@ -49,6 +49,10 @@ function runCli(args: string[], cwd: string) {
   return spawnSync('node', [CLI_PATH, ...args], { cwd, encoding: 'utf8' });
 }
 
+function runInternal(args: string[], cwd: string) {
+  return spawnSync('node', [INTERNAL_CLI_PATH, ...args], { cwd, encoding: 'utf8' });
+}
+
 test('ai task log <ref> renders legacy done-only entries as one row each, sorted ascending', () => {
   const { repoRoot, activeDir } = mkFixture();
   const taskId = 'TASK-20260101-000007';
@@ -85,6 +89,113 @@ test('ai task log folds a started+done pair onto one row', () => {
   // One row: STARTED and DONE both populated, step base has the suffix stripped.
   assert.match(out.stdout, /^1\s+Plan Task \(Round 1\)\s+claude\s+2026-06-18 14:00:00\+08:00\s+2026-06-18 14:30:00\+08:00\s+Plan completed → plan\.md/m);
   assert.match(out.stdout, /^Total: 1 steps$/m);
+});
+
+test('typed task-activity intents produce a compact paired Review PR row', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000019';
+  const taskDir = path.join(activeDir, taskId);
+  const head = 'a'.repeat(40);
+  writeTask(activeDir, taskId, '## 活动日志', [
+    '- 2026-06-18 13:00:00+08:00 — **Plan Task (Round 1)** by claude — plan done'
+  ]);
+  const artifactPath = path.join(taskDir, 'pr-review.md');
+  fs.writeFileSync(artifactPath, `# PR 审查报告
+
+## 身份信息
+
+- **被审 head SHA**：${head}
+
+## 发布结果
+
+- **正式 Review 状态**：pending
+`);
+
+  const started = runInternal([
+    'task-activity', taskId, 'pr-review-start', '--agent', 'claude-code',
+    '--artifact', 'pr-review.md', '--head', head
+  ], repoRoot);
+  assert.equal(started.status, 0, started.stderr || started.stdout);
+  assert.equal(JSON.parse(started.stdout).status, 'applied');
+
+  fs.writeFileSync(artifactPath, fs.readFileSync(artifactPath, 'utf8').replace('pending', 'applied'));
+  const completed = runInternal([
+    'task-activity', taskId, 'pr-review-complete', '--agent', 'claude-code',
+    '--artifact', 'pr-review.md', '--head', head, '--verdict', 'approved',
+    '--blockers', '0', '--major', '1', '--minor', '2'
+  ], repoRoot);
+  assert.equal(completed.status, 0, completed.stderr || completed.stdout);
+  assert.equal(JSON.parse(completed.stdout).status, 'applied');
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(
+    out.stdout,
+    /^2\s+Review PR \(Round 1\)\s+claude\s+\d{4}-\d{2}-\d{2} \S+\s+\d{4}-\d{2}-\d{2} \S+\s+Verdict: Approved, blockers: 0, major: 1, minor: 2 → pr-review\.md/m
+  );
+
+  const invalid = runInternal([
+    'task-activity', taskId, 'pr-review-complete', '--agent', 'codex',
+    '--artifact', 'pr-review.md', '--head', head, '--verdict', 'approved'
+  ], repoRoot);
+  assert.equal(invalid.status, 1);
+  assert.equal(JSON.parse(invalid.stdout).error.code, 'ACTIVITY_PAYLOAD_INVALID');
+});
+
+test('typed task-activity terminate intents render paired aborted and superseded Review PR rows', () => {
+  const { repoRoot, activeDir } = mkFixture();
+  const taskId = 'TASK-20260101-000020';
+  const taskDir = path.join(activeDir, taskId);
+  const firstHead = 'a'.repeat(40);
+  const secondHead = 'b'.repeat(40);
+  writeTask(activeDir, taskId, '## 活动日志', [
+    '- 2026-06-18 13:00:00+08:00 — **Plan Task (Round 1)** by claude — plan done'
+  ]);
+
+  const runTermination = (
+    artifact: string,
+    head: string,
+    outcome: 'aborted' | 'superseded',
+    reason: string
+  ) => {
+    const artifactPath = path.join(taskDir, artifact);
+    fs.writeFileSync(artifactPath, `# PR 审查报告
+
+## 身份信息
+
+- **被审 head SHA**：${head}
+
+## 发布结果
+
+- **正式 Review 状态**：pending
+`);
+    const started = runInternal([
+      'task-activity', taskId, 'pr-review-start', '--agent', 'claude',
+      '--artifact', artifact, '--head', head
+    ], repoRoot);
+    assert.equal(started.status, 0, started.stderr || started.stdout);
+
+    fs.writeFileSync(artifactPath, fs.readFileSync(artifactPath, 'utf8').replace('pending', outcome));
+    const terminated = runInternal([
+      'task-activity', taskId, 'pr-review-terminate', '--agent', 'claude',
+      '--artifact', artifact, '--head', head, '--outcome', outcome, '--reason', reason
+    ], repoRoot);
+    assert.equal(terminated.status, 0, terminated.stderr || terminated.stdout);
+  };
+
+  runTermination('pr-review.md', firstHead, 'superseded', 'head changed before publish');
+  runTermination('pr-review-r2.md', secondHead, 'aborted', 'validation failed before publish');
+
+  const out = runCli(['task', 'log', taskId], repoRoot);
+  assert.equal(out.status, 0, out.stderr);
+  assert.match(
+    out.stdout,
+    /^2\s+Review PR \(Round 1\)\s+claude\s+\d{4}-\d{2}-\d{2} \S+\s+\d{4}-\d{2}-\d{2} \S+\s+Outcome: Superseded, reason: head changed before publish → pr-review\.md/m
+  );
+  assert.match(
+    out.stdout,
+    /^3\s+Review PR \(Round 2\)\s+claude\s+\d{4}-\d{2}-\d{2} \S+\s+\d{4}-\d{2}-\d{2} \S+\s+Outcome: Aborted, reason: validation failed before publish → pr-review-r2\.md/m
+  );
 });
 
 test('ai task log shows a started-only step as in progress', () => {

--- a/tests/integration/cli/task-verify.test.ts
+++ b/tests/integration/cli/task-verify.test.ts
@@ -68,7 +68,8 @@ test('review-pr task-verify gate requires re-sync after publication write-back (
       ``,
       `## 活动日志`,
       ``,
-      `- 2026-08-04 20:00:00+08:00 — **Review PR (Round 1)** by claude-code — receipt r1-abc`,
+      `- 2026-08-04 19:30:00+08:00 — **Review PR (Round 1) [started]** by claude — started`,
+      `- 2026-08-04 20:00:00+08:00 — **Review PR (Round 1)** by claude — Verdict: Approved, blockers: 0, major: 0, minor: 0 → pr-review.md`,
       ``
     ].join('\n'));
     const artifactContent = [

--- a/tests/unit/task/activity-intent.test.ts
+++ b/tests/unit/task/activity-intent.test.ts
@@ -4,15 +4,20 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { applyActivityAppendIntent } from '../../../lib/task/activity-intent.ts';
+import {
+  applyPrReviewActivityIntent,
+  inspectPrReviewActivity
+} from '../../../lib/task/activity-intent.ts';
 import { VERSION } from '../../../lib/version.ts';
+
+const HEAD = 'a'.repeat(40);
 
 function fixtureTask() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-intent-'));
   const taskId = 'TASK-20260101-000001';
   const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
   fs.mkdirSync(taskDir, { recursive: true });
-  const content = `---
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---
 id: ${taskId}
 type: feature
 workflow: feature-development
@@ -21,114 +26,286 @@ created_at: 2026-01-01 00:00:00+08:00
 updated_at: 2026-01-01 00:00:00+08:00
 agent_infra_version: v0.9.2
 current_step: technical-design-review
-assigned_to: claude-code
+assigned_to: claude
 ---
 
 # 任务
 
+## 审查反馈
+
+<!-- review artifacts -->
+
 ## 活动日志
 
-- 2026-01-01 00:00:00+08:00 — **Plan Task** by claude-code — plan done
-`;
-  fs.writeFileSync(path.join(taskDir, 'task.md'), content);
+- 2026-01-01 00:00:00+08:00 — **Plan Task** by claude — plan done
+`);
   return { root, taskId, taskDir };
 }
 
-test('task-activity append adds an Activity Log entry and refreshes version stamps without changing current_step', () => {
+function writeArtifact(taskDir: string, name = 'pr-review.md', status = 'pending', head = HEAD): void {
+  fs.writeFileSync(path.join(taskDir, name), `# PR 审查报告
+
+## 身份信息
+
+- **被审 head SHA**：${head}
+
+## 发布结果
+
+- **正式 Review 状态**：${status}
+`);
+}
+
+function setArtifactStatus(taskDir: string, name: string, status: string): void {
+  const file = path.join(taskDir, name);
+  const content = fs.readFileSync(file, 'utf8');
+  fs.writeFileSync(file, content.replace(/(正式 Review 状态\*\*：).+/, `$1${status}`));
+}
+
+function metadata(timestamp: string) {
+  return { metadataProvider: () => ({ timestamp, agentInfraVersion: VERSION }) };
+}
+
+test('PR review start and complete create a paired compact Activity Log row without changing current_step', () => {
   const fixture = fixtureTask();
   try {
-    const result = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: 'Review PR (Round 1)', agent: 'claude-code', note: 'receipt abc123'
-    }, { repoRoot: fixture.root });
-    assert.equal(result.status, 'applied');
-    assert.equal(result.changed, true);
+    writeArtifact(fixture.taskDir);
+    const started = applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'claude-code', artifact: 'pr-review.md', head: HEAD
+    }, { repoRoot: fixture.root, ...metadata('2026-01-01 01:00:00+08:00') });
+    assert.equal(started.status, 'applied');
+
+    setArtifactStatus(fixture.taskDir, 'pr-review.md', 'applied');
+    const completed = applyPrReviewActivityIntent({
+      kind: 'pr-review-complete', taskRef: fixture.taskId,
+      agent: 'claude-code', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'changes-requested', blockers: 1, major: 2, minor: 3
+    }, { repoRoot: fixture.root, ...metadata('2026-01-01 01:30:00+08:00') });
+    assert.equal(completed.status, 'applied');
+
     const updated = fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8');
-    assert.match(updated, /\*\*Review PR \(Round 1\)\*\* by claude-code — receipt abc123/);
-    assert.match(updated, /^current_step: technical-design-review$/m, 'current_step must not change');
+    assert.match(updated, /\*\*Review PR \(Round 1\) \[started\]\*\* by claude — started/);
+    assert.match(updated, /\*\*Review PR \(Round 1\)\*\* by claude — Verdict: Changes Requested, blockers: 1, major: 2, minor: 3 → pr-review\.md/);
+    assert.match(updated, /\[PR 审查报告（Round 1）\]\(pr-review\.md\)/);
+    assert.match(updated, /^current_step: technical-design-review$/m);
     assert.match(updated, new RegExp(`^agent_infra_version: ${VERSION.replace('.', '\\.')}$`, 'm'));
-    assert.match(updated, /^updated_at: \d{4}-\d{2}-\d{2} /m);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test('task-activity append with a canonical pr-review artifact adds a review-feedback link', () => {
+test('identical PR review start and terminal intents replay as no-op', () => {
   const fixture = fixtureTask();
   try {
-    const result = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: 'Review PR (Round 2)', agent: 'claude-code', note: 'receipt abc123', artifact: 'pr-review-r2.md'
-    }, { repoRoot: fixture.root });
-    assert.equal(result.status, 'applied');
+    writeArtifact(fixture.taskDir);
+    const startIntent = {
+      kind: 'pr-review-start' as const, taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
+    };
+    assert.equal(applyPrReviewActivityIntent(startIntent, { repoRoot: fixture.root }).status, 'applied');
+    assert.equal(applyPrReviewActivityIntent(startIntent, { repoRoot: fixture.root }).status, 'no-op');
+
+    setArtifactStatus(fixture.taskDir, 'pr-review.md', 'no-op');
+    const completeIntent = {
+      kind: 'pr-review-complete' as const, taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'approved' as const, blockers: 0, major: 0, minor: 0
+    };
+    assert.equal(applyPrReviewActivityIntent(completeIntent, { repoRoot: fixture.root }).status, 'applied');
+    assert.equal(applyPrReviewActivityIntent(completeIntent, { repoRoot: fixture.root }).status, 'no-op');
+
     const updated = fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8');
-    assert.match(updated, /## 审查反馈/);
-    assert.match(updated, /\[PR 审查报告（Round 2）\]\(pr-review-r2\.md\)/);
+    assert.equal((updated.match(/Review PR \(Round 1\) \[started\]/g) ?? []).length, 1);
+    assert.equal((updated.match(/Verdict: Approved/g) ?? []).length, 1);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test('task-activity append rejects non-canonical or non-pr-review artifacts', () => {
+test('PR review terminate closes an open row and rejects a conflicting terminal payload', () => {
   const fixture = fixtureTask();
   try {
-    const result = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: 'Review PR (Round 1)', agent: 'claude-code', note: 'receipt', artifact: 'code.md'
-    }, { repoRoot: fixture.root });
-    assert.equal(result.status, 'failed');
-    assert.equal(result.error?.code, 'ACTIVITY_ARTIFACT_INVALID');
+    writeArtifact(fixture.taskDir);
+    assert.equal(applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
+    }, { repoRoot: fixture.root }).status, 'applied');
+    setArtifactStatus(fixture.taskDir, 'pr-review.md', 'superseded');
+
+    const intent = {
+      kind: 'pr-review-terminate' as const, taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      outcome: 'superseded' as const, reason: 'head changed before publish'
+    };
+    assert.equal(applyPrReviewActivityIntent(intent, { repoRoot: fixture.root }).status, 'applied');
+    assert.equal(applyPrReviewActivityIntent(intent, { repoRoot: fixture.root }).status, 'no-op');
+
+    const conflict = applyPrReviewActivityIntent({ ...intent, reason: 'different reason' }, { repoRoot: fixture.root });
+    assert.equal(conflict.status, 'failed');
+    assert.equal(conflict.error?.code, 'ACTIVITY_STATE_CONFLICT');
+    assert.match(fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8'), /Outcome: Superseded, reason: head changed before publish → pr-review\.md/);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test('task-activity append rejects empty or multiline payloads', () => {
+test('PR review inspection reports prepared, open and latest successful identities', () => {
   const fixture = fixtureTask();
   try {
-    const missing = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: '', agent: 'claude-code', note: 'receipt'
-    }, { repoRoot: fixture.root });
-    assert.equal(missing.status, 'failed');
-    assert.equal(missing.error?.code, 'ACTIVITY_INTENT_INVALID');
+    writeArtifact(fixture.taskDir);
+    const prepared = inspectPrReviewActivity({ kind: 'pr-review-inspect', taskRef: fixture.taskId }, { repoRoot: fixture.root });
+    assert.equal(prepared.status, 'ready');
+    assert.equal(prepared.snapshot?.prepared?.artifact, 'pr-review.md');
+    assert.equal(prepared.snapshot?.nextRound, 2);
 
-    const multiline = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: 'Review PR (Round 1)', agent: 'claude-code', note: 'line1\nline2'
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
     }, { repoRoot: fixture.root });
-    assert.equal(multiline.status, 'failed');
-    assert.equal(multiline.error?.code, 'ACTIVITY_INTENT_INVALID');
+    const open = inspectPrReviewActivity({ kind: 'pr-review-inspect', taskRef: fixture.taskId }, { repoRoot: fixture.root });
+    assert.equal(open.snapshot?.open?.artifact, 'pr-review.md');
+    assert.equal(open.snapshot?.open?.head, HEAD);
+
+    setArtifactStatus(fixture.taskDir, 'pr-review.md', 'applied');
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-complete', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'approved', blockers: 0, major: 0, minor: 0
+    }, { repoRoot: fixture.root });
+    const completed = inspectPrReviewActivity({ kind: 'pr-review-inspect', taskRef: fixture.taskId }, { repoRoot: fixture.root });
+    assert.equal(completed.snapshot?.latestSuccessful?.artifact, 'pr-review.md');
+    assert.equal(completed.snapshot?.latestSuccessful?.head, HEAD);
+    assert.equal(completed.snapshot?.open, null);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test('task-activity append dry-run reports planned and leaves the task untouched', () => {
+test('PR review inspection accepts annotated formal review statuses from legacy artifacts', () => {
   const fixture = fixtureTask();
   try {
+    writeArtifact(fixture.taskDir, 'pr-review.md', 'applied（APPROVE）');
+    const taskPath = path.join(fixture.taskDir, 'task.md');
+    fs.appendFileSync(
+      taskPath,
+      '- 2026-01-01 01:00:00+08:00 — **Review PR (Round 1)** by claude — receipt legacy-review\n'
+    );
+
+    const inspected = inspectPrReviewActivity(
+      { kind: 'pr-review-inspect', taskRef: fixture.taskId },
+      { repoRoot: fixture.root }
+    );
+    assert.equal(inspected.status, 'ready');
+    assert.equal(inspected.snapshot?.latestSuccessful?.artifactStatus, 'applied');
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('inspection keeps a prior applied round as latest successful after a later aborted round', () => {
+  const fixture = fixtureTask();
+  try {
+    writeArtifact(fixture.taskDir, 'pr-review.md');
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
+    }, { repoRoot: fixture.root });
+    setArtifactStatus(fixture.taskDir, 'pr-review.md', 'applied');
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-complete', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'approved', blockers: 0, major: 0, minor: 0
+    }, { repoRoot: fixture.root });
+
+    const secondHead = 'b'.repeat(40);
+    writeArtifact(fixture.taskDir, 'pr-review-r2.md', 'pending', secondHead);
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review-r2.md', head: secondHead
+    }, { repoRoot: fixture.root });
+    setArtifactStatus(fixture.taskDir, 'pr-review-r2.md', 'aborted');
+    applyPrReviewActivityIntent({
+      kind: 'pr-review-terminate', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review-r2.md', head: secondHead,
+      outcome: 'aborted', reason: 'validation failed before publish'
+    }, { repoRoot: fixture.root });
+
+    const inspected = inspectPrReviewActivity({ kind: 'pr-review-inspect', taskRef: fixture.taskId }, { repoRoot: fixture.root });
+    assert.equal(inspected.snapshot?.latestSuccessful?.artifact, 'pr-review.md');
+    assert.equal(inspected.snapshot?.latestTerminal?.artifact, 'pr-review-r2.md');
+    assert.equal(inspected.snapshot?.latestTerminal?.artifactStatus, 'aborted');
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('PR review intents reject missing starts, identity mismatches and invalid payloads', () => {
+  const fixture = fixtureTask();
+  try {
+    writeArtifact(fixture.taskDir, 'pr-review.md', 'applied');
+    const missingStart = applyPrReviewActivityIntent({
+      kind: 'pr-review-complete', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'approved', blockers: 0, major: 0, minor: 0
+    }, { repoRoot: fixture.root });
+    assert.equal(missingStart.error?.code, 'ACTIVITY_STATE_CONFLICT');
+
+    const wrongHead = applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: 'b'.repeat(40)
+    }, { repoRoot: fixture.root });
+    assert.equal(wrongHead.error?.code, 'ACTIVITY_IDENTITY_MISMATCH');
+
+    const badCount = applyPrReviewActivityIntent({
+      kind: 'pr-review-complete', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD,
+      verdict: 'approved', blockers: -1, major: 0, minor: 0
+    }, { repoRoot: fixture.root });
+    assert.equal(badCount.error?.code, 'ACTIVITY_INTENT_INVALID');
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('PR review dry-run validates without writing and lock failures fail closed', () => {
+  const fixture = fixtureTask();
+  try {
+    writeArtifact(fixture.taskDir);
     const before = fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8');
-    const result = applyActivityAppendIntent({
-      kind: 'append', taskRef: fixture.taskId,
-      step: 'Review PR (Round 1)', agent: 'claude-code', note: 'receipt', dryRun: true
+    const planned = applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD, dryRun: true
     }, { repoRoot: fixture.root });
-    assert.equal(result.status, 'planned');
+    assert.equal(planned.status, 'planned');
+    assert.equal(fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8'), before);
+
+    const unsupported = Object.assign(new Error('unsupported'), { code: 'EPERM' });
+    const failed = applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: fixture.taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
+    }, {
+      repoRoot: fixture.root,
+      lockOptions: { lockRoot: path.join(fixture.root, 'locks'), linkSync: () => { throw unsupported; } }
+    });
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.error?.code, 'ORCHESTRATION_LOCK_UNSUPPORTED');
     assert.equal(fs.readFileSync(path.join(fixture.taskDir, 'task.md'), 'utf8'), before);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test('task-activity append rejects a task that is not active', () => {
+test('PR review intents reject a task that is not active', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-intent-'));
   try {
     const taskId = 'TASK-20260101-000001';
     const taskDir = path.join(root, '.agents', 'workspace', 'completed', taskId);
     fs.mkdirSync(taskDir, { recursive: true });
     fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\nstatus: completed\n---\n`);
-    const result = applyActivityAppendIntent({
-      kind: 'append', taskRef: taskId,
-      step: 'Review PR (Round 1)', agent: 'claude-code', note: 'receipt'
+    writeArtifact(taskDir);
+    const result = applyPrReviewActivityIntent({
+      kind: 'pr-review-start', taskRef: taskId,
+      agent: 'codex', artifact: 'pr-review.md', head: HEAD
     }, { repoRoot: root });
     assert.equal(result.status, 'failed');
     assert.equal(result.error?.code, 'TASK_STATE_MISMATCH');

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1360,23 +1360,32 @@ test("review-pr keeps the sync -> write-back -> re-sync -> verify closed-loop or
   ];
   const artifactSync = "platform-comment sync {task-id} --kind artifact --artifact {pr-review-artifact} --agent {agent}";
   const taskSync = "platform-comment sync {task-id} --kind task --agent {agent}";
-  const activity = "task-activity {task-id} append";
+  const activityStart = "task-activity {task-id} pr-review-start";
+  const activityComplete = "task-activity {task-id} pr-review-complete";
+  const activityTerminate = "task-activity {task-id} pr-review-terminate";
+  const decide = "pr-review-grade decide";
   const verify = "agent-infra-internal task-verify {task-id} review-pr.completed";
 
   variants.forEach((relativePath) => {
     const content = read(relativePath);
+    const startIndex = content.indexOf(activityStart);
+    const decideIndex = content.indexOf(decide);
     const firstTaskSync = content.indexOf(taskSync);
     const firstArtifactSync = content.indexOf(artifactSync);
-    const taskActivityIndex = content.indexOf(activity);
+    const completeIndex = content.indexOf(activityComplete);
+    const terminateIndex = content.indexOf(activityTerminate);
     const lastTaskSync = content.lastIndexOf(taskSync);
     const lastArtifactSync = content.lastIndexOf(artifactSync);
     const verifyIndex = content.indexOf(verify);
 
+    assert.notEqual(startIndex, -1, `${relativePath} should start task activity after host resolution`);
+    assert.notEqual(terminateIndex, -1, `${relativePath} should define non-success terminal activity`);
+    assert.ok(startIndex < decideIndex, `${relativePath} should write started before evidence grading`);
     assert.notEqual(firstTaskSync, -1, `${relativePath} should sync the task comment (step 4)`);
     assert.notEqual(firstArtifactSync, -1, `${relativePath} should sync the artifact comment (step 4)`);
     assert.ok(firstTaskSync < firstArtifactSync, `${relativePath} should sync task before artifact (step 4)`);
-    assert.ok(firstArtifactSync < taskActivityIndex, `${relativePath} should write back after the first sync (step 6)`);
-    assert.ok(taskActivityIndex < lastTaskSync, `${relativePath} should re-sync the task comment after write-back (step 7)`);
+    assert.ok(firstArtifactSync < completeIndex, `${relativePath} should complete after the first sync (step 6)`);
+    assert.ok(completeIndex < lastTaskSync, `${relativePath} should re-sync the task comment after write-back (step 7)`);
     assert.ok(lastTaskSync < lastArtifactSync, `${relativePath} should re-sync the artifact comment after task (step 7)`);
     assert.ok(lastArtifactSync < verifyIndex, `${relativePath} should verify after the re-sync (step 8)`);
   });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #788

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that does not need an issue

Closes #788

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

改进任务锚定的 `review-pr` 活动日志：在证据分级前写入可配对的开始记录，并以审查结论、finding 数量和产物引用替代冗长的 receipt、完整 SHA 与 Review URL，同时保留既有审计信息来源。

Improve task-anchored `review-pr` activity logs by recording a pairable start event before evidence grading and replacing verbose receipts, full SHAs, and Review URLs with the verdict, finding counts, and artifact reference while preserving the existing audit trail.

## 📋 主要变更 / Brief Changelog

- 新增 typed `pr-review-start`、`pr-review-complete` 与 `pr-review-terminate` 活动意图，按 task/round/head 幂等管理 started、成功和非成功终态。
- 让 head 漂移将旧轮闭合为 `superseded`，并让发布前受控失败闭合为 `aborted`，避免遗留无终态的活动记录。
- 将成功 NOTE 收敛为 verdict 与 blocker/major/minor 数量，将非成功 NOTE 收敛为 outcome 与原因，并保留对应 `pr-review-rN.md` 引用。
- 同步英文、中文技能模板与任务管理规则，补充历史状态兼容、重放、双轮配对和 CLI 渲染测试。
- Add idempotent typed lifecycle intents, explicit superseded/aborted terminal states, compact outcome notes, synchronized templates, and regression coverage.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run the targeted activity-intent and task-log tests.
3. Run `npm test` and `git diff --check main...HEAD`.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：定向测试 25 passed、0 failed；smoke 1100 passed、0 failed；core 1874 passed、0 failed、2 skipped；完整测试 2184 passed、0 failed、3 skipped；TypeScript 类型检查与 `git diff --check` 均通过。

Verification result: targeted tests 25 passed and 0 failed; smoke 1100 passed and 0 failed; core 1874 passed, 0 failed, and 2 skipped; full suite 2184 passed, 0 failed, and 3 skipped; TypeScript checks and `git diff --check` passed.

## 📸 截图 / Screenshots

不适用；本次变更涉及内部任务活动生命周期、技能说明与 CLI 文本输出。

Not applicable; this change affects internal task activity lifecycles, skill instructions, and CLI text output.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 GitHub Issue / A corresponding GitHub Issue exists
- [x] PR 只解决一个 Issue / This PR addresses one issue
- [x] Commit 具有有意义的主题和正文 / The commit has a meaningful subject and body
- [x] 代码遵循项目规范并完成独立审查 / Code follows project conventions and independent review is complete
- [x] 已编写必要的单元和集成测试 / Necessary unit and integration tests are included
- [x] 类型检查、完整测试和 whitespace 校验通过 / Type checks, the full suite, and whitespace checks pass
- [x] 已同步英文、中文受管模板 / Managed English and Chinese templates are synchronized
- [x] 已考虑历史状态兼容与幂等重放 / Historical status compatibility and idempotent replay are covered

## 📋 附加信息 / Additional Notes

- 最新代码审查结论：Approved，0 blocker、0 major、0 minor。
- 本轮无需人工校验。
- receipt、完整被审 HEAD、Review ID 和 Review URL 仍保存在审查产物与 GitHub 正式 Review 中。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 task/round/head 幂等键、head 漂移时旧轮闭合、新旧 activity 记录的兼容读取，以及成功和非成功终态在 `ai task log` 中的独立配对与紧凑摘要。

Generated with AI assistance
