### PR TITLE
fix(release): 统一 post-release 远端发布确认协议


### DIFF
--- a/.agents/rules/no-mid-flow-questions.md
+++ b/.agents/rules/no-mid-flow-questions.md
@@ -47,6 +47,7 @@
 
 - `release`：展示最新 release snapshot 后确认是否 publish
 - `create-release-note`：展示 stage 后的精确 notes 与摘要后确认是否 publish
+- `post-release`：完成本地 post commit 并展示完整 `postConfirmation` 与摘要后确认是否普通 push
 
 ### 例外 5：生命周期启动缺少完整模型策略
 

--- a/.agents/skills/post-release/SKILL.md
+++ b/.agents/skills/post-release/SKILL.md
@@ -15,18 +15,42 @@ description: >
 agent-infra-internal release-workflow inspect {version}
 ```
 
-pending/unknown 必须 blocked，确定失败必须 failed。
+pending/unknown 必须 blocked，确定失败必须 failed。`complete` 直接按外部事实报告完成。
 
-## 2. 执行后处理
+## 2. 准备本地后处理
+
+尚未完成时执行：
 
 ```bash
-agent-infra-internal release-workflow post {version}
+agent-infra-internal release-workflow post-prepare {version}
+agent-infra-internal release-workflow inspect {version}
 ```
 
-core 负责 build、下一开发版本、内联产物、显式路径 commit 与普通 push，并在写后复核。项目增量还包括可选 demo；每次写后重新 inspect，重跑必须幂等。
+core 负责 build、可选 demo、下一开发版本、内联产物和显式路径 post commit；该动作不得 push。重跑从 Git 与渠道事实恢复，不重复已完成操作。
 
-core 在 prerelease bump 前计算 canonical demo inputs 摘要。摘要未变化时幂等跳过且不探测录制工具；变化时要求 Git LFS，并在 `vhs` 与 `ffmpeg` 可用时执行 `npm run demo:regen`。core 必须验证 GIF magic、4 MiB 上限和 LFS 跟踪，将 `assets/demo-init.gif` 与 `assets/demo-init.inputs.sha256` 纳入同一 post commit；录制、校验或 LFS 失败不得推进摘要。
+## 3. 检查确认快照
 
-## 3. 输出摘要
+- `complete`：报告完成，不询问、不 publish。
+- 存在 `postConfirmation`：展示完整字段和 `sha256`，进入步骤 4。
+- 不存在 `postConfirmation`：报告 `isHead=false`、工作树或暂存区非空等诊断并停止，不询问、不 publish。
 
-报告全部渠道、released/new version、smoke、post commit 与 push 事实，不把 degraded/blocked 表述为完成。
+## 4. 获取当前快照授权
+
+仅在当前会话已展示完整 `postConfirmation` 后询问一次是否发布。只有无歧义肯定答复才继续；否定、调整、疑问、歧义或中断均停止。授权不跨会话或快照复用。
+
+## 5. 发布已确认快照
+
+```bash
+agent-infra-internal release-workflow post-publish {version} \
+  --expected-sha256 "{post-confirmation-sha256}"
+```
+
+core 重新 inspect 并校验摘要后仅执行普通 branch push，禁止 force push。摘要漂移时停止并回到步骤 1 重新展示、重新确认。
+
+## 6. 写后复核并报告
+
+```bash
+agent-infra-internal release-workflow inspect {version}
+```
+
+报告全部渠道、released/new version、smoke、post commit 与远端 branch 事实；只有阶段为 `complete` 才表述为完成，不把 failed/degraded/blocked 表述为成功。

--- a/lib/internal/release-workflow.ts
+++ b/lib/internal/release-workflow.ts
@@ -8,7 +8,7 @@ import { commitExplicitPaths, inspectGitWorkflow, pushGitRefs } from '../git/wor
 import { inspectPlatformRelease, reconcileReleaseMilestones } from '../platform/releases.ts';
 import { inspectHomebrewChannel, inspectNpmChannel } from '../release/channels.ts';
 import { releaseSnapshot } from '../release/workflow.ts';
-import type { ReleaseFacts } from '../release/workflow.ts';
+import type { PostReleaseFacts, ReleaseFacts } from '../release/workflow.ts';
 
 function command(cwd: string, executable: string, args: string[]) {
   return spawnSync(executable, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
@@ -168,10 +168,50 @@ function inspectLocalReleaseFacts(cwd: string, version: string, run: CommandRunn
   const localTagConflict = Boolean(tagCommit && !localTag && !localTagAncestor);
   const postSubject = `chore: prepare next dev iteration after v${version}`;
   const postLog = localTag || localTagAncestor
-    ? git(cwd, ['log', '--format=%s', `${tag}..HEAD`], run) ?? ''
+    ? git(cwd, ['log', '--format=%H%x00%s', `${tag}..HEAD`], run) ?? ''
     : '';
-  const postCommit = postLog.split('\n').some((subject) => subject === postSubject);
+  const postCommit = postLog.split('\n').map((line) => line.split('\0'))
+    .find(([, subject]) => subject === postSubject)?.[0] ?? null;
   return { localTag, localTagAncestor, localTagConflict, postCommit };
+}
+
+function inspectPostReleaseFacts(
+  cwd: string,
+  commit: string | null,
+  run: CommandRunner = command
+): PostReleaseFacts {
+  const inspected = inspectGitWorkflow(cwd);
+  const snapshot = inspected.snapshot;
+  const branch = snapshot?.branch ?? '';
+  const remoteLine = branch ? git(cwd, ['ls-remote', '--heads', 'origin', `refs/heads/${branch}`], run) : null;
+  const remoteHead = remoteLine?.split(/\s+/)[0] ?? null;
+  const packageJson = commit ? git(cwd, ['show', `${commit}:package.json`], run, false) : null;
+  let newVersion: string | null = null;
+  if (packageJson) {
+    try {
+      const version = (JSON.parse(packageJson) as { version?: unknown }).version;
+      newVersion = typeof version === 'string' ? version : null;
+    } catch {
+      newVersion = null;
+    }
+  }
+  const paths = commit ? git(cwd, ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', '-z', commit], run, false) : null;
+  const changedPaths = paths ? paths.split('\0').filter(Boolean)
+    .sort((left, right) => Buffer.from(left).compare(Buffer.from(right))) : [];
+  const digest = commit ? git(cwd, ['show', `${commit}:${DEMO_DIGEST_PATH}`], run) : null;
+  return {
+    commit,
+    isHead: Boolean(commit && snapshot?.head === commit),
+    published: Boolean(commit && remoteHead === commit),
+    branch,
+    upstream: snapshot?.upstream ?? null,
+    remoteHead,
+    newVersion,
+    changedPaths,
+    demoInputSha256: digest && /^[0-9a-f]{64}$/.test(digest) ? digest : null,
+    worktree: snapshot?.worktree ?? [],
+    staged: snapshot?.staged ?? []
+  };
 }
 
 function releaseSmokeStatus(workflows: Array<Record<string, unknown>>, version: string, tagCommit: string | null): ReleaseFacts['smoke'] {
@@ -220,12 +260,15 @@ async function inspectFacts(cwd: string, version: string): Promise<ReleaseFacts>
   const workflows = platform.workflows as Array<Record<string, unknown>>;
   const smoke = releaseSmokeStatus(workflows, version, localTagTarget);
   return {
-    ...local,
+    localTag: local.localTag,
+    localTagAncestor: local.localTagAncestor,
+    localTagConflict: local.localTagConflict,
     remoteBranch: Boolean(remoteBranch && remoteBranch.split(/\s+/)[0] === head), remoteTag: Boolean(remoteTag),
     githubRelease: platform.platform.type !== 'github'
       ? true
       : platform.status === 'blocked' ? null : Boolean(platform.release?.published),
-    npm: npm.published, homebrew: homebrew.published, smoke
+    npm: npm.published, homebrew: homebrew.published, smoke,
+    post: inspectPostReleaseFacts(cwd, local.postCommit)
   };
 }
 
@@ -258,13 +301,21 @@ function updateReleaseMetadata(cwd: string, version: string): void {
   }
 }
 
+function optionValues(args: string[], name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) values.push(args[index + 1] ?? '');
+  }
+  return values;
+}
+
 async function releaseWorkflow(args: string[] = []): Promise<void> {
   const [action, rawVersion, ...rest] = args;
   const version = String(rawVersion || '').replace(/^v/, '');
   const cwdIndex = rest.indexOf('--cwd');
   const cwd = path.resolve(cwdIndex >= 0 && rest[cwdIndex + 1] ? rest[cwdIndex + 1]! : process.cwd());
-  if (!['inspect', 'prepare', 'publish', 'post'].includes(action || '') || !semver.valid(version)) {
-    process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'RELEASE_INPUT_INVALID', message: 'Usage: release-workflow inspect|prepare|publish|post <version>' } })}\n`);
+  if (!['inspect', 'prepare', 'publish', 'post-prepare', 'post-publish'].includes(action || '') || !semver.valid(version)) {
+    process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'RELEASE_INPUT_INVALID', message: 'Usage: release-workflow inspect|prepare|publish|post-prepare|post-publish <version>' } })}\n`);
     process.exitCode = 1; return;
   }
   const before = releaseSnapshot(version, await inspectFacts(cwd, version));
@@ -310,9 +361,50 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
     const result = pushGitRefs({ cwd, remote: 'origin', refs });
     process.stdout.write(`${JSON.stringify({ ...result, snapshot: releaseSnapshot(version, await inspectFacts(cwd, version)) })}\n`); process.exitCode = result.status === 'failed' ? 1 : result.status === 'degraded' ? 2 : 0; return;
   }
+  if (action === 'post-publish') {
+    const expectedValues = optionValues(rest, '--expected-sha256');
+    if (expectedValues.length !== 1 || !/^sha256:[0-9a-f]{64}$/.test(expectedValues[0]!)) {
+      process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'RELEASE_INPUT_INVALID', message: 'post-publish requires one --expected-sha256 sha256:<64 hex>' } })}\n`);
+      process.exitCode = 1; return;
+    }
+    if (before.phase === 'complete') {
+      process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`);
+      return;
+    }
+    const confirmation = 'postConfirmation' in before ? before.postConfirmation : null;
+    if (before.phase !== 'post-prepared' || !confirmation) {
+      process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: confirmation ? 'RELEASE_PHASE_INVALID' : 'RELEASE_POST_CONFIRMATION_UNAVAILABLE', message: 'Post-release facts cannot authorize publish' } })}\n`);
+      process.exitCode = 1; return;
+    }
+    if (confirmation.sha256 !== expectedValues[0]) {
+      process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'RELEASE_POST_SNAPSHOT_MISMATCH', message: 'Post-release confirmation snapshot changed' } })}\n`);
+      process.exitCode = 1; return;
+    }
+    const channelsComplete = before.facts.githubRelease === true && before.facts.npm === true && before.facts.homebrew === true;
+    if (!channelsComplete || before.facts.smoke !== 'success') {
+      process.stdout.write(`${JSON.stringify({ status: before.facts.smoke === 'failed' ? 'failed' : 'blocked', changed: false, snapshot: before, error: { code: 'RELEASE_CHANNELS_PENDING', message: 'Release channels or smoke workflow are not complete' } })}\n`);
+      process.exitCode = before.facts.smoke === 'failed' ? 1 : 2; return;
+    }
+    const pushed = pushGitRefs({ cwd, remote: 'origin', refs: [before.facts.post.branch] });
+    const snapshot = releaseSnapshot(version, await inspectFacts(cwd, version));
+    if (snapshot.phase === 'complete') {
+      process.stdout.write(`${JSON.stringify({ ...pushed, status: 'applied', changed: true, snapshot, error: null })}\n`);
+      return;
+    }
+    const blocked = pushed.status !== 'failed';
+    process.stdout.write(`${JSON.stringify({ ...pushed, status: blocked ? 'blocked' : 'failed', snapshot, error: pushed.error ?? { code: 'RELEASE_PROGRESS_PENDING', message: 'Post-release push is not visible at the expected remote head' } })}\n`);
+    process.exitCode = blocked ? 2 : 1; return;
+  }
+
   if (before.phase === 'complete') {
     process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`);
     return;
