### PR TITLE
fix(commit): 修复提交编排错误绑定工作树


### DIFF
--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -70,6 +70,7 @@
   `- {time} — **{基名} [started]** by {agent} — started`
 - **done 行**（步骤完成时写，与现状一致）：action 即基名本身：
   `- {time} — **{基名}** by {agent} — {完成说明}`
+- **Commit 专用 attempt**：commit 技能不得手写 started。`commit-start` 在任务锁内写入带 `attempt`、`baseline`、`agent` 的结构化 `Commit [started]`；无副作用放弃时由 `commit-terminate` 写匹配的 `Commit [aborted]`。aborted 只闭合活动日志，不构成提交成功证据。
 - `{基名}` 指该 SKILL 既有 done 条目的 action 文本，含 `(Round {N})`（如 `Plan Task (Round 1)`）。
   started 与 done 共用同一 `{基名}` 才能配对。
 

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -31,21 +31,17 @@ description: >
 
 未显式指定 task scope 时，只有 `TASK_CONTEXT_NOT_FOUND` 可继续既有纯提交路径；detached HEAD、损坏候选或多匹配属于歧义，必须失败。显式 task scope 解析失败时一律失败。
 
-## 步骤开始：先恢复，再写 started 标记
+## 步骤开始：恢复或创建受控 attempt
 
 已解析出 `{task-id}` 时，先调用 `agent-infra-internal task-orchestration {task-id} commit-status`：
 
-- `recoverable` / `prepared`：调用 `commit-recover --agent {standard-agent-token}`；不得追加第二条 started、重复 commit 或重复 push。recoverable 完成后直接进入同步与完成校验；prepared 清理后复用既有 open started 并继续正常提交。
+- `recoverable`：调用 `commit-recover --agent {standard-agent-token}` 完成收尾，不得重复 commit 或 push。
+- `prepared`：调用 `commit-recover --agent {standard-agent-token}` 安全清理 intent，再次查询 status 并复用返回的 `retryable-start` attempt。
+- `retryable-start`：调用 `commit-recover --agent {standard-agent-token}` 取得原 attempt，不追加第二条 started。
 - `invalid` / `conflict` / `orphaned-start`：输出结构化 code 与状态证据并停止。
-- `idle`：继续下方正常流程。
+- `idle`：调用 `commit-start --agent {standard-agent-token}`，由核心在任务锁内原子写入结构化 started 并返回 attempt/baseline。
 
-开始检查本地修改之前，向 task.md `## 活动日志` 追加一条 started 标记（与本步骤 done 条目同基名 + ` [started]` 后缀，note 用 `started`）：
-
-```
-- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit [started]** by {agent} — started
-```
-
-`ai task log` 会把它与提交完成时写入的 done 条目配对成一行（进行中 → 已完成）。格式与配对规则见 `.agents/rules/task-management.md` 的「Activity Log started / done 双标记约定」。仅当本任务存在 task.md 时写入（无任务上下文的纯提交可跳过）。
+只从 `commit-start` / `commit-recover` 的结构化输出读取 `{commit-attempt}`；不得手写、复制或猜测 attempt。无任务上下文的纯提交跳过本协议。
 
 ## 1. 检查本地修改（关键）
 

--- a/.agents/skills/commit/reference/commit-orchestration.md
+++ b/.agents/skills/commit/reference/commit-orchestration.md
@@ -9,18 +9,18 @@
 
 ## 副作用前 begin
 
-每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` 调用以下无 token 恢复入口，其他非 `idle` 状态 fail closed：
+每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` / `retryable-start` 调用以下无 token 恢复入口，`idle` 调用 `commit-start --agent {standard-agent-token}`；其他状态 fail closed：
 
 ```bash
 agent-infra-internal task-orchestration {task-id} commit-recover --agent {standard-agent-token}
 ```
 
-恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。recoverable 会幂等补齐 task/run 并最后删除 intent；prepared 仅在 HEAD=baseline 且恰有一个 open Commit started 时安全清理，随后复用该 started 继续正常流程。
+恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。从 start/recover 结构化输出读取 `finalization.attempt.attempt` 为 `commit_attempt`，不得手写 attempt。
 
 完成状态、版权、提交信息、review snapshot 和 push 场景的只读准备后，记录 `baseline_head=$(git rev-parse HEAD)`，并在任何 commit、push、任务成功日志或平台成功同步之前调用：
 
 ```bash
-commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head")
+commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head" --attempt "$commit_attempt")
 commit_intent_token=$(printf '%s' "$commit_intent_result" | node -e 'let input = ""; process.stdin.on("data", chunk => input += chunk).on("end", () => process.stdout.write(JSON.parse(input).token))')
 ```
 
