### PR TITLE
fix(commit): 修复提交收尾断链仍可进入 PR


### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -31,7 +31,13 @@ description: >
 
 未显式指定 task scope 时，只有 `TASK_CONTEXT_NOT_FOUND` 可继续既有纯提交路径；detached HEAD、损坏候选或多匹配属于歧义，必须失败。显式 task scope 解析失败时一律失败。
 
-## 步骤开始：写入 started 标记
+## 步骤开始：先恢复，再写 started 标记
+
+已解析出 `{task-id}` 时，先调用 `agent-infra-internal task-orchestration {task-id} commit-status`：
+
+- `recoverable` / `prepared`：调用 `commit-recover --agent {standard-agent-token}`；不得追加第二条 started、重复 commit 或重复 push。recoverable 完成后直接进入同步与完成校验；prepared 清理后复用既有 open started 并继续正常提交。
+- `invalid` / `conflict` / `orphaned-start`：输出结构化 code 与状态证据并停止。
+- `idle`：继续下方正常流程。
 
 开始检查本地修改之前，向 task.md `## 活动日志` 追加一条 started 标记（与本步骤 done 条目同基名 + ` [started]` 后缀，note 用 `started`）：
 
@@ -77,7 +83,7 @@ git diff
 - 暂存明确文件后记录 `pre_head=$(git rev-parse HEAD)`，并以 helper 的 JSON 模式生成当前完整工作区树 `W` 与规范化暂存树 `S`
 - 在 `git commit` 前要求 `pre_head == R && W == T && S == T`；分别运行 helper 的 `compare` 模式生成 worktree/staged 的 added、missing、different 路径诊断
 - 任一条件不满足时进入 `reference/task-status-update.md` 的“场景 4：提交前快照阻断”，不得执行 `git commit`、push、成功状态更新、PR 摘要同步或完成 gate
-- 全部相等并成功提交后，在 task.md frontmatter 写入 `last_reviewed_commit: <new_head>`
+- 全部相等并成功提交后，由步骤 6 的 `commit-complete` 核心收尾原子写入 `last_reviewed_commit` 与 Commit done；调用方不得手写
 - 不向后扫描更早的 Approved 产物；最高轮 `review-code` 产物是唯一权威来源
 
 ## 5. 推送到已有 PR（按需）
@@ -102,6 +108,14 @@ c. 安全降级（不阻塞已完成的 `git commit`，仅提示用户）：
 
 ## 6. 按需更新任务状态
 
+普通 commit/push checkpoint 完成后，先调用核心收尾；它在同一任务锁内写入审查锚点、Commit done 与 orchestration planned bytes，最后删除 intent：
+
+```bash
+agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
+```
+
+失败时保留 intent，输出 `commit-status` 后停止；重跑本技能由开头的 status/recover 路由恢复。调用方不得重复追加 Commit done 或修改 `last_reviewed_commit`。
+
 获取当前时间：
 
 ```bash
@@ -112,7 +126,7 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 
 > 渲染下一步前先读取 `.agents/rules/next-step-output.md`，并按 `reference/task-status-update.md` 的已选场景调用统一 helper。
 
-追加 Commit 的 Activity Log，并且只能选择一个下一步分支：
+核心收尾成功后只能选择一个下一步分支：
 - 已有开放 PR 且 push 成功 -> `watch-pr {task-ref}`；该分支优先于最终提交的 `prFlow` 路由
 - push 失败 -> 保持任务 active，只输出推送/同步诊断，不输出 `watch-pr` 或 `complete-task`
 - 最终提交 -> 按 `.agents/.airc.json` 的 `prFlow` 渲染下一步（`disabled` → 单选 `complete-task`；`required` → 单选 `create-pr`；缺省 → 二选一 `create-pr` / `complete-task`），详见 `reference/task-status-update.md` 场景 1
@@ -154,13 +168,7 @@ agent-infra-internal task-verify {task-id} commit.completed --format text
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-校验通过后，按 `reference/commit-orchestration.md` 完成 commit intent。standalone 只释放 intent 且不改写历史 run；orchestrated 原子提交 begin 时已预检的 receipt 完成态：
-
-```bash
-agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
-```
-
-命令失败时保留 intent、输出 `commit-status` 恢复证据并停止，不得重复副作用或把缺少完整 receipt 生命周期的 run 标记为完成。
+本 gate 只在步骤 6 核心收尾成功后运行；不得把完成校验放在 `commit-complete` 之前。
 
 ## 注意事项
 

--- a/.agents/skills/commit/reference/commit-orchestration.md
+++ b/.agents/skills/commit/reference/commit-orchestration.md
@@ -9,6 +9,14 @@
 
 ## 副作用前 begin
 
+每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` 调用以下无 token 恢复入口，其他非 `idle` 状态 fail closed：
+
+```bash
+agent-infra-internal task-orchestration {task-id} commit-recover --agent {standard-agent-token}
+```
+
+恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。recoverable 会幂等补齐 task/run 并最后删除 intent；prepared 仅在 HEAD=baseline 且恰有一个 open Commit started 时安全清理，随后复用该 started 继续正常流程。
+
 完成状态、版权、提交信息、review snapshot 和 push 场景的只读准备后，记录 `baseline_head=$(git rev-parse HEAD)`，并在任何 commit、push、任务成功日志或平台成功同步之前调用：
 
 ```bash
@@ -36,12 +44,12 @@ push-only 路径跳过 committed checkpoint，pushed HEAD 必须等于 begin 时
 
 ## 完成与恢复
 
-`task-verify commit.completed` 通过后调用：
+committed/pushed checkpoint 完成后、任务同步与 `task-verify commit.completed` 之前调用：
 
 ```bash
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
 - 第一个副作用前失败时，仅可在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`。
-- commit、push、任务或平台副作用发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。
+- commit 或 push 发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。跨会话重跑通过 `commit-recover` 收尾。
 - `commit-complete` 失败时停止。不得重复执行 commit/push，也不得把缺少完整 receipt 生命周期的 run 标记为完成。

--- a/.agents/skills/commit/reference/task-status-update.md
+++ b/.agents/skills/commit/reference/task-status-update.md
@@ -12,19 +12,19 @@
 date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 ```
 
-对于每一次与任务相关的提交，都要在 `task.md` 中追加以下 Activity Log：
+`commit-complete` / `commit-recover` 核心已原子写入以下 Activity Log：
 
 ```text
 - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
-如果提交阶段已确认最高轮 `review-code` 产物 Approved、`pre_head == R`、完整工作区树 `W == T` 且规范化暂存树 `S == T`，成功提交后同时写入或刷新：
+证据满足时核心同时写入或刷新：
 
 ```yaml
 last_reviewed_commit: {new_head}
 ```
 
-该字段是 `complete-task` 的 `post-review-commit` gate 唯一 baseline。条件不满足时不要写入或推进该字段。
+该字段是 `complete-task` 的 `post-review-commit` gate 唯一 baseline。调用方只读取核心结果选择后续路由，不得再次追加 Commit done 或手写/推进该字段。
 
 ### 场景 5：已有 PR 推送收尾
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -68,7 +68,7 @@ description: >
 
 ### 5. 创建或恢复 PR
 
-执行前先读取 `.agents/rules/issue-pr-commands.md`，把标题和正文写入临时文件，并调用其中的 `platform-pr create` intent。core 先按 head/base 精确定位：唯一既有 PR 会复用并绑定，零个才创建，多个稳定失败；重放不得产生重复 PR。
+执行前先读取 `.agents/rules/issue-pr-commands.md`，把标题和正文写入临时文件，并调用其中的 `platform-pr create` intent。core 在任务锁内、任何 Create PR started / POST / reuse-bind 之前检查 commit finalization；active intent、open Commit、审查锚点缺失或 tree 漂移时返回稳定 code 并指向重跑 commit/review-code，不自动恢复。门禁通过后才按 head/base 精确定位：唯一既有 PR 会复用并绑定，零个才创建，多个稳定失败；重放不得产生重复 PR。
 
 如果获取到 `{task-id}` 且对应任务提供了 `issue_number`，必须在 PR 正文中保留 `Closes #{issue-number}`。
 