+  }
+  if (before.phase === 'post-prepared') {
+    const confirmation = 'postConfirmation' in before ? before.postConfirmation : null;
+    const status = confirmation ? 'no-op' : 'blocked';
+    process.stdout.write(`${JSON.stringify({ status, changed: false, snapshot: before, error: confirmation ? null : { code: 'RELEASE_POST_CONFIRMATION_UNAVAILABLE', message: 'Post commit is not the clean current HEAD' } })}\n`);
+    process.exitCode = confirmation ? 0 : 2; return;
   }
   const channelsComplete = before.facts.githubRelease === true && before.facts.npm === true && before.facts.homebrew === true;
   if (!['published', 'post-pending'].includes(before.phase) || !channelsComplete || before.facts.smoke !== 'success') {
@@ -338,10 +430,14 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
   }
   const committed = commitExplicitPaths({ cwd, paths: changedPaths(cwd), message: `chore: prepare next dev iteration after v${version}` });
   if (committed.status === 'failed') { process.stdout.write(`${JSON.stringify(committed)}\n`); process.exitCode = 1; return; }
-  const branch = git(cwd, ['branch', '--show-current']) || '';
-  const pushed = pushGitRefs({ cwd, remote: 'origin', refs: [branch] });
-  process.stdout.write(`${JSON.stringify({ ...pushed, demo, snapshot: releaseSnapshot(version, await inspectFacts(cwd, version)) })}\n`); process.exitCode = pushed.status === 'failed' ? 1 : pushed.status === 'degraded' ? 2 : 0;
+  const snapshot = releaseSnapshot(version, await inspectFacts(cwd, version));
+  const confirmation = 'postConfirmation' in snapshot ? snapshot.postConfirmation : null;
+  if (snapshot.phase !== 'post-prepared' || !confirmation) {
+    process.stdout.write(`${JSON.stringify({ status: 'failed', changed: true, demo, snapshot, error: { code: 'RELEASE_POST_CONFIRMATION_UNAVAILABLE', message: 'Prepared post commit did not produce a confirmation snapshot' } })}\n`);
+    process.exitCode = 1; return;
+  }
+  process.stdout.write(`${JSON.stringify({ status: 'applied', changed: true, demo, snapshot, error: null })}\n`);
 }
 