@@ -50,6 +50,7 @@ committed/pushed checkpoint 完成后、任务同步与 `task-verify commit.comp
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
-- 第一个副作用前失败时，仅可在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`。
+- begin 已创建 intent、但第一个副作用前失败时，先在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`；若本轮明确放弃，再调用 `commit-terminate --attempt "$commit_attempt" --agent {standard-agent-token} --code <STABLE_CODE>` 闭合 started。
+- begin 在 intent 创建前失败时可保留 attempt 供下次复用；明确放弃时仅可在 HEAD 未漂移时调用 `commit-terminate`。
 - commit 或 push 发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。跨会话重跑通过 `commit-recover` 收尾。
 - `commit-complete` 失败时停止。不得重复执行 commit/push，也不得把缺少完整 receipt 生命周期的 run 标记为完成。

--- a/lib/git/worktree-identity.ts
+++ b/lib/git/worktree-identity.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+type GitWorktreeIdentity = Readonly<{
+  worktreeRoot: string;
+  commonDir: string;
+  branch: string;
+}>;
+
+function normalizeCanonicalPath(value: string, platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32'
+    ? path.win32.normalize(value).replaceAll('/', '\\').toLowerCase()
+    : path.posix.normalize(value);
+}
+
+function sameFilesystemEntry(left: string, right: string, platform: NodeJS.Platform = process.platform): boolean {
+  const leftReal = fs.realpathSync.native(left);
+  const rightReal = fs.realpathSync.native(right);
+  const leftStat = fs.statSync(leftReal, { bigint: true });
+  const rightStat = fs.statSync(rightReal, { bigint: true });
+  if (leftStat.ino !== 0n && rightStat.ino !== 0n) {
+    return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino;
+  }
+  return normalizeCanonicalPath(leftReal, platform) === normalizeCanonicalPath(rightReal, platform);
+}
+
+function git(root: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function resolveGitWorktreeIdentity(worktreeRoot: string): GitWorktreeIdentity {
+  try {
+    const canonical = fs.realpathSync.native(worktreeRoot);
+    const topLevel = fs.realpathSync.native(git(canonical, ['rev-parse', '--show-toplevel']));
+    if (!sameFilesystemEntry(canonical, topLevel)) {
+      throw new Error('worktree root is not the Git top-level directory');
+    }
+    const commonDir = fs.realpathSync.native(git(canonical, [
+      'rev-parse', '--path-format=absolute', '--git-common-dir'
+    ]));
+    const branch = git(canonical, ['symbolic-ref', '--short', 'HEAD']);
+    return { worktreeRoot: canonical, commonDir, branch };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`SANDBOX_CONTROL_WORKTREE_INVALID: ${message}`);
+  }
+}
+
+function assertGitWorktreeBinding(
+  stateRoot: string,
+  worktreeRoot: string,
+  expectedBranch: string
+): GitWorktreeIdentity {
+  const state = resolveGitWorktreeIdentity(stateRoot);
+  const worktree = resolveGitWorktreeIdentity(worktreeRoot);
+  if (!sameFilesystemEntry(state.commonDir, worktree.commonDir)) {
+    throw new Error('SANDBOX_CONTROL_WORKTREE_INVALID: state and worktree roots have different Git common directories');
+  }
+  if (worktree.branch !== expectedBranch) {
+    throw new Error(`SANDBOX_CONTROL_WORKTREE_INVALID: expected branch '${expectedBranch}', got '${worktree.branch}'`);
+  }
+  return worktree;
+}
+
+function assertGitRepositoryBinding(stateRoot: string, worktreeRoot: string): GitWorktreeIdentity {
+  const state = resolveGitWorktreeIdentity(stateRoot);
+  const worktree = resolveGitWorktreeIdentity(worktreeRoot);
+  if (!sameFilesystemEntry(state.commonDir, worktree.commonDir)) {
+    throw new Error('SANDBOX_CONTROL_WORKTREE_INVALID: state and worktree roots have different Git common directories');
+  }
+  return worktree;
+}
+
+export {
+  assertGitWorktreeBinding,
+  assertGitRepositoryBinding,
+  normalizeCanonicalPath,
+  resolveGitWorktreeIdentity,
+  sameFilesystemEntry
+};
+export type { GitWorktreeIdentity };

--- a/lib/internal/task-orchestration.ts
+++ b/lib/internal/task-orchestration.ts
@@ -14,13 +14,15 @@ import {
   routeOrchestration,
   sealMatchingOrchestrationDelegation,
   sealOrchestrationDelegation,
+  startCommitAttempt,
   statusCommitIntent,
-  statusOrchestration
+  statusOrchestration,
+  terminateCommitAttempt
 } from '../task/orchestration.ts';
 import { isAgentClientId } from '../agent-clients/types.ts';
 import type { AgentClientId } from '../agent-clients/types.ts';
 
-const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|hook-start|hook-stop|advance|pause|status|commit-begin|commit-checkpoint|commit-complete|commit-recover|commit-abort|commit-status> [options]\n';
+const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|hook-start|hook-stop|advance|pause|status|commit-start|commit-begin|commit-checkpoint|commit-complete|commit-recover|commit-abort|commit-terminate|commit-status> [options]\n';
 
 function usageFailure(message: string): void {
   process.stdout.write(`${JSON.stringify({
@@ -43,7 +45,7 @@ function taskOrchestration(args: string[] = []): void {
   const [taskRef, intent] = args;
   if (![
     'begin-or-resume', 'route', 'prepare', 'hook-start', 'hook-stop', 'advance', 'pause', 'status',
-    'commit-begin', 'commit-checkpoint', 'commit-complete', 'commit-recover', 'commit-abort', 'commit-status'
+    'commit-start', 'commit-begin', 'commit-checkpoint', 'commit-complete', 'commit-recover', 'commit-abort', 'commit-terminate', 'commit-status'
   ].includes(intent!)) {
     usageFailure(`unknown intent '${intent}'`);
     return;
@@ -67,6 +69,7 @@ function taskOrchestration(args: string[] = []): void {
       '--model-fallback-reason', '--reasoning-effort-fallback-reason',
       '--exit-code', '--after-fingerprint', '--changed-paths', '--code', '--message', '--recoverable', '--agent',
       '--baseline-head', '--token', '--kind', '--head', '--remote', '--ref', '--expected-head'
+      , '--attempt', '--git-worktree-root'
     ].includes(flag)) {
       usageFailure(`unknown option '${flag}'`);
       return;
@@ -84,12 +87,14 @@ function taskOrchestration(args: string[] = []): void {
     values[flag] = value;
   }
   const commitIntentFlags: Record<string, readonly string[]> = {
-    'commit-begin': ['--agent', '--baseline-head', '--orchestrated'],
-    'commit-checkpoint': ['--token', '--kind', '--head', '--remote', '--ref'],
-    'commit-complete': ['--token', '--agent'],
-    'commit-recover': ['--agent'],
-    'commit-abort': ['--token', '--expected-head'],
-    'commit-status': []
+    'commit-start': ['--agent', '--git-worktree-root'],
+    'commit-begin': ['--agent', '--baseline-head', '--attempt', '--orchestrated', '--git-worktree-root'],
+    'commit-checkpoint': ['--token', '--kind', '--head', '--remote', '--ref', '--git-worktree-root'],
+    'commit-complete': ['--token', '--agent', '--git-worktree-root'],
+    'commit-recover': ['--agent', '--git-worktree-root'],
+    'commit-abort': ['--token', '--expected-head', '--git-worktree-root'],
+    'commit-terminate': ['--attempt', '--agent', '--code', '--git-worktree-root'],
+    'commit-status': ['--git-worktree-root']
   };
   if (intent! in commitIntentFlags) {
     const allowed = commitIntentFlags[intent!]!;
@@ -97,24 +102,33 @@ function taskOrchestration(args: string[] = []): void {
     if (invalid) { usageFailure(`intent '${intent}' does not accept '${invalid}'`); return; }
   } else {
     const commitOnly = [...seen].find((flag) => [
-      '--orchestrated', '--baseline-head', '--token', '--kind', '--head', '--remote', '--ref', '--expected-head'
+      '--orchestrated', '--baseline-head', '--attempt', '--token', '--kind', '--head', '--remote', '--ref', '--expected-head'
     ].includes(flag));
     if (commitOnly) { usageFailure(`intent '${intent}' does not accept '${commitOnly}'`); return; }
   }
   const requireValues = (flags: string[]) => flags.find((flag) => values[flag] === undefined);
+  const coreOptions = values['--git-worktree-root'] === undefined
+    ? {}
+    : { gitWorktreeRoot: values['--git-worktree-root'] };
   if (values['--client'] !== undefined && !isAgentClientId(values['--client'])) {
     usageFailure(`unknown client '${values['--client']}'`);
     return;
   }
   let result;
-  if (intent === 'commit-begin') {
-    const missing = requireValues(['--agent', '--baseline-head']);
+  if (intent === 'commit-start') {
+    const missing = requireValues(['--agent']);
+    if (missing) { usageFailure(`intent 'commit-start' requires '${missing}'`); return; }
+    const agent = normalizeAgentToken(values['--agent']!);
+    if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
+    result = startCommitAttempt(taskRef!, { agent }, coreOptions);
+  } else if (intent === 'commit-begin') {
+    const missing = requireValues(['--agent', '--baseline-head', '--attempt']);
     if (missing) { usageFailure(`intent 'commit-begin' requires '${missing}'`); return; }
     const agent = normalizeAgentToken(values['--agent']!);
     if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
     result = beginCommitIntent(taskRef!, {
-      agent, orchestrated, baselineHead: values['--baseline-head']!
-    });
+      agent, orchestrated, baselineHead: values['--baseline-head']!, attempt: values['--attempt']!
+    }, coreOptions);
   } else if (intent === 'commit-checkpoint') {
     const missing = requireValues(['--token', '--kind', '--head']);
     if (missing) { usageFailure(`intent 'commit-checkpoint' requires '${missing}'`); return; }
@@ -130,25 +144,36 @@ function taskOrchestration(args: string[] = []): void {
     result = checkpointCommitIntent(taskRef!, {
       token: values['--token']!, kind: values['--kind'] as 'committed' | 'pushed',
       head: values['--head']!, remote: values['--remote'], ref: values['--ref']
-    });
+    }, coreOptions);
   } else if (intent === 'commit-complete') {
     const missing = requireValues(['--token', '--agent']);
     if (missing) { usageFailure(`intent 'commit-complete' requires '${missing}'`); return; }
     const agent = normalizeAgentToken(values['--agent']!);
     if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
-    result = completeCommitIntent(taskRef!, { token: values['--token']!, agent });
+    result = completeCommitIntent(taskRef!, { token: values['--token']!, agent }, coreOptions);
   } else if (intent === 'commit-recover') {
     const missing = requireValues(['--agent']);
     if (missing) { usageFailure(`intent 'commit-recover' requires '${missing}'`); return; }
     const agent = normalizeAgentToken(values['--agent']!);
     if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
-    result = recoverCommitIntent(taskRef!, { agent });
+    result = recoverCommitIntent(taskRef!, { agent }, coreOptions);
   } else if (intent === 'commit-abort') {
     const missing = requireValues(['--token', '--expected-head']);
     if (missing) { usageFailure(`intent 'commit-abort' requires '${missing}'`); return; }
-    result = abortCommitIntent(taskRef!, { token: values['--token']!, expectedHead: values['--expected-head']! });
+    result = abortCommitIntent(taskRef!, { token: values['--token']!, expectedHead: values['--expected-head']! }, coreOptions);
+  } else if (intent === 'commit-terminate') {
+    const missing = requireValues(['--attempt', '--agent', '--code']);
+    if (missing) { usageFailure(`intent 'commit-terminate' requires '${missing}'`); return; }
+    const agent = normalizeAgentToken(values['--agent']!);
+    if (!agent) { usageFailure(`invalid --agent '${values['--agent']}': ${AGENT_USAGE_HINT}`); return; }
+    if (!/^[A-Z][A-Z0-9_]{2,63}$/.test(values['--code']!)) {
+      usageFailure('--code must be a stable uppercase identifier'); return;
+    }
+    result = terminateCommitAttempt(taskRef!, {
+      attempt: values['--attempt']!, agent, code: values['--code']!
+    }, coreOptions);
   } else if (intent === 'commit-status') {
-    result = statusCommitIntent(taskRef!);
+    result = statusCommitIntent(taskRef!, coreOptions);
   } else if (intent === 'begin-or-resume') {
     const missing = requireValues(['--client']);
     if (missing) { usageFailure(`intent 'begin-or-resume' requires '${missing}'`); return; }
@@ -166,6 +191,7 @@ function taskOrchestration(args: string[] = []): void {
       return;
     }
     result = beginOrResumeOrchestration(taskRef!, {
+      ...coreOptions,
       maxSteps,
       client: values['--client'] as AgentClientId,
       modelPolicy: hasAnyPolicy ? {
@@ -180,9 +206,9 @@ function taskOrchestration(args: string[] = []): void {
       } : undefined
     });
   } else if (intent === 'route') {
-    result = routeOrchestration(taskRef!);
+    result = routeOrchestration(taskRef!, coreOptions);
   } else if (intent === 'status') {
-    result = statusOrchestration(taskRef!);
+    result = statusOrchestration(taskRef!, coreOptions);
   } else if (intent === 'prepare') {
     const missing = requireValues(['--client']);
     if (missing) { usageFailure(`intent 'prepare' requires '${missing}'`); return; }
@@ -190,7 +216,7 @@ function taskOrchestration(args: string[] = []): void {
       client: values['--client'] as AgentClientId,
       requestedModel: values['--requested-model'],
       requestedReasoningEffort: values['--requested-reasoning-effort']
-    });
+    }, coreOptions);
   } else if (intent === 'hook-start') {
     const missing = requireValues([
       ...(taskRef === 'auto' ? ['--client'] : []),
@@ -206,15 +232,15 @@ function taskOrchestration(args: string[] = []): void {
       reasoningEffortFallbackReason: values['--reasoning-effort-fallback-reason']
     };
     result = taskRef === 'auto'
-      ? activateMatchingOrchestrationDelegation(values['--client'] as AgentClientId, event)
-      : activateOrchestrationDelegation(taskRef!, event);
+      ? activateMatchingOrchestrationDelegation(values['--client'] as AgentClientId, event, coreOptions)
+      : activateOrchestrationDelegation(taskRef!, event, coreOptions);
   } else if (intent === 'hook-stop') {
     if (taskRef === 'auto') {
       const missing = requireValues(['--client', '--native-agent', '--child-id']);
       if (missing) { usageFailure(`intent 'hook-stop' requires '${missing}'`); return; }
       result = sealMatchingOrchestrationDelegation(values['--client'] as AgentClientId, {
         nativeAgent: values['--native-agent']!, childId: values['--child-id']!
-      });
+      }, coreOptions);
     } else {
       const missing = requireValues(['--child-id', '--exit-code', '--after-fingerprint']);
       if (missing) { usageFailure(`intent 'hook-stop' requires '${missing}'`); return; }
@@ -224,15 +250,15 @@ function taskOrchestration(args: string[] = []): void {
         childId: values['--child-id']!, exitCode,
         afterFingerprint: values['--after-fingerprint']!,
         changedPaths: values['--changed-paths'] ? values['--changed-paths']!.split(',').filter(Boolean) : []
-      });
+      }, coreOptions);
     }
   } else if (intent === 'advance') {
-    result = advanceOrchestration(taskRef!);
+    result = advanceOrchestration(taskRef!, coreOptions);
   } else {
     const missing = requireValues(['--code', '--message', '--recoverable']);
     if (missing) { usageFailure(`intent 'pause' requires '${missing}'`); return; }
     if (!['true', 'false'].includes(values['--recoverable']!)) { usageFailure('--recoverable must be true or false'); return; }
-    result = pauseOrchestration(taskRef!, values['--code']!, values['--message']!, values['--recoverable'] === 'true');
+    result = pauseOrchestration(taskRef!, values['--code']!, values['--message']!, values['--recoverable'] === 'true', coreOptions);
   }
   process.stdout.write(`${JSON.stringify(result)}\n`);
   if (result.status === 'failed') process.exitCode = 1;

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1345,6 +1345,7 @@ export async function create(args: string[]): Promise<void> {
             const control = materializeSandboxControl({
               base: effectiveConfig.controlBase,
               repoRoot: effectiveConfig.repoRoot,
+              worktreeRoot: worktree,
               project: effectiveConfig.project,
               container,
               branch,

--- a/lib/sandbox/control/protocol.ts
+++ b/lib/sandbox/control/protocol.ts
@@ -6,8 +6,9 @@ export const SANDBOX_CONTROL_FAMILIES = ['task-lifecycle', 'task-orchestration',
 export type SandboxControlFamily = typeof SANDBOX_CONTROL_FAMILIES[number];
 
 export type SandboxControlManifest = Readonly<{
-  version: 1;
+  version: 2;
   repoRoot: string;
+  worktreeRoot: string;
   project: string;
   container: string;
   branch: string;
@@ -85,6 +86,12 @@ export function validateSandboxControlRequest(
   }
   if (manifest.mode !== 'task-bound' || !manifest.taskId) {
     throw new Error('SANDBOX_CONTROL_BRANCH_ONLY: branch-only sandboxes cannot coordinate tasks');
+  }
+  if (
+    request.family === 'task-orchestration'
+    && request.args.some((arg) => arg === '--git-worktree-root' || arg.startsWith('--git-worktree-root='))
+  ) {
+    throw new Error('SANDBOX_CONTROL_REQUEST_INVALID: worktree binding is reserved for the control broker');
   }
   return request as SandboxTaskCommandRequest;
 }

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getProcessStartTime } from '../../server/process-state.ts';
 import { createTask } from '../../task/create-service.ts';
+import { assertGitWorktreeBinding } from '../../git/worktree-identity.ts';
 import {
   bindSandboxControlTask,
   validateSandboxControlRequest,
@@ -14,9 +15,12 @@ function readManifest(manifestPath: string): SandboxControlManifest {
   const stat = fs.lstatSync(manifestPath);
   if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('SANDBOX_CONTROL_MANIFEST_INVALID');
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as SandboxControlManifest;
+  if (manifest.version !== 2) {
+    throw new Error('SANDBOX_CONTROL_MANIFEST_VERSION_INVALID: expected version 2; recreate the sandbox');
+  }
   if (
-    manifest.version !== 1
-    || typeof manifest.repoRoot !== 'string'
+    typeof manifest.repoRoot !== 'string'
+    || typeof manifest.worktreeRoot !== 'string'
     || typeof manifest.channelDir !== 'string'
     || typeof manifest.token !== 'string'
   ) throw new Error('SANDBOX_CONTROL_MANIFEST_INVALID');
@@ -61,6 +65,7 @@ function consumeRequest(directory: string, id: string): void {
 
 export function serveSandboxControl(manifestPath: string, signal: AbortSignal = new AbortController().signal): void {
   const manifest = readManifest(manifestPath);
+  assertGitWorktreeBinding(manifest.repoRoot, manifest.worktreeRoot, manifest.branch);
   const brokerPath = path.join(path.dirname(manifestPath), 'broker.json');
   const startTime = getProcessStartTime(process.pid);
   if (!startTime) throw new Error('SANDBOX_CONTROL_BROKER_IDENTITY_UNAVAILABLE');
@@ -83,6 +88,7 @@ export function serveSandboxControl(manifestPath: string, signal: AbortSignal = 
   while (!signal.aborted) {
     const current = readManifest(manifestPath);
     if (current.token !== manifest.token) return;
+    assertGitWorktreeBinding(current.repoRoot, current.worktreeRoot, current.branch);
     assertRealDirectory(requestsDir, manifest.channelDir);
     assertRealDirectory(responsesDir, manifest.channelDir);
     for (const name of fs.readdirSync(requestsDir).sort()) {
@@ -107,9 +113,13 @@ export function serveSandboxControl(manifestPath: string, signal: AbortSignal = 
             stdout: `${JSON.stringify(result)}\n`, stderr: ''
           };
         } else {
+          const boundArgs = bindSandboxControlTask(request, manifest.taskId!);
+          if (request.family === 'task-orchestration') {
+            boundArgs.push('--git-worktree-root', manifest.worktreeRoot);
+          }
           const result = spawnSync(
             process.execPath,
-            ['--experimental-strip-types', '--no-warnings', process.argv[1]!, request.family, ...bindSandboxControlTask(request, manifest.taskId!)],
+            ['--experimental-strip-types', '--no-warnings', process.argv[1]!, request.family, ...boundArgs],
             {
               cwd: manifest.repoRoot,
               encoding: 'utf8',

--- a/lib/sandbox/workspace-view.ts
+++ b/lib/sandbox/workspace-view.ts
@@ -113,6 +113,7 @@ export function materializeSandboxWorkspaceView(params: Readonly<{
 export function materializeSandboxControl(params: Readonly<{
   base: string;
   repoRoot: string;
+  worktreeRoot: string;
   project: string;
   container: string;
   branch: string;
@@ -131,9 +132,11 @@ export function materializeSandboxControl(params: Readonly<{
     fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
   }
   const token = randomBytes(32).toString('hex');
+  const repoRoot = fs.realpathSync.native(params.repoRoot);
   const manifest: SandboxControlManifest = {
-    version: 1,
-    repoRoot: fs.realpathSync.native(params.repoRoot),
+    version: 2,
+    repoRoot,
+    worktreeRoot: fs.realpathSync.native(params.worktreeRoot),
     project: params.project,
     container: params.container,
     branch: params.branch,

--- a/lib/task/activity-log.ts
+++ b/lib/task/activity-log.ts
@@ -2,10 +2,14 @@ const HEADING_RE = /^##\s+(活动日志|Activity Log)\s*$/;
 const NEXT_H2_RE = /^##\s/;
 const ENTRY_RE = /^- (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}) — \*\*(.+?)\*\* by (.+?) — (.*)$/;
 const STARTED_SUFFIX_RE = /\s*\[started\]\s*$/;
+const ABORTED_SUFFIX_RE = /\s*\[aborted\]\s*$/;
+const ATTEMPT_RE = /(?:^|;\s*)attempt=([A-Za-z0-9-]{8,64})(?:;|$)/;
+const COMMIT_STARTED_RE = /^started; attempt=([A-Za-z0-9-]{8,64}); baseline=([a-f0-9]{40,64}); agent=([a-z-]+)$/;
 
 type LogEntry = { time: string; step: string; agent: string; note: string };
-type StepRow = { step: string; agent: string; started: string; done: string; note: string };
+type StepRow = { step: string; agent: string; started: string; done: string; note: string; attempt?: string };
 type ActivityLogSection = { heading: string; body: string; entries: LogEntry[] };
+type CommitAttempt = Readonly<{ attempt: string; baseline: string; agent: string }>;
 
 function parseActivityLog(content: string): { sectionFound: boolean; entries: LogEntry[] } {
   const section = locateActivityLog(content);
@@ -37,26 +41,61 @@ function appendActivityEntry(section: ActivityLogSection, entry: LogEntry): stri
   return section.body ? `${section.body}\n${line}` : line;
 }
 
+function activityAttempt(note: string): string | null {
+  return ATTEMPT_RE.exec(note)?.[1] ?? null;
+}
+
+function parseCommitAttemptStarted(note: string): CommitAttempt | null {
+  const match = COMMIT_STARTED_RE.exec(note);
+  return match ? { attempt: match[1]!, baseline: match[2]!, agent: match[3]! } : null;
+}
+
+function commitAttemptStartedNote(attempt: CommitAttempt): string {
+  return `started; attempt=${attempt.attempt}; baseline=${attempt.baseline}; agent=${attempt.agent}`;
+}
+
 function pairEntries(entries: LogEntry[]): StepRow[] {
   const rows: StepRow[] = [];
   const open = new Map<string, StepRow[]>();
   for (const entry of entries) {
     const started = STARTED_SUFFIX_RE.test(entry.step);
-    const base = entry.step.replace(STARTED_SUFFIX_RE, '');
+    const aborted = ABORTED_SUFFIX_RE.test(entry.step);
+    const base = entry.step.replace(STARTED_SUFFIX_RE, '').replace(ABORTED_SUFFIX_RE, '');
     if (started) {
-      const row = { step: base, agent: entry.agent, started: entry.time, done: '', note: entry.note };
+      const attempt = activityAttempt(entry.note);
+      const row: StepRow = {
+        step: base, agent: entry.agent, started: entry.time, done: '', note: entry.note,
+        ...(attempt ? { attempt } : {})
+      };
       rows.push(row);
       const queue = open.get(base) ?? [];
       queue.push(row);
       open.set(base, queue);
     } else {
-      const pending = open.get(base)?.shift();
+      const queue = open.get(base) ?? [];
+      const terminalAttempt = aborted ? activityAttempt(entry.note) : null;
+      const pendingIndex = terminalAttempt === null
+        ? 0
+        : queue.findIndex((row) => row.attempt === terminalAttempt);
+      const pending = pendingIndex >= 0 ? queue.splice(pendingIndex, 1)[0] : undefined;
       if (pending) Object.assign(pending, { done: entry.time, agent: entry.agent, note: entry.note });
-      else rows.push({ step: base, agent: entry.agent, started: '', done: entry.time, note: entry.note });
+      else rows.push({
+        step: aborted ? entry.step : base,
+        agent: entry.agent, started: '', done: entry.time, note: entry.note,
+        ...(terminalAttempt ? { attempt: terminalAttempt } : {})
+      });
     }
   }
   return rows;
 }
 
-export { parseActivityLog, locateActivityLog, appendActivityEntry, pairEntries };
-export type { LogEntry, StepRow, ActivityLogSection };
+export {
+  activityAttempt,
+  appendActivityEntry,
+  commitAttemptStartedNote,
+  locateActivityLog,
+  pairEntries,
+  parseActivityLog,
+  parseCommitAttemptStarted
+};
+export type { ActivityLogSection, CommitAttempt, LogEntry, StepRow };

--- a/lib/task/commit-finalization.ts
+++ b/lib/task/commit-finalization.ts
@@ -2,7 +2,13 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { locateActivityLog, appendActivityEntry, pairEntries } from './activity-log.ts';
+import {
+  locateActivityLog,
+  appendActivityEntry,
+  pairEntries,
+  parseCommitAttemptStarted
+} from './activity-log.ts';
+import type { CommitAttempt } from './activity-log.ts';
 import { commitIntentPath, digest, readCommitIntent } from './commit-intent.ts';
 import type { CommitIntent } from './commit-intent.ts';
 import { parseTypedTaskFrontmatter } from './frontmatter.ts';
@@ -10,7 +16,8 @@ import { parseReviewSummary } from './review-artifacts.ts';
 import {
   extractReviewBaseline,
   extractReviewedSnapshotTree,
-  findAuthoritativeReviewCodeArtifact
+  findAuthoritativeReviewCodeArtifact,
+  parseReviewedGitTree
 } from './review-fingerprint.ts';
 import type { TaskMutation } from './write.ts';
 
@@ -20,6 +27,7 @@ type CommitFinalizationDisposition =
   | 'recoverable'
   | 'invalid'
   | 'conflict'
+  | 'retryable-start'
   | 'orphaned-start';
 
 type CommitFinalizationCode =
@@ -39,6 +47,7 @@ type CommitFinalizationInspection = Readonly<{
   needsLog: boolean;
   intent: CommitIntent | null;
   intentDigest: string | null;
+  attempt: CommitAttempt | null;
 }>;
 
 type CreatePrCommitGate = Readonly<{
@@ -93,6 +102,7 @@ function outcome(
     needsLog: false,
     intent: null,
     intentDigest: null,
+    attempt: null,
     ...overrides
   };
 }
@@ -128,6 +138,16 @@ function inspectCommitFinalization(
   const openRows = commitRows.filter((row) => row.started !== '' && row.done === '');
   const file = commitIntentPath(taskDir);
   if (!fs.existsSync(file)) {
+    if (openRows.length === 1) {
+      const attempt = parseCommitAttemptStarted(openRows[0]!.note);
+      if (attempt && attempt.baseline === currentHead) {
+        return outcome('retryable-start', {
+          message: 'a structured Commit attempt can be safely reused',
+          currentHead,
+          attempt
+        });
+      }
+    }
     if (openRows.length > 0) {
       return outcome('orphaned-start', {
         code: 'COMMIT_FINALIZATION_EVIDENCE_MISSING',
@@ -204,7 +224,7 @@ function inspectCommitFinalization(
     const summary = parseReviewSummary(reviewContent);
     const reviewBaseline = extractReviewBaseline(reviewContent);
     const reviewTree = extractReviewedSnapshotTree(reviewContent);
-    if (!summary.ok || summary.summary.verdict !== 'Approved' || !commitExists(repoRoot, reviewBaseline) || !SHA_RE.test(reviewTree)) {
+    if (!summary.ok || summary.summary.verdict !== 'Approved' || !commitExists(repoRoot, reviewBaseline) || !parseReviewedGitTree(reviewTree)) {
       return invalid('authoritative review-code evidence is not a valid approved snapshot', currentHead, 'COMMIT_FINALIZATION_EVIDENCE_INVALID', shared);
     }
     const committedTree = git(repoRoot, ['rev-parse', `${intent.committedHead}^{tree}`]);

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -36,6 +36,8 @@ import {
   diffWorkspaceSnapshots
 } from './workspace-snapshot.ts';
 import type { RepositorySnapshot } from './workspace-snapshot.ts';
+import type { WorkspaceSnapshotContext } from './workspace-snapshot.ts';
+import { assertGitRepositoryBinding } from '../git/worktree-identity.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
 import {
   CommitIntentError,
@@ -55,6 +57,12 @@ import {
 } from './commit-finalization.ts';
 import type { CommitFinalizationInspection } from './commit-finalization.ts';
 import { captureTaskWriteMetadata, writeTask } from './write.ts';
+import {
+  appendActivityEntry,
+  commitAttemptStartedNote,
+  locateActivityLog,
+  pairEntries
+} from './activity-log.ts';
 
 type OrchestrationStatus = 'running' | 'paused' | 'completed';
 type LegacyOrchestrationModelPolicy = Readonly<{
@@ -147,12 +155,13 @@ type OrchestrationCompletionPlanResult = Readonly<{
 }>;
 type OrchestrationOptions = {
   repoRoot?: string;
+  gitWorktreeRoot?: string;
   id?: () => string;
   now?: () => string;
   maxSteps?: number;
   client?: AgentClientId;
   modelPolicy?: OrchestrationModelPolicy;
-  captureWorkspace?: (repoRoot: string, taskId: string | null) => string;
+  captureWorkspace?: (context: WorkspaceSnapshotContext) => string;
   captureRepository?: (repoRoot: string) => RepositorySnapshot;
   inspectPullRequest?: (taskId: string, options: { cwd: string }) => Readonly<{
     status: string;
@@ -188,6 +197,7 @@ type CommitIntentResult = Readonly<{
     committedHead: string | null;
     needsAnchor: boolean;
     needsLog: boolean;
+    attempt: Readonly<{ attempt: string; baseline: string; agent: string }> | null;
   }>;
   token?: string;
   error: Readonly<{ code: string; message: string }> | null;
@@ -259,6 +269,11 @@ function repositoryHead(repoRoot: string): string {
   }).trim();
 }
 
+function gitRootFor(stateRoot: string, options: OrchestrationOptions): string {
+  if (!options.gitWorktreeRoot) return stateRoot;
+  return assertGitRepositoryBinding(stateRoot, options.gitWorktreeRoot).worktreeRoot;
+}
+
 function isAncestor(repoRoot: string, ancestor: string, descendant: string): boolean {
   return spawnSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
     cwd: repoRoot,
@@ -287,7 +302,8 @@ function commitFinalizationView(inspection: CommitFinalizationInspection): NonNu
     currentHead: inspection.currentHead,
     committedHead: inspection.committedHead,
     needsAnchor: inspection.needsAnchor,
-    needsLog: inspection.needsLog
+    needsLog: inspection.needsLog,
+    attempt: inspection.attempt
   };
 }
 
@@ -607,6 +623,12 @@ function routeFromFacts(taskDir: string): Omit<OrchestrationNext, 'requestedMode
 function routeOrchestration(taskRef: string, options: OrchestrationOptions = {}): OrchestrationResult {
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return failed(resolved.code, resolved.message, resolved.taskId);
+  let gitRoot: string;
+  try {
+    gitRoot = gitRootFor(resolved.repoRoot, options);
+  } catch (error) {
+    return failed('ORCHESTRATION_WORKTREE_INVALID', error instanceof Error ? error.message : String(error), resolved.taskId);
+  }
   let content: string;
   try {
     content = fs.readFileSync(resolved.taskMdPath, 'utf8');
@@ -677,7 +699,7 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
     const capture = options.captureRepository ?? captureRepositorySnapshot;
     let before: RepositorySnapshot;
     try {
-      before = capture(resolved.repoRoot);
+      before = capture(gitRoot);
     } catch (error) {
       return failed('ORCHESTRATION_SNAPSHOT_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
     }
@@ -693,7 +715,7 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
       options.inspectPullRequest ?? inspectPlatformPullRequest;
     let inspection: ReturnType<NonNullable<OrchestrationOptions['inspectPullRequest']>>;
     try {
-      inspection = inspect(resolved.taskId, { cwd: resolved.repoRoot });
+      inspection = inspect(resolved.taskId, { cwd: gitRoot });
     } catch (error) {
       return failed('ORCHESTRATION_PR_INSPECTION_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
     }
@@ -714,7 +736,7 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
 
     let after: RepositorySnapshot;
     try {
-      after = capture(resolved.repoRoot);
+      after = capture(gitRoot);
     } catch (error) {
       return failed('ORCHESTRATION_SNAPSHOT_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
     }
@@ -748,16 +770,119 @@ function routeOrchestration(taskRef: string, options: OrchestrationOptions = {})
   return { status: 'running', changed: false, taskId: resolved.taskId, run, next, error: null };
 }
 
-function beginCommitIntent(
+function appendCommitActivity(
+  resolved: Extract<ReturnType<typeof resolveTaskRef>, { ok: true }>,
+  step: string,
+  agent: string,
+  note: string
+): Readonly<{ code: string; message: string }> | null {
+  const taskContent = fs.readFileSync(resolved.taskMdPath, 'utf8');
+  const activity = locateActivityLog(taskContent);
+  if (!activity) return { code: 'ORCHESTRATION_TASK_INVALID', message: 'task activity log is missing or ambiguous' };
+  const metadata = captureTaskWriteMetadata();
+  const written = writeTask({
+    taskRef: resolved.taskId,
+    expectedState: 'active',
+    mutations: [{
+      kind: 'section',
+      aliases: ['活动日志', 'Activity Log'],
+      heading: activity.heading,
+      body: appendActivityEntry(activity, { time: metadata.timestamp, step, agent, note })
+    }]
+  }, { repoRoot: resolved.repoRoot, metadataProvider: () => metadata });
+  return written.status === 'failed' ? written.error : null;
+}
+
+function startCommitAttempt(
   taskRef: string,
-  input: Readonly<{ agent: string; orchestrated: boolean; baselineHead: string }>,
+  input: Readonly<{ agent: string }>,
   options: OrchestrationOptions = {}
 ): CommitIntentResult {
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
+    return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-attempt.start', () => {
+      if (fs.existsSync(commitIntentPath(resolved.taskDir))) {
+        return commitIntentFailed('ORCHESTRATION_COMMIT_INTENT_BUSY', 'an active commit intent already exists', resolved.taskId);
+      }
+      const taskContent = fs.readFileSync(resolved.taskMdPath, 'utf8');
+      const activity = locateActivityLog(taskContent);
+      if (!activity) return commitIntentFailed('ORCHESTRATION_TASK_INVALID', 'task activity log is missing or ambiguous', resolved.taskId);
+      const open = pairEntries(activity.entries).filter((row) => row.step === 'Commit' && row.started !== '' && row.done === '');
+      if (open.length > 0) {
+        return commitIntentFailed('ORCHESTRATION_COMMIT_ATTEMPT_BUSY', 'an open Commit activity entry already exists', resolved.taskId);
+      }
+      const currentHead = repositoryHead(gitRoot);
+      const attempt = (options.id ?? randomUUID)();
+      const error = appendCommitActivity(resolved, 'Commit [started]', input.agent, commitAttemptStartedNote({
+        attempt,
+        baseline: currentHead,
+        agent: input.agent
+      }));
+      if (error) return commitIntentFailed(error.code, error.message, resolved.taskId);
+      const inspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
+      return {
+        status: 'ready', changed: true, taskId: resolved.taskId, intent: null,
+        finalization: commitFinalizationView(inspection), error: null
+      };
+    });
+  } catch (error) {
+    return mapCommitIntentError(error, resolved.taskId);
+  }
+}
+
+function terminateCommitAttempt(
+  taskRef: string,
+  input: Readonly<{ attempt: string; agent: string; code: string }>,
+  options: OrchestrationOptions = {}
+): CommitIntentResult {
+  const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
+  try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
+    return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-attempt.terminate', () => {
+      if (fs.existsSync(commitIntentPath(resolved.taskDir))) {
+        return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'an active commit intent must be aborted or recovered first', resolved.taskId);
+      }
+      const inspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
+      if (
+        inspection.disposition !== 'retryable-start'
+        || inspection.attempt?.attempt !== input.attempt
+        || inspection.attempt.agent !== input.agent
+        || inspection.attempt.baseline !== inspection.currentHead
+      ) {
+        return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'commit attempt identity or repository HEAD has drifted', resolved.taskId);
+      }
+      const error = appendCommitActivity(
+        resolved,
+        'Commit [aborted]',
+        input.agent,
+        `aborted; attempt=${input.attempt}; code=${input.code}`
+      );
+      if (error) return commitIntentFailed(error.code, error.message, resolved.taskId);
+      return {
+        status: 'ready', changed: true, taskId: resolved.taskId, intent: null,
+        finalization: commitFinalizationView(inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId)),
+        error: null
+      };
+    });
+  } catch (error) {
+    return mapCommitIntentError(error, resolved.taskId);
+  }
+}
+
+function beginCommitIntent(
+  taskRef: string,
+  input: Readonly<{ agent: string; orchestrated: boolean; baselineHead: string; attempt: string }>,
+  options: OrchestrationOptions = {}
+): CommitIntentResult {
+  const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
+  try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.begin', () => {
-      const currentHead = repositoryHead(resolved.repoRoot);
+      const currentHead = repositoryHead(gitRoot);
       if (currentHead !== input.baselineHead) {
         return commitIntentFailed('ORCHESTRATION_COMMIT_BASELINE_MISMATCH', 'baseline HEAD does not match the repository HEAD', resolved.taskId);
       }
@@ -769,7 +894,19 @@ function beginCommitIntent(
         }
         return commitIntentFailed('ORCHESTRATION_COMMIT_INTENT_BUSY', 'an active commit intent already exists', resolved.taskId);
       }
-
+      const attemptInspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
+      if (
+        attemptInspection.disposition !== 'retryable-start'
+        || attemptInspection.attempt?.attempt !== input.attempt
+        || attemptInspection.attempt.agent !== input.agent
+        || attemptInspection.attempt.baseline !== input.baselineHead
+      ) {
+        return commitIntentFailed(
+          'ORCHESTRATION_COMMIT_ATTEMPT_MISMATCH',
+          'commit begin requires one matching retryable Commit attempt',
+          resolved.taskId
+        );
+      }
       const runFile = orchestrationPath(resolved.taskDir);
       let run: OrchestrationRun | null = null;
       let sourceRunBytes: string | null = null;
@@ -883,13 +1020,14 @@ function checkpointCommitIntent(
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.checkpoint', () => {
       const intent = readCommitIntent(resolved.taskDir, resolved.taskId, input.token);
-      const currentHead = repositoryHead(resolved.repoRoot);
+      const currentHead = repositoryHead(gitRoot);
       if (currentHead !== input.head) {
         return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'checkpoint HEAD does not match the repository HEAD', resolved.taskId);
       }
-      if (input.kind === 'committed' && !isAncestor(resolved.repoRoot, intent.baselineHead, input.head)) {
+      if (input.kind === 'committed' && !isAncestor(gitRoot, intent.baselineHead, input.head)) {
         return commitIntentFailed('ORCHESTRATION_COMMIT_RECOVERY_REQUIRED', 'committed HEAD does not descend from the baseline', resolved.taskId);
       }
       if (input.kind === 'pushed') {
@@ -1016,9 +1154,10 @@ function completeCommitIntent(
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.complete', () => {
       readCommitIntent(resolved.taskDir, resolved.taskId, input.token);
-      const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+      const inspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
       return finalizeCommitIntentUnlocked(resolved, inspection, input.agent, () => {
         removeCommitIntent(resolved.taskDir, resolved.taskId, input.token);
       });
@@ -1036,8 +1175,15 @@ function recoverCommitIntent(
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.recover', () => {
-      const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+      const inspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
+      if (inspection.disposition === 'retryable-start') {
+        return {
+          status: 'ready', changed: false, taskId: resolved.taskId, intent: null,
+          finalization: commitFinalizationView(inspection), error: null
+        };
+      }
       if (inspection.disposition === 'prepared' && inspection.intentDigest) {
         removeCommitIntentByDigest(resolved.taskDir, resolved.taskId, inspection.intentDigest);
         return { status: 'ready', changed: true, taskId: resolved.taskId, intent: null, error: null };
@@ -1066,9 +1212,10 @@ function abortCommitIntent(
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
   try {
+    const gitRoot = gitRootFor(resolved.repoRoot, options);
     return withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'commit-intent.abort', () => {
       const intent = readCommitIntent(resolved.taskDir, resolved.taskId, input.token);
-      const currentHead = repositoryHead(resolved.repoRoot);
+      const currentHead = repositoryHead(gitRoot);
       if (
         intent.phase !== 'prepared'
         || intent.pushEvidence !== null
@@ -1088,7 +1235,13 @@ function abortCommitIntent(
 function statusCommitIntent(taskRef: string, options: OrchestrationOptions = {}): CommitIntentResult {
   const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
   if (!resolved.ok) return commitIntentFailed(resolved.code, resolved.message, resolved.taskId);
-  const inspection = inspectCommitFinalization(resolved.taskDir, resolved.repoRoot, resolved.taskId);
+  let gitRoot: string;
+  try {
+    gitRoot = gitRootFor(resolved.repoRoot, options);
+  } catch (error) {
+    return commitIntentFailed('ORCHESTRATION_WORKTREE_INVALID', error instanceof Error ? error.message : String(error), resolved.taskId);
+  }
+  const inspection = inspectCommitFinalization(resolved.taskDir, gitRoot, resolved.taskId);
   return {
     status: 'ready',
     changed: false,
@@ -1156,7 +1309,11 @@ function prepareOrchestrationDelegationUnlocked(
   }
   let beforeFingerprint: string;
   try {
-    beforeFingerprint = (options.captureWorkspace ?? captureWorkspaceSnapshot)(resolved.repoRoot, resolved.taskId);
+    beforeFingerprint = (options.captureWorkspace ?? captureWorkspaceSnapshot)({
+      gitRoot: gitRootFor(resolved.repoRoot, options),
+      stateRoot: resolved.repoRoot,
+      taskId: resolved.taskId
+    });
   } catch (error) {
     return failed('ORCHESTRATION_SNAPSHOT_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId);
   }
@@ -1280,9 +1437,14 @@ function sealMatchingOrchestrationDelegation(
   }
   const repoRoot = options.repoRoot ?? process.cwd();
   try {
+    const gitRoot = gitRootFor(repoRoot, options);
     const snapshotTaskId = receipt.workspaceSnapshotScope === 'task' ? receipt.taskId : null;
-    const afterFingerprint = (options.captureWorkspace ?? captureWorkspaceSnapshot)(repoRoot, snapshotTaskId);
-    const changedPaths = (options.diffWorkspace ?? diffWorkspaceSnapshots)(repoRoot, receipt.beforeFingerprint, afterFingerprint);
+    const afterFingerprint = (options.captureWorkspace ?? captureWorkspaceSnapshot)({
+      gitRoot,
+      stateRoot: repoRoot,
+      taskId: snapshotTaskId
+    });
+    const changedPaths = (options.diffWorkspace ?? diffWorkspaceSnapshots)(gitRoot, receipt.beforeFingerprint, afterFingerprint);
     return sealOrchestrationDelegation(matched.taskId, {
       childId: event.childId,
       exitCode: 0,
@@ -1474,8 +1636,10 @@ export {
   routeOrchestration,
   sealMatchingOrchestrationDelegation,
   sealOrchestrationDelegation,
+  startCommitAttempt,
   statusCommitIntent,
-  statusOrchestration
+  statusOrchestration,
+  terminateCommitAttempt
 };
 export type {
   CommitIntentResult,

--- a/lib/task/review-fingerprint.ts
+++ b/lib/task/review-fingerprint.ts
@@ -3,6 +3,13 @@ import path from "node:path";
 
 import { artifactName, maxRound } from "./review-artifacts.ts";
 
+type ReviewedGitTree = string & { readonly __reviewedGitTree: unique symbol };
+const REVIEWED_TREE_RE = /^[a-f0-9]{40,64}$/;
+
+export function parseReviewedGitTree(value: string): ReviewedGitTree | null {
+  return REVIEWED_TREE_RE.test(value) ? value as ReviewedGitTree : null;
+}
+
 // Paths excluded from the post-review coverage gate. Fail-closed: the gate
 // covers ALL tracked changes by default. This default denylist is EMPTY —
 // projects opt into exclusions explicitly via review.post_review_exclude_globs.
@@ -70,6 +77,8 @@ export function extractReviewedSnapshotTree(content: string): string {
   const match = String(content).match(/^[-*]?\s*\*\*(?:审查快照树|Reviewed Snapshot Tree)\*\*[:：]\s*(.*?)\s*$/m);
   return match ? match[1]!.trim().replace(/`/g, "") : "";
 }
+
+export type { ReviewedGitTree };
 
 export function parseReviewVerdict(content: string): string {
   const match = String(content).match(/^[-*]?\s*\*\*(?:总体结论|Overall Verdict)\*\*[:：]\s*(.*?)\s*$/m);

--- a/lib/task/workspace-snapshot.ts
+++ b/lib/task/workspace-snapshot.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -18,6 +19,25 @@ type RepositorySnapshot = Readonly<{
   worktreeTree: string;
 }>;
 
+type WorkspaceSnapshotContext = Readonly<{
+  gitRoot: string;
+  stateRoot: string;
+  taskId: string | null;
+}>;
+
+type TaskFileFingerprint = Readonly<{
+  path: string;
+  mode: number;
+  kind: 'file' | 'symlink';
+  sha256: string;
+}>;
+
+type OrchestrationWorkspaceFingerprint = Readonly<{
+  version: 2;
+  gitTree: string;
+  taskFiles: readonly TaskFileFingerprint[];
+}>;
+
 function captureWorktreeTree(repoRoot: string, forcedPath: string | null): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-orchestration-index-'));
   const indexFile = path.join(tempDir, 'index');
@@ -33,11 +53,70 @@ function captureWorktreeTree(repoRoot: string, forcedPath: string | null): strin
   }
 }
 
-function captureWorkspaceSnapshot(repoRoot: string, taskId: string | null): string {
+function captureLegacyWorkspaceSnapshot(repoRoot: string, taskId: string | null): string {
   const workspaceRelative = taskId
     ? `.agents/workspace/active/${taskId}`
     : '.agents/workspace/active';
   return captureWorktreeTree(repoRoot, workspaceRelative);
+}
+
+function taskFileFingerprints(stateRoot: string, taskId: string | null): TaskFileFingerprint[] {
+  const activeRoot = path.join(stateRoot, '.agents', 'workspace', 'active');
+  const roots = taskId ? [path.join(activeRoot, taskId)] : [activeRoot];
+  const records: TaskFileFingerprint[] = [];
+  const visit = (absolute: string, relative: string): void => {
+    const stat = fs.lstatSync(absolute);
+    if (stat.isDirectory()) {
+      for (const name of fs.readdirSync(absolute).sort()) {
+        visit(path.join(absolute, name), path.posix.join(relative, name));
+      }
+      return;
+    }
+    if (!stat.isFile() && !stat.isSymbolicLink()) return;
+    const content = stat.isSymbolicLink()
+      ? Buffer.from(fs.readlinkSync(absolute))
+      : fs.readFileSync(absolute);
+    records.push({
+      path: relative,
+      mode: stat.mode & 0o777,
+      kind: stat.isSymbolicLink() ? 'symlink' : 'file',
+      sha256: createHash('sha256').update(content).digest('hex')
+    });
+  };
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    const relative = path.posix.join('.agents/workspace/active', path.relative(activeRoot, root).split(path.sep).join('/'));
+    visit(root, relative.replace(/\/$/, ''));
+  }
+  return records.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function encodeWorkspaceFingerprint(value: OrchestrationWorkspaceFingerprint): string {
+  return `ws2:${Buffer.from(JSON.stringify(value)).toString('base64url')}`;
+}
+
+function decodeWorkspaceFingerprint(value: string): OrchestrationWorkspaceFingerprint | null {
+  if (!value.startsWith('ws2:')) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value.slice(4), 'base64url').toString('utf8')) as OrchestrationWorkspaceFingerprint;
+    if (parsed.version !== 2 || !/^[a-f0-9]{40,64}$/.test(parsed.gitTree) || !Array.isArray(parsed.taskFiles)) {
+      throw new Error('invalid workspace fingerprint fields');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`ORCHESTRATION_SNAPSHOT_FAILED: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function captureWorkspaceSnapshot(context: WorkspaceSnapshotContext): string;
+function captureWorkspaceSnapshot(repoRoot: string, taskId: string | null): string;
+function captureWorkspaceSnapshot(contextOrRoot: WorkspaceSnapshotContext | string, taskId?: string | null): string {
+  if (typeof contextOrRoot === 'string') return captureLegacyWorkspaceSnapshot(contextOrRoot, taskId ?? null);
+  return encodeWorkspaceFingerprint({
+    version: 2,
+    gitTree: captureWorktreeTree(contextOrRoot.gitRoot, null),
+    taskFiles: taskFileFingerprints(contextOrRoot.stateRoot, contextOrRoot.taskId)
+  });
 }
 
 function captureRepositorySnapshot(repoRoot: string): RepositorySnapshot {
@@ -49,9 +128,24 @@ function captureRepositorySnapshot(repoRoot: string): RepositorySnapshot {
 }
 
 function diffWorkspaceSnapshots(repoRoot: string, before: string, after: string): string[] {
-  const output = git(repoRoot, null, ['diff', '--name-only', '-z', before, after]);
-  return output.split('\0').filter(Boolean);
+  const beforeV2 = decodeWorkspaceFingerprint(before);
+  const afterV2 = decodeWorkspaceFingerprint(after);
+  if ((beforeV2 === null) !== (afterV2 === null)) {
+    throw new Error('ORCHESTRATION_SNAPSHOT_FAILED: workspace fingerprint versions cannot be mixed');
+  }
+  if (!beforeV2 || !afterV2) {
+    const output = git(repoRoot, null, ['diff', '--name-only', '-z', before, after]);
+    return output.split('\0').filter(Boolean);
+  }
+  const output = git(repoRoot, null, ['diff', '--name-only', '-z', beforeV2.gitTree, afterV2.gitTree]);
+  const changed = new Set(output.split('\0').filter(Boolean));
+  const beforeFiles = new Map(beforeV2.taskFiles.map((record) => [record.path, JSON.stringify(record)]));
+  const afterFiles = new Map(afterV2.taskFiles.map((record) => [record.path, JSON.stringify(record)]));
+  for (const filePath of new Set([...beforeFiles.keys(), ...afterFiles.keys()])) {
+    if (beforeFiles.get(filePath) !== afterFiles.get(filePath)) changed.add(filePath);
+  }
+  return [...changed].sort();
 }
 
 export { captureRepositorySnapshot, captureWorkspaceSnapshot, diffWorkspaceSnapshots };
-export type { RepositorySnapshot };
+export type { OrchestrationWorkspaceFingerprint, RepositorySnapshot, WorkspaceSnapshotContext };

--- a/templates/.agents/rules/task-management.en.md
+++ b/templates/.agents/rules/task-management.en.md
@@ -68,6 +68,7 @@ The six internal commands (`task-event` / `task-lifecycle` / `platform-issue` / 
   `- {time} — **{base} [started]** by {agent} — started`
 - **done line** (written when the step completes, unchanged from today): the action is the base itself:
   `- {time} — **{base}** by {agent} — {completion summary}`
+- **Commit-specific attempt**: the commit skill must not hand-write started. `commit-start` writes a structured `Commit [started]` with `attempt`, `baseline`, and `agent` under the task lock; `commit-terminate` writes the matching `Commit [aborted]` when an attempt is abandoned before side effects. Aborted closes activity only and is never successful commit evidence.
 - `{base}` is that skill's existing done action text, including `(Round {N})` (e.g. `Plan Task (Round 1)`). started and done must share the same `{base}` to pair.
 
 **Pairing and rendering** (`ai task log`): a started entry pairs with the next same-`{base}` done entry onto one row (repeated executions of the same base pair FIFO by ascending time). The STARTED column shows the start time, DONE the completion time; started with no done = in progress (DONE shows `(in progress)`); done with no started (legacy logs) = a standalone completed row. All three shapes are valid and never error.

--- a/templates/.agents/rules/task-management.zh-CN.md
+++ b/templates/.agents/rules/task-management.zh-CN.md
@@ -70,6 +70,7 @@
   `- {time} — **{基名} [started]** by {agent} — started`
 - **done 行**（步骤完成时写，与现状一致）：action 即基名本身：
   `- {time} — **{基名}** by {agent} — {完成说明}`
+- **Commit 专用 attempt**：commit 技能不得手写 started。`commit-start` 在任务锁内写入带 `attempt`、`baseline`、`agent` 的结构化 `Commit [started]`；无副作用放弃时由 `commit-terminate` 写匹配的 `Commit [aborted]`。aborted 只闭合活动日志，不构成提交成功证据。
 - `{基名}` 指该 SKILL 既有 done 条目的 action 文本，含 `(Round {N})`（如 `Plan Task (Round 1)`）。
   started 与 done 共用同一 `{基名}` 才能配对。
 

--- a/templates/.agents/skills/commit/SKILL.en.md
+++ b/templates/.agents/skills/commit/SKILL.en.md
@@ -31,17 +31,11 @@ Direct invocation still requires explicit user authorization. An orchestrated in
 
 Without explicit task scope, only `TASK_CONTEXT_NOT_FOUND` may continue through the existing bare-commit path. Detached HEAD, damaged candidates, or multiple matches are ambiguity errors. Any explicit task-scope failure is fatal.
 
-## Step Start: Recover First, Then Write the started Marker
+## Step Start: Recover or Create a Controlled Attempt
 
-When `{task-id}` is resolved, call `commit-status` first. For `recoverable` / `prepared`, call `commit-recover --agent {standard-agent-token}` without adding a second started entry or repeating Git side effects. Fail closed for `invalid` / `conflict` / `orphaned-start`; only `idle` enters the normal flow.
+When `{task-id}` is resolved, call `commit-status` first. Finalize `recoverable`; safely clear `prepared` and query status again; reuse `retryable-start` through `commit-recover --agent {standard-agent-token}`. Fail closed for `invalid` / `conflict` / `orphaned-start`. For `idle`, call `commit-start --agent {standard-agent-token}` so the core atomically writes the structured started entry and returns its attempt/baseline.
 
-Before checking local modifications, append a started marker to task.md `## Activity Log` (same base action as this step's done entry plus a ` [started]` suffix, note `started`):
-
-```
-- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit [started]** by {agent} — started
-```
-
-`ai task log` pairs it with the done entry written when the commit completes onto one row (in progress → done). Format and pairing rules: see the "Activity Log started / done dual-marker convention" in `.agents/rules/task-management.md`. Only write it when this task has a task.md (a bare commit with no task context may skip it).
+Read `{commit-attempt}` only from structured `commit-start` / `commit-recover` output. Never hand-write, copy, or guess an attempt. A bare commit without task context skips this protocol.
 
 ## 1. Check Local Modifications (CRITICAL)
 

--- a/templates/.agents/skills/commit/SKILL.zh-CN.md
+++ b/templates/.agents/skills/commit/SKILL.zh-CN.md
@@ -31,21 +31,17 @@ description: >
 
 未显式指定 task scope 时，只有 `TASK_CONTEXT_NOT_FOUND` 可继续既有纯提交路径；detached HEAD、损坏候选或多匹配属于歧义，必须失败。显式 task scope 解析失败时一律失败。
 
-## 步骤开始：先恢复，再写 started 标记
+## 步骤开始：恢复或创建受控 attempt
 
 已解析出 `{task-id}` 时，先调用 `agent-infra-internal task-orchestration {task-id} commit-status`：
 
-- `recoverable` / `prepared`：调用 `commit-recover --agent {standard-agent-token}`；不得追加第二条 started、重复 commit 或重复 push。recoverable 完成后直接进入同步与完成校验；prepared 清理后复用既有 open started 并继续正常提交。
+- `recoverable`：调用 `commit-recover --agent {standard-agent-token}` 完成收尾，不得重复 commit 或 push。
+- `prepared`：调用 `commit-recover --agent {standard-agent-token}` 安全清理 intent，再次查询 status 并复用返回的 `retryable-start` attempt。
+- `retryable-start`：调用 `commit-recover --agent {standard-agent-token}` 取得原 attempt，不追加第二条 started。
 - `invalid` / `conflict` / `orphaned-start`：输出结构化 code 与状态证据并停止。
-- `idle`：继续下方正常流程。
+- `idle`：调用 `commit-start --agent {standard-agent-token}`，由核心在任务锁内原子写入结构化 started 并返回 attempt/baseline。
 
-开始检查本地修改之前，向 task.md `## 活动日志` 追加一条 started 标记（与本步骤 done 条目同基名 + ` [started]` 后缀，note 用 `started`）：
-
-```
-- {YYYY-MM-DD HH:mm:ss±HH:MM} — **Commit [started]** by {agent} — started
-```
-
-`ai task log` 会把它与提交完成时写入的 done 条目配对成一行（进行中 → 已完成）。格式与配对规则见 `.agents/rules/task-management.md` 的「Activity Log started / done 双标记约定」。仅当本任务存在 task.md 时写入（无任务上下文的纯提交可跳过）。
+只从 `commit-start` / `commit-recover` 的结构化输出读取 `{commit-attempt}`；不得手写、复制或猜测 attempt。无任务上下文的纯提交跳过本协议。
 
 ## 1. 检查本地修改（关键）
 

--- a/templates/.agents/skills/commit/reference/commit-orchestration.en.md
+++ b/templates/.agents/skills/commit/reference/commit-orchestration.en.md
@@ -9,12 +9,12 @@ This protocol applies only when `{task-id}` was resolved. A taskless Git-only co
 
 ## Begin before side effects
 
-Call `commit-status` whenever the commit skill starts. For `recoverable` / `prepared`, call `commit-recover --agent {standard-agent-token}`; fail closed for every other non-`idle` state. The recovery intent accepts no token, head, or `--orchestrated` flag.
+Call `commit-status` whenever the commit skill starts. Use `commit-recover --agent {standard-agent-token}` for `recoverable` / `prepared` / `retryable-start`; use `commit-start --agent {standard-agent-token}` for `idle`; fail closed for every other state. Read `commit_attempt` only from `finalization.attempt.attempt` in start/recover output.
 
 After read-only preparation of status, copyright, message, review snapshot, and push routing, record `baseline_head=$(git rev-parse HEAD)` and run this before any commit, push, success log, or platform success sync:
 
 ```bash
-commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head")
+commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head" --attempt "$commit_attempt")
 commit_intent_token=$(printf '%s' "$commit_intent_result" | node -e 'let input = ""; process.stdin.on("data", chunk => input += chunk).on("end", () => process.stdout.write(JSON.parse(input).token))')
 ```
 
@@ -44,6 +44,7 @@ After the committed/pushed checkpoint and before task synchronization or `task-v
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
-- Before the first side effect, abort only while HEAD still equals the baseline by using `commit-abort --token ... --expected-head ...`.
+- If an intent exists but no side effect occurred, use `commit-abort --token ... --expected-head ...` while HEAD still equals baseline; when abandoning the attempt, then close it with `commit-terminate --attempt "$commit_attempt" --agent {standard-agent-token} --code <STABLE_CODE>`.
+- If begin failed before intent creation, retain the attempt for retry or terminate it only while HEAD is unchanged.
 - After a commit or push, never abort. Retain the intent and use `commit-status` / `commit-recover` for cross-session recovery.
 - Stop when `commit-complete` fails. Do not repeat commit/push or mark a run complete without its full receipt lifecycle.

--- a/templates/.agents/skills/commit/reference/commit-orchestration.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/commit-orchestration.zh-CN.md
@@ -9,18 +9,18 @@
 
 ## 副作用前 begin
 
-每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` 调用以下无 token 恢复入口，其他非 `idle` 状态 fail closed：
+每次进入 commit 技能先调用 `commit-status`。`recoverable` / `prepared` / `retryable-start` 调用以下无 token 恢复入口，`idle` 调用 `commit-start --agent {standard-agent-token}`；其他状态 fail closed：
 
 ```bash
 agent-infra-internal task-orchestration {task-id} commit-recover --agent {standard-agent-token}
 ```
 
-恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。recoverable 会幂等补齐 task/run 并最后删除 intent；prepared 仅在 HEAD=baseline 且恰有一个 open Commit started 时安全清理，随后复用该 started 继续正常流程。
+恢复入口只接受 `--agent`；不得传 token、head 或 `--orchestrated`。从 start/recover 结构化输出读取 `finalization.attempt.attempt` 为 `commit_attempt`，不得手写 attempt。
 
 完成状态、版权、提交信息、review snapshot 和 push 场景的只读准备后，记录 `baseline_head=$(git rev-parse HEAD)`，并在任何 commit、push、任务成功日志或平台成功同步之前调用：
 
 ```bash
-commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head")
+commit_intent_result=$(agent-infra-internal task-orchestration {task-id} commit-begin --agent {standard-agent-token} {execution-flag} --baseline-head "$baseline_head" --attempt "$commit_attempt")
 commit_intent_token=$(printf '%s' "$commit_intent_result" | node -e 'let input = ""; process.stdin.on("data", chunk => input += chunk).on("end", () => process.stdout.write(JSON.parse(input).token))')
 ```
 
@@ -50,6 +50,7 @@ committed/pushed checkpoint 完成后、任务同步与 `task-verify commit.comp
 agent-infra-internal task-orchestration {task-id} commit-complete --token "$commit_intent_token" --agent {standard-agent-token}
 ```
 
-- 第一个副作用前失败时，仅可在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`。
+- begin 已创建 intent、但第一个副作用前失败时，先在 HEAD 仍等于 baseline 时调用 `commit-abort --token ... --expected-head ...`；若本轮明确放弃，再调用 `commit-terminate --attempt "$commit_attempt" --agent {standard-agent-token} --code <STABLE_CODE>` 闭合 started。
+- begin 在 intent 创建前失败时可保留 attempt 供下次复用；明确放弃时仅可在 HEAD 未漂移时调用 `commit-terminate`。
 - commit 或 push 发生后失败时不得 abort；保留 intent，并调用 `commit-status` 输出不含 token/digest 的恢复证据。跨会话重跑通过 `commit-recover` 收尾。
 - `commit-complete` 失败时停止。不得重复执行 commit/push，也不得把缺少完整 receipt 生命周期的 run 标记为完成。

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -15,18 +15,30 @@ function waitForFile(filePath: string, timeoutMs: number): void {
   throw new Error(`Timed out waiting for ${filePath}`);
 }
 
+function initializeRepository(root: string): string {
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
+  execFileSync('git', ['add', 'source.txt'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+  return execFileSync('git', ['branch', '--show-current'], { cwd: root, encoding: 'utf8' }).trim();
+}
+
 test('sandbox control client and broker exchange a task-bound response', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-control-roundtrip-'));
   const channelDir = path.join(root, 'channel');
   const manifestPath = path.join(root, 'manifest.json');
   const token = 'roundtrip-secret';
   fs.mkdirSync(channelDir, { recursive: true });
+  const branch = initializeRepository(root);
   fs.writeFileSync(manifestPath, `${JSON.stringify({
-    version: 1,
+    version: 2,
     repoRoot: root,
+    worktreeRoot: root,
     project: 'demo',
     container: 'demo-dev-feature',
-    branch: 'feature',
+    branch,
     mode: 'task-bound',
     taskId: 'TASK-20260809-010203',
     token,
@@ -64,6 +76,7 @@ test('branch-only broker persists a typed task-create request on the host', asyn
   const manifestPath = path.join(root, 'control', 'manifest.json');
   const token = 'roundtrip-secret';
   fs.mkdirSync(channelDir, { recursive: true });
+  const branch = initializeRepository(root);
   fs.mkdirSync(path.join(root, '.agents', 'workspace', 'active'), { recursive: true });
   fs.mkdirSync(path.join(root, '.agents', 'templates'), { recursive: true });
   fs.mkdirSync(path.join(root, '.agents', 'skills', 'create-task', 'config'), { recursive: true });
@@ -71,7 +84,7 @@ test('branch-only broker persists a typed task-create request on the host', asyn
   fs.copyFileSync(path.resolve('.agents/templates/task.md'), path.join(root, '.agents', 'templates', 'task.md'));
   fs.copyFileSync(path.resolve('.agents/skills/create-task/config/verify.json'), path.join(root, '.agents', 'skills', 'create-task', 'config', 'verify.json'));
   fs.writeFileSync(manifestPath, `${JSON.stringify({
-    version: 1, repoRoot: root, project: 'demo', container: 'demo-dev-feature', branch: 'feature',
+    version: 2, repoRoot: root, worktreeRoot: root, project: 'demo', container: 'demo-dev-feature', branch,
     mode: 'branch-only', taskId: null, token, channelDir
   })}\n`);
   const child = spawn(

--- a/tests/integration/cli/sandbox-custom-tools.test.ts
+++ b/tests/integration/cli/sandbox-custom-tools.test.ts
@@ -58,6 +58,7 @@ test("sandbox recovery does not replay custom postSetupCmds or versionCmd", asyn
     }]
   } as unknown as SandboxConfig;
   fs.mkdirSync(config.repoRoot, { recursive: true });
+  fs.mkdirSync(path.join(config.worktreeBase, branchDir), { recursive: true });
   const view = materializeSandboxWorkspaceView({
     base: config.workspaceViewBase,
     project: config.project,
@@ -67,6 +68,7 @@ test("sandbox recovery does not replay custom postSetupCmds or versionCmd", asyn
   const control = materializeSandboxControl({
     base: config.controlBase,
     repoRoot: config.repoRoot,
+    worktreeRoot: path.join(config.worktreeBase, branchDir),
     project: config.project,
     container: "demo-dev-feature..demo",
     branch: "feature/demo",

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -127,6 +127,7 @@ function recoveryFixtureConfig(tmpDir: string): SandboxConfig {
   materializeSandboxControl({
     base: config.controlBase,
     repoRoot: config.repoRoot,
+    worktreeRoot: path.join(config.worktreeBase, branchDir),
     project,
     container: "demo-dev-feature..demo",
     branch: "feature/demo",

--- a/tests/integration/cli/task-orchestration.test.ts
+++ b/tests/integration/cli/task-orchestration.test.ts
@@ -13,7 +13,7 @@ function fixture() {
   const id = 'TASK-20260101-000001';
   const dir = path.join(root, '.agents', 'workspace', 'active', id);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${id}\ncurrent_step: requirement-analysis\n---\n\n# Task\n`);
+  fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${id}\nstatus: active\ncurrent_step: requirement-analysis\n---\n\n# Task\n\n## Activity Log\n`);
   spawnSync('git', ['config', 'user.name', 'Test'], { cwd: root });
   spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
   spawnSync('git', ['add', '.'], { cwd: root });
@@ -117,7 +117,12 @@ test('task-orchestration exposes token-guarded standalone commit intents and rej
   assert.equal(legacy.status, 2);
   assert.equal(JSON.parse(legacy.stdout).error.code, 'ORCHESTRATION_PAYLOAD_INVALID');
 
-  const begun = run(f.root, [f.id, 'commit-begin', '--agent', 'codex', '--baseline-head', head]);
+  const started = run(f.root, [f.id, 'commit-start', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr || started.stdout);
+  const attempt = JSON.parse(started.stdout).finalization.attempt.attempt;
+  const begun = run(f.root, [
+    f.id, 'commit-begin', '--agent', 'codex', '--baseline-head', head, '--attempt', attempt
+  ]);
   assert.equal(begun.status, 0, begun.stderr || begun.stdout);
   const payload = JSON.parse(begun.stdout);
   assert.equal(payload.intent.mode, 'standalone');
@@ -148,20 +153,31 @@ test('task-orchestration exposes token-guarded standalone commit intents and rej
   assert.equal(emptyPayload.changed, false);
   assert.equal(emptyPayload.taskId, f.id);
   assert.equal(emptyPayload.intent, null);
-  assert.equal(emptyPayload.finalization.disposition, 'invalid');
+  assert.equal(emptyPayload.finalization.disposition, 'retryable-start');
+  assert.equal(emptyPayload.finalization.attempt.attempt, attempt);
   assert.equal(emptyPayload.error, null);
   assert.equal(emptyStatus.stdout.includes(f.dir), false);
+
+  const terminated = run(f.root, [
+    f.id, 'commit-terminate', '--attempt', attempt, '--agent', 'codex', '--code', 'ABORTED_BEFORE_SIDE_EFFECT'
+  ]);
+  assert.equal(terminated.status, 0, terminated.stderr || terminated.stdout);
+  assert.equal(JSON.parse(terminated.stdout).finalization.disposition, 'idle');
 });
 
 test('task-orchestration recovers committed finalization without the original token', () => {
   const f = fixture();
   fs.writeFileSync(path.join(f.dir, 'task.md'), [
     '---', `id: ${f.id}`, 'status: active', 'current_step: code-review', '---', '',
-    '# Task', '', '## Activity Log', '',
-    '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started', ''
+    '# Task', '', '## Activity Log', ''
   ].join('\n'));
   const baseline = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: f.root, encoding: 'utf8' }).stdout.trim();
-  const begun = run(f.root, [f.id, 'commit-begin', '--agent', 'codex', '--baseline-head', baseline]);
+  const started = run(f.root, [f.id, 'commit-start', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr || started.stdout);
+  const attempt = JSON.parse(started.stdout).finalization.attempt.attempt;
+  const begun = run(f.root, [
+    f.id, 'commit-begin', '--agent', 'codex', '--baseline-head', baseline, '--attempt', attempt
+  ]);
   assert.equal(begun.status, 0, begun.stderr || begun.stdout);
   const token = JSON.parse(begun.stdout).token;
   fs.writeFileSync(path.join(f.root, 'source.txt'), 'change\n');

--- a/tests/integration/core/workspace-snapshot.test.ts
+++ b/tests/integration/core/workspace-snapshot.test.ts
@@ -123,3 +123,35 @@ test('repository snapshots ignore lifecycle artifacts while detecting Git-visibl
   fs.writeFileSync(path.join(root, 'untracked.ts'), 'untracked\n');
   assert.notEqual(captureRepositorySnapshot(root).worktreeTree, clean.headTree);
 });
+
+test('versioned orchestration snapshots combine a linked worktree with task state from another root', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchestration-split-snapshot-'));
+  const stateRoot = path.join(root, 'state');
+  const gitRoot = path.join(root, 'worktree');
+  fs.mkdirSync(stateRoot);
+  fs.mkdirSync(gitRoot);
+  git(gitRoot, ['init', '-q']);
+  git(gitRoot, ['config', 'user.name', 'Test']);
+  git(gitRoot, ['config', 'user.email', 'test@example.com']);
+  fs.writeFileSync(path.join(gitRoot, 'source.ts'), 'before\n');
+  git(gitRoot, ['add', 'source.ts']);
+  git(gitRoot, ['commit', '-qm', 'baseline']);
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(stateRoot, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), 'before\n');
+
+  const before = captureWorkspaceSnapshot({ gitRoot, stateRoot, taskId });
+  fs.writeFileSync(path.join(gitRoot, 'source.ts'), 'after\n');
+  fs.writeFileSync(path.join(taskDir, 'task.md'), 'after\n');
+  const after = captureWorkspaceSnapshot({ gitRoot, stateRoot, taskId });
+
+  assert.deepEqual(diffWorkspaceSnapshots(gitRoot, before, after), [
+    '.agents/workspace/active/TASK-20260101-000001/task.md',
+    'source.ts'
+  ]);
+  assert.throws(
+    () => diffWorkspaceSnapshots(gitRoot, captureWorkspaceSnapshot(gitRoot, taskId), after),
+    /versions cannot be mixed/
+  );
+});

--- a/tests/unit/cli/task-activity-log.test.ts
+++ b/tests/unit/cli/task-activity-log.test.ts
@@ -204,6 +204,28 @@ test('pairEntries folds a started+done pair onto one row', () => {
   });
 });
 
+test('pairEntries closes a structured Commit attempt with its aborted terminal row', () => {
+  const rows = pairEntries([
+    entry(
+      '2026-06-16 09:00:00+08:00',
+      'Commit [started]',
+      'codex',
+      `started; attempt=attempt-0001; baseline=${'a'.repeat(40)}; agent=codex`
+    ),
+    entry(
+      '2026-06-16 09:01:00+08:00',
+      'Commit [aborted]',
+      'codex',
+      'aborted; attempt=attempt-0001; code=BEGIN_FAILED'
+    )
+  ]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.step, 'Commit');
+  assert.equal(rows[0]!.attempt, 'attempt-0001');
+  assert.equal(rows[0]!.done, '2026-06-16 09:01:00+08:00');
+  assert.equal(rows[0]!.note, 'aborted; attempt=attempt-0001; code=BEGIN_FAILED');
+});
+
 test('pairEntries pairs each Round independently', () => {
   const rows = pairEntries([
     entry('2026-06-16 09:00:00+08:00', 'Analyze Task (Round 1) [started]'),

--- a/tests/unit/core/commit-orchestration.test.ts
+++ b/tests/unit/core/commit-orchestration.test.ts
@@ -15,7 +15,9 @@ import {
   readRun,
   recoverCommitIntent,
   sealOrchestrationDelegation,
-  statusCommitIntent
+  startCommitAttempt,
+  statusCommitIntent,
+  terminateCommitAttempt
 } from '../../../lib/task/orchestration.ts';
 import { readCommitIntent } from '../../../lib/task/commit-intent.ts';
 
@@ -25,7 +27,7 @@ function git(root: string, args: string[]): string {
   return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
 }
 
-function fixture() {
+function fixture(agent = 'codex') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commit-orchestration-'));
   git(root, ['init', '-q']);
   git(root, ['config', 'user.name', 'Test']);
@@ -33,14 +35,16 @@ function fixture() {
   fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
   git(root, ['add', 'source.txt']);
   git(root, ['commit', '-qm', 'base']);
+  const head = git(root, ['rev-parse', 'HEAD']);
+  const attempt = 'attempt-0001';
   const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
   fs.mkdirSync(taskDir, { recursive: true });
   fs.writeFileSync(path.join(taskDir, 'task.md'), [
     '---', `id: ${taskId}`, 'status: active', 'current_step: code-review', '---', '',
     '# Task', '', '## Activity Log', '',
-    '- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started', ''
+    `- 2026-01-01 00:00:00+00:00 — **Commit [started]** by ${agent} — started; attempt=${attempt}; baseline=${head}; agent=${agent}`, ''
   ].join('\n'));
-  return { root, taskDir, head: git(root, ['rev-parse', 'HEAD']) };
+  return { root, taskDir, head, attempt };
 }
 
 function checkpointReviewed(f: ReturnType<typeof fixture>, token: string) {
@@ -87,7 +91,7 @@ test('standalone begin and complete preserve historical orchestration bytes', ()
     const before = fs.readFileSync(runPath);
 
     const begun = beginCommitIntent(taskId, {
-      agent: 'codex', orchestrated: false, baselineHead: f.head
+      agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
     }, { repoRoot: f.root, token: () => `token-${status}` });
     assert.equal(begun.status, 'ready');
     assert.equal(begun.intent?.mode, 'standalone');
@@ -102,7 +106,7 @@ test('standalone begin and complete preserve historical orchestration bytes', ()
 test('standalone commit without review finalizes without creating a review anchor', () => {
   const f = fixture();
   const begun = beginCommitIntent(taskId, {
-    agent: 'codex', orchestrated: false, baselineHead: f.head
+    agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root, token: () => 'token' });
   assert.equal(begun.status, 'ready');
   fs.writeFileSync(path.join(f.root, 'source.txt'), 'changed\n');
@@ -125,21 +129,33 @@ test('standalone commit without review finalizes without creating a review ancho
   assert.equal(task.includes('last_reviewed_commit:'), false);
 });
 
+test('repeated commit begin reports the active intent as busy', () => {
+  const f = fixture();
+  const input = {
+    agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
+  } as const;
+  assert.equal(beginCommitIntent(taskId, input, { repoRoot: f.root, token: () => 'token' }).status, 'ready');
+
+  const repeated = beginCommitIntent(taskId, input, { repoRoot: f.root });
+
+  assert.equal(repeated.error?.code, 'ORCHESTRATION_COMMIT_INTENT_BUSY');
+});
+
 test('standalone fails before intent creation when any delegation is pending', () => {
   const f = fixture();
   fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), `${JSON.stringify(activatedRun(), null, 2)}\n`);
   const result = beginCommitIntent(taskId, {
-    agent: 'codex', orchestrated: false, baselineHead: f.head
+    agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root });
   assert.equal(result.error?.code, 'ORCHESTRATION_STANDALONE_BUSY');
   assert.equal(fs.existsSync(path.join(f.taskDir, 'commit-intent.json')), false);
 });
 
 test('orchestrated complete commits the preplanned receipt without consuming authorization', () => {
-  const f = fixture();
+  const f = fixture('claude');
   fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), `${JSON.stringify(activatedRun(), null, 2)}\n`);
   const begun = beginCommitIntent(taskId, {
-    agent: 'claude', orchestrated: true, baselineHead: f.head
+    agent: 'claude', orchestrated: true, baselineHead: f.head, attempt: f.attempt
   }, {
     repoRoot: f.root, token: () => 'token', now: () => '2026-01-01T00:00:01.000Z'
   });
@@ -158,11 +174,11 @@ test('orchestrated complete commits the preplanned receipt without consuming aut
 });
 
 test('orchestrated complete recovers after the planned run was written but the intent remains', () => {
-  const f = fixture();
+  const f = fixture('claude');
   const runPath = path.join(f.taskDir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(activatedRun(), null, 2)}\n`);
   beginCommitIntent(taskId, {
-    agent: 'claude', orchestrated: true, baselineHead: f.head
+    agent: 'claude', orchestrated: true, baselineHead: f.head, attempt: f.attempt
   }, {
     repoRoot: f.root, token: () => 'token', now: () => '2026-01-01T00:00:01.000Z'
   });
@@ -187,7 +203,7 @@ test('orchestrated complete recovers after the planned run was written but the i
 test('token-less recovery finalizes a committed intent exactly once', () => {
   const f = fixture();
   beginCommitIntent(taskId, {
-    agent: 'codex', orchestrated: false, baselineHead: f.head
+    agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root, token: () => 'lost-token' });
   const committedHead = checkpointReviewed(f, 'lost-token');
 
@@ -207,16 +223,91 @@ test('commit intent status is ready when no intent exists', () => {
   assert.equal(status.changed, false);
   assert.equal(status.taskId, taskId);
   assert.equal(status.intent, null);
-  assert.equal(status.finalization?.disposition, 'orphaned-start');
+  assert.equal(status.finalization?.disposition, 'retryable-start');
+  assert.equal(status.finalization?.attempt?.attempt, f.attempt);
   assert.equal(status.error, null);
 });
 
-test('orchestrated complete fails closed on run drift and retains recovery evidence', () => {
+test('commit attempts can be reused and safely terminated before an intent exists', () => {
   const f = fixture();
+  const taskPath = path.join(f.taskDir, 'task.md');
+  fs.writeFileSync(taskPath, fs.readFileSync(taskPath, 'utf8').replace(/^.*Commit \[started\].*\n/m, ''));
+
+  const started = startCommitAttempt(taskId, { agent: 'codex' }, {
+    repoRoot: f.root, id: () => 'attempt-0002'
+  });
+  assert.equal(started.status, 'ready');
+  assert.equal(started.finalization?.disposition, 'retryable-start');
+  assert.equal(started.finalization?.attempt?.attempt, 'attempt-0002');
+  const recovered = recoverCommitIntent(taskId, { agent: 'codex' }, { repoRoot: f.root });
+  assert.equal(recovered.changed, false);
+  assert.equal(recovered.finalization?.attempt?.attempt, 'attempt-0002');
+
+  const terminated = terminateCommitAttempt(taskId, {
+    attempt: 'attempt-0002', agent: 'codex', code: 'BEGIN_FAILED'
+  }, { repoRoot: f.root });
+  assert.equal(terminated.finalization?.disposition, 'idle');
+  assert.match(fs.readFileSync(taskPath, 'utf8'), /\*\*Commit \[aborted\]\*\*/);
+});
+
+test('commit start refuses to stack on a legacy plain open started row', () => {
+  const f = fixture();
+  const taskPath = path.join(f.taskDir, 'task.md');
+  fs.writeFileSync(taskPath, fs.readFileSync(taskPath, 'utf8').replace(
+    /started; attempt=.*; baseline=.*; agent=codex/,
+    'started'
+  ));
+  const result = startCommitAttempt(taskId, { agent: 'codex' }, { repoRoot: f.root });
+  assert.equal(result.error?.code, 'ORCHESTRATION_COMMIT_ATTEMPT_BUSY');
+  assert.equal((fs.readFileSync(taskPath, 'utf8').match(/Commit \[started\]/g) ?? []).length, 1);
+});
+
+test('commit status and begin use a bound linked worktree while keeping intent state in the main repository', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commit-linked-worktree-'));
+  const main = path.join(root, 'main');
+  const linked = path.join(root, 'linked');
+  fs.mkdirSync(main);
+  git(main, ['init', '-q']);
+  git(main, ['config', 'user.name', 'Test']);
+  git(main, ['config', 'user.email', 'test@example.com']);
+  fs.writeFileSync(path.join(main, 'source.txt'), 'main\n');
+  git(main, ['add', 'source.txt']);
+  git(main, ['commit', '-qm', 'main']);
+  const mainHead = git(main, ['rev-parse', 'HEAD']);
+  git(main, ['worktree', 'add', '-qb', 'feature', linked]);
+  fs.writeFileSync(path.join(linked, 'source.txt'), 'feature\n');
+  git(linked, ['add', 'source.txt']);
+  git(linked, ['commit', '-qm', 'feature']);
+  const linkedHead = git(linked, ['rev-parse', 'HEAD']);
+  assert.notEqual(linkedHead, mainHead);
+
+  const taskDir = path.join(main, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), [
+    '---', `id: ${taskId}`, 'status: active', 'current_step: code-review', '---', '',
+    '# Task', '', '## Activity Log', '',
+    `- 2026-01-01 00:00:00+00:00 — **Commit [started]** by codex — started; attempt=attempt-linked; baseline=${linkedHead}; agent=codex`, ''
+  ].join('\n'));
+
+  const options = { repoRoot: main, gitWorktreeRoot: linked, token: () => 'linked-token' };
+  const status = statusCommitIntent(taskId, options);
+  assert.equal(status.finalization?.currentHead, linkedHead);
+  assert.equal(status.finalization?.disposition, 'retryable-start');
+  const begun = beginCommitIntent(taskId, {
+    agent: 'codex', orchestrated: false, baselineHead: linkedHead, attempt: 'attempt-linked'
+  }, options);
+  assert.equal(begun.status, 'ready');
+  assert.equal(begun.intent?.currentHead, linkedHead);
+  assert.equal(fs.existsSync(path.join(taskDir, 'commit-intent.json')), true);
+  assert.equal(fs.existsSync(path.join(linked, '.agents', 'workspace', 'active', taskId, 'commit-intent.json')), false);
+});
+
+test('orchestrated complete fails closed on run drift and retains recovery evidence', () => {
+  const f = fixture('claude');
   const runPath = path.join(f.taskDir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(activatedRun(), null, 2)}\n`);
   beginCommitIntent(taskId, {
-    agent: 'claude', orchestrated: true, baselineHead: f.head
+    agent: 'claude', orchestrated: true, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root, token: () => 'token' });
   checkpointReviewed(f, 'token');
   const drifted = JSON.parse(fs.readFileSync(runPath, 'utf8'));
@@ -229,11 +320,11 @@ test('orchestrated complete fails closed on run drift and retains recovery evide
 });
 
 test('orchestrated begin pauses invalid authorization before creating an intent', () => {
-  const f = fixture();
+  const f = fixture('claude');
   const invalid = { ...activatedRun(), commitAuthorization: { issuedAt: null, consumedAt: null } };
   fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), `${JSON.stringify(invalid, null, 2)}\n`);
   const result = beginCommitIntent(taskId, {
-    agent: 'claude', orchestrated: true, baselineHead: f.head
+    agent: 'claude', orchestrated: true, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root, now: () => '2026-01-01T00:00:01.000Z' });
   assert.equal(result.error?.code, 'ORCHESTRATION_COMMIT_AUTHORIZATION_INVALID');
   assert.equal(readRun(f.taskDir)?.status, 'paused');
@@ -243,7 +334,7 @@ test('orchestrated begin pauses invalid authorization before creating an intent'
 test('commit checkpoints follow repository HEAD and active intent blocks prepare', () => {
   const f = fixture();
   const begun = beginCommitIntent(taskId, {
-    agent: 'codex', orchestrated: false, baselineHead: f.head
+    agent: 'codex', orchestrated: false, baselineHead: f.head, attempt: f.attempt
   }, { repoRoot: f.root, token: () => 'token' });
   assert.equal(begun.status, 'ready');
   const blocked = prepareOrchestrationDelegation(taskId, {
@@ -294,7 +385,7 @@ test('commit begin and delegation prepare serialize across independent processes
   const beginSource = `
     import { beginCommitIntent } from ${JSON.stringify(moduleUrl)};
     console.log(JSON.stringify(beginCommitIntent(${JSON.stringify(taskId)}, {
-      agent: 'codex', orchestrated: false, baselineHead: ${JSON.stringify(f.head)}
+      agent: 'codex', orchestrated: false, baselineHead: ${JSON.stringify(f.head)}, attempt: ${JSON.stringify(f.attempt)}
     }, { repoRoot: ${JSON.stringify(f.root)} })));
   `;
   const prepareSource = `

--- a/tests/unit/core/review-fingerprint.test.ts
+++ b/tests/unit/core/review-fingerprint.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseReviewedGitTree } from '../../../lib/task/review-fingerprint.ts';
+
+test('reviewed Git trees accept object IDs and reject orchestration workspace fingerprints', () => {
+  assert.equal(parseReviewedGitTree('a'.repeat(40)), 'a'.repeat(40));
+  assert.equal(parseReviewedGitTree('ws2:eyJ2ZXJzaW9uIjoyfQ'), null);
+});

--- a/tests/unit/core/task-orchestration.test.ts
+++ b/tests/unit/core/task-orchestration.test.ts
@@ -657,7 +657,7 @@ test('repository pending guard includes paused runs that retain a delegation', (
 test('native stop derives the workspace delta before sealing the unique delegation', () => {
   const f = fixture('requirement-analysis-review');
   const capturedScopes: Array<string | null> = [];
-  const captureWorkspace = (_repoRoot: string, taskId: string | null) => {
+  const captureWorkspace = ({ taskId }: { taskId: string | null }) => {
     capturedScopes.push(taskId);
     return capturedScopes.length === 1 ? 'before-tree' : 'after-tree';
   };
@@ -697,7 +697,7 @@ test('native stop derives the workspace delta before sealing the unique delegati
 test('native stop preserves legacy snapshot scope for an old pending receipt', () => {
   const f = fixture('requirement-analysis-review');
   const capturedScopes: Array<string | null> = [];
-  const captureWorkspace = (_repoRoot: string, taskId: string | null) => {
+  const captureWorkspace = ({ taskId }: { taskId: string | null }) => {
     capturedScopes.push(taskId);
     return capturedScopes.length === 1 ? 'before-tree' : 'after-tree';
   };

--- a/tests/unit/git/worktree-identity.test.ts
+++ b/tests/unit/git/worktree-identity.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  assertGitWorktreeBinding,
+  normalizeCanonicalPath,
+  sameFilesystemEntry
+} from '../../../lib/git/worktree-identity.ts';
+
+function git(root: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+}
+
+test('platform path fallback normalizes Windows identity without folding POSIX case', () => {
+  assert.equal(
+    normalizeCanonicalPath('C:\\Repo\\Feature', 'win32'),
+    normalizeCanonicalPath('c:/repo/feature', 'win32')
+  );
+  assert.notEqual(
+    normalizeCanonicalPath('/Repo/Feature', 'darwin'),
+    normalizeCanonicalPath('/repo/feature', 'darwin')
+  );
+});
+
+test('filesystem identity recognizes two canonical names for the same directory', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-identity-'));
+  assert.equal(sameFilesystemEntry(root, path.join(root, '.')), true);
+});
+
+test('linked worktree binding accepts the same common directory and rejects another repository', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-binding-'));
+  const main = path.join(root, 'main');
+  const linked = path.join(root, 'linked');
+  const unrelated = path.join(root, 'unrelated');
+  fs.mkdirSync(main);
+  git(main, ['init', '-q']);
+  git(main, ['config', 'user.name', 'Test']);
+  git(main, ['config', 'user.email', 'test@example.com']);
+  fs.writeFileSync(path.join(main, 'source.txt'), 'base\n');
+  git(main, ['add', 'source.txt']);
+  git(main, ['commit', '-qm', 'base']);
+  git(main, ['worktree', 'add', '-qb', 'feature', linked]);
+
+  const identity = assertGitWorktreeBinding(main, linked, 'feature');
+  assert.equal(identity.worktreeRoot, fs.realpathSync.native(linked));
+  assert.equal(identity.branch, 'feature');
+
+  fs.mkdirSync(unrelated);
+  git(unrelated, ['init', '-q']);
+  assert.throws(
+    () => assertGitWorktreeBinding(main, unrelated, 'master'),
+    /SANDBOX_CONTROL_WORKTREE_INVALID/
+  );
+});

--- a/tests/unit/sandbox/workspace-control.test.ts
+++ b/tests/unit/sandbox/workspace-control.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,8 +15,9 @@ import {
 } from '../../../lib/sandbox/control/protocol.ts';
 
 const manifest: SandboxControlManifest = {
-  version: 1,
+  version: 2,
   repoRoot: '/repo',
+  worktreeRoot: '/worktree',
   project: 'p',
   container: 'p-dev-feature',
   branch: 'feature',
@@ -63,6 +65,16 @@ test('branch-only sandboxes and incorrect tokens fail closed', () => {
   );
 });
 
+test('task-orchestration requests cannot override the manifest worktree binding', () => {
+  assert.throws(() => validateSandboxControlRequest({
+    version: 1,
+    id: '12345678-1234-1234-1234-123456789abc',
+    token: 'secret',
+    family: 'task-orchestration',
+    args: ['08', 'commit-status', '--git-worktree-root', '/other']
+  }, manifest), /REQUEST_INVALID/);
+});
+
 test('control broker strips mixed-case sandbox authority from child environments', () => {
   assert.deepEqual(sandboxControlSafeEnv({
     agent_infra_control_token: 'live-token',
@@ -105,10 +117,20 @@ test('task-create is authorized in both sandbox modes without task rebinding', (
 
 test('control broker ownership is acquired exclusively', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-control-owner-'));
+  fs.writeFileSync(path.join(root, 'source.txt'), 'base\n');
+  const git = (args: string[]) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+  git(['init', '-q']);
+  git(['config', 'user.name', 'Test']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['add', 'source.txt']);
+  git(['commit', '-qm', 'base']);
+  const branch = git(['branch', '--show-current']);
   const channelDir = path.join(root, 'channel');
   const manifestPath = path.join(root, 'manifest.json');
   fs.mkdirSync(channelDir, { recursive: true });
-  fs.writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, repoRoot: root, channelDir })}\n`);
+  fs.writeFileSync(manifestPath, `${JSON.stringify({
+    ...manifest, repoRoot: root, worktreeRoot: root, branch, channelDir
+  })}\n`);
   fs.writeFileSync(path.join(root, 'broker.json'), '{}\n');
   const controller = new AbortController();
   controller.abort();
@@ -116,6 +138,20 @@ test('control broker ownership is acquired exclusively', () => {
     assert.throws(
       () => serveSandboxControl(manifestPath, controller.signal),
       (error: unknown) => error instanceof Error && 'code' in error && error.code === 'EEXIST'
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('control broker rejects legacy manifests with sandbox refresh guidance', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-control-legacy-manifest-'));
+  const manifestPath = path.join(root, 'manifest.json');
+  fs.writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, version: 1, worktreeRoot: undefined })}\n`);
+  try {
+    assert.throws(
+      () => serveSandboxControl(manifestPath),
+      /SANDBOX_CONTROL_MANIFEST_VERSION_INVALID: expected version 2; recreate the sandbox/
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/tests/unit/sandbox/workspace-view.test.ts
+++ b/tests/unit/sandbox/workspace-view.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -55,8 +56,16 @@ test('control materialization rotates the token and clears host-only replay mark
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-control-view-'));
   const repoRoot = path.join(root, 'repo');
   fs.mkdirSync(repoRoot);
+  fs.writeFileSync(path.join(repoRoot, 'source.txt'), 'base\n');
+  const git = (args: string[]) => execFileSync('git', args, { cwd: repoRoot });
+  git(['init', '-q']);
+  git(['config', 'user.name', 'Test']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['add', 'source.txt']);
+  git(['commit', '-qm', 'base']);
+  const branch = execFileSync('git', ['branch', '--show-current'], { cwd: repoRoot, encoding: 'utf8' }).trim();
   const params = {
-    base: path.join(root, 'controls'), repoRoot, project: 'p', container: 'p-dev-feature', branch: 'feature',
+    base: path.join(root, 'controls'), repoRoot, worktreeRoot: repoRoot, project: 'p', container: 'p-dev-feature', branch,
     identity: { mode: 'branch-only' as const }
   };
   const first = materializeSandboxControl(params);
@@ -66,4 +75,7 @@ test('control materialization rotates the token and clears host-only replay mark
   assert.notEqual(second.token, first.token);
   assert.deepEqual(fs.readdirSync(path.join(controlRoot, 'consumed')), []);
   assert.equal(path.dirname(path.join(controlRoot, 'consumed')), controlRoot);
+  const manifest = JSON.parse(fs.readFileSync(second.manifestPath, 'utf8'));
+  assert.equal(manifest.version, 2);
+  assert.equal(manifest.worktreeRoot, fs.realpathSync.native(repoRoot));
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #832

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix

## 📝 变更目的 / Purpose of the Change

修复受控提交编排错误绑定主检出、导致 linked worktree 的合法提交被错误拒绝的问题，并让副作用前失败的 commit attempt 可以安全恢复或终止。

## 📋 主要变更 / Brief Changelog

- 分离 sandbox state root 与 canonical worktree root，并升级控制 manifest 到 version 2。
- 校验 linked worktree 的 canonical Git identity，确保控制通道和本地 Git 使用同一工作树。
- 引入结构化 commit attempt 的 start/recover/terminate 生命周期，避免 orphaned-start。
- 扩展 review snapshot、workspace snapshot 以及跨层单元/集成测试。

## 🧪 验证变更 / Verifying this Change

### 测试覆盖 / Test Coverage

- [x] 已添加单元测试和集成测试 / Added unit and integration tests
- [x] npm test：2252 tests，2248 passed，4 skipped，0 failed
- [x] 提交树与 Round 3 Approved review snapshot 完全一致

### ⚠️ 待人工验证 / Manual Validation Pending

- 在真实宿主的 linked worktree 场景复验 canonical identity 与控制通道绑定。
- 在 macOS/Windows 宿主文件系统确认 canonical path identity 不误拒合法 worktree。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只处理 Issue #832
- [x] 已完成自我检查和独立代码审查
- [x] 已更新对应英文/中文模板与规则
- [x] 已考虑向后兼容和失败关闭语义

Closes #832

Generated with AI assistance