--- a/lib/internal/task-orchestration.ts
+++ b/lib/internal/task-orchestration.ts
@@ -10,6 +10,7 @@ import {
   completeCommitIntent,
   pauseOrchestration,
   prepareOrchestrationDelegation,
+  recoverCommitIntent,
   routeOrchestration,
   sealMatchingOrchestrationDelegation,
   sealOrchestrationDelegation,
@@ -19,7 +20,7 @@ import {
 import { isAgentClientId } from '../agent-clients/types.ts';
 import type { AgentClientId } from '../agent-clients/types.ts';
 
-const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|hook-start|hook-stop|advance|pause|status|commit-begin|commit-checkpoint|commit-complete|commit-abort|commit-status> [options]\n';
+const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|hook-start|hook-stop|advance|pause|status|commit-begin|commit-checkpoint|commit-complete|commit-recover|commit-abort|commit-status> [options]\n';
 
 function usageFailure(message: string): void {
   process.stdout.write(`${JSON.stringify({
@@ -42,7 +43,7 @@ function taskOrchestration(args: string[] = []): void {
   const [taskRef, intent] = args;
   if (![
     'begin-or-resume', 'route', 'prepare', 'hook-start', 'hook-stop', 'advance', 'pause', 'status',
-    'commit-begin', 'commit-checkpoint', 'commit-complete', 'commit-abort', 'commit-status'
+    'commit-begin', 'commit-checkpoint', 'commit-complete', 'commit-recover', 'commit-abort', 'commit-status'
   ].includes(intent!)) {
     usageFailure(`unknown intent '${intent}'`);
     return;
@@ -86,6 +87,7 @@ function taskOrchestration(args: string[] = []): void {
     'commit-begin': ['--agent', '--baseline-head', '--orchestrated'],
     'commit-checkpoint': ['--token', '--kind', '--head', '--remote', '--ref'],
     'commit-complete': ['--token', '--agent'],
+    'commit-recover': ['--agent'],
     'commit-abort': ['--token', '--expected-head'],
     'commit-status': []
   };
@@ -135,6 +137,12 @@ function taskOrchestration(args: string[] = []): void {
     const agent = normalizeAgentToken(values['--agent']!);
     if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
     result = completeCommitIntent(taskRef!, { token: values['--token']!, agent });
+  } else if (intent === 'commit-recover') {
+    const missing = requireValues(['--agent']);
+    if (missing) { usageFailure(`intent 'commit-recover' requires '${missing}'`); return; }
+    const agent = normalizeAgentToken(values['--agent']!);
+    if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
+    result = recoverCommitIntent(taskRef!, { agent });
   } else if (intent === 'commit-abort') {
     const missing = requireValues(['--token', '--expected-head']);
     if (missing) { usageFailure(`intent 'commit-abort' requires '${missing}'`); return; }

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -19,6 +19,8 @@ import { planPullRequestMetadata } from './pull-request-metadata.ts';
 import { platformResult } from './types.ts';
 import type { PlatformOperation, PlatformResult } from './types.ts';
 import { inspectCompletionArtifacts } from '../task/finalization-artifacts.ts';
+import { inspectCreatePrCommitGate } from '../task/commit-finalization.ts';
+import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
 
 type PullRequestSnapshot = PlatformChangeRequestSnapshot;
 
@@ -747,13 +749,23 @@ function resolveExternalPullRequest(taskRef: string, options: ResolveExternalOpt
   }), { mode: 'external', authorization: selected.source, candidates: selected.candidates, eligible: selected.eligible, selected: selected.selected });
 }
 
-function createPlatformPullRequest(taskRef: string, options: CreateOptions): PullRequestResult {
+function createPlatformPullRequestUnlocked(taskRef: string, options: CreateOptions): PullRequestResult {
   const base = resolvedContext(taskRef, options);
   if (!base.ok) return base.output;
   if (!options.base || !options.head || !options.title.trim() || !options.body.trim()) return result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
     error: { code: 'PR_PAYLOAD_INVALID', message: 'base, head, title and body are required', retryable: false }
   });
   if (base.prNumber) return inspectPlatformPullRequest(taskRef, options);
+  const gate = inspectCreatePrCommitGate(base.resolved.taskDir, base.resolved.repoRoot, base.resolved.taskId);
+  if (!gate.allowed) return result('blocked', base.resolved.taskId, base.issueNumber, null, {
+    platform: base.context.platform,
+    capabilities: base.context.capabilities,
+    error: {
+      code: gate.code!,
+      message: `${gate.message}; action=${gate.action}`,
+      retryable: gate.action === 'rerun-commit' || gate.action === 'rerun-review-code'
+    }
+  });
   const located = locatePullRequest(base, options.head, options.base);
   if (!located.ok && located.error.code === 'PR_IDENTITY_AMBIGUOUS') return result('failed', base.resolved.taskId, base.issueNumber, null, {
     platform: base.context.platform, capabilities: base.context.capabilities, error: located.error
@@ -809,6 +821,42 @@ function createPlatformPullRequest(taskRef: string, options: CreateOptions): Pul
     resource: { kind: 'pull-request', number: pullRequest.number }, pullRequest,
     operations: [{ name: created ? 'pr:create' : 'pr:reuse', status: created ? 'applied' : 'no-op', reasonCode: null }, { name: 'task:bind-pr', status: 'applied', reasonCode: null }], error: null
   });
+}
+
+function createPlatformPullRequest(taskRef: string, options: CreateOptions): PullRequestResult {
+  const base = resolvedContext(taskRef, options);
+  if (!base.ok) return base.output;
+  if (!options.base || !options.head || !options.title.trim() || !options.body.trim()) {
+    return result('failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      error: { code: 'PR_PAYLOAD_INVALID', message: 'base, head, title and body are required', retryable: false }
+    });
+  }
+  if (base.prNumber) return inspectPlatformPullRequest(taskRef, options);
+  try {
+    return withTaskExecutionLock(
+      base.resolved.repoRoot,
+      base.resolved.taskId,
+      'platform-pr.create',
+      () => createPlatformPullRequestUnlocked(taskRef, options)
+    );
+  } catch (error) {
+    if (error instanceof TaskExecutionLockError) {
+      return result('blocked', base.resolved.taskId, base.issueNumber, null, {
+        platform: base.context.platform,
+        capabilities: base.context.capabilities,
+        error: { code: error.code, message: error.message, retryable: true }
+      });
+    }
+    return result('failed', base.resolved.taskId, base.issueNumber, null, {
+      platform: base.context.platform,
+      capabilities: base.context.capabilities,
+      error: {
+        code: 'PR_CREATE_FAILED',
+        message: error instanceof Error ? error.message : String(error),
+        retryable: false
+      }
+    });
+  }
 }
 
 function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullRequestResult {

--- a/lib/task/commit-finalization.ts
+++ b/lib/task/commit-finalization.ts
@@ -1,0 +1,356 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { locateActivityLog, appendActivityEntry, pairEntries } from './activity-log.ts';
+import { commitIntentPath, digest, readCommitIntent } from './commit-intent.ts';
+import type { CommitIntent } from './commit-intent.ts';
+import { parseTypedTaskFrontmatter } from './frontmatter.ts';
+import { parseReviewSummary } from './review-artifacts.ts';
+import {
+  extractReviewBaseline,
+  extractReviewedSnapshotTree,
+  findAuthoritativeReviewCodeArtifact
+} from './review-fingerprint.ts';
+import type { TaskMutation } from './write.ts';
+
+type CommitFinalizationDisposition =
+  | 'idle'
+  | 'prepared'
+  | 'recoverable'
+  | 'invalid'
+  | 'conflict'
+  | 'orphaned-start';
+
+type CommitFinalizationCode =
+  | 'COMMIT_FINALIZATION_PENDING'
+  | 'COMMIT_FINALIZATION_EVIDENCE_MISSING'
+  | 'COMMIT_FINALIZATION_EVIDENCE_INVALID'
+  | 'COMMIT_FINALIZATION_CONFLICT';
+
+type CommitFinalizationInspection = Readonly<{
+  disposition: CommitFinalizationDisposition;
+  code: CommitFinalizationCode | null;
+  message: string;
+  currentHead: string;
+  committedHead: string | null;
+  commitNote: string | null;
+  needsAnchor: boolean;
+  needsLog: boolean;
+  intent: CommitIntent | null;
+  intentDigest: string | null;
+}>;
+
+type CreatePrCommitGate = Readonly<{
+  allowed: boolean;
+  code: CommitFinalizationCode | null;
+  message: string;
+  disposition: CommitFinalizationDisposition;
+  action: 'continue' | 'rerun-commit' | 'rerun-review-code';
+}>;
+
+type CommitTaskFinalizationPlan = Readonly<{
+  mutations: readonly TaskMutation[];
+  commitNote: string;
+}>;
+
+const SHA_RE = /^[a-f0-9]{40,64}$/;
+
+function git(repoRoot: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function commitExists(repoRoot: string, value: string): boolean {
+  return SHA_RE.test(value) && spawnSync('git', ['cat-file', '-e', `${value}^{commit}`], {
+    cwd: repoRoot,
+    stdio: 'ignore'
+  }).status === 0;
+}
+
+function isAncestor(repoRoot: string, ancestor: string, descendant: string): boolean {
+  return spawnSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+    cwd: repoRoot,
+    stdio: 'ignore'
+  }).status === 0;
+}
+
+function outcome(
+  disposition: CommitFinalizationDisposition,
+  overrides: Partial<CommitFinalizationInspection> = {}
+): CommitFinalizationInspection {
+  return {
+    disposition,
+    code: null,
+    message: disposition,
+    currentHead: '',
+    committedHead: null,
+    commitNote: null,
+    needsAnchor: false,
+    needsLog: false,
+    intent: null,
+    intentDigest: null,
+    ...overrides
+  };
+}
+
+function invalid(
+  message: string,
+  currentHead = '',
+  code: CommitFinalizationCode = 'COMMIT_FINALIZATION_EVIDENCE_INVALID',
+  overrides: Partial<CommitFinalizationInspection> = {}
+): CommitFinalizationInspection {
+  return outcome('invalid', { code, message, currentHead, ...overrides });
+}
+
+function inspectCommitFinalization(
+  taskDir: string,
+  repoRoot: string,
+  taskId: string
+): CommitFinalizationInspection {
+  let currentHead: string;
+  let taskContent: string;
+  let metadata: ReturnType<typeof parseTypedTaskFrontmatter>;
+  try {
+    currentHead = git(repoRoot, ['rev-parse', 'HEAD']);
+    taskContent = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+    metadata = parseTypedTaskFrontmatter(taskContent);
+  } catch (error) {
+    return invalid(error instanceof Error ? error.message : String(error));
+  }
+
+  const activity = locateActivityLog(taskContent);
+  if (!activity) return invalid('task activity log is missing or ambiguous', currentHead);
+  const commitRows = pairEntries(activity.entries).filter((row) => row.step === 'Commit');
+  const openRows = commitRows.filter((row) => row.started !== '' && row.done === '');
+  const file = commitIntentPath(taskDir);
+  if (!fs.existsSync(file)) {
+    if (openRows.length > 0) {
+      return outcome('orphaned-start', {
+        code: 'COMMIT_FINALIZATION_EVIDENCE_MISSING',
+        message: 'an open Commit activity entry exists without a commit intent',
+        currentHead
+      });
+    }
+    return outcome('idle', { message: 'no active commit finalization exists', currentHead });
+  }
+
+  let raw: string;
+  let intent: CommitIntent;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+    intent = readCommitIntent(taskDir, taskId);
+  } catch (error) {
+    return invalid(error instanceof Error ? error.message : String(error), currentHead);
+  }
+  const intentDigest = digest(raw);
+  const shared = { currentHead, intent, intentDigest, committedHead: intent.committedHead };
+
+  if (!commitExists(repoRoot, intent.baselineHead)) {
+    return invalid('commit intent baseline is not a valid Git commit', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+  }
+
+  if (intent.phase === 'prepared') {
+    if (intent.committedHead !== null || intent.pushEvidence !== null) {
+      return invalid('prepared commit intent contains commit or push evidence', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+    }
+    if (currentHead !== intent.baselineHead || openRows.length !== 1) {
+      return outcome('conflict', {
+        ...shared,
+        code: 'COMMIT_FINALIZATION_CONFLICT',
+        message: 'prepared commit intent does not match HEAD and exactly one open Commit entry'
+      });
+    }
+    return outcome('prepared', { ...shared, message: 'prepared commit intent can be safely retried' });
+  }
+
+  if (!intent.committedHead || !commitExists(repoRoot, intent.committedHead)) {
+    return invalid('committed intent head is missing or invalid', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+  }
+  if (intent.phase === 'committed' && intent.pushEvidence !== null) {
+    return invalid('committed intent contains premature push evidence', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+  }
+  if (
+    intent.phase === 'pushed'
+    && (
+      intent.pushEvidence === null
+      || intent.pushEvidence.head !== intent.committedHead
+      || !intent.pushEvidence.remote
+      || !intent.pushEvidence.ref
+    )
+  ) {
+    return invalid('pushed intent evidence is missing or inconsistent', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+  }
+  if (currentHead !== intent.committedHead || !isAncestor(repoRoot, intent.baselineHead, intent.committedHead)) {
+    return outcome('conflict', {
+      ...shared,
+      code: 'COMMIT_FINALIZATION_CONFLICT',
+      message: 'repository HEAD or ancestry conflicts with the commit intent'
+    });
+  }
+
+  const review = findAuthoritativeReviewCodeArtifact(taskDir);
+  let needsAnchor = false;
+  if (review.ok && review.path) {
+    let reviewContent: string;
+    try {
+      reviewContent = fs.readFileSync(review.path, 'utf8');
+    } catch (error) {
+      return invalid(error instanceof Error ? error.message : String(error), currentHead, 'COMMIT_FINALIZATION_EVIDENCE_MISSING', shared);
+    }
+    const summary = parseReviewSummary(reviewContent);
+    const reviewBaseline = extractReviewBaseline(reviewContent);
+    const reviewTree = extractReviewedSnapshotTree(reviewContent);
+    if (!summary.ok || summary.summary.verdict !== 'Approved' || !commitExists(repoRoot, reviewBaseline) || !SHA_RE.test(reviewTree)) {
+      return invalid('authoritative review-code evidence is not a valid approved snapshot', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
+    }
+    const committedTree = git(repoRoot, ['rev-parse', `${intent.committedHead}^{tree}`]);
+    if (reviewBaseline !== intent.baselineHead || reviewTree !== committedTree) {
+      return outcome('conflict', {
+        ...shared,
+        code: 'COMMIT_FINALIZATION_CONFLICT',
+        message: 'review baseline or snapshot tree conflicts with the committed intent'
+      });
+    }
+
+    const anchor = String(metadata.last_reviewed_commit ?? '').trim();
+    if (anchor && anchor !== intent.committedHead) {
+      return outcome('conflict', {
+        ...shared,
+        code: 'COMMIT_FINALIZATION_CONFLICT',
+        message: 'task review anchor conflicts with the committed intent'
+      });
+    }
+    needsAnchor = anchor === '';
+  }
+  const commitNote = git(repoRoot, ['show', '-s', '--format=%h%x20%s', intent.committedHead]);
+  const matchingDone = commitRows.filter((row) => row.done !== '' && row.note === commitNote);
+  const needsLog = matchingDone.length === 0 && openRows.length === 1;
+  if (!(needsLog || (matchingDone.length === 1 && openRows.length === 0))) {
+    return outcome('conflict', {
+      ...shared,
+      code: 'COMMIT_FINALIZATION_CONFLICT',
+      message: 'Commit activity identity is missing, duplicated, or ambiguous',
+      commitNote
+    });
+  }
+  return outcome('recoverable', {
+    ...shared,
+    message: 'commit finalization can be recovered',
+    commitNote,
+    needsAnchor,
+    needsLog
+  });
+}
+
+function planCommitTaskFinalization(
+  taskDir: string,
+  inspection: CommitFinalizationInspection,
+  agent: string,
+  timestamp: string
+): CommitTaskFinalizationPlan {
+  if (inspection.disposition !== 'recoverable' || !inspection.committedHead || !inspection.commitNote) {
+    throw new Error('commit finalization task mutations require a recoverable inspection');
+  }
+  const taskContent = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+  const frontmatter: Record<string, string> = { assigned_to: agent };
+  if (inspection.needsAnchor) frontmatter.last_reviewed_commit = inspection.committedHead;
+  const mutations: TaskMutation[] = [{
+    kind: 'frontmatter',
+    set: frontmatter
+  }];
+  if (inspection.needsLog) {
+    const activity = locateActivityLog(taskContent);
+    if (!activity) throw new Error('task activity log is missing or ambiguous');
+    mutations.push({
+      kind: 'section',
+      aliases: ['活动日志', 'Activity Log'],
+      heading: activity.heading,
+      body: appendActivityEntry(activity, {
+        time: timestamp,
+        step: 'Commit',
+        agent,
+        note: inspection.commitNote
+      })
+    });
+  }
+  return { mutations, commitNote: inspection.commitNote };
+}
+
+function inspectCreatePrCommitGate(taskDir: string, repoRoot: string, taskId: string): CreatePrCommitGate {
+  const lifecycle = inspectCommitFinalization(taskDir, repoRoot, taskId);
+  if (lifecycle.disposition !== 'idle') {
+    const pending = lifecycle.disposition === 'prepared' || lifecycle.disposition === 'recoverable';
+    return {
+      allowed: false,
+      code: pending ? 'COMMIT_FINALIZATION_PENDING' : lifecycle.code ?? 'COMMIT_FINALIZATION_CONFLICT',
+      message: pending ? 'commit finalization must complete before creating a pull request' : lifecycle.message,
+      disposition: lifecycle.disposition,
+      action: 'rerun-commit'
+    };
+  }
+
+  const review = findAuthoritativeReviewCodeArtifact(taskDir);
+  if (!review.ok || !review.path) {
+    return { allowed: true, code: null, message: 'no review-code history requires an anchor', disposition: 'idle', action: 'continue' };
+  }
+  try {
+    const content = fs.readFileSync(review.path, 'utf8');
+    const summary = parseReviewSummary(content);
+    if (!summary.ok || summary.summary.verdict !== 'Approved') {
+      return {
+        allowed: false,
+        code: 'COMMIT_FINALIZATION_EVIDENCE_INVALID',
+        message: 'latest authoritative review-code is not approved',
+        disposition: 'idle',
+        action: 'rerun-review-code'
+      };
+    }
+    const task = parseTypedTaskFrontmatter(fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8'));
+    const currentHead = git(repoRoot, ['rev-parse', 'HEAD']);
+    const anchor = String(task.last_reviewed_commit ?? '').trim();
+    if (!anchor || !commitExists(repoRoot, anchor)) {
+      return {
+        allowed: false,
+        code: 'COMMIT_FINALIZATION_EVIDENCE_MISSING',
+        message: 'approved review snapshot is not anchored to a Git commit',
+        disposition: 'idle',
+        action: 'rerun-commit'
+      };
+    }
+    if (anchor !== currentHead || extractReviewedSnapshotTree(content) !== git(repoRoot, ['rev-parse', 'HEAD^{tree}'])) {
+      return {
+        allowed: false,
+        code: 'COMMIT_FINALIZATION_CONFLICT',
+        message: 'approved review anchor or tree does not match repository HEAD',
+        disposition: 'idle',
+        action: 'rerun-review-code'
+      };
+    }
+    return { allowed: true, code: null, message: 'commit finalization evidence is complete', disposition: 'idle', action: 'continue' };
+  } catch (error) {
+    return {
+      allowed: false,
+      code: 'COMMIT_FINALIZATION_EVIDENCE_INVALID',
+      message: error instanceof Error ? error.message : String(error),
+      disposition: 'idle',
+      action: 'rerun-review-code'
+    };
+  }
+}
+
+export {
+  inspectCommitFinalization,
+  inspectCreatePrCommitGate,
+  planCommitTaskFinalization
+};
+export type {
+  CommitFinalizationCode,
+  CommitFinalizationDisposition,
+  CommitFinalizationInspection,
+  CommitTaskFinalizationPlan,
+  CreatePrCommitGate
+};

--- a/lib/task/commit-intent.ts
+++ b/lib/task/commit-intent.ts
@@ -196,6 +196,26 @@ function removeCommitIntent(taskDir: string, taskId: string, token: string): voi
   fs.unlinkSync(commitIntentPath(taskDir));
 }
 
+function removeCommitIntentByDigest(taskDir: string, taskId: string, expectedDigest: string): void {
+  const file = commitIntentPath(taskDir);
+  const raw = fs.readFileSync(file);
+  parseIntent(raw.toString('utf8'), taskId);
+  const actual = digest(raw);
+  const expected = Buffer.from(expectedDigest, 'hex');
+  const observed = Buffer.from(actual, 'hex');
+  if (
+    !/^[a-f0-9]{64}$/.test(expectedDigest)
+    || expected.length !== observed.length
+    || !timingSafeEqual(expected, observed)
+  ) {
+    throw new CommitIntentError(
+      'ORCHESTRATION_COMMIT_RECOVERY_REQUIRED',
+      'commit intent changed after recovery inspection'
+    );
+  }
+  fs.unlinkSync(file);
+}
+
 export {
   CommitIntentError,
   commitIntentPath,
@@ -203,6 +223,7 @@ export {
   digest,
   readCommitIntent,
   removeCommitIntent,
+  removeCommitIntentByDigest,
   serialize,
   updateCommitIntent
 };

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -44,10 +44,17 @@ import {
   digest,
   readCommitIntent,
   removeCommitIntent,
+  removeCommitIntentByDigest,
   serialize,
   updateCommitIntent
 } from './commit-intent.ts';
 import type { CommitIntent, PushEvidence } from './commit-intent.ts';
+import {
+  inspectCommitFinalization,
+  planCommitTaskFinalization
+} from './commit-finalization.ts';
+import type { CommitFinalizationInspection } from './commit-finalization.ts';
+import { captureTaskWriteMetadata, writeTask } from './write.ts';
 
 type OrchestrationStatus = 'running' | 'paused' | 'completed';
 type LegacyOrchestrationModelPolicy = Readonly<{
@@ -173,6 +180,15 @@ type CommitIntentResult = Readonly<{
     runId: string | null;
     receiptId: string | null;
   }> | null;
+  finalization?: Readonly<{
+    disposition: CommitFinalizationInspection['disposition'];
+    code: CommitFinalizationInspection['code'];
+    message: string;
+    currentHead: string;
+    committedHead: string | null;
+    needsAnchor: boolean;
+    needsLog: boolean;
+  }>;
   token?: string;
   error: Readonly<{ code: string; message: string }> | null;
 }>;
@@ -260,6 +276,18 @@ function commitIntentView(intent: CommitIntent, currentHead: string): NonNullabl
     pushEvidence: intent.pushEvidence,
     runId: intent.orchestration?.runId ?? null,
     receiptId: intent.orchestration?.receiptId ?? null
+  };
+}
+
+function commitFinalizationView(inspection: CommitFinalizationInspection): NonNullable<CommitIntentResult['finalization']> {
+  return {
+    disposition: inspection.disposition,
+    code: inspection.code,
+    message: inspection.message,
+    currentHead: inspection.currentHead,
+    committedHead: inspection.committedHead,
+    needsAnchor: inspection.needsAnchor,
+    needsLog: inspection.needsLog
   };
 }
 
@@ -874,7 +902,7 @@ function checkpointCommitIntent(
       const updated = updateCommitIntent(resolved.taskDir, resolved.taskId, input.token, input.kind === 'committed'
         ? { phase: 'committed', committedHead: input.head, updatedAt: now }
         : {
-            phase: 'pushed', updatedAt: now,
+            phase: 'pushed', committedHead: intent.committedHead ?? intent.baselineHead, updatedAt: now,
             pushEvidence: { remote: input.remote!, ref: input.ref!, head: input.head }
           });
       return {
@@ -887,6 +915,99 @@ function checkpointCommitIntent(
   }
 }
 
+function completeCommitOrchestration(
+  resolved: Extract<ReturnType<typeof resolveTaskRef>, { ok: true }>,
+  intent: CommitIntent,
+  agent: string
+): Readonly<{ code: string; message: string }> | null {
+  if (intent.orchestration === null) return null;
+  if (intent.orchestration.plannedReceipt.agent !== agent) {
+    return { code: 'ORCHESTRATION_PROVENANCE_MISMATCH', message: 'completion agent does not match the planned receipt' };
+  }
+  const runFile = orchestrationPath(resolved.taskDir);
+  if (!fs.existsSync(runFile)) {
+    return { code: 'ORCHESTRATION_RUN_MISSING', message: 'orchestration run disappeared' };
+  }
+  const currentBytes = fs.readFileSync(runFile, 'utf8');
+  const currentDigest = digest(currentBytes);
+  if (currentDigest === intent.orchestration.sourceRunDigest) {
+    const run = readRun(resolved.taskDir);
+    if (!run) return { code: 'ORCHESTRATION_RUN_MISSING', message: 'orchestration run disappeared' };
+    const plannedRun: OrchestrationRun = Object.freeze({
+      ...run,
+      pendingDelegation: intent.orchestration.plannedReceipt,
+      updatedAt: intent.orchestration.completionUpdatedAt
+    });
+    if (digest(serialize(plannedRun)) !== intent.orchestration.plannedRunDigest) {
+      return { code: 'ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', message: 'planned orchestration bytes no longer match the intent' };
+    }
+    atomicWrite(runFile, plannedRun);
+    if (digest(fs.readFileSync(runFile)) !== intent.orchestration.plannedRunDigest) {
+      return { code: 'ORCHESTRATION_COMMIT_COMPLETE_PARTIAL', message: 'orchestration completion could not be verified' };
+    }
+  } else if (currentDigest !== intent.orchestration.plannedRunDigest) {
+    return { code: 'ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', message: 'orchestration state changed after commit begin' };
+  }
+  return null;
+}
+
+function finalizeCommitIntentUnlocked(
+  resolved: Extract<ReturnType<typeof resolveTaskRef>, { ok: true }>,
+  inspection: CommitFinalizationInspection,
+  agent: string,
+  remove: () => void
+): CommitIntentResult {
+  if (inspection.disposition !== 'recoverable' || !inspection.intent) {
+    return commitIntentFailed(
+      inspection.code ?? 'COMMIT_FINALIZATION_PENDING',
+      inspection.message,
+      resolved.taskId
+    );
+  }
+  if (
+    inspection.intent.orchestration !== null
+    && inspection.intent.orchestration.plannedReceipt.agent !== agent
+  ) {
+    return commitIntentFailed(
+      'ORCHESTRATION_PROVENANCE_MISMATCH',
+      'completion agent does not match the planned receipt',
+      resolved.taskId
+    );
+  }
+  const metadata = captureTaskWriteMetadata();
+  const taskPlan = planCommitTaskFinalization(
+    resolved.taskDir,
+    inspection,
+    agent,
+    metadata.timestamp
+  );
+  const written = writeTask({
+    taskRef: resolved.taskId,
+    expectedState: 'active',
+    mutations: taskPlan.mutations
+  }, {
+    repoRoot: resolved.repoRoot,
+    metadataProvider: () => metadata
+  });
+  if (written.status === 'failed') {
+    return commitIntentFailed(written.error.code, written.error.message, resolved.taskId);
+  }
+  const orchestrationError = completeCommitOrchestration(resolved, inspection.intent, agent);
+  if (orchestrationError) {
+    return commitIntentFailed(orchestrationError.code, orchestrationError.message, resolved.taskId);
+  }
+  try {
+    remove();
+  } catch (error) {
+    return commitIntentFailed(
+      'ORCHESTRATION_COMMIT_COMPLETE_PARTIAL',
+      error instanceof Error ? error.message : String(error),
+      resolved.taskId
+    );
+  }
+  return { status: 'ready', changed: true, taskId: resolved.taskId, intent: null, error: null };
+}
+
 function completeCommitIntent(
   taskRef: string,
   input: Readonly<{ token: string; agent: string }>,
@@ -896,46 +1017,41 @@ function completeCommitIntent(
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.complete', () => {
-      const intent = readCommitIntent(resolved.taskDir, resolved.taskId, input.token);
-      const currentHead = repositoryHead(resolved.repoRoot);
-      if (intent.orchestration === null) {
+      readCommitIntent(resolved.taskDir, resolved.taskId, input.token);
+      const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+      return finalizeCommitIntentUnlocked(resolved, inspection, input.agent, () => {
         removeCommitIntent(resolved.taskDir, resolved.taskId, input.token);
+      });
+    });
+  } catch (error) {
+    return mapCommitIntentError(error, resolved.taskId);
+  }
+}
+
+function recoverCommitIntent(
+  taskRef: string,
+  input: Readonly<{ agent: string }>,
+  options: OrchestrationOptions = {}
+): CommitIntentResult {
+  const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
+  try {
+    return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.recover', () => {
+      const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+      if (inspection.disposition === 'prepared' && inspection.intentDigest) {
+        removeCommitIntentByDigest(resolved.taskDir, resolved.taskId, inspection.intentDigest);
         return { status: 'ready', changed: true, taskId: resolved.taskId, intent: null, error: null };
       }
-      if (intent.orchestration.plannedReceipt.agent !== input.agent) {
-        return commitIntentFailed('ORCHESTRATION_PROVENANCE_MISMATCH', 'completion agent does not match the planned receipt', resolved.taskId);
-      }
-      const runFile = orchestrationPath(resolved.taskDir);
-      const currentBytes = fs.readFileSync(runFile, 'utf8');
-      const currentDigest = digest(currentBytes);
-      if (currentDigest === intent.orchestration.sourceRunDigest) {
-        const run = readRun(resolved.taskDir);
-        if (!run) return commitIntentFailed('ORCHESTRATION_RUN_MISSING', 'orchestration run disappeared', resolved.taskId);
-        const plannedRun: OrchestrationRun = Object.freeze({
-          ...run,
-          pendingDelegation: intent.orchestration.plannedReceipt,
-          updatedAt: intent.orchestration.completionUpdatedAt
-        });
-        if (digest(serialize(plannedRun)) !== intent.orchestration.plannedRunDigest) {
-          return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'planned orchestration bytes no longer match the intent', resolved.taskId);
-        }
-        atomicWrite(runFile, plannedRun);
-        if (digest(fs.readFileSync(runFile)) !== intent.orchestration.plannedRunDigest) {
-          return commitIntentFailed('ORCHESTRATION_COMMIT_COMPLETE_PARTIAL', 'orchestration completion could not be verified', resolved.taskId);
-        }
-      } else if (currentDigest !== intent.orchestration.plannedRunDigest) {
-        return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'orchestration state changed after commit begin', resolved.taskId);
-      }
-      try {
-        removeCommitIntent(resolved.taskDir, resolved.taskId, input.token);
-      } catch (error) {
+      if (!inspection.intentDigest) {
         return commitIntentFailed(
-          'ORCHESTRATION_COMMIT_COMPLETE_PARTIAL',
-          error instanceof Error ? error.message : String(error),
+          inspection.code ?? 'COMMIT_FINALIZATION_EVIDENCE_MISSING',
+          inspection.message,
           resolved.taskId
         );
       }
-      return { status: 'ready', changed: true, taskId: resolved.taskId, intent: null, error: null };
+      return finalizeCommitIntentUnlocked(resolved, inspection, input.agent, () => {
+        removeCommitIntentByDigest(resolved.taskDir, resolved.taskId, inspection.intentDigest!);
+      });
     });
   } catch (error) {
     return mapCommitIntentError(error, resolved.taskId);
@@ -972,18 +1088,15 @@ function abortCommitIntent(
 function statusCommitIntent(taskRef: string, options: OrchestrationOptions = {}): CommitIntentResult {
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
-  try {
-    const intent = readCommitIntent(resolved.taskDir, resolved.taskId);
-    return {
-      status: 'ready', changed: false, taskId: resolved.taskId,
-      intent: commitIntentView(intent, repositoryHead(resolved.repoRoot)), error: null
-    };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { status: 'ready', changed: false, taskId: resolved.taskId, intent: null, error: null };
-    }
-    return mapCommitIntentError(error, resolved.taskId);
-  }
+  const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+  return {
+    status: 'ready',
+    changed: false,
+    taskId: resolved.taskId,
+    intent: inspection.intent ? commitIntentView(inspection.intent, inspection.currentHead) : null,
+    finalization: commitFinalizationView(inspection),
+    error: null
+  };
 }
 
 function statusOrchestration(taskRef: string, options: OrchestrationOptions = {}): OrchestrationResult {
@@ -1357,6 +1470,7 @@ export {
   planOrchestrationStageCompletion,
   prepareOrchestrationDelegation,
   readRun,
+  recoverCommitIntent,
   routeOrchestration,
   sealMatchingOrchestrationDelegation,
   sealOrchestrationDelegation,

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -31,7 +31,9 @@ Direct invocation still requires explicit user authorization. An orchestrated in
 
 Without explicit task scope, only `TASK_CONTEXT_NOT_FOUND` may continue through the existing bare-commit path. Detached HEAD, damaged candidates, or multiple matches are ambiguity errors. Any explicit task-scope failure is fatal.
 
-## Step Start: Write the started Marker
+## Step Start: Recover First, Then Write the started Marker
+
+When `{task-id}` is resolved, call `commit-status` first. For `recoverable` / `prepared`, call `commit-recover --agent {standard-agent-token}` without adding a second started entry or repeating Git side effects. Fail closed for `invalid` / `conflict` / `orphaned-start`; only `idle` enters the normal flow.
 
 Before checking local modifications, append a started marker to task.md `## Activity Log` (same base action as this step's done entry plus a ` [started]` suffix, note `started`):
 
@@ -77,7 +79,7 @@ If this commit is associated with a task and a `review-code` artifact exists, re
 - After staging the explicit files, record `pre_head=$(git rev-parse HEAD)` and use the helper's JSON mode to generate the complete worktree tree `W` and normalized staged tree `S`
 - Before `git commit`, require `pre_head == R && W == T && S == T`; use the helper's `compare` mode to produce added, missing, and different diagnostics for both worktree and staged snapshots
 - If any condition fails, enter Scenario 4 in `reference/task-status-update.md`; do not run `git commit`, push, successful state updates, PR summary sync, or the completion gate
-- After all comparisons match and the commit succeeds, write `last_reviewed_commit: <new_head>` to task.md frontmatter
+- After all comparisons match and the commit succeeds, the Step 6 `commit-complete` core finalizer atomically writes `last_reviewed_commit` and Commit done; the caller must not write them
 - Do not scan backward to earlier Approved artifacts; the highest-round `review-code` artifact is the only authoritative source
 
 ## 5. Push to the Existing PR When Applicable
@@ -102,6 +104,12 @@ Fold the push outcome (pushed / skipped(no PR) / failed) into the next step's "U
 
 ## 6. Update Task Status When Applicable
 
+After checkpoints and before synchronization or the completion gate, call `commit-complete`. Under the task lock, core writes the review anchor, Commit done, and planned orchestration bytes, then deletes the intent last. On failure retain the intent and let the next skill run use status/recover.
+
+```bash
+agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
+```
+
 Get the current time:
 
 ```bash
@@ -112,7 +120,7 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 
 > Before rendering next steps, read `.agents/rules/next-step-output.md` and invoke the shared helper for the scenario selected from `reference/task-status-update.md`.
 
-Append the Commit Activity Log entry and choose exactly one next-step case:
+After core finalization succeeds, choose exactly one next-step case:
 - open PR and successful push -> `watch-pr {task-ref}`; this takes precedence over the final-commit `prFlow` route
 - failed push -> keep the task active and show only push/synchronization diagnostics; do not show `watch-pr` or `complete-task`
 - final commit -> render the next step by `.agents/.airc.json`'s `prFlow` (`disabled` -> single option `complete-task`; `required` -> single option `create-pr`; absent -> two options `create-pr` / `complete-task`); see Case 1 in `reference/task-status-update.md`
@@ -154,13 +162,7 @@ Handle the result as follows:
 
 Keep the gate output in your reply as fresh evidence. Do not claim completion without output from this run.
 
-After the gate passes, complete the commit intent as defined by `reference/commit-orchestration.md`. Standalone only releases the intent without changing a historical run; orchestrated atomically commits the receipt completion prevalidated at begin:
-
-```bash
-agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
-```
-
-On failure, retain the intent, show `commit-status` recovery evidence, and stop. Do not repeat side effects or mark a run complete without the full receipt lifecycle.
+Run this gate only after core finalization succeeds; never place it before `commit-complete`.
 
 ## Notes
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -31,7 +31,13 @@ description: >
 
 未显式指定 task scope 时，只有 `TASK_CONTEXT_NOT_FOUND` 可继续既有纯提交路径；detached HEAD、损坏候选或多匹配属于歧义，必须失败。显式 task scope 解析失败时一律失败。
 
-## 步骤开始：写入 started 标记
+## 步骤开始：先恢复，再写 started 标记
+
+已解析出 `{task-id}` 时，先调用 `agent-infra-internal task-orchestration {task-id} commit-status`：
+
+- `recoverable` / `prepared`：调用 `commit-recover --agent {standard-agent-token}`；不得追加第二条 started、重复 commit 或重复 push。recoverable 完成后直接进入同步与完成校验；prepared 清理后复用既有 open started 并继续正常提交。
+- `invalid` / `conflict` / `orphaned-start`：输出结构化 code 与状态证据并停止。
+- `idle`：继续下方正常流程。
 
 开始检查本地修改之前，向 task.md `## 活动日志` 追加一条 started 标记（与本步骤 done 条目同基名 + ` [started]` 后缀，note 用 `started`）：
 
@@ -77,7 +83,7 @@ git diff
 - 暂存明确文件后记录 `pre_head=$(git rev-parse HEAD)`，并以 helper 的 JSON 模式生成当前完整工作区树 `W` 与规范化暂存树 `S`
 - 在 `git commit` 前要求 `pre_head == R && W == T && S == T`；分别运行 helper 的 `compare` 模式生成 worktree/staged 的 added、missing、different 路径诊断
 - 任一条件不满足时进入 `reference/task-status-update.md` 的“场景 4：提交前快照阻断”，不得执行 `git commit`、push、成功状态更新、PR 摘要同步或完成 gate
-- 全部相等并成功提交后，在 task.md frontmatter 写入 `last_reviewed_commit: <new_head>`
+- 全部相等并成功提交后，由步骤 6 的 `commit-complete` 核心收尾原子写入 `last_reviewed_commit` 与 Commit done；调用方不得手写
 - 不向后扫描更早的 Approved 产物；最高轮 `review-code` 产物是唯一权威来源
 
 ## 5. 推送到已有 PR（按需）
@@ -102,6 +108,14 @@ c. 安全降级（不阻塞已完成的 `git commit`，仅提示用户）：
 
 ## 6. 按需更新任务状态
 
+普通 commit/push checkpoint 完成后，先调用核心收尾；它在同一任务锁内写入审查锚点、Commit done 与 orchestration planned bytes，最后删除 intent：
+
+```bash
+agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
+```
+
+失败时保留 intent，输出 `commit-status` 后停止；重跑本技能由开头的 status/recover 路由恢复。调用方不得重复追加 Commit done 或修改 `last_reviewed_commit`。
+
 获取当前时间：
 
 ```bash
@@ -112,7 +126,7 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 
 > 渲染下一步前先读取 `.agents/rules/next-step-output.md`，并按 `reference/task-status-update.md` 的已选场景调用统一 helper。
 
-追加 Commit 的 Activity Log，并且只能选择一个下一步分支：
+核心收尾成功后只能选择一个下一步分支：
 - 已有开放 PR 且 push 成功 -> `watch-pr {task-ref}`；该分支优先于最终提交的 `prFlow` 路由
 - push 失败 -> 保持任务 active，只输出推送/同步诊断，不输出 `watch-pr` 或 `complete-task`
 - 最终提交 -> 按 `.agents/.airc.json` 的 `prFlow` 渲染下一步（`disabled` → 单选 `complete-task`；`required` → 单选 `create-pr`；缺省 → 二选一 `create-pr` / `complete-task`），详见 `reference/task-status-update.md` 场景 1
@@ -154,13 +168,7 @@ agent-infra-internal task-verify {task-id} commit.completed --format text
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-校验通过后，按 `reference/commit-orchestration.md` 完成 commit intent。standalone 只释放 intent 且不改写历史 run；orchestrated 原子提交 begin 时已预检的 receipt 完成态：
-
-```bash
-agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
-```
-
-命令失败时保留 intent、输出 `commit-status` 恢复证据并停止，不得重复副作用或把缺少完整 receipt 生命周期的 run 标记为完成。
+本 gate 只在步骤 6 核心收尾成功后运行；不得把完成校验放在 `commit-complete` 之前。
 
 ## 注意事项
 

--- a/templates/.agents/skills/commit/reference/commit-orchestration.en.md
+++ b/templates/.agents/skills/commit/reference/commit-orchestration.en.md
@@ -9,6 +9,8 @@ This protocol applies only when `{task-id}` was resolved. A taskless Git-only co
 
 ## Begin before side effects
 
+Call `commit-status` whenever the commit skill starts. For `recoverable` / `prepared`, call `commit-recover --agent {standard-agent-token}`; fail closed for every other non-`idle` state. The recovery intent accepts no token, head, or `--orchestrated` flag.
+
 After read-only preparation of status, copyright, message, review snapshot, and push routing, record `baseline_head=$(git rev-parse HEAD)` and run this before any commit, push, success log, or platform success sync:
 
 ```bash
@@ -36,12 +38,12 @@ A push-only path skips the committed checkpoint; its pushed HEAD must equal the 
 
 ## Completion and recovery
 
-After `task-verify commit.completed` passes, run:
+After the committed/pushed checkpoint and before task synchronization or `task-verify commit.completed`, run:
 
 ```bash
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
 - Before the first side effect, abort only while HEAD still equals the baseline by using `commit-abort --token ... --expected-head ...`.
-- After any commit, push, task, or platform side effect, never abort. Retain the intent and use `commit-status` for recovery evidence that excludes token/digest data.
+- After a commit or push, never abort. Retain the intent and use `commit-status` / `commit-recover` for cross-session recovery.
 - Stop when `commit-complete` fails. Do not repeat commit/push or mark a run complete without its full receipt lifecycle.

--- a/templates/.agents/skills/commit/reference/commit-orchestration.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/commit-orchestration.zh-CN.md
@@ -9,6 +9,14 @@
 
 ## 副作用前 begin
 
+每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` 调用以下无 token 恢复入口，其他非 `idle` 状态 fail closed：
+
+```bash
+agent-infra-internal task-orchestration {task-id} commit-recover --agent {standard-agent-token}
+```
+
+恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。recoverable 会幂等补齐 task/run 并最后删除 intent；prepared 仅在 HEAD=baseline 且恰有一个 open Commit started 时安全清理，随后复用该 started 继续正常流程。
+
 完成状态、版权、提交信息、review snapshot 和 push 场景的只读准备后，记录 `baseline_head=$(git rev-parse HEAD)`，并在任何 commit、push、任务成功日志或平台成功同步之前调用：
 
 ```bash
@@ -36,12 +44,12 @@ push-only 路径跳过 committed checkpoint，pushed HEAD 必须等于 begin 时
 
 ## 完成与恢复
 
-`task-verify commit.completed` 通过后调用：
+committed/pushed checkpoint 完成后、任务同步与 `task-verify commit.completed` 之前调用：
 
 ```bash
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
 - 第一个副作用前失败时，仅可在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`。
-- commit、push、任务或平台副作用发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。
+- commit 或 push 发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。跨会话重跑通过 `commit-recover` 收尾。
 - `commit-complete` 失败时停止。不得重复执行 commit/push，也不得把缺少完整 receipt 生命周期的 run 标记为完成。

--- a/templates/.agents/skills/commit/reference/task-status-update.en.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.en.md
@@ -12,19 +12,19 @@ Get the current time first:
 date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 ```
 
-For every task-related commit, append this Activity Log entry in `task.md`:
+The `commit-complete` / `commit-recover` core has already atomically written this Activity Log entry:
 
 ```text
 - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
-If the commit stage confirmed that the highest-round `review-code` artifact is Approved, `pre_head == R`, complete worktree tree `W == T`, and normalized staged tree `S == T`, also write or refresh after a successful commit:
+When the evidence is satisfied, core also writes or refreshes:
 
 ```yaml
 last_reviewed_commit: {new_head}
 ```
 
-This field is the only baseline for the `complete-task` `post-review-commit` gate. When any condition is not met, do not write or advance it.
+This field is the only baseline for the `complete-task` `post-review-commit` gate. The caller must not append Commit done again or write this field directly.
 
 ### Scenario 5: Existing-PR push wrap-up
 

--- a/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/task-status-update.zh-CN.md
@@ -12,19 +12,19 @@
 date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 ```
 
-对于每一次与任务相关的提交，都要在 `task.md` 中追加以下 Activity Log：
+`commit-complete` / `commit-recover` 核心已原子写入以下 Activity Log：
 
 ```text
 - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit** by {agent} — {commit hash short} {commit subject}
 ```
 
-如果提交阶段已确认最高轮 `review-code` 产物 Approved、`pre_head == R`、完整工作区树 `W == T` 且规范化暂存树 `S == T`，成功提交后同时写入或刷新：
+证据满足时核心同时写入或刷新：
 
 ```yaml
 last_reviewed_commit: {new_head}
 ```
 
-该字段是 `complete-task` 的 `post-review-commit` gate 唯一 baseline。条件不满足时不要写入或推进该字段。
+该字段是 `complete-task` 的 `post-review-commit` gate 唯一 baseline。调用方只读取核心结果选择后续路由，不得再次追加 Commit done 或手写/推进该字段。
 
 ### 场景 5：已有 PR 推送收尾
 

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -68,7 +68,7 @@ Use `agent-infra-internal git-workflow inspect` for upstream/remote facts and `g
 
 ### 5. Create or Recover the PR
 
-Read `.agents/rules/issue-pr-commands.md`, write the title and body to temporary files, then invoke its `platform-pr create` intent. The core first performs exact head/base lookup: one existing PR is reused and bound, zero creates, and multiple matches fail deterministically. Replays must not create duplicate PRs.
+Read `.agents/rules/issue-pr-commands.md`, write the title and body to temporary files, then invoke its `platform-pr create` intent. Under the task lock and before any Create PR started entry, POST, or reuse-bind, core checks commit finalization. An active intent, open Commit, missing review anchor, or tree drift returns a stable code and directs the caller to rerun commit/review-code; create-pr never repairs Commit state. Only after the gate passes does core perform exact head/base lookup: one existing PR is reused and bound, zero creates, and multiple matches fail deterministically. Replays must not create duplicate PRs.
 
 If `{task-id}` is available and the related task provides `issue_number`, keep `Closes #{issue-number}` in the PR body.
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -68,7 +68,7 @@ description: >
 
 ### 5. 创建或恢复 PR
 
-执行前先读取 `.agents/rules/issue-pr-commands.md`，把标题和正文写入临时文件，并调用其中的 `platform-pr create` intent。core 先按 head/base 精确定位：唯一既有 PR 会复用并绑定，零个才创建，多个稳定失败；重放不得产生重复 PR。
+执行前先读取 `.agents/rules/issue-pr-commands.md`，把标题和正文写入临时文件，并调用其中的 `platform-pr create` intent。core 在任务锁内、任何 Create PR started / POST / reuse-bind 之前检查 commit finalization；active intent、open Commit、审查锚点缺失或 tree 漂移时返回稳定 code 并指向重跑 commit/review-code，不自动恢复。门禁通过后才按 head/base 精确定位：唯一既有 PR 会复用并绑定，零个才创建，多个稳定失败；重放不得产生重复 PR。
 
 如果获取到 `{task-id}` 且对应任务提供了 `issue_number`，必须在 PR 正文中保留 `Closes #{issue-number}`。
 

--- a/tests/integration/cli/platform-pr.test.ts
+++ b/tests/integration/cli/platform-pr.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 
 import { filePath, gitSafeEnv, INTERNAL_CLI_PATH } from '../../helpers.ts';
+import { createCommitIntent } from '../../../lib/task/commit-intent.ts';
+import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
 
 function run(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
   return spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'platform-pr', ...args], {
@@ -116,6 +118,11 @@ test('platform-pr create binds one remote PR and replay performs no duplicate PO
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-pr-cli-'));
   try {
     execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
+    execFileSync('git', ['add', 'source.txt'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
     execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:fitlab-ai/agent-infra.git'], { cwd: root });
     const taskId = 'TASK-20260101-000001';
     const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
@@ -151,6 +158,73 @@ test('platform-pr create binds one remote PR and replay performs no duplicate PO
     assert.equal(JSON.parse(replay.stdout).status, 'no-op');
     const records = fs.readFileSync(calls, 'utf8').trim().split(/\r?\n/).map((line) => JSON.parse(line) as string[]);
     assert.equal(records.filter((call) => call.includes('POST') && call.some((item) => /\/pulls$/.test(item))).length, 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('platform-pr create blocks active commit finalization before task or remote writes', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-pr-gate-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
+    execFileSync('git', ['add', 'source.txt'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:fitlab-ai/agent-infra.git'], { cwd: root });
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    const taskId = 'TASK-20260101-000001';
+    const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+    fs.mkdirSync(taskDir, { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), '{"platform":{"type":"github"}}');
+    fs.writeFileSync(path.join(taskDir, 'task.md'), [
+      '---', `id: ${taskId}`, 'type: feature', 'status: active', 'issue_number: 7', '---', '',
+      '# Task', '', '## Activity Log', '',
+      '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started', ''
+    ].join('\n'));
+    createCommitIntent(taskDir, {
+      taskId, mode: 'standalone', phase: 'prepared', baselineHead: head,
+      committedHead: null, pushEvidence: null, orchestration: null,
+      createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z'
+    }, { token: () => 'token' });
+    const title = path.join(root, 'title.txt');
+    const body = path.join(root, 'body.md');
+    const pulls = path.join(root, 'pulls.json');
+    const calls = path.join(root, 'calls.jsonl');
+    const fake = path.join(root, 'fake-gh.cjs');
+    fs.writeFileSync(title, 'feat: blocked\n');
+    fs.writeFileSync(body, 'Body\n');
+    fs.writeFileSync(pulls, '[]');
+    fs.copyFileSync(filePath('tests/fixtures/validate-artifact/fake-gh.js'), fake);
+    const env = {
+      AGENT_INFRA_GH_BIN: process.execPath,
+      AGENT_INFRA_GH_ARGS_JSON: JSON.stringify([fake]),
+      GH_FAKE_PRS_PATH: pulls,
+      GH_FAKE_ARGS_PATH: calls
+    };
+
+    const created = run([
+      'create', taskId, '--agent', 'codex', '--base', 'main', '--head', 'feature',
+      '--title-file', title, '--body-file', body
+    ], { cwd: root, env });
+    assert.equal(created.status, 2, created.stderr || created.stdout);
+    const payload = JSON.parse(created.stdout);
+    assert.equal(payload.status, 'blocked');
+    assert.equal(payload.error.code, 'COMMIT_FINALIZATION_PENDING');
+    const records = fs.readFileSync(calls, 'utf8').trim().split(/\r?\n/).filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    assert.equal(records.filter((call) => call.includes('POST') && call.some((item) => /\/pulls$/.test(item))).length, 0);
+    const task = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+    assert.equal(task.includes('Create PR [started]'), false);
+    assert.equal(task.includes('pr_number:'), false);
+
+    const lockBusy = withTaskExecutionLock(root, taskId, 'test-holder', () => run([
+      'create', taskId, '--agent', 'codex', '--base', 'main', '--head', 'feature',
+      '--title-file', title, '--body-file', body
+    ], { cwd: root, env }));
+    assert.equal(lockBusy.status, 2, lockBusy.stderr || lockBusy.stdout);
+    assert.equal(JSON.parse(lockBusy.stdout).error.code, 'ORCHESTRATION_LOCK_BUSY');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/integration/cli/task-orchestration.test.ts
+++ b/tests/integration/cli/task-orchestration.test.ts
@@ -143,10 +143,51 @@ test('task-orchestration exposes token-guarded standalone commit intents and rej
 
   const emptyStatus = run(f.root, [f.id, 'commit-status']);
   assert.equal(emptyStatus.status, 0, emptyStatus.stderr || emptyStatus.stdout);
-  assert.deepEqual(JSON.parse(emptyStatus.stdout), {
-    status: 'ready', changed: false, taskId: f.id, intent: null, error: null
-  });
+  const emptyPayload = JSON.parse(emptyStatus.stdout);
+  assert.equal(emptyPayload.status, 'ready');
+  assert.equal(emptyPayload.changed, false);
+  assert.equal(emptyPayload.taskId, f.id);
+  assert.equal(emptyPayload.intent, null);
+  assert.equal(emptyPayload.finalization.disposition, 'invalid');
+  assert.equal(emptyPayload.error, null);
   assert.equal(emptyStatus.stdout.includes(f.dir), false);
+});
+
+test('task-orchestration recovers committed finalization without the original token', () => {
+  const f = fixture();
+  fs.writeFileSync(path.join(f.dir, 'task.md'), [
+    '---', `id: ${f.id}`, 'status: active', 'current_step: code-review', '---', '',
+    '# Task', '', '## Activity Log', '',
+    '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started', ''
+  ].join('\n'));
+  const baseline = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: f.root, encoding: 'utf8' }).stdout.trim();
+  const begun = run(f.root, [f.id, 'commit-begin', '--agent', 'codex', '--baseline-head', baseline]);
+  assert.equal(begun.status, 0, begun.stderr || begun.stdout);
+  const token = JSON.parse(begun.stdout).token;
+  fs.writeFileSync(path.join(f.root, 'source.txt'), 'change\n');
+  spawnSync('git', ['add', 'source.txt'], { cwd: f.root });
+  spawnSync('git', ['commit', '-qm', 'change'], { cwd: f.root });
+  const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: f.root, encoding: 'utf8' }).stdout.trim();
+  const checkpoint = run(f.root, [f.id, 'commit-checkpoint', '--token', token, '--kind', 'committed', '--head', head]);
+  assert.equal(checkpoint.status, 0, checkpoint.stderr || checkpoint.stdout);
+  const tree = spawnSync('git', ['rev-parse', 'HEAD^{tree}'], { cwd: f.root, encoding: 'utf8' }).stdout.trim();
+  fs.writeFileSync(path.join(f.dir, 'review-code.md'), [
+    '# Review', '', `- **Review Baseline Commit**: \`${baseline}\``,
+    `- **Reviewed Snapshot Tree**: \`${tree}\``, '', '## Review Summary', '',
+    '- **Overall Verdict**: Approved',
+    '- **Findings (AI-actionable)**: 0 blockers, 0 major, 0 minor / **Manual-validation**: 0', ''
+  ].join('\n'));
+
+  const recovered = run(f.root, [f.id, 'commit-recover', '--agent', 'codex']);
+  assert.equal(recovered.status, 0, recovered.stderr || recovered.stdout);
+  const task = fs.readFileSync(path.join(f.dir, 'task.md'), 'utf8');
+  assert.match(task, new RegExp(`^last_reviewed_commit: ${head}$`, 'm'));
+  assert.equal((task.match(/\*\*Commit\*\*/g) || []).length, 1);
+  assert.equal(fs.existsSync(path.join(f.dir, 'commit-intent.json')), false);
+
+  const invalid = run(f.root, [f.id, 'commit-recover', '--agent', 'codex', '--token', token]);
+  assert.equal(invalid.status, 2);
+  assert.equal(JSON.parse(invalid.stdout).error.code, 'ORCHESTRATION_PAYLOAD_INVALID');
 });
 
 test('task-orchestration rejects partial model policy options before core state changes', () => {

--- a/tests/unit/core/commit-finalization.test.ts
+++ b/tests/unit/core/commit-finalization.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  inspectCommitFinalization,
+  inspectCreatePrCommitGate,
+  planCommitTaskFinalization
+} from '../../../lib/task/commit-finalization.ts';
+import { createCommitIntent, updateCommitIntent } from '../../../lib/task/commit-intent.ts';
+
+const taskId = 'TASK-20260101-000001';
+
+function git(root: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function fixture(options: { anchor?: string; activity?: string } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commit-finalization-'));
+  git(root, ['init', '-q']);
+  git(root, ['config', 'user.name', 'Test']);
+  git(root, ['config', 'user.email', 'test@example.com']);
+  fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
+  git(root, ['add', 'source.txt']);
+  git(root, ['commit', '-qm', 'base']);
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  const anchor = options.anchor === undefined ? '' : `last_reviewed_commit: ${options.anchor}\n`;
+  fs.writeFileSync(path.join(taskDir, 'task.md'), [
+    '---', `id: ${taskId}`, 'status: active', anchor.trimEnd(), '---', '', '# Task', '',
+    '## Activity Log', '', options.activity ?? ''
+  ].filter((line) => line !== '').join('\n') + '\n');
+  return { root, taskDir, head: git(root, ['rev-parse', 'HEAD']) };
+}
+
+function approve(taskDir: string, baseline: string, tree: string) {
+  fs.writeFileSync(path.join(taskDir, 'review-code.md'), [
+    '# Review', '', `- **Review Baseline Commit**: \`${baseline}\``,
+    `- **Reviewed Snapshot Tree**: \`${tree}\``, '', '## Review Summary', '',
+    '- **Overall Verdict**: Approved',
+    '- **Findings (AI-actionable)**: 0 blockers, 0 major, 0 minor / **Manual-validation**: 0', ''
+  ].join('\n'));
+}
+
+test('idle lifecycle keeps normal commit reachable while create-pr requires an anchor', () => {
+  const f = fixture();
+  approve(f.taskDir, f.head, git(f.root, ['rev-parse', 'HEAD^{tree}']));
+
+  const lifecycle = inspectCommitFinalization(f.taskDir, f.root, taskId);
+  assert.equal(lifecycle.disposition, 'idle');
+  const gate = inspectCreatePrCommitGate(f.taskDir, f.root, taskId);
+  assert.equal(gate.allowed, false);
+  assert.equal(gate.code, 'COMMIT_FINALIZATION_EVIDENCE_MISSING');
+});
+
+test('prepared intent requires exactly one open Commit started entry', () => {
+  const f = fixture();
+  createCommitIntent(f.taskDir, {
+    taskId, mode: 'standalone', phase: 'prepared', baselineHead: f.head,
+    committedHead: null, pushEvidence: null, orchestration: null,
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z'
+  }, { token: () => 'token' });
+
+  assert.equal(inspectCommitFinalization(f.taskDir, f.root, taskId).disposition, 'conflict');
+});
+
+test('committed intent with matching review and Git tree is recoverable and plans one task write', () => {
+  const started = '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started';
+  const f = fixture({ activity: started });
+  approve(f.taskDir, f.head, git(f.root, ['rev-parse', 'HEAD^{tree}']));
+  createCommitIntent(f.taskDir, {
+    taskId, mode: 'standalone', phase: 'prepared', baselineHead: f.head,
+    committedHead: null, pushEvidence: null, orchestration: null,
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z'
+  }, { token: () => 'token' });
+  updateCommitIntent(f.taskDir, taskId, 'token', {
+    phase: 'committed', committedHead: f.head, updatedAt: '2026-01-01T00:00:01.000Z'
+  });
+
+  const inspection = inspectCommitFinalization(f.taskDir, f.root, taskId);
+  assert.equal(inspection.disposition, 'recoverable');
+  const plan = planCommitTaskFinalization(f.taskDir, inspection, 'codex', '2026-01-01 00:00:02+00:00');
+  assert.equal(plan.mutations.length, 2);
+  assert.match(String(plan.commitNote), /^[a-f0-9]{7,} base$/);
+});
+
+test('malformed intent is invalid and never treated as recoverable', () => {
+  const f = fixture();
+  fs.writeFileSync(path.join(f.taskDir, 'commit-intent.json'), '{');
+
+  const inspection = inspectCommitFinalization(f.taskDir, f.root, taskId);
+  assert.equal(inspection.disposition, 'invalid');
+  assert.equal(inspection.code, 'COMMIT_FINALIZATION_EVIDENCE_INVALID');
+});

--- a/tests/unit/core/commit-intent.test.ts
+++ b/tests/unit/core/commit-intent.test.ts
@@ -6,7 +6,9 @@ import test from 'node:test';
 
 import {
   createCommitIntent,
+  digest,
   readCommitIntent,
+  removeCommitIntentByDigest,
   removeCommitIntent,
   updateCommitIntent
 } from '../../../lib/task/commit-intent.ts';
@@ -69,5 +71,18 @@ test('commit intent removal is token guarded', () => {
     (error: unknown) => (error as { code?: string }).code === 'ORCHESTRATION_COMMIT_INTENT_TOKEN_MISMATCH'
   );
   removeCommitIntent(f.taskDir, base.taskId, 'token');
+  assert.equal(fs.existsSync(f.file), false);
+});
+
+test('commit intent recovery removal compares the complete captured bytes', () => {
+  const f = fixture();
+  createCommitIntent(f.taskDir, base, { token: () => 'token' });
+  const captured = digest(fs.readFileSync(f.file));
+
+  assert.throws(
+    () => removeCommitIntentByDigest(f.taskDir, base.taskId, '0'.repeat(64)),
+    (error: unknown) => (error as { code?: string }).code === 'ORCHESTRATION_COMMIT_RECOVERY_REQUIRED'
+  );
+  removeCommitIntentByDigest(f.taskDir, base.taskId, captured);
   assert.equal(fs.existsSync(f.file), false);
 });

--- a/tests/unit/core/commit-orchestration.test.ts
+++ b/tests/unit/core/commit-orchestration.test.ts
@@ -13,6 +13,7 @@ import {
   completeCommitIntent,
   prepareOrchestrationDelegation,
   readRun,
+  recoverCommitIntent,
   sealOrchestrationDelegation,
   statusCommitIntent
 } from '../../../lib/task/orchestration.ts';
@@ -34,8 +35,29 @@ function fixture() {
   git(root, ['commit', '-qm', 'base']);
   const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
   fs.mkdirSync(taskDir, { recursive: true });
-  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\ncurrent_step: code-review\n---\n`);
+  fs.writeFileSync(path.join(taskDir, 'task.md'), [
+    '---', `id: ${taskId}`, 'status: active', 'current_step: code-review', '---', '',
+    '# Task', '', '## Activity Log', '',
+    '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started', ''
+  ].join('\n'));
   return { root, taskDir, head: git(root, ['rev-parse', 'HEAD']) };
+}
+
+function checkpointReviewed(f: ReturnType<typeof fixture>, token: string) {
+  fs.writeFileSync(path.join(f.root, 'source.txt'), 'changed\n');
+  git(f.root, ['add', 'source.txt']);
+  git(f.root, ['commit', '-qm', 'change']);
+  const head = git(f.root, ['rev-parse', 'HEAD']);
+  assert.equal(checkpointCommitIntent(taskId, {
+    token, kind: 'committed', head
+  }, { repoRoot: f.root }).status, 'ready');
+  fs.writeFileSync(path.join(f.taskDir, 'review-code.md'), [
+    '# Review', '', `- **Review Baseline Commit**: \`${f.head}\``,
+    `- **Reviewed Snapshot Tree**: \`${git(f.root, ['rev-parse', 'HEAD^{tree}'])}\``, '',
+    '## Review Summary', '', '- **Overall Verdict**: Approved',
+    '- **Findings (AI-actionable)**: 0 blockers, 0 major, 0 minor / **Manual-validation**: 0', ''
+  ].join('\n'));
+  return head;
 }
 
 function activatedRun() {
@@ -70,10 +92,37 @@ test('standalone begin and complete preserve historical orchestration bytes', ()
     assert.equal(begun.status, 'ready');
     assert.equal(begun.intent?.mode, 'standalone');
     assert.deepEqual(fs.readFileSync(runPath), before);
+    checkpointReviewed(f, begun.token!);
     assert.equal(completeCommitIntent(taskId, { token: begun.token!, agent: 'codex' }, { repoRoot: f.root }).status, 'ready');
     assert.deepEqual(fs.readFileSync(runPath), before);
     assert.equal(fs.existsSync(path.join(f.taskDir, 'commit-intent.json')), false);
   }
+});
+
+test('standalone commit without review finalizes without creating a review anchor', () => {
+  const f = fixture();
+  const begun = beginCommitIntent(taskId, {
+    agent: 'codex', orchestrated: false, baselineHead: f.head
+  }, { repoRoot: f.root, token: () => 'token' });
+  assert.equal(begun.status, 'ready');
+  fs.writeFileSync(path.join(f.root, 'source.txt'), 'changed\n');
+  git(f.root, ['add', 'source.txt']);
+  git(f.root, ['commit', '-qm', 'change']);
+  const head = git(f.root, ['rev-parse', 'HEAD']);
+  assert.equal(checkpointCommitIntent(taskId, {
+    token: 'token', kind: 'committed', head
+  }, { repoRoot: f.root }).status, 'ready');
+
+  const completed = completeCommitIntent(taskId, {
+    token: 'token', agent: 'codex'
+  }, { repoRoot: f.root });
+
+  assert.equal(completed.status, 'ready');
+  assert.equal(completed.error, null);
+  assert.equal(fs.existsSync(path.join(f.taskDir, 'commit-intent.json')), false);
+  const task = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+  assert.equal((task.match(/\*\*Commit\*\*/g) || []).length, 1);
+  assert.equal(task.includes('last_reviewed_commit:'), false);
 });
 
 test('standalone fails before intent creation when any delegation is pending', () => {
@@ -95,6 +144,7 @@ test('orchestrated complete commits the preplanned receipt without consuming aut
     repoRoot: f.root, token: () => 'token', now: () => '2026-01-01T00:00:01.000Z'
   });
   assert.equal(begun.status, 'ready');
+  checkpointReviewed(f, 'token');
   assert.equal(completeCommitIntent(taskId, { token: 'token', agent: 'claude' }, { repoRoot: f.root }).status, 'ready');
   assert.equal(readRun(f.taskDir)?.pendingDelegation?.status, 'stage-completed');
   assert.equal(readRun(f.taskDir)?.commitAuthorization.consumedAt, null);
@@ -116,6 +166,7 @@ test('orchestrated complete recovers after the planned run was written but the i
   }, {
     repoRoot: f.root, token: () => 'token', now: () => '2026-01-01T00:00:01.000Z'
   });
+  checkpointReviewed(f, 'token');
   const intent = readCommitIntent(f.taskDir, taskId, 'token');
   assert.notEqual(intent.orchestration, null);
   const plannedRun = {
@@ -133,11 +184,31 @@ test('orchestrated complete recovers after the planned run was written but the i
   assert.equal(fs.existsSync(path.join(f.taskDir, 'commit-intent.json')), false);
 });
 
+test('token-less recovery finalizes a committed intent exactly once', () => {
+  const f = fixture();
+  beginCommitIntent(taskId, {
+    agent: 'codex', orchestrated: false, baselineHead: f.head
+  }, { repoRoot: f.root, token: () => 'lost-token' });
+  const committedHead = checkpointReviewed(f, 'lost-token');
+
+  const recovered = recoverCommitIntent(taskId, { agent: 'codex' }, { repoRoot: f.root });
+  assert.equal(recovered.status, 'ready');
+  assert.equal(fs.existsSync(path.join(f.taskDir, 'commit-intent.json')), false);
+  const content = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+  assert.match(content, new RegExp(`^last_reviewed_commit: ${committedHead}$`, 'm'));
+  assert.equal((content.match(/\*\*Commit\*\*/g) || []).length, 1);
+  assert.equal(statusCommitIntent(taskId, { repoRoot: f.root }).finalization?.disposition, 'idle');
+});
+
 test('commit intent status is ready when no intent exists', () => {
   const f = fixture();
-  assert.deepEqual(statusCommitIntent(taskId, { repoRoot: f.root }), {
-    status: 'ready', changed: false, taskId, intent: null, error: null
-  });
+  const status = statusCommitIntent(taskId, { repoRoot: f.root });
+  assert.equal(status.status, 'ready');
+  assert.equal(status.changed, false);
+  assert.equal(status.taskId, taskId);
+  assert.equal(status.intent, null);
+  assert.equal(status.finalization?.disposition, 'orphaned-start');
+  assert.equal(status.error, null);
 });
 
 test('orchestrated complete fails closed on run drift and retains recovery evidence', () => {
@@ -147,6 +218,7 @@ test('orchestrated complete fails closed on run drift and retains recovery evide
   beginCommitIntent(taskId, {
     agent: 'claude', orchestrated: true, baselineHead: f.head
   }, { repoRoot: f.root, token: () => 'token' });
+  checkpointReviewed(f, 'token');
   const drifted = JSON.parse(fs.readFileSync(runPath, 'utf8'));
   drifted.pause = { code: 'DRIFT', message: 'changed', recoverable: true };
   fs.writeFileSync(runPath, `${JSON.stringify(drifted, null, 2)}\n`);

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1778,9 +1778,9 @@ test("commit skill variants preserve the commit-intent protocol structure", () =
     const gate = skill.indexOf("agent-infra-internal task-verify {task-id} commit.completed");
     const complete = skill.indexOf("agent-infra-internal task-orchestration {task-id} commit-complete");
     assert.ok(navigation >= 0 && navigation < commit, `${skillPath} should load the protocol before commit`);
-    assert.ok(gate >= 0 && gate < complete, `${skillPath} should complete the intent after the gate`);
+    assert.ok(complete >= 0 && complete < gate, `${skillPath} should finalize task state before the gate`);
 
-    const commands = ["commit-begin", "--kind committed", "--kind pushed", "commit-complete"]
+    const commands = ["commit-status", "commit-recover", "commit-begin", "--kind committed", "--kind pushed", "commit-complete"]
       .map((token) => reference.indexOf(token));
     assert.ok(commands.every((position) => position >= 0), `${referencePath} should contain every protocol command`);
     assert.deepEqual([...commands].sort((left, right) => left - right), commands, `${referencePath} command order should be stable`);


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #820

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that does not need an issue

Closes #820

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [x] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

修复 Git commit 已成功并写入 committed intent，但任务审查锚点和 Commit 完成日志尚未落账时，后续 PR 创建仍可继续的问题。提交收尾现在具备可恢复、幂等的语义，PR 创建会在任何远端副作用前阻止未完成或证据冲突的提交状态。

Fix the workflow gap where PR creation could continue after Git commit success while the reviewed commit anchor and Commit activity record were not finalized. Commit finalization is now recoverable and idempotent, and PR creation fails closed before remote side effects when finalization evidence is incomplete or conflicting.

## 📋 主要变更 / Brief Changelog

- 新增提交收尾领域检查，统一分类 idle、prepared、recoverable、invalid、conflict 与 orphaned-start 状态。
- 为 committed/pushed intent 增加跨会话 `commit-recover`，按 task → orchestration → intent 删除顺序幂等收尾。
- 在 PR create/reuse-bind 路径的任务锁内增加前置门禁，确保阻断时 POST、绑定和 Create PR 日志均为零。
- 保持 Approved review baseline/tree/anchor 的 fail-closed 边界，并兼容无 review 提交只写 Commit done、不生成审查锚点。
- 同步 commit/create-pr 技能、reference 和英中模板，并补充单元与 CLI/平台集成测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run test:core`.
2. Run `npm test`.
3. Run `git diff --check main...HEAD` and inspect the reviewed snapshot identity.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

验证结果：定向回归 36/36 通过；core 1878 通过、2 跳过；完整测试 2188 通过、3 跳过；0 失败。TypeScript 构建和 `git diff --check` 通过。

Verification result: 36/36 targeted tests passed; core passed 1878 with 2 skipped; the full suite passed 2188 with 3 skipped; 0 failures. TypeScript build and `git diff --check` passed.

## 📸 截图 / Screenshots

不适用；本次变更涉及内部提交生命周期、PR 门禁、技能协议和自动化测试。

Not applicable; this change affects internal commit lifecycle, PR gates, skill protocols, and automated tests.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 有对应 GitHub Issue / A corresponding GitHub Issue exists
- [x] PR 只解决一个 Issue / This PR addresses one issue
- [x] Commit 具有有意义的主题和正文 / The commit has a meaningful subject and body
- [x] 代码遵循项目规范 / Code follows project conventions
- [x] 已完成自我审查与独立代码审查 / Self-review and independent code review are complete
- [x] 已编写必要的单元和集成测试 / Necessary unit and integration tests are included
- [x] 类型检查、构建和完整测试通过 / Type checks, build, and the full test suite pass
- [x] 已同步英中技能模板 / English and Chinese skill templates are synchronized
- [x] 已考虑向后兼容性和并发安全边界 / Backward compatibility and concurrency safety were considered

## 📋 附加信息 / Additional Notes

- 最新代码审查结论：Approved，0 blocker、0 major、0 minor。
- 本轮无需人工校验。
- 多提交 follow-up 的恢复边界与 no-review PR 兼容面保留为后续独立评估项，不影响本任务验收。

---

**审查者注意事项 / Reviewer Notes:**

请重点检查 commit finalization 状态分类、task/orchestration/intent 的幂等写入顺序、compare-before-unlink 防护，以及 PR 创建门禁是否完整覆盖 create/reuse-bind 的锁内远端副作用边界。

Generated with AI assistance