-export { changedPaths, computeDemoInputDigest, inspectFacts, inspectLocalReleaseFacts, inspectPostWorktree, releaseSmokeStatus, releaseWorkflow, runOptionalDemo };
+export { changedPaths, computeDemoInputDigest, inspectFacts, inspectLocalReleaseFacts, inspectPostReleaseFacts, inspectPostWorktree, releaseSmokeStatus, releaseWorkflow, runOptionalDemo };
 export type { CommandRunner, DemoResult };

--- a/lib/release/workflow.ts
+++ b/lib/release/workflow.ts
@@ -1,32 +1,81 @@
-type ReleasePhase = 'unprepared' | 'prepared' | 'partially-published' | 'published' | 'post-pending' | 'complete';
-type ReleaseFacts = { localTag: boolean; localTagAncestor?: boolean; localTagConflict?: boolean; remoteBranch: boolean; remoteTag: boolean; githubRelease: boolean | null; npm: boolean | null; homebrew: boolean | null; smoke: 'success' | 'pending' | 'failed' | null; postCommit: boolean };
+import crypto from 'node:crypto';
+
+type ReleasePhase = 'unprepared' | 'prepared' | 'partially-published' | 'published' | 'post-pending' | 'post-prepared' | 'complete';
+type PostReleaseFacts = {
+  commit: string | null;
+  isHead: boolean;
+  published: boolean;
+  branch: string;
+  upstream: string | null;
+  remoteHead: string | null;
+  newVersion: string | null;
+  changedPaths: string[];
+  demoInputSha256: string | null;
+  worktree: string[];
+  staged: string[];
+};
+type ReleaseFacts = {
+  localTag: boolean;
+  localTagAncestor?: boolean;
+  localTagConflict?: boolean;
+  remoteBranch: boolean;
+  remoteTag: boolean;
+  githubRelease: boolean | null;
+  npm: boolean | null;
+  homebrew: boolean | null;
+  smoke: 'success' | 'pending' | 'failed' | null;
+  post: PostReleaseFacts;
+};
+type PostConfirmation = {
+  version: string;
+  commit: string;
+  branch: string;
+  upstream: string | null;
+  remoteHead: string | null;
+  newVersion: string | null;
+  changedPaths: string[];
+  demoInputSha256: string | null;
+  worktree: string[];
+  staged: string[];
+  sha256: string;
+};
+
+function byteSort(values: readonly string[]): string[] {
+  return [...values].sort((left, right) => Buffer.from(left).compare(Buffer.from(right)));
+}
 
 function deriveReleasePhase(facts: ReleaseFacts): ReleasePhase {
   if (!facts.localTag && !facts.localTagAncestor) return 'unprepared';
+  if (facts.post.commit) return facts.post.published ? 'complete' : 'post-prepared';
   if (!facts.remoteBranch && !facts.remoteTag) return 'prepared';
   if (!facts.remoteBranch || !facts.remoteTag) return 'partially-published';
   if (facts.githubRelease !== true || facts.npm !== true || facts.homebrew !== true) return 'published';
-  if (facts.smoke !== 'success' || !facts.postCommit) return 'post-pending';
-  return 'complete';
+  return 'post-pending';
+}
+
+function createPostConfirmation(version: string, post: PostReleaseFacts): PostConfirmation | null {
+  if (!post.commit || !post.isHead || post.worktree.length || post.staged.length) return null;
+  const canonical = {
+    version,
+    commit: post.commit,
+    branch: post.branch,
+    upstream: post.upstream,
+    remoteHead: post.remoteHead,
+    newVersion: post.newVersion,
+    changedPaths: byteSort(post.changedPaths),
+    demoInputSha256: post.demoInputSha256,
+    worktree: byteSort(post.worktree),
+    staged: byteSort(post.staged)
+  };
+  const sha256 = `sha256:${crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex')}`;
+  return { ...canonical, sha256 };
 }
 
 function releaseSnapshot(version: string, facts: ReleaseFacts) {
-  return { version, tag: `v${version.replace(/^v/, '')}`, phase: deriveReleasePhase(facts), facts };
+  const snapshot = { version, tag: `v${version.replace(/^v/, '')}`, phase: deriveReleasePhase(facts), facts };
+  const postConfirmation = createPostConfirmation(version, facts.post);
+  return postConfirmation ? { ...snapshot, postConfirmation } : snapshot;
 }
 
-async function runReleaseAction(input: { version: string; action: 'inspect' | 'prepare' | 'publish' | 'post'; inspect: () => Promise<ReleaseFacts>; prepare?: () => Promise<void>; publish?: () => Promise<void>; post?: () => Promise<void> }) {
-  const before = releaseSnapshot(input.version, await input.inspect());
-  if (input.action === 'inspect') return { status: 'no-op' as const, changed: false, before, snapshot: before, error: null };
-  if (before.facts.localTagConflict) return { status: 'failed' as const, changed: false, before, snapshot: before, error: { code: 'GIT_TAG_CONFLICT', message: `Tag ${before.tag} is not reachable from HEAD` } };
-  const allowed = input.action === 'prepare' ? before.phase === 'unprepared'
-    : input.action === 'publish' ? before.facts.localTag && ['prepared', 'partially-published'].includes(before.phase)
-      : ['published', 'post-pending'].includes(before.phase);
-  if (!allowed) return { status: before.phase === 'complete' ? 'no-op' as const : 'failed' as const, changed: false, before, snapshot: before, error: before.phase === 'complete' ? null : { code: 'RELEASE_PHASE_INVALID', message: `Cannot ${input.action} from ${before.phase}` } };
-  await input[input.action]?.();
-  const snapshot = releaseSnapshot(input.version, await input.inspect());
-  const progressed = snapshot.phase !== before.phase;
-  return { status: progressed ? 'applied' as const : 'blocked' as const, changed: progressed, before, snapshot, error: progressed ? null : { code: 'RELEASE_PROGRESS_PENDING', message: `${input.action} has not reached the next observable phase` } };
-}
-
-export { deriveReleasePhase, releaseSnapshot, runReleaseAction };
-export type { ReleaseFacts, ReleasePhase };
+export { createPostConfirmation, deriveReleasePhase, releaseSnapshot };
+export type { PostConfirmation, PostReleaseFacts, ReleaseFacts, ReleasePhase };

--- a/templates/.agents/rules/no-mid-flow-questions.en.md
+++ b/templates/.agents/rules/no-mid-flow-questions.en.md
@@ -47,6 +47,7 @@ SKILLs currently covered by this exemption:
 
 - `release`: may confirm publish after presenting the latest release snapshot
 - `create-release-note`: may confirm publish after presenting exact staged notes and their digest
+- `post-release`: may confirm a normal push after preparing the local post commit and presenting the complete `postConfirmation` and digest
 
 ### Exemption 5: Complete model policy missing at lifecycle start
 

--- a/templates/.agents/rules/no-mid-flow-questions.zh-CN.md
+++ b/templates/.agents/rules/no-mid-flow-questions.zh-CN.md
@@ -47,6 +47,7 @@
 
 - `release`：展示最新 release snapshot 后确认是否 publish
 - `create-release-note`：展示 stage 后的精确 notes 与摘要后确认是否 publish
+- `post-release`：完成本地 post commit 并展示完整 `postConfirmation` 与摘要后确认是否普通 push
 
 ### 例外 5：生命周期启动缺少完整模型策略
 

--- a/templates/.agents/skills/post-release/SKILL.en.md
+++ b/templates/.agents/skills/post-release/SKILL.en.md
@@ -15,16 +15,42 @@ Require one explicit canonical SemVer `{version}`. Do not fall back to the lates
 agent-infra-internal release-workflow inspect {version}
 ```
 
-Pending or unknown is blocked; a definite failure is failed.
+Pending or unknown is blocked; a definite failure is failed. Report `complete` directly from external facts.
 
-## 2. Run Post-release
+## 2. Prepare Local Post-release Work
+
+When incomplete, run:
 
 ```bash
-agent-infra-internal release-workflow post {version}
+agent-infra-internal release-workflow post-prepare {version}
+agent-infra-internal release-workflow inspect {version}
 ```
 
-The core owns build, next development version, inline artifacts, explicit-path commit, normal push, and post-write inspection.
+The core owns build, the optional demo, next development version, inline artifacts, and the explicit-path post commit. This action must not push. Replays recover from Git and channel facts without repeating completed work.
 
-## 3. Report the Snapshot
+## 3. Check the Confirmation Snapshot
 
-Report channel, smoke, commit, and push facts without presenting degraded or blocked as complete.
+- `complete`: report completion without asking or publishing.
+- `postConfirmation` present: display every field and its `sha256`, then continue to step 4.
+- `postConfirmation` absent: report diagnostics such as `isHead=false` or a dirty worktree/index and stop without asking or publishing.
+
+## 4. Authorize the Current Snapshot
+
+Only after displaying the complete `postConfirmation` in the current session, ask once whether to publish. Continue only for an unambiguous affirmative answer. Denial, adjustment, a question, ambiguity, or interruption stops. Authorization never carries across sessions or snapshots.
+
+## 5. Publish the Confirmed Snapshot
+
+```bash
+agent-infra-internal release-workflow post-publish {version} \
+  --expected-sha256 "{post-confirmation-sha256}"
+```
+
+The core re-inspects and verifies the digest before one normal branch push; force pushes are forbidden. On snapshot drift, stop and return to step 1 for a new display and authorization.
+
+## 6. Re-inspect and Report
+
+```bash
+agent-infra-internal release-workflow inspect {version}
+```
+
+Report all channel, released/new version, smoke, post commit, and remote branch facts. Describe completion only for phase `complete`; never present failed, degraded, or blocked as success.

--- a/templates/.agents/skills/post-release/SKILL.zh-CN.md
+++ b/templates/.agents/skills/post-release/SKILL.zh-CN.md
@@ -15,16 +15,42 @@ description: >
 agent-infra-internal release-workflow inspect {version}
 ```
 
-pending/unknown 必须 blocked，确定失败必须 failed。
+pending/unknown 必须 blocked，确定失败必须 failed。`complete` 直接按外部事实报告完成。
 
-## 2. 执行后处理
+## 2. 准备本地后处理
+
+尚未完成时执行：
 
 ```bash
-agent-infra-internal release-workflow post {version}
+agent-infra-internal release-workflow post-prepare {version}
+agent-infra-internal release-workflow inspect {version}
 ```
 
-core 负责 build、下一开发版本、内联产物、显式路径 commit 与普通 push，并在写后复核。
+core 负责 build、可选 demo、下一开发版本、内联产物和显式路径 post commit；该动作不得 push。重跑从 Git 与渠道事实恢复，不重复已完成操作。
 
-## 3. 输出摘要
+## 3. 检查确认快照
 
-报告全部渠道、smoke、commit 与 push 事实，不把 degraded/blocked 表述为完成。
+- `complete`：报告完成，不询问、不 publish。
+- 存在 `postConfirmation`：展示完整字段和 `sha256`，进入步骤 4。
+- 不存在 `postConfirmation`：报告 `isHead=false`、工作树或暂存区非空等诊断并停止，不询问、不 publish。
+
+## 4. 获取当前快照授权
+
+仅在当前会话已展示完整 `postConfirmation` 后询问一次是否发布。只有无歧义肯定答复才继续；否定、调整、疑问、歧义或中断均停止。授权不跨会话或快照复用。
+
+## 5. 发布已确认快照
+
+```bash
+agent-infra-internal release-workflow post-publish {version} \
+  --expected-sha256 "{post-confirmation-sha256}"
+```
+
+core 重新 inspect 并校验摘要后仅执行普通 branch push，禁止 force push。摘要漂移时停止并回到步骤 1 重新展示、重新确认。
+
+## 6. 写后复核并报告
+
+```bash
+agent-infra-internal release-workflow inspect {version}
+```
+
+报告全部渠道、released/new version、smoke、post commit 与远端 branch 事实；只有阶段为 `complete` 才表述为完成，不把 failed/degraded/blocked 表述为成功。

--- a/tests/integration/cli/release-workflow.test.ts
+++ b/tests/integration/cli/release-workflow.test.ts
@@ -6,68 +6,260 @@ import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
-import { INTERNAL_CLI_PATH, gitSafeEnv } from '../../helpers.ts';
+import { INTERNAL_CLI_PATH, gitSafeEnv, onPlatforms } from '../../helpers.ts';
+import { computeDemoInputDigest } from '../../../lib/internal/release-workflow.ts';
+
+type Fixture = { root: string; origin: string; preload: string; tools: string; environment: NodeJS.ProcessEnv };
+
+function fixture(version = '0.8.6'): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-workflow-cli-'));
+  const origin = fs.mkdtempSync(path.join(os.tmpdir(), 'release-workflow-origin-'));
+  const tools = fs.mkdtempSync(path.join(os.tmpdir(), 'release-workflow-tools-'));
+  const preload = path.join(root, 'fake-fetch.mjs');
+  execFileSync('git', ['init', '-q', '--bare', origin]);
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: root });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: root });
+  execFileSync('git', ['config', 'tag.gpgsign', 'false'], { cwd: root });
+  execFileSync('git', ['remote', 'add', 'origin', origin], { cwd: root });
+  fs.mkdirSync(path.join(root, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version }));
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ project: 'widgets', org: 'acme', platform: { type: 'gitea' } }));
+  fs.writeFileSync(path.join(root, 'tracked.txt'), 'initial\n');
+  fs.writeFileSync(preload, 'globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}), text: async () => "" });\n');
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'initial'], { cwd: root });
+  return { root, origin, preload, tools, environment: {} };
+}
+
+function runCli(input: Fixture, ...args: string[]) {
+  return spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'release-workflow', ...args, '--cwd', input.root], {
+    cwd: input.root,
+    encoding: 'utf8',
+    env: { ...gitSafeEnv(), ...input.environment, NODE_OPTIONS: `--import=${pathToFileURL(input.preload).href}` }
+  });
+}
+
+function remoteSha(input: Fixture, ref: string): string | null {
+  const output = spawnSync('git', ['ls-remote', '--exit-code', input.origin, ref], { encoding: 'utf8' });
+  return output.status === 0 ? output.stdout.trim().split(/\s+/)[0] ?? null : null;
+}
+
+function cleanup(input: Fixture) {
+  fs.rmSync(input.root, { recursive: true, force: true });
+  fs.rmSync(input.origin, { recursive: true, force: true });
+  fs.rmSync(input.tools, { recursive: true, force: true });
+}
+
+function enableGitHubChannels(input: Fixture, version: string, tagSha: string) {
+  fs.writeFileSync(path.join(input.root, '.agents', '.airc.json'), JSON.stringify({ project: 'widgets', org: 'acme', platform: { type: 'github' } }));
+  fs.writeFileSync(input.preload, `globalThis.fetch = async (url) => String(url).includes('registry.npmjs.org')
+    ? ({ ok: true, status: 200, json: async () => ({ version: '${version}' }), text: async () => '' })
+    : ({ ok: true, status: 200, json: async () => ({}), text: async () => 'url "https://registry.npmjs.org/@acme/widgets/-/widgets-${version}.tgz"\\nbottle do\\nend\\n' });\n`);
+  const git = path.join(input.tools, 'git');
+  fs.writeFileSync(git, '#!/bin/sh\nif [ "$1" = remote ] && [ "$2" = get-url ] && [ "$3" = origin ]; then printf "%s\\n" https://github.com/acme/widgets; exit 0; fi\nexec /usr/bin/git "$@"\n');
+  fs.chmodSync(git, 0o755);
+  const gh = path.join(input.tools, 'gh-fake.mjs');
+  fs.writeFileSync(gh, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === '--version') console.log('gh version 2.80.0');
+else if (args[0] === 'api' && args[1] === 'user') console.log(JSON.stringify({ login: 'codex' }));
+else if (args[0] === 'api') console.log(JSON.stringify({ full_name: 'acme/widgets', permissions: { triage: true, push: true, admin: true } }));
+else if (args[0] === 'release') console.log(JSON.stringify({ tagName: 'v${version}', isDraft: false, url: 'https://example.test/release' }));
+else if (args[0] === 'run') console.log(JSON.stringify([{ workflowName: 'Post-Release Smoke', event: 'workflow_run', headSha: '${tagSha}', status: 'completed', conclusion: 'success', createdAt: '2026-08-14T00:00:00Z', databaseId: 1, attempt: 1 }]));
+else process.exitCode = 1;
+`);
+  fs.chmodSync(gh, 0o755);
+  input.environment = {
+    PATH: `${input.tools}:${process.env.PATH}`,
+    AGENT_INFRA_GH_BIN: gh,
+    AGENT_INFRA_PLATFORM_RETRY_DELAYS_MS: '0'
+  };
+}
+
+function addPostPrepareInputs(input: Fixture) {
+  const files = [
+    'assets/demo-init.tape', 'scripts/demo-regen.sh', 'scripts/normalize-gif-duration.py',
+    'bin/cli.ts', 'lib/init.ts', 'lib/log.ts', 'lib/prompt.ts', 'lib/paths.ts',
+    'lib/render.ts', 'lib/builtin-tuis.ts', 'lib/sandbox/engines/index.ts',
+    'src/sync-templates.js', 'templates/AGENTS.md', 'scripts/build-inline.js'
+  ];
+  for (const file of files) {
+    fs.mkdirSync(path.dirname(path.join(input.root, file)), { recursive: true });
+    fs.writeFileSync(path.join(input.root, file), file === 'scripts/build-inline.js' ? '' : `${file}\n`);
+  }
+  fs.writeFileSync(path.join(input.root, 'package.json'), JSON.stringify({
+    name: '@acme/widgets', version: '0.8.6', scripts: { build: 'node -e ""' }
+  }));
+  execFileSync('git', ['add', '.'], { cwd: input.root });
+  fs.writeFileSync(path.join(input.root, 'assets', 'demo-init.inputs.sha256'), `${computeDemoInputDigest(input.root)}\n`);
+  execFileSync('git', ['add', '.'], { cwd: input.root });
+  execFileSync('git', ['commit', '-qm', 'release inputs'], { cwd: input.root });
+}
 
 test('release-workflow CLI rebuilds inspect phase from observable facts', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-workflow-cli-'));
-  const preload = path.join(root, 'fake-fetch.mjs');
+  const input = fixture();
   try {
-    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
-    execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: root });
-    execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: root });
-    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: root });
-    execFileSync('git', ['config', 'tag.gpgsign', 'false'], { cwd: root });
-    fs.mkdirSync(path.join(root, '.agents'), { recursive: true });
-    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version: '0.8.6-alpha.0' }));
-    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ project: 'widgets', org: 'acme', platform: { type: 'gitea' } }));
-    fs.writeFileSync(path.join(root, 'tracked.txt'), 'initial\n');
-    execFileSync('git', ['add', '.'], { cwd: root });
-    execFileSync('git', ['commit', '-qm', 'initial'], { cwd: root });
-    fs.writeFileSync(preload, 'globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}), text: async () => "" });\n');
-    const result = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'release-workflow', 'inspect', '0.8.6'], {
-      cwd: root, encoding: 'utf8', env: { ...gitSafeEnv(), NODE_OPTIONS: `--import=${pathToFileURL(preload).href}` }
-    });
+    const result = runCli(input, 'inspect', '0.8.6');
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.snapshot.phase, 'unprepared');
     assert.equal(payload.snapshot.facts.npm, false);
     assert.equal(payload.snapshot.facts.homebrew, false);
+    assert.equal(payload.snapshot.facts.post.commit, null);
   } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    cleanup(input);
   }
 });
 
-test('release-workflow CLI keeps a completed post fact after later commits', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-workflow-history-'));
-  const preload = path.join(root, 'fake-fetch.mjs');
+test('release publish requires an exact local tag and leaves the remote unchanged', () => {
+  const input = fixture();
   try {
-    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
-    execFileSync('git', ['config', 'user.name', 'Codex'], { cwd: root });
-    execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: root });
-    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: root });
-    execFileSync('git', ['config', 'tag.gpgsign', 'false'], { cwd: root });
-    fs.mkdirSync(path.join(root, '.agents'), { recursive: true });
-    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version: '0.8.6-alpha.0' }));
-    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ project: 'widgets', org: 'acme', platform: { type: 'gitea' } }));
-    fs.writeFileSync(path.join(root, 'tracked.txt'), 'release\n');
-    execFileSync('git', ['add', '.'], { cwd: root });
-    execFileSync('git', ['commit', '-qm', 'release'], { cwd: root });
-    execFileSync('git', ['tag', 'v0.8.6'], { cwd: root });
-    fs.appendFileSync(path.join(root, 'tracked.txt'), 'post\n');
-    execFileSync('git', ['commit', '-qam', 'chore: prepare next dev iteration after v0.8.6'], { cwd: root });
-    fs.appendFileSync(path.join(root, 'tracked.txt'), 'later\n');
-    execFileSync('git', ['commit', '-qam', 'fix: later change'], { cwd: root });
-    fs.writeFileSync(preload, 'globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}), text: async () => "" });\n');
-    const result = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'release-workflow', 'inspect', '0.8.6'], {
-      cwd: root, encoding: 'utf8', env: { ...gitSafeEnv(), NODE_OPTIONS: `--import=${pathToFileURL(preload).href}` }
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const facts = JSON.parse(result.stdout).snapshot.facts;
-    assert.equal(facts.localTag, false);
-    assert.equal(facts.localTagAncestor, true);
-    assert.equal(facts.localTagConflict, false);
-    assert.equal(facts.postCommit, true);
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    fs.appendFileSync(path.join(input.root, 'tracked.txt'), 'later\n');
+    execFileSync('git', ['commit', '-qam', 'fix: later change'], { cwd: input.root });
+
+    const result = runCli(input, 'publish', '0.8.6');
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error.code, 'RELEASE_PHASE_INVALID');
+    assert.equal(remoteSha(input, 'refs/heads/main'), null);
+    assert.equal(remoteSha(input, 'refs/tags/v0.8.6'), null);
   } finally {
-    fs.rmSync(root, { recursive: true, force: true });
+    cleanup(input);
+  }
+});
+
+test('release prepare never publishes and partial publish can be replayed', () => {
+  const input = fixture();
+  try {
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    const prepared = runCli(input, 'prepare', '0.8.6');
+    assert.equal(prepared.status, 0, prepared.stderr);
+    assert.equal(remoteSha(input, 'refs/heads/main'), null);
+    assert.equal(remoteSha(input, 'refs/tags/v0.8.6'), null);
+
+    execFileSync('git', ['push', '-q', 'origin', 'main'], { cwd: input.root });
+    const published = runCli(input, 'publish', '0.8.6');
+    assert.equal(published.status, 0, published.stderr);
+    assert.equal(remoteSha(input, 'refs/heads/main'), execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim());
+    assert.equal(remoteSha(input, 'refs/tags/v0.8.6'), execFileSync('git', ['rev-parse', 'v0.8.6^{commit}'], { cwd: input.root, encoding: 'utf8' }).trim());
+  } finally {
+    cleanup(input);
+  }
+});
+
+test('post inspect exposes confirmation only for a clean current post commit', () => {
+  const input = fixture();
+  try {
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    execFileSync('git', ['push', '-q', 'origin', 'main', 'refs/tags/v0.8.6'], { cwd: input.root });
+    fs.writeFileSync(path.join(input.root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version: '0.8.7-alpha.0' }));
+    execFileSync('git', ['commit', '-qam', 'chore: prepare next dev iteration after v0.8.6'], { cwd: input.root });
+
+    const prepared = JSON.parse(runCli(input, 'inspect', '0.8.6').stdout).snapshot;
+    assert.equal(prepared.phase, 'post-prepared');
+    assert.equal(prepared.facts.post.isHead, true);
+    assert.match(prepared.postConfirmation.sha256, /^sha256:[0-9a-f]{64}$/);
+
+    fs.appendFileSync(path.join(input.root, 'tracked.txt'), 'dirty\n');
+    const dirty = JSON.parse(runCli(input, 'inspect', '0.8.6').stdout).snapshot;
+    assert.equal(dirty.phase, 'post-prepared');
+    assert.equal(Object.hasOwn(dirty, 'postConfirmation'), false);
+    fs.writeFileSync(path.join(input.root, 'tracked.txt'), 'initial\n');
+
+    fs.appendFileSync(path.join(input.root, 'tracked.txt'), 'later\n');
+    execFileSync('git', ['commit', '-qam', 'fix: later change'], { cwd: input.root });
+    const drifted = JSON.parse(runCli(input, 'inspect', '0.8.6').stdout).snapshot;
+    assert.equal(drifted.facts.post.isHead, false);
+    assert.equal(Object.hasOwn(drifted, 'postConfirmation'), false);
+  } finally {
+    cleanup(input);
+  }
+});
+
+test('post publish rejects a stale confirmation without changing the remote', () => {
+  const input = fixture();
+  try {
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    execFileSync('git', ['push', '-q', 'origin', 'main', 'refs/tags/v0.8.6'], { cwd: input.root });
+    const baseline = remoteSha(input, 'refs/heads/main');
+    fs.writeFileSync(path.join(input.root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version: '0.8.7-alpha.0' }));
+    execFileSync('git', ['commit', '-qam', 'chore: prepare next dev iteration after v0.8.6'], { cwd: input.root });
+
+    const result = runCli(input, 'post-publish', '0.8.6', '--expected-sha256', `sha256:${'0'.repeat(64)}`);
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error.code, 'RELEASE_POST_SNAPSHOT_MISMATCH');
+    assert.equal(remoteSha(input, 'refs/heads/main'), baseline);
+  } finally {
+    cleanup(input);
+  }
+});
+
+test('post prepare creates a confirmable commit without changing the remote', onPlatforms('linux', 'darwin'), () => {
+  const input = fixture();
+  try {
+    addPostPrepareInputs(input);
+    let tagSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim();
+    enableGitHubChannels(input, '0.8.6', tagSha);
+    execFileSync('git', ['add', '.'], { cwd: input.root });
+    execFileSync('git', ['commit', '--amend', '--no-edit', '-q'], { cwd: input.root });
+    tagSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim();
+    enableGitHubChannels(input, '0.8.6', tagSha);
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    execFileSync('git', ['push', '-q', 'origin', 'main', 'refs/tags/v0.8.6'], { cwd: input.root });
+    const baseline = remoteSha(input, 'refs/heads/main');
+
+    const prepared = runCli(input, 'post-prepare', '0.8.6');
+    assert.equal(prepared.status, 0, prepared.stderr);
+    const snapshot = JSON.parse(prepared.stdout).snapshot;
+    assert.equal(snapshot.phase, 'post-prepared');
+    assert.match(snapshot.postConfirmation.sha256, /^sha256:[0-9a-f]{64}$/);
+    assert.equal(remoteSha(input, 'refs/heads/main'), baseline);
+  } finally {
+    cleanup(input);
+  }
+});
+
+test('post publish performs one normal push and complete replay is a no-op', onPlatforms('linux', 'darwin'), () => {
+  const input = fixture();
+  try {
+    fs.appendFileSync(path.join(input.root, 'tracked.txt'), 'release\n');
+    execFileSync('git', ['commit', '-qam', 'release'], { cwd: input.root });
+    const tagSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim();
+    enableGitHubChannels(input, '0.8.6', tagSha);
+    execFileSync('git', ['add', '.'], { cwd: input.root });
+    execFileSync('git', ['commit', '--amend', '--no-edit', '-q'], { cwd: input.root });
+    const amendedTagSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim();
+    enableGitHubChannels(input, '0.8.6', amendedTagSha);
+    execFileSync('git', ['tag', 'v0.8.6'], { cwd: input.root });
+    execFileSync('git', ['push', '-q', 'origin', 'main', 'refs/tags/v0.8.6'], { cwd: input.root });
+    fs.writeFileSync(path.join(input.root, 'package.json'), JSON.stringify({ name: '@acme/widgets', version: '0.8.7-alpha.0' }));
+    execFileSync('git', ['commit', '-qam', 'chore: prepare next dev iteration after v0.8.6'], { cwd: input.root });
+
+    const prepared = JSON.parse(runCli(input, 'inspect', '0.8.6').stdout).snapshot;
+    assert.equal(prepared.phase, 'post-prepared');
+    const published = runCli(input, 'post-publish', '0.8.6', '--expected-sha256', prepared.postConfirmation.sha256);
+    assert.equal(published.status, 0, published.stderr);
+    assert.equal(JSON.parse(published.stdout).snapshot.phase, 'complete');
+    assert.equal(remoteSha(input, 'refs/heads/main'), execFileSync('git', ['rev-parse', 'HEAD'], { cwd: input.root, encoding: 'utf8' }).trim());
+
+    const replayed = runCli(input, 'post-publish', '0.8.6', '--expected-sha256', prepared.postConfirmation.sha256);
+    assert.equal(replayed.status, 0, replayed.stderr);
+    assert.equal(JSON.parse(replayed.stdout).status, 'no-op');
+  } finally {
+    cleanup(input);
+  }
+});
+
+test('legacy post action fails closed without changing the remote', () => {
+  const input = fixture();
+  try {
+    const result = runCli(input, 'post', '0.8.6');
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error.code, 'RELEASE_INPUT_INVALID');
+    assert.equal(remoteSha(input, 'refs/heads/main'), null);
+  } finally {
+    cleanup(input);
   }
 });

--- a/tests/unit/release/post-release.test.ts
+++ b/tests/unit/release/post-release.test.ts
@@ -9,6 +9,7 @@ import {
   changedPaths,
   computeDemoInputDigest,
   inspectLocalReleaseFacts,
+  inspectPostReleaseFacts,
   inspectPostWorktree,
   releaseSmokeStatus,
   runOptionalDemo
@@ -91,14 +92,15 @@ test('local release facts distinguish exact, ancestor, and divergent tags with b
   const root = releaseFixture();
   try {
     assert.deepEqual(inspectLocalReleaseFacts(root, '1.2.3'), {
-      localTag: true, localTagAncestor: false, localTagConflict: false, postCommit: false
+      localTag: true, localTagAncestor: false, localTagConflict: false, postCommit: null
     });
     fs.appendFileSync(path.join(root, 'tracked.txt'), 'post\n');
     commit(root, 'chore: prepare next dev iteration after v1.2.3');
     fs.appendFileSync(path.join(root, 'tracked.txt'), 'ordinary\n');
     commit(root, 'fix: ordinary follow-up');
+    const postCommit = spawnSync('git', ['rev-parse', 'HEAD~1'], { cwd: root, encoding: 'utf8' }).stdout.trim();
     assert.deepEqual(inspectLocalReleaseFacts(root, '1.2.3'), {
-      localTag: false, localTagAncestor: true, localTagConflict: false, postCommit: true
+      localTag: false, localTagAncestor: true, localTagConflict: false, postCommit
     });
 
     spawnSync('git', ['switch', '-q', '--orphan', 'divergent'], { cwd: root });
@@ -106,8 +108,36 @@ test('local release facts distinguish exact, ancestor, and divergent tags with b
     fs.writeFileSync(path.join(root, 'other.txt'), 'other\n');
     commit(root, 'divergent');
     assert.deepEqual(inspectLocalReleaseFacts(root, '1.2.3'), {
-      localTag: false, localTagAncestor: false, localTagConflict: true, postCommit: false
+      localTag: false, localTagAncestor: false, localTagConflict: true, postCommit: null
     });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('post release facts are rebuilt from the commit tree and current Git state', () => {
+  const root = releaseFixture();
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: '1.2.4-alpha.0' }));
+    fs.mkdirSync(path.join(root, 'assets'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'assets', 'demo-init.inputs.sha256'), `${'a'.repeat(64)}\n`);
+    commit(root, 'chore: prepare next dev iteration after v1.2.3');
+    const postCommit = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).stdout.trim();
+
+    const post = inspectPostReleaseFacts(root, postCommit);
+    assert.equal(post.commit, postCommit);
+    assert.equal(post.isHead, true);
+    assert.equal(post.published, false);
+    assert.equal(post.branch, 'main');
+    assert.equal(post.newVersion, '1.2.4-alpha.0');
+    assert.equal(post.demoInputSha256, 'a'.repeat(64));
+    assert.deepEqual(post.changedPaths, ['assets/demo-init.inputs.sha256', 'package.json']);
+    assert.deepEqual(post.worktree, []);
+    assert.deepEqual(post.staged, []);
+
+    fs.appendFileSync(path.join(root, 'tracked.txt'), 'later\n');
+    commit(root, 'fix: later change');
+    assert.equal(inspectPostReleaseFacts(root, postCommit).isHead, false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/release/workflow.test.ts
+++ b/tests/unit/release/workflow.test.ts
@@ -1,9 +1,34 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { deriveReleasePhase, runReleaseAction } from '../../../lib/release/workflow.ts';
-import type { ReleaseFacts } from '../../../lib/release/workflow.ts';
+import { createPostConfirmation, deriveReleasePhase } from '../../../lib/release/workflow.ts';
+import type { PostReleaseFacts, ReleaseFacts } from '../../../lib/release/workflow.ts';
 
-const facts = (overrides: Partial<ReleaseFacts> = {}): ReleaseFacts => ({ localTag: false, remoteBranch: false, remoteTag: false, githubRelease: false, npm: false, homebrew: false, smoke: null, postCommit: false, ...overrides });
+const postFacts = (overrides: Partial<PostReleaseFacts> = {}): PostReleaseFacts => ({
+  commit: null,
+  isHead: false,
+  published: false,
+  branch: 'main',
+  upstream: 'origin/main',
+  remoteHead: null,
+  newVersion: null,
+  changedPaths: [],
+  demoInputSha256: null,
+  worktree: [],
+  staged: [],
+  ...overrides
+});
+
+const facts = (overrides: Partial<ReleaseFacts> = {}): ReleaseFacts => ({
+  localTag: false,
+  remoteBranch: false,
+  remoteTag: false,
+  githubRelease: false,
+  npm: false,
+  homebrew: false,
+  smoke: null,
+  post: postFacts(),
+  ...overrides
+});
 
 test('release phase is derived only from observable facts', () => {
   assert.equal(deriveReleasePhase(facts()), 'unprepared');
@@ -13,33 +38,54 @@ test('release phase is derived only from observable facts', () => {
   assert.equal(deriveReleasePhase(facts({ localTag: true, remoteBranch: true, remoteTag: true })), 'published');
   assert.equal(deriveReleasePhase(facts({ localTagAncestor: true, remoteBranch: true, remoteTag: true })), 'published');
   assert.equal(deriveReleasePhase(facts({ localTag: true, remoteBranch: true, remoteTag: true, githubRelease: true, npm: true, homebrew: true })), 'post-pending');
-  assert.equal(deriveReleasePhase(facts({ localTagAncestor: true, remoteBranch: true, remoteTag: true, githubRelease: true, npm: true, homebrew: true, smoke: 'success', postCommit: true })), 'complete');
+
+  const prepared = postFacts({ commit: 'a'.repeat(40), isHead: true });
+  assert.equal(deriveReleasePhase(facts({ localTagAncestor: true, post: prepared })), 'post-prepared');
+  assert.equal(deriveReleasePhase(facts({ localTagAncestor: true, post: { ...prepared, published: true } })), 'complete');
 });
 
-test('publish is independently authorized and replayable after partial progress', async () => {
-  let current = facts({ localTag: true, remoteBranch: true });
-  const result = await runReleaseAction({ version: '1.2.3', action: 'publish', inspect: async () => current, publish: async () => { current = facts({ localTag: true, remoteBranch: true, remoteTag: true }); } });
-  assert.equal(result.status, 'applied');
-  assert.equal(result.before.phase, 'partially-published');
-  assert.equal(result.snapshot.phase, 'published');
-});
-
-test('prepare never performs publish and invalid phase fails closed', async () => {
-  let publishCalls = 0;
-  const result = await runReleaseAction({ version: '1.2.3', action: 'prepare', inspect: async () => facts({ localTag: true }), publish: async () => { publishCalls += 1; } });
-  assert.equal(result.status, 'failed');
-  assert.equal(publishCalls, 0);
-});
-
-test('publish requires an exact local tag even when ancestor facts derive a publishable phase', async () => {
-  let publishCalls = 0;
-  const result = await runReleaseAction({
-    version: '1.2.3',
-    action: 'publish',
-    inspect: async () => facts({ localTagAncestor: true, remoteBranch: true }),
-    publish: async () => { publishCalls += 1; }
+test('post confirmation is deterministic and only available for a clean post HEAD', () => {
+  const post = postFacts({
+    commit: 'a'.repeat(40),
+    isHead: true,
+    remoteHead: 'b'.repeat(40),
+    newVersion: '1.2.4-alpha.0',
+    changedPaths: ['z.txt', 'a.txt'],
+    demoInputSha256: 'c'.repeat(64)
   });
-  assert.equal(result.status, 'failed');
-  assert.equal(result.error?.code, 'RELEASE_PHASE_INVALID');
-  assert.equal(publishCalls, 0);
+
+  const first = createPostConfirmation('1.2.3', post);
+  const second = createPostConfirmation('1.2.3', { ...post, changedPaths: ['a.txt', 'z.txt'] });
+  assert.ok(first);
+  assert.deepEqual(second, first);
+  assert.deepEqual(first.changedPaths, ['a.txt', 'z.txt']);
+  assert.match(first.sha256, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(createPostConfirmation('1.2.3', { ...post, isHead: false }), null);
+  assert.equal(createPostConfirmation('1.2.3', { ...post, worktree: ['dirty.txt'] }), null);
+  assert.equal(createPostConfirmation('1.2.3', { ...post, staged: ['staged.txt'] }), null);
+});
+
+test('post confirmation digest changes when any authorized fact changes', () => {
+  const post = postFacts({
+    commit: 'a'.repeat(40),
+    isHead: true,
+    remoteHead: 'b'.repeat(40),
+    newVersion: '1.2.4-alpha.0',
+    changedPaths: ['package.json'],
+    demoInputSha256: 'c'.repeat(64)
+  });
+  const baseline = createPostConfirmation('1.2.3', post)?.sha256;
+  assert.ok(baseline);
+
+  const variants: PostReleaseFacts[] = [
+    { ...post, commit: 'd'.repeat(40) },
+    { ...post, branch: 'release' },
+    { ...post, upstream: 'fork/main' },
+    { ...post, remoteHead: 'e'.repeat(40) },
+    { ...post, newVersion: '1.2.5-alpha.0' },
+    { ...post, changedPaths: ['package-lock.json'] },
+    { ...post, demoInputSha256: 'f'.repeat(64) }
+  ];
+  for (const variant of variants) assert.notEqual(createPostConfirmation('1.2.3', variant)?.sha256, baseline);
+  assert.notEqual(createPostConfirmation('1.2.4', post)?.sha256, baseline);
 });

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -123,6 +123,14 @@ test("release skills keep staging, publishing, and versioned follow-up commands 
     assert.match(content.slice(publish), /--expected-sha256/, relativePath);
     assert.match(content.slice(next), /--version <version>/, relativePath);
   }
+
+  for (const relativePath of skillDocPaths("post-release")) {
+    const content = read(relativePath);
+    const prepare = content.indexOf("release-workflow post-prepare {version}");
+    const publish = content.indexOf("release-workflow post-publish {version}");
+    assert.ok(prepare >= 0 && publish > prepare, relativePath);
+    assert.match(content.slice(publish), /--expected-sha256/, relativePath);
+  }
 });
 
 test("post-release command templates expose and forward one version argument", () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #826

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix

## 📝 变更目的 / Purpose of the Change

修复 `post-release` 完成本地后处理后未经独立确认便直接推送远端的问题，使远端发布授权绑定到当前已展示且经过复核的精确快照。

## 📋 主要变更 / Brief Changelog

- 将 post-release 拆分为本地 `post-prepare` 与远端 `post-publish` 两个阶段。
- 使用覆盖 commit、分支、upstream、版本、路径及 demo facts 的摘要绑定发布授权，并在快照漂移时默认拒绝。
- 保留普通 push、外部事实恢复及幂等重放语义，移除旧的一步式发布旁路。
- 同步运行时技能、禁言规则、英文/中文模板及单元和集成测试。

## 🧪 验证变更 / Verifying this Change

### 测试覆盖 / Test Coverage

- [x] 已添加单元测试和集成测试 / Added unit and integration tests
- [x] `npm run build` 通过
- [x] `npm test`：2258 tests，2254 passed，4 skipped，0 failed
- [x] 提交树与 Round 3 Approved review snapshot 完全一致

### ✅ 人工验证 / Manual Validation

- 无需人工校验；远端零写入、确认后发布、摘要漂移拒绝和幂等重放均由自动化测试覆盖。

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只处理 Issue #826
- [x] 已完成自我检查和代码审查
- [x] 已更新对应英文/中文模板与规则
- [x] 已考虑兼容性、失败关闭和重试语义

Closes #826

Generated with AI assistance
