### PR TITLE
fix(sandbox): 阻止 sandbox 删除脏 worktree


### DIFF
--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -164,12 +164,20 @@ the host and the sandbox without polluting the git worktree:
 These paths are intentionally hardcoded; there is no `.airc.json` knob. Both
 host directories are created automatically on first `create`. When you
 `ai sandbox rm <branch>`, you will be prompted (default yes) to clean up the
-corresponding share dirs alongside the worktrees. `ai sandbox rm --all` batch
-removes every sandbox **not bound to an active task** (i.e. the `-` rows in
-`ai sandbox ls`); add `--dry-run` to preview or `--yes` to skip the confirmation
-(required in non-interactive shells). `ai sandbox rm --purge` tears down **all**
-project sandboxes (containers, worktrees, image, VM). **Breaking change:** prior
-to this, `--all` meant the full teardown that `--purge` now performs.
+corresponding share dirs alongside the worktrees. `ai sandbox rm --unbound`
+batch-removes every sandbox **not bound to an active task** (i.e. the `-` rows
+in `ai sandbox ls`); add `--dry-run` to preview or `--yes` to skip the ordinary
+confirmation (required in non-interactive shells). `ai sandbox rm --purge`
+tears down **all** project sandboxes (containers, worktrees, image, VM).
+**Breaking change:** `--all` has been removed; old calls fail with a migration
+error and must use `--unbound`.
+
+All removal paths inspect every target worktree before destructive cleanup.
+Staged, unstaged, conflicted, or non-ignored untracked changes make batch,
+purge, prune, `--yes`, and other non-interactive removal fail closed. A single
+interactive `ai sandbox rm <branch>` may discard changes only after displaying
+the exact dirty snapshot and receiving a separate confirmation that defaults
+to no. If the snapshot changes before deletion, authorization expires.
 Use `ai sandbox prune --dry-run` to inspect orphaned per-branch state dirs left
 behind by older versions or interrupted cleanup, then `ai sandbox prune` to
 remove only dirs without an active sandbox container.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -149,7 +149,9 @@ tmpfs runtime 数据本来就是临时数据。tmpfs 丢失后，`/home/devuser/
 - `/share/branch` <- `~/.agent-infra/share/<project>/branches/<branch>/`：分支独占。
 - `/clipboard` <- `~/.agent-infra/clipboard/`：macOS 图片粘贴桥接使用的只读存储。
 
-这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；执行 `ai sandbox rm <branch>` 删除时会附带询问是否清理（默认 yes）。`ai sandbox rm --all` 批量删除所有**未绑定 active 任务**的沙箱（即 `ai sandbox ls` 中短号为 `-` 的行）；可加 `--dry-run` 预览，或 `--yes` 跳过确认（非交互 shell 中必须显式传 `--yes`）。`ai sandbox rm --purge` 则拆除项目的**全部**沙箱（容器、worktree、镜像、VM）。**破坏性变更**：此前 `--all` 的语义即现在 `--purge` 的全量拆除。
+这两条路径硬编码，不暴露 `.airc.json` 配置项。首次 `create` 时会自动创建宿主目录；执行 `ai sandbox rm <branch>` 删除时会附带询问是否清理（默认 yes）。`ai sandbox rm --unbound` 批量删除所有**未绑定 active 任务**的沙箱（即 `ai sandbox ls` 中短号为 `-` 的行）；可加 `--dry-run` 预览，或 `--yes` 跳过普通确认（非交互 shell 中必须显式传 `--yes`）。`ai sandbox rm --purge` 则拆除项目的**全部**沙箱（容器、worktree、镜像、VM）。**破坏性变更**：`--all` 已移除；旧调用会返回迁移错误，必须改用 `--unbound`。
+
+所有删除路径都会在破坏性清理前检查全部目标 worktree。存在 staged、unstaged、冲突或非 ignored untracked 修改时，批量删除、purge、prune、`--yes` 和其他非交互删除都会 fail closed。只有交互式 `ai sandbox rm <branch>` 可以在展示精确 dirty snapshot 后，通过一次默认否定的独立确认放弃修改；删除前 snapshot 一旦变化，授权立即失效。
 可先用 `ai sandbox prune --dry-run` 查看旧版本或异常中断遗留的孤儿 per-branch 状态目录，再用 `ai sandbox prune` 只删除没有活跃 sandbox 容器对应的目录。
 已有沙箱需要执行 `ai sandbox rm <branch>` 后再执行 `ai sandbox create <branch>`，才能加载挂载点变更，包括已移除的挂载。
 

--- a/lib/sandbox/commands/prune.ts
+++ b/lib/sandbox/commands/prune.ts
@@ -6,15 +6,26 @@ import pc from 'picocolors';
 import { loadConfig } from '../config.ts';
 import type { SandboxConfig } from '../config.ts';
 import { safeNameCandidates, sandboxBranchLabel, sandboxLabel } from '../constants.ts';
-import { detectEngine } from '../engine.ts';
+import { detectEngine, ENGINES } from '../engine.ts';
 import { hostJoin } from '../engines/wsl2-paths.ts';
 import { removeManagedDir, removeWorktreeDir } from '../managed-fs.ts';
 import { parseLabels } from './ls.ts';
 import { runEngine, runSafe } from '../shell.ts';
 import { createSandboxCapabilityPlan } from '../agent-client-reconciler.ts';
 import type { SandboxTool } from '../tools.ts';
+import { createCleanPermit, formatWorktreeSnapshot, inspectWorktrees } from '../worktree-safety.ts';
+import type { WorktreeRemovalPermit } from '../worktree-safety.ts';
 
 const USAGE = `Usage: ai sandbox prune [--dry-run]`;
+
+type PruneDependencies = {
+  config?: SandboxConfig;
+  tools?: SandboxTool[];
+  engine?: string;
+  labelsOutput?: string;
+  confirm?: typeof p.confirm;
+  isCancel?: typeof p.isCancel;
+};
 
 type OrphanKind = 'shell' | 'worktree' | 'share' | 'tool';
 
@@ -107,12 +118,19 @@ export function collectOrphanGroups(
   return groups;
 }
 
-export function removeOrphanGroups(config: SandboxConfig, groups: OrphanGroup[]): boolean {
+export function removeOrphanGroups(
+  config: SandboxConfig,
+  groups: OrphanGroup[],
+  permits: ReadonlyMap<string, WorktreeRemovalPermit>,
+  allowRegisteredPathFallback = false
+): boolean {
   let removedWorktrees = false;
   for (const group of groups) {
     for (const dir of group.dirs) {
       if (group.kind === 'worktree') {
-        removeWorktreeDir(config.repoRoot, group.base, dir);
+        const permit = permits.get(path.resolve(dir));
+        if (!permit) throw new Error(`Missing worktree removal permit: ${dir}`);
+        removeWorktreeDir(config.repoRoot, group.base, dir, permit, { allowRegisteredPathFallback });
         removedWorktrees = true;
       } else {
         removeManagedDir(group.base, dir);
@@ -142,7 +160,7 @@ function writeGroups(groups: OrphanGroup[]): void {
   }
 }
 
-export async function prune(args: string[]): Promise<void> {
+export async function prune(args: string[], dependencies: PruneDependencies = {}): Promise<void> {
   const { values } = parseArgs({
     args,
     strict: true,
@@ -157,9 +175,9 @@ export async function prune(args: string[]): Promise<void> {
     return;
   }
 
-  const config = loadConfig();
-  const tools = [...createSandboxCapabilityPlan(config).cleanupInventory];
-  const engine = detectEngine(config);
+  const config = dependencies.config ?? loadConfig();
+  const tools = dependencies.tools ?? [...createSandboxCapabilityPlan(config).cleanupInventory];
+  const engine = dependencies.engine ?? detectEngine(config);
   const psArgs = [
     'ps',
     '-a',
@@ -168,14 +186,25 @@ export async function prune(args: string[]): Promise<void> {
     '--format',
     '{{.Labels}}'
   ];
-  let labelsOutput: string;
-  try {
-    labelsOutput = runEngine(engine, 'docker', psArgs);
-  } catch {
-    throw new Error('Unable to determine active sandbox branches: docker ps failed');
+  let labelsOutput = dependencies.labelsOutput;
+  if (labelsOutput === undefined) {
+    try {
+      labelsOutput = runEngine(engine, 'docker', psArgs);
+    } catch {
+      throw new Error('Unable to determine active sandbox branches: docker ps failed');
+    }
   }
+  const confirm = dependencies.confirm ?? p.confirm;
+  const isCancel = dependencies.isCancel ?? p.isCancel;
   const groups = collectOrphanGroups(config, tools, activeBranchesFromLabels(config, labelsOutput));
   const count = orphanCount(groups);
+  const worktrees = groups.filter((group) => group.kind === 'worktree').flatMap((group) => group.dirs);
+  const inspections = inspectWorktrees(worktrees);
+  const blockers = inspections.filter((inspection) => inspection.status !== 'clean');
+  const permits = new Map<string, WorktreeRemovalPermit>();
+  for (const inspection of inspections) {
+    if (inspection.status === 'clean') permits.set(inspection.snapshot.worktree, createCleanPermit(inspection.snapshot));
+  }
 
   p.intro(pc.cyan(`Pruning orphaned sandbox state for ${config.project}`));
 
@@ -186,23 +215,32 @@ export async function prune(args: string[]): Promise<void> {
   }
 
   writeGroups(groups);
+  for (const blocker of blockers) {
+    p.log.error(blocker.status === 'failed'
+      ? `${JSON.stringify(blocker.worktree)}: ${blocker.message}`
+      : formatWorktreeSnapshot(blocker.snapshot));
+  }
 
   if (values['dry-run']) {
     p.outro(pc.green('Dry run complete'));
     return;
   }
 
-  const shouldRemove = await p.confirm({
+  if (blockers.length > 0) {
+    throw new Error('Refusing to prune because worktree preflight found blocker(s); no orphan state was deleted');
+  }
+
+  const shouldRemove = await confirm({
     message: `Remove ${count} orphaned sandbox state dirs?`,
     initialValue: true
   });
 
-  if (p.isCancel(shouldRemove) || !shouldRemove) {
+  if (isCancel(shouldRemove) || !shouldRemove) {
     p.outro('Cancelled');
     return;
   }
 
-  const removedWorktrees = removeOrphanGroups(config, groups);
+  const removedWorktrees = removeOrphanGroups(config, groups, permits, engine === ENGINES.WSL2);
   if (removedWorktrees) {
     runSafe('git', ['-C', config.repoRoot, 'worktree', 'prune']);
   }

--- a/lib/sandbox/commands/rm.ts
+++ b/lib/sandbox/commands/rm.ts
@@ -24,10 +24,18 @@ import { createSandboxCapabilityPlan } from '../agent-client-reconciler.ts';
 import type { SandboxTool } from '../tools.ts';
 import { fetchSandboxRows } from './list-running.ts';
 import { lookupShortIdByBranch } from '../../task/short-id.ts';
+import {
+  createCleanPermit,
+  createDiscardPermit,
+  formatWorktreeSnapshot,
+  inspectWorktrees,
+  verifyWorktreePermit
+} from '../worktree-safety.ts';
+import type { WorktreeInspection, WorktreeRemovalPermit } from '../worktree-safety.ts';
 
 const USAGE = `Usage:
   ai sandbox rm <branch>                    Remove one sandbox (branch | TASK-id | short id)
-  ai sandbox rm --all [--dry-run] [--yes]   Remove every sandbox not bound to an active task
+  ai sandbox rm --unbound [--dry-run] [--yes] Remove every sandbox not bound to an active task
   ai sandbox rm --purge                     Tear down ALL sandboxes for the project (containers, worktrees, image, VM)`;
 export { assertManagedPath } from '../managed-fs.ts';
 
@@ -35,14 +43,30 @@ function projectToolDirs(config: SandboxConfig, tools: SandboxTool[]): string[] 
   return tools.flatMap((tool) => toolProjectDirCandidates(tool, config.project));
 }
 
-type RmOneOptions = { assumeYes?: boolean; quiet?: boolean };
+type RmTarget = {
+  branch: string;
+  effectiveBranch: string;
+  engine: string;
+  matchedContainers: string[];
+  existingWorktrees: string[];
+  toolCandidates: Array<{ tool: SandboxTool; candidates: string[] }>;
+};
 
-async function rmOne(
-  config: SandboxConfig,
-  tools: SandboxTool[],
-  branch: string,
-  options: RmOneOptions = {}
-): Promise<void> {
+type RmOneOptions = {
+  assumeYes?: boolean;
+  quiet?: boolean;
+  target?: RmTarget;
+  permits?: ReadonlyMap<string, WorktreeRemovalPermit>;
+  allowDirtyDiscard?: boolean;
+  prompt?: PromptDependencies;
+};
+
+type PromptDependencies = {
+  confirm?: typeof p.confirm;
+  isCancel?: typeof p.isCancel;
+};
+
+function resolveRmTarget(config: SandboxConfig, tools: SandboxTool[], branch: string): RmTarget {
   assertValidBranchName(branch);
   const engine = detectEngine(config);
   let effectiveBranch = branch;
@@ -51,14 +75,8 @@ async function rmOne(
     tool,
     candidates: toolConfigDirCandidates(tool, config.project, branch)
   }));
-
-  if (!options.quiet) {
-    p.intro(pc.cyan(`Removing sandbox for ${branch}`));
-  }
-
   const existing = runSafeEngine(engine, 'docker', ['ps', '-a', '--format', '{{.Names}}']).split('\n').filter(Boolean);
-  const matchedContainers = containerNameCandidates(config, branch)
-    .filter((name) => existing.includes(name));
+  const matchedContainers = containerNameCandidates(config, branch).filter((name) => existing.includes(name));
 
   if (matchedContainers.length > 0) {
     const resolvedBranch = runSafeEngine(engine, 'docker', [
@@ -75,7 +93,107 @@ async function rmOne(
         candidates: toolConfigDirCandidates(tool, config.project, effectiveBranch)
       }));
     }
+  }
 
+  return {
+    branch,
+    effectiveBranch,
+    engine,
+    matchedContainers,
+    existingWorktrees: worktreeCandidates.filter((candidate) => fs.existsSync(candidate)),
+    toolCandidates
+  };
+}
+
+function inspectionBlockers(inspections: readonly WorktreeInspection[]): WorktreeInspection[] {
+  return inspections.filter((inspection) => inspection.status !== 'clean');
+}
+
+function blockerMessage(blockers: readonly WorktreeInspection[]): string {
+  return blockers.map((blocker) => {
+    if (blocker.status === 'failed') return `${JSON.stringify(blocker.worktree)}: ${blocker.message}`;
+    return `${formatWorktreeSnapshot(blocker.snapshot)}\n  Action: commit, stash, clean, or remove this sandbox interactively.`;
+  }).join('\n');
+}
+
+function cleanPermits(inspections: readonly WorktreeInspection[]): Map<string, WorktreeRemovalPermit> {
+  const permits = new Map<string, WorktreeRemovalPermit>();
+  for (const inspection of inspections) {
+    if (inspection.status === 'clean') permits.set(inspection.snapshot.worktree, createCleanPermit(inspection.snapshot));
+  }
+  return permits;
+}
+
+async function authorizeWorktrees(
+  worktrees: readonly string[],
+  { allowDirtyDiscard, assumeYes }: { allowDirtyDiscard: boolean; assumeYes: boolean },
+  {
+    interactive = Boolean(process.stdin.isTTY),
+    confirm = p.confirm,
+    isCancel = p.isCancel
+  }: PromptDependencies & { interactive?: boolean } = {}
+): Promise<Map<string, WorktreeRemovalPermit>> {
+  const inspections = inspectWorktrees(worktrees);
+  const failures = inspections.filter((inspection) => inspection.status === 'failed');
+  if (failures.length > 0) throw new Error(`Unable to inspect worktree(s):\n${blockerMessage(failures)}`);
+  const permits = cleanPermits(inspections);
+  for (const inspection of inspections) {
+    if (inspection.status !== 'dirty') continue;
+    if (!allowDirtyDiscard || assumeYes || !interactive) {
+      throw new Error(`Refusing to remove dirty worktree(s):\n${blockerMessage([inspection])}`);
+    }
+    p.log.warn(formatWorktreeSnapshot(inspection.snapshot));
+    const confirmed = await confirm({
+      message: 'Discard these exact uncommitted changes?',
+      initialValue: false
+    });
+    if (isCancel(confirmed) || !confirmed) throw new Error('Dirty worktree removal cancelled; nothing was deleted');
+    permits.set(inspection.snapshot.worktree, createDiscardPermit(inspection.snapshot));
+  }
+  return permits;
+}
+
+async function rmOne(
+  config: SandboxConfig,
+  tools: SandboxTool[],
+  branch: string,
+  options: RmOneOptions = {}
+): Promise<void> {
+  const target = options.target ?? resolveRmTarget(config, tools, branch);
+  const { effectiveBranch, engine, matchedContainers, existingWorktrees, toolCandidates } = target;
+  const confirm = options.prompt?.confirm ?? p.confirm;
+  const isCancel = options.prompt?.isCancel ?? p.isCancel;
+
+  if (!options.quiet) {
+    p.intro(pc.cyan(`Removing sandbox for ${branch}`));
+  }
+
+  const permits = options.permits
+    ? new Map(options.permits)
+    : await authorizeWorktrees(existingWorktrees, {
+        allowDirtyDiscard: options.allowDirtyDiscard ?? true,
+        assumeYes: Boolean(options.assumeYes)
+      }, options.prompt);
+  for (const worktree of existingWorktrees) {
+    const permit = permits.get(path.resolve(worktree));
+    if (!permit) throw new Error(`Missing worktree removal permit: ${worktree}`);
+    verifyWorktreePermit(permit);
+  }
+
+  const shouldRemoveWorktree = existingWorktrees.length === 0
+    ? false
+    : options.assumeYes
+      ? true
+      : await confirm({
+          message: `Remove worktree(s): ${existingWorktrees.join(', ')}?`,
+          initialValue: true
+        });
+  if (isCancel(shouldRemoveWorktree)) {
+    p.outro('Cancelled');
+    return;
+  }
+
+  if (matchedContainers.length > 0) {
     const spinner = p.spinner();
     spinner.start(`Stopping container(s): ${matchedContainers.join(', ')}`);
     for (const name of matchedContainers) {
@@ -97,36 +215,25 @@ async function rmOne(
     p.log.warn(`No sandbox container found for '${branch}'`);
   }
 
-  const existingWorktrees = worktreeCandidates.filter((candidate) => fs.existsSync(candidate));
-  if (existingWorktrees.length > 0) {
-    const shouldRemoveWorktree = options.assumeYes
+  if (shouldRemoveWorktree) {
+    for (const worktree of existingWorktrees) {
+      const permit = permits.get(path.resolve(worktree));
+      if (!permit) throw new Error(`Missing worktree removal permit: ${worktree}`);
+      removeWorktreeDir(config.repoRoot, config.worktreeBase, worktree, permit, {
+        allowRegisteredPathFallback: engine === ENGINES.WSL2
+      });
+    }
+
+    const shouldDeleteBranch = options.assumeYes
       ? true
-      : await p.confirm({
-          message: `Remove worktree(s): ${existingWorktrees.join(', ')}?`,
+      : await confirm({
+          message: `Also delete local branch '${effectiveBranch}'?`,
           initialValue: true
         });
 
-    if (p.isCancel(shouldRemoveWorktree)) {
-      p.outro('Cancelled');
-      return;
-    }
-
-    if (shouldRemoveWorktree) {
-      for (const worktree of existingWorktrees) {
-        removeWorktreeDir(config.repoRoot, config.worktreeBase, worktree);
-      }
-
-      const shouldDeleteBranch = options.assumeYes
-        ? true
-        : await p.confirm({
-            message: `Also delete local branch '${effectiveBranch}'?`,
-            initialValue: true
-          });
-
-      if (!p.isCancel(shouldDeleteBranch) && shouldDeleteBranch) {
-        if (!runOk('git', ['-C', config.repoRoot, 'branch', '-D', effectiveBranch])) {
-          p.log.warn(`Local branch '${effectiveBranch}' was not deleted`);
-        }
+    if (!isCancel(shouldDeleteBranch) && shouldDeleteBranch) {
+      if (!runOk('git', ['-C', config.repoRoot, 'branch', '-D', effectiveBranch])) {
+        p.log.warn(`Local branch '${effectiveBranch}' was not deleted`);
       }
     }
   }
@@ -147,11 +254,11 @@ async function rmOne(
   if (fs.existsSync(shareBranch)) {
     const shouldRemoveShare = options.assumeYes
       ? true
-      : await p.confirm({
+      : await confirm({
           message: `Remove share dir for branch '${effectiveBranch}' (${shareBranch})?`,
           initialValue: true
         });
-    if (!p.isCancel(shouldRemoveShare) && shouldRemoveShare) {
+    if (!isCancel(shouldRemoveShare) && shouldRemoveShare) {
       removeManagedDir(config.shareBase, shareBranch);
       p.log.success(`Share dir removed: ${shareBranch}`);
     }
@@ -162,9 +269,29 @@ async function rmOne(
   }
 }
 
-async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<void> {
+async function rmPurge(
+  config: SandboxConfig,
+  tools: SandboxTool[],
+  prompt: PromptDependencies = {}
+): Promise<void> {
   const engine = detectEngine(config);
+  const confirm = prompt.confirm ?? p.confirm;
+  const isCancel = prompt.isCancel ?? p.isCancel;
   p.intro(pc.cyan(`Removing all sandboxes for ${config.project}`));
+
+  const worktrees = fs.existsSync(config.worktreeBase)
+    ? fs.readdirSync(config.worktreeBase)
+        .map((entry) => path.join(config.worktreeBase, entry))
+        .filter((entry) => {
+          try { return fs.statSync(entry).isDirectory(); } catch { return false; }
+        })
+    : [];
+  const inspections = inspectWorktrees(worktrees);
+  const blockers = inspectionBlockers(inspections);
+  if (blockers.length > 0) {
+    throw new Error(`Refusing to purge because worktree preflight found blocker(s):\n${blockerMessage(blockers)}`);
+  }
+  const permits = cleanPermits(inspections);
 
   const containers = runSafeEngine(engine, 'docker', [
     'ps',
@@ -186,16 +313,19 @@ async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<voi
     p.log.warn('No project sandbox containers found');
   }
 
-  if (fs.existsSync(config.worktreeBase) && fs.readdirSync(config.worktreeBase).length > 0) {
-    const shouldRemoveWorktrees = await p.confirm({
+  if (worktrees.length > 0) {
+    const shouldRemoveWorktrees = await confirm({
       message: `Remove all worktrees in ${config.worktreeBase}?`,
       initialValue: true
     });
 
-    if (!p.isCancel(shouldRemoveWorktrees) && shouldRemoveWorktrees) {
-      for (const entry of fs.readdirSync(config.worktreeBase)) {
-        const dir = path.join(config.worktreeBase, entry);
-        removeWorktreeDir(config.repoRoot, config.worktreeBase, dir);
+    if (!isCancel(shouldRemoveWorktrees) && shouldRemoveWorktrees) {
+      for (const dir of worktrees) {
+        const permit = permits.get(path.resolve(dir));
+        if (!permit) throw new Error(`Missing worktree removal permit: ${dir}`);
+        removeWorktreeDir(config.repoRoot, config.worktreeBase, dir, permit, {
+          allowRegisteredPathFallback: engine === ENGINES.WSL2
+        });
       }
       runSafe('git', ['-C', config.repoRoot, 'worktree', 'prune']);
     }
@@ -209,12 +339,12 @@ async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<voi
   }
 
   if (fs.existsSync(config.shellConfigBase) && fs.readdirSync(config.shellConfigBase).length > 0) {
-    const shouldRemoveShellConfigs = await p.confirm({
+    const shouldRemoveShellConfigs = await confirm({
       message: `Remove all shell config dirs in ${config.shellConfigBase}?`,
       initialValue: true
     });
 
-    if (!p.isCancel(shouldRemoveShellConfigs) && shouldRemoveShellConfigs) {
+    if (!isCancel(shouldRemoveShellConfigs) && shouldRemoveShellConfigs) {
       for (const entry of fs.readdirSync(config.shellConfigBase)) {
         const dir = path.join(config.shellConfigBase, entry);
         removeManagedDir(config.shellConfigBase, dir);
@@ -224,11 +354,11 @@ async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<voi
   }
 
   if (fs.existsSync(config.shareBase) && fs.readdirSync(config.shareBase).length > 0) {
-    const shouldRemoveAllShares = await p.confirm({
+    const shouldRemoveAllShares = await confirm({
       message: `Remove all share dirs for project (${config.shareBase})?`,
       initialValue: true
     });
-    if (!p.isCancel(shouldRemoveAllShares) && shouldRemoveAllShares) {
+    if (!isCancel(shouldRemoveAllShares) && shouldRemoveAllShares) {
       removeManagedDir(path.dirname(config.shareBase), config.shareBase);
       p.log.success(`Project share dirs removed: ${config.shareBase}`);
     }
@@ -245,11 +375,11 @@ async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<voi
     }
   }
 
-  const shouldRemoveImage = await p.confirm({
+  const shouldRemoveImage = await confirm({
     message: `Remove image ${config.imageName}?`,
     initialValue: false
   });
-  if (!p.isCancel(shouldRemoveImage) && shouldRemoveImage) {
+  if (!isCancel(shouldRemoveImage) && shouldRemoveImage) {
     runSafeEngine(engine, 'docker', ['rmi', config.imageName]);
   }
 
@@ -263,11 +393,11 @@ async function rmPurge(config: SandboxConfig, tools: SandboxTool[]): Promise<voi
     }
 
     const name = engineDisplayName(engine);
-    const shouldStopVm = await p.confirm({
+    const shouldStopVm = await confirm({
       message: `Stop ${name} VM?`,
       initialValue: false
     });
-    if (!p.isCancel(shouldStopVm) && shouldStopVm) {
+    if (!isCancel(shouldStopVm) && shouldStopVm) {
       stopManagedVm(config);
     }
   }
@@ -293,35 +423,41 @@ async function rmUnbound(
     return;
   }
 
+  const targets = removable.map((row) => resolveRmTarget(config, tools, row.branch));
+  const inspections = inspectWorktrees(targets.flatMap((target) => target.existingWorktrees));
+  const blockers = inspectionBlockers(inspections);
+  const permits = cleanPermits(inspections);
+
   for (const row of removable) {
     p.log.message(`${row.name}  ${row.branch}`);
   }
+  if (blockers.length > 0) p.log.error(blockerMessage(blockers));
 
   if (options.dryRun) {
-    p.outro(`Dry run: ${removable.length} sandbox(es) would be removed, nothing deleted`);
+    p.outro(`Dry run: ${removable.length} sandbox(es) inspected, nothing deleted`);
     return;
   }
 
-  if (!options.assumeYes) {
-    if (!process.stdin.isTTY) {
-      throw new Error(
-        'Refusing to remove sandboxes without confirmation in a non-interactive shell; pass --yes to proceed.'
-      );
-    }
-    const confirmed = await p.confirm({
-      message: `Remove these ${removable.length} sandbox(es)?`,
-      initialValue: false
-    });
-    if (p.isCancel(confirmed) || !confirmed) {
-      p.outro('Cancelled');
-      return;
-    }
+  if (blockers.length > 0) {
+    throw new Error(`Refusing batch removal because worktree preflight found blocker(s):\n${blockerMessage(blockers)}`);
+  }
+
+  if (!options.assumeYes && !process.stdin.isTTY) {
+    throw new Error(
+      'Refusing to remove sandboxes without confirmation in a non-interactive shell; pass --yes to proceed.'
+    );
   }
 
   const failures: { branch: string; message: string }[] = [];
-  for (const row of removable) {
+  for (const [index, row] of removable.entries()) {
     try {
-      await rmOne(config, tools, row.branch, { assumeYes: true, quiet: true });
+      await rmOne(config, tools, row.branch, {
+        assumeYes: options.assumeYes,
+        quiet: true,
+        target: targets[index],
+        permits,
+        allowDirtyDiscard: false
+      });
     } catch (error) {
       failures.push({ branch: row.branch, message: error instanceof Error ? error.message : String(error) });
     }
@@ -346,6 +482,7 @@ export async function rm(args: string[]): Promise<void> {
     strict: true,
     options: {
       all: { type: 'boolean' },
+      unbound: { type: 'boolean' },
       purge: { type: 'boolean' },
       'dry-run': { type: 'boolean' },
       yes: { type: 'boolean', short: 'y' },
@@ -353,24 +490,28 @@ export async function rm(args: string[]): Promise<void> {
     }
   });
 
+  if (values.all) {
+    throw new Error('CLI_FLAG_REMOVED: --all was removed; use --unbound');
+  }
+
   if (values.help) {
     process.stdout.write(`${USAGE}\n`);
     return;
   }
 
-  if (values.all && values.purge) {
-    throw new Error('--all and --purge are mutually exclusive');
+  if (values.unbound && values.purge) {
+    throw new Error('--unbound and --purge are mutually exclusive');
   }
 
-  if ((values['dry-run'] || values.yes) && !values.all) {
-    throw new Error('--dry-run and --yes only apply to --all');
+  if ((values['dry-run'] || values.yes) && !values.unbound) {
+    throw new Error('--dry-run and --yes only apply to --unbound');
   }
 
-  if ((values.all || values.purge) && positionals.length > 0) {
-    throw new Error(`${values.all ? '--all' : '--purge'} does not take a branch argument`);
+  if ((values.unbound || values.purge) && positionals.length > 0) {
+    throw new Error(`${values.unbound ? '--unbound' : '--purge'} does not take a branch argument`);
   }
 
-  if (!values.all && !values.purge && positionals.length !== 1) {
+  if (!values.unbound && !values.purge && positionals.length !== 1) {
     throw new Error(USAGE);
   }
 
@@ -382,7 +523,7 @@ export async function rm(args: string[]): Promise<void> {
     return;
   }
 
-  if (values.all) {
+  if (values.unbound) {
     await rmUnbound(config, tools, {
       dryRun: Boolean(values['dry-run']),
       assumeYes: Boolean(values.yes)
@@ -393,3 +534,5 @@ export async function rm(args: string[]): Promise<void> {
   const target = resolveSandboxTarget(positionals[0] ?? '', config.repoRoot);
   await rmOne(config, tools, target.branch);
 }
+
+export { authorizeWorktrees, rmOne, rmPurge };

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -15,9 +15,9 @@ Commands:
   rebuild [--quiet] [--refresh]
                                Rebuild the sandbox image (--refresh pulls base + tools)
   refresh                      Sync host Claude Code credentials to all sandbox copies
-  rm <branch> | --all | --purge
+  rm <branch> | --unbound | --purge
                                Remove one sandbox, all sandboxes not bound to an
-                               active task (--all), or tear down everything (--purge)
+                               active task (--unbound), or tear down everything (--purge)
   start [--recreate] <branch | TASK-id | N>
                                Verify or recover an existing sandbox container;
                                optionally replace only the container on failure

--- a/lib/sandbox/managed-fs.ts
+++ b/lib/sandbox/managed-fs.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { run, runSafe } from './shell.ts';
 import { removeDirRecursive } from '../remove-dir.ts';
+import { verifyWorktreePermit } from './worktree-safety.ts';
+import type { WorktreeRemovalPermit } from './worktree-safety.ts';
 
 export function assertManagedPath(root: string, target: string): void {
   const resolvedRoot = path.resolve(root);
@@ -22,18 +24,31 @@ export function removeWorktreeDir(
   repoRoot: string,
   worktreeBase: string,
   dir: string,
-  { runFn = run, runSafeFn = runSafe }: {
+  permit: WorktreeRemovalPermit,
+  { runFn = run, runSafeFn = runSafe, allowRegisteredPathFallback = false }: {
     runFn?: typeof run;
     runSafeFn?: typeof runSafe;
+    allowRegisteredPathFallback?: boolean;
   } = {}
 ): void {
+  assertManagedPath(worktreeBase, dir);
+  if (path.resolve(permit.snapshot.worktree) !== path.resolve(dir)) {
+    throw new Error(`Worktree permit target mismatch: ${dir}`);
+  }
+  verifyWorktreePermit(permit);
   try {
     runFn('git', ['-C', repoRoot, 'worktree', 'remove', dir, '--force']);
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const registeredPathMismatch = /(?:is not|not a valid) working tree|not a working tree/i.test(message);
+    if (!allowRegisteredPathFallback || !registeredPathMismatch) {
+      throw error;
+    }
     // On WSL2 the worktree is registered under its `/mnt/<drive>/...` path, so
     // `git worktree remove <windows-path>` cannot match it. Delete the managed
     // directory directly, then prune the now-dangling worktree metadata so the
     // branch is no longer reported as checked out.
+    verifyWorktreePermit(permit);
     removeManagedDir(worktreeBase, dir);
     runSafeFn('git', ['-C', repoRoot, 'worktree', 'prune']);
   }

--- a/lib/sandbox/worktree-safety.ts
+++ b/lib/sandbox/worktree-safety.ts
@@ -1,0 +1,229 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { runProbe } from './shell.ts';
+
+type WorktreeChange = {
+  indexStatus: string;
+  worktreeStatus: string;
+  path: string;
+  originalPath?: string;
+};
+
+type WorktreeSnapshot = {
+  worktree: string;
+  head: string;
+  changes: readonly WorktreeChange[];
+  identity: string;
+};
+
+type WorktreeInspection =
+  | { status: 'clean'; snapshot: WorktreeSnapshot }
+  | { status: 'dirty'; snapshot: WorktreeSnapshot }
+  | { status: 'failed'; worktree: string; message: string };
+
+type WorktreeRemovalPermit = {
+  mode: 'clean' | 'discard';
+  snapshot: WorktreeSnapshot;
+};
+
+type Probe = typeof runProbe;
+
+function probeText(probe: Probe, cwd: string, args: string[]): string {
+  const result = probe('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : result.stderr.toString('utf8').trim();
+    throw new Error(stderr || `git ${args[0] ?? 'command'} failed with exit code ${result.status ?? 'unknown'}`);
+  }
+  return typeof result.stdout === 'string' ? result.stdout : result.stdout.toString('utf8');
+}
+
+function parseStatus(raw: string): WorktreeChange[] {
+  const records = raw.split('\0');
+  const changes: WorktreeChange[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index] ?? '';
+    if (!record || record.startsWith('# ')) continue;
+    if (record.startsWith('? ')) {
+      changes.push({ indexStatus: '?', worktreeStatus: '?', path: record.slice(2) });
+      continue;
+    }
+    if (record.startsWith('1 ')) {
+      const match = /^1 (..) \S+ \S+ \S+ \S+ \S+ \S+ (.*)$/s.exec(record);
+      if (!match) throw new Error('Unable to parse git porcelain v2 ordinary record');
+      changes.push({ indexStatus: match[1]![0]!, worktreeStatus: match[1]![1]!, path: match[2]! });
+      continue;
+    }
+    if (record.startsWith('2 ')) {
+      const match = /^2 (..) \S+ \S+ \S+ \S+ \S+ \S+ \S+ (.*)$/s.exec(record);
+      const originalPath = records[++index];
+      if (!match || originalPath === undefined || originalPath === '') {
+        throw new Error('Unable to parse git porcelain v2 rename record');
+      }
+      changes.push({
+        indexStatus: match[1]![0]!,
+        worktreeStatus: match[1]![1]!,
+        path: match[2]!,
+        originalPath
+      });
+      continue;
+    }
+    if (record.startsWith('u ')) {
+      const match = /^u (..) \S+ \S+ \S+ \S+ \S+ \S+ \S+ \S+ (.*)$/s.exec(record);
+      if (!match) throw new Error('Unable to parse git porcelain v2 unmerged record');
+      changes.push({ indexStatus: match[1]![0]!, worktreeStatus: match[1]![1]!, path: match[2]! });
+      continue;
+    }
+    throw new Error(`Unsupported git porcelain v2 record '${record[0] ?? ''}'`);
+  }
+  return changes;
+}
+
+function updatePart(hash: ReturnType<typeof createHash>, label: string, value: string | Buffer): void {
+  const data = Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+  hash.update(`${label.length}:${label}:${data.length}:`, 'utf8');
+  hash.update(data);
+}
+
+function resolveSnapshotPath(worktree: string, relativePath: string): string {
+  const resolved = path.resolve(worktree, relativePath);
+  const relative = path.relative(worktree, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Git reported a path outside the worktree: ${JSON.stringify(relativePath)}`);
+  }
+  return resolved;
+}
+
+function hashPath(hash: ReturnType<typeof createHash>, worktree: string, relativePath: string, probe: Probe): void {
+  updatePart(hash, 'path', relativePath);
+  const target = resolveSnapshotPath(worktree, relativePath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      updatePart(hash, 'kind', 'absent');
+      return;
+    }
+    throw error;
+  }
+
+  updatePart(hash, 'mode', String(stat.mode & 0o7777));
+  if (stat.isFile()) {
+    updatePart(hash, 'kind', 'file');
+    updatePart(hash, 'content', fs.readFileSync(target));
+    return;
+  }
+  if (stat.isSymbolicLink()) {
+    updatePart(hash, 'kind', 'symlink');
+    updatePart(hash, 'target', fs.readlinkSync(target));
+    return;
+  }
+  if (stat.isDirectory()) {
+    updatePart(hash, 'kind', 'git-directory');
+    const nestedHead = probeText(probe, target, ['rev-parse', '--verify', 'HEAD']).trim();
+    const nestedStatus = probeText(probe, target, [
+      'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=all', '--ignore-submodules=none'
+    ]);
+    const nestedIndex = probeText(probe, target, ['ls-files', '--stage', '-z']);
+    updatePart(hash, 'nested-head', nestedHead);
+    updatePart(hash, 'nested-status', nestedStatus);
+    updatePart(hash, 'nested-index', nestedIndex);
+    for (const change of parseStatus(nestedStatus)) {
+      hashPath(hash, target, change.path, probe);
+      if (change.originalPath) hashPath(hash, target, change.originalPath, probe);
+    }
+    return;
+  }
+  throw new Error(`Unsupported file type in dirty snapshot: ${JSON.stringify(relativePath)}`);
+}
+
+function captureOnce(worktree: string, probe: Probe): WorktreeSnapshot {
+  const resolvedWorktree = path.resolve(worktree);
+  const head = probeText(probe, resolvedWorktree, ['rev-parse', '--verify', 'HEAD']).trim();
+  const status = probeText(probe, resolvedWorktree, [
+    'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=all', '--ignore-submodules=none'
+  ]);
+  const index = probeText(probe, resolvedWorktree, ['ls-files', '--stage', '-z']);
+  if (!head) throw new Error('Unable to determine worktree HEAD');
+  const changes = parseStatus(status);
+  const hash = createHash('sha256');
+  updatePart(hash, 'worktree', resolvedWorktree);
+  updatePart(hash, 'head', head);
+  updatePart(hash, 'status', status);
+  updatePart(hash, 'index', index);
+  for (const change of changes) {
+    hashPath(hash, resolvedWorktree, change.path, probe);
+    if (change.originalPath) hashPath(hash, resolvedWorktree, change.originalPath, probe);
+  }
+  return { worktree: resolvedWorktree, head, changes, identity: hash.digest('hex') };
+}
+
+function inspectWorktree(worktree: string, { probe = runProbe }: { probe?: Probe } = {}): WorktreeInspection {
+  const resolvedWorktree = path.resolve(worktree);
+  try {
+    const first = captureOnce(resolvedWorktree, probe);
+    const second = captureOnce(resolvedWorktree, probe);
+    if (first.identity !== second.identity) {
+      return { status: 'failed', worktree: resolvedWorktree, message: 'Snapshot changed while inspecting worktree' };
+    }
+    return { status: second.changes.length === 0 ? 'clean' : 'dirty', snapshot: second };
+  } catch (error) {
+    return {
+      status: 'failed',
+      worktree: resolvedWorktree,
+      message: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+function inspectWorktrees(worktrees: readonly string[]): WorktreeInspection[] {
+  return [...new Set(worktrees.map((worktree) => path.resolve(worktree)))].sort()
+    .map((worktree) => inspectWorktree(worktree));
+}
+
+function createCleanPermit(snapshot: WorktreeSnapshot): WorktreeRemovalPermit {
+  if (snapshot.changes.length > 0) throw new Error('Cannot create a clean permit for a dirty worktree');
+  return { mode: 'clean', snapshot };
+}
+
+function createDiscardPermit(snapshot: WorktreeSnapshot): WorktreeRemovalPermit {
+  if (snapshot.changes.length === 0) throw new Error('Cannot create a discard permit for a clean worktree');
+  return { mode: 'discard', snapshot };
+}
+
+function verifyWorktreePermit(
+  permit: WorktreeRemovalPermit,
+  options: { probe?: Probe } = {}
+): WorktreeSnapshot {
+  const current = inspectWorktree(permit.snapshot.worktree, options);
+  if (current.status === 'failed') throw new Error(`Unable to verify worktree permit: ${current.message}`);
+  if (current.snapshot.identity !== permit.snapshot.identity || (permit.mode === 'clean' && current.status !== 'clean')) {
+    throw new Error(`Worktree changed after authorization: ${permit.snapshot.worktree}`);
+  }
+  return current.snapshot;
+}
+
+function formatWorktreeSnapshot(snapshot: WorktreeSnapshot): string {
+  const lines = snapshot.changes.map((change) => {
+    const rename = change.originalPath ? ` <- ${JSON.stringify(change.originalPath)}` : '';
+    return `  ${change.indexStatus}${change.worktreeStatus} ${JSON.stringify(change.path)}${rename}`;
+  });
+  return [
+    `Worktree: ${JSON.stringify(snapshot.worktree)}`,
+    `HEAD: ${snapshot.head}`,
+    ...lines,
+    `Snapshot identity: ${snapshot.identity}`
+  ].join('\n');
+}
+
+export {
+  createCleanPermit,
+  createDiscardPermit,
+  formatWorktreeSnapshot,
+  inspectWorktree,
+  inspectWorktrees,
+  verifyWorktreePermit
+};
+export type { WorktreeChange, WorktreeInspection, WorktreeRemovalPermit, WorktreeSnapshot };

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -94,7 +94,7 @@ type PruneModule = {
     label: string;
     base: string;
     dirs: string[];
-  }>): boolean;
+  }>, permits: ReadonlyMap<string, unknown>): boolean;
 };
 
 function spawnSandboxCli(
@@ -173,17 +173,6 @@ test("sandbox create rejects invalid selinux disable environment before loading 
   }
 });
 
-test("sandbox rm defaults local branch deletion confirmation to yes", () => {
-  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
-
-  // The interactive confirm is gated by options.assumeYes (batch --all passes
-  // assumeYes:true); when prompting it still defaults to yes.
-  assert.match(
-    commandSource,
-    /const shouldDeleteBranch = options\.assumeYes[\s\S]*?await p\.confirm\(\{[\s\S]*?message: `Also delete local branch '\$\{effectiveBranch\}'\?`,[\s\S]*?initialValue: true[\s\S]*?\}\);/
-  );
-});
-
 test("sandbox rm cleans per-branch shell config dir", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-sandbox-rm-shell-config-"));
   const project = "demo";
@@ -208,15 +197,6 @@ test("sandbox rm cleans per-branch shell config dir", () => {
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
-});
-
-test("sandbox rm --purge cleans shell config dirs through a single confirm", () => {
-  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
-
-  assert.match(
-    commandSource,
-    /config\.shellConfigBase[\s\S]*?p\.confirm\(\{[\s\S]*?config\.shellConfigBase[\s\S]*?\}\);[\s\S]*?readdirSync\(config\.shellConfigBase\)[\s\S]*?removeManagedDir\(config\.shellConfigBase, dir\);/
-  );
 });
 
 test("sandbox rm --purge prunes project-scoped dangling images before managed-engine branch", () => {
@@ -279,7 +259,7 @@ function hasDockerVerb(calls: string[][], verb: string): boolean {
   return calls.some((call) => call[0] === verb);
 }
 
-test("sandbox rm --all --dry-run lists unbound sandboxes and removes nothing", () => {
+test("sandbox rm --unbound --dry-run lists unbound sandboxes and removes nothing", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-dry-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, {
@@ -287,7 +267,7 @@ test("sandbox rm --all --dry-run lists unbound sandboxes and removes nothing", (
       dockerStdoutForPs: sandboxRow("sb-orphan", "orphan-branch")
     });
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--dry-run"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--dry-run"]);
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /orphan-branch/);
@@ -299,7 +279,7 @@ test("sandbox rm --all --dry-run lists unbound sandboxes and removes nothing", (
   }
 });
 
-test("sandbox rm --all skips containers bound to an active task", () => {
+test("sandbox rm --unbound skips containers bound to an active task", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-skip-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, {
@@ -312,7 +292,7 @@ test("sandbox rm --all skips containers bound to an active task", () => {
     writeShortIdRegistry(fixture.repoDir, { "07": "TASK-20260101-000001" });
     writeActiveTaskBranch(fixture.repoDir, "TASK-20260101-000001", "bound-branch");
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--dry-run"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--dry-run"]);
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /free-branch/);
@@ -322,7 +302,7 @@ test("sandbox rm --all skips containers bound to an active task", () => {
   }
 });
 
-test("sandbox rm --all exits 0 with a notice when nothing is removable", () => {
+test("sandbox rm --unbound exits 0 with a notice when nothing is removable", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-empty-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, {
@@ -332,7 +312,7 @@ test("sandbox rm --all exits 0 with a notice when nothing is removable", () => {
     writeShortIdRegistry(fixture.repoDir, { "07": "TASK-20260101-000001" });
     writeActiveTaskBranch(fixture.repoDir, "TASK-20260101-000001", "bound-branch");
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound"]);
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /No removable sandboxes/);
@@ -344,21 +324,21 @@ test("sandbox rm --all exits 0 with a notice when nothing is removable", () => {
   }
 });
 
-test("sandbox rm --all rejects a positional branch argument", () => {
+test("sandbox rm --unbound rejects a positional branch argument", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-mutex-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "feature/x"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "feature/x"]);
 
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /--all does not take a branch argument/);
+    assert.match(result.stderr, /--unbound does not take a branch argument/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
-test("sandbox rm --all without --yes fails safe in a non-interactive shell", () => {
+test("sandbox rm --unbound without --yes fails safe in a non-interactive shell", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-tty-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, {
@@ -366,7 +346,7 @@ test("sandbox rm --all without --yes fails safe in a non-interactive shell", () 
       dockerStdoutForPs: sandboxRow("sb-orphan", "orphan-branch")
     });
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound"]);
 
     assert.equal(result.status, 1);
     assert.match(result.stderr, /--yes/);
@@ -378,7 +358,7 @@ test("sandbox rm --all without --yes fails safe in a non-interactive shell", () 
   }
 });
 
-test("sandbox rm --dry-run without --all is rejected", () => {
+test("sandbox rm --dry-run without --unbound is rejected", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-dry-misuse-"));
   try {
     const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
@@ -386,13 +366,13 @@ test("sandbox rm --dry-run without --all is rejected", () => {
     const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--dry-run"]);
 
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /only apply to --all/);
+    assert.match(result.stderr, /only apply to --unbound/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
-test("sandbox rm --all --yes routes each unbound branch through rmOne cleanup", () => {
+test("sandbox rm --unbound --yes routes each unbound branch through rmOne cleanup", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-yes-"));
   const project = "demo";
   try {
@@ -407,7 +387,7 @@ test("sandbox rm --all --yes routes each unbound branch through rmOne cleanup", 
     fs.mkdirSync(keptBranchDir, { recursive: true });
     fs.writeFileSync(path.join(removedBranchDir, ".bash_aliases"), "alias demo=true\n", "utf8");
 
-    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--all", "--yes"]);
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--yes"]);
 
     assert.equal(result.status, 0, result.stderr);
     // The unbound branch was passed into rmOne, whose unconditional per-branch
@@ -420,21 +400,20 @@ test("sandbox rm --all --yes routes each unbound branch through rmOne cleanup", 
   }
 });
 
-test("sandbox rm --all delegates to rmOne with assumeYes/quiet and aggregates failures", () => {
-  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/rm.js"), "utf8");
+test("sandbox rm --all returns a migration error before loading project config", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-all-removed-"));
+  try {
+    const result = spawnSync(process.execPath, cliArgs("sandbox", "rm", "--all"), {
+      cwd: tmpDir,
+      env: gitSafeEnv({ HOME: tmpDir, USERPROFILE: tmpDir }),
+      encoding: "utf8"
+    });
 
-  const rmUnboundMatch = commandSource.match(
-    /async function rmUnbound\b[\s\S]*?(?=\n(?:async function|export async function|export function)\b|$)/
-  );
-  assert.ok(rmUnboundMatch, "expected to locate rmUnbound function body in rm.js");
-  const rmUnboundBody = rmUnboundMatch[0];
-
-  // T7b: batch path forwards the removable branch into the single-container path,
-  // suppressing per-item confirms and framing.
-  assert.match(rmUnboundBody, /rmOne\([\s\S]*?assumeYes:\s*true[\s\S]*?quiet:\s*true[\s\S]*?\)/);
-  // T8: partial-failure contract — keep going, collect failures, then throw a summary.
-  assert.match(rmUnboundBody, /try\s*\{[\s\S]*?rmOne\([\s\S]*?\}\s*catch[\s\S]*?failures\.push/);
-  assert.match(rmUnboundBody, /failures\.length[\s\S]*?throw new Error\(/);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /CLI_FLAG_REMOVED: --all was removed; use --unbound/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("managed sandbox fs helpers remove only paths under the managed root", async () => {
@@ -453,57 +432,6 @@ test("managed sandbox fs helpers remove only paths under the managed root", asyn
       () => managedFs.removeManagedDir(root, path.join(tmpDir, "outside")),
       /outside managed sandbox root/
     );
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("managed sandbox fs worktree removal falls back to managed rm", async () => {
-  const managedFs = await loadFreshEsm<ManagedFsModule>("lib/sandbox/managed-fs.js");
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-managed-worktree-"));
-  const worktreeBase = path.join(tmpDir, "worktrees");
-  const worktree = path.join(worktreeBase, "feature..stale");
-
-  try {
-    fs.mkdirSync(worktree, { recursive: true });
-
-    managedFs.removeWorktreeDir(tmpDir, worktreeBase, worktree);
-
-    assert.equal(fs.existsSync(worktree), false);
-    assert.equal(fs.existsSync(worktreeBase), true);
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("managed sandbox fs worktree removal prunes stale metadata after a fallback delete", async () => {
-  const managedFs = await loadFreshEsm<ManagedFsModule>("lib/sandbox/managed-fs.js");
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-managed-worktree-prune-"));
-  const worktreeBase = path.join(tmpDir, "worktrees");
-  const worktree = path.join(worktreeBase, "feature..wsl2");
-  const calls: string[][] = [];
-
-  try {
-    fs.mkdirSync(worktree, { recursive: true });
-
-    managedFs.removeWorktreeDir(tmpDir, worktreeBase, worktree, {
-      // Simulate WSL2: `git worktree remove <windows-path>` cannot match the
-      // `/mnt/c/...` registration, so it throws and the directory is deleted
-      // through the managed fallback instead.
-      runFn: (cmd, args) => {
-        calls.push([cmd, ...args]);
-        throw new Error("fatal: is not a working tree");
-      },
-      runSafeFn: (cmd, args) => {
-        calls.push([cmd, ...args]);
-        return "";
-      }
-    });
-
-    assert.equal(fs.existsSync(worktree), false);
-    // The stale `/mnt/c/...` worktree record must be pruned so the branch is
-    // no longer reported as checked out and can be deleted.
-    assert.deepEqual(calls.at(-1), ["git", "-C", tmpDir, "worktree", "prune"]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -1279,11 +1207,12 @@ test("sandbox prune collects orphaned per-branch dirs while preserving active an
       orphanWorktreeDir
     ].sort());
 
-    const removedWorktrees = sandboxPrune.removeOrphanGroups(config, groups);
+    const nonWorktreeGroups = groups.filter((group) => group.kind !== "worktree");
+    const removedWorktrees = sandboxPrune.removeOrphanGroups(config, nonWorktreeGroups, new Map<string, unknown>());
 
-    assert.equal(removedWorktrees, true);
+    assert.equal(removedWorktrees, false);
     assert.equal(fs.existsSync(orphanShellDir), false);
-    assert.equal(fs.existsSync(orphanWorktreeDir), false);
+    assert.equal(fs.existsSync(orphanWorktreeDir), true);
     assert.equal(fs.existsSync(orphanShareDir), false);
     assert.equal(fs.existsSync(orphanToolDir), false);
     assert.equal(fs.existsSync(config.shellConfigBase), true);
@@ -1356,15 +1285,6 @@ test("sandbox prune --dry-run lists orphans without deleting them", onPlatforms(
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
-});
-
-test("sandbox prune uses a single confirmation gate for deletion", () => {
-  const commandSource = fs.readFileSync(filePath("lib/sandbox/commands/prune.js"), "utf8");
-
-  assert.match(
-    commandSource,
-    /const shouldRemove = await p\.confirm\(\{[\s\S]*?Remove \$\{count\} orphaned sandbox state[\s\S]*?initialValue: true[\s\S]*?\}\);/
-  );
 });
 
 test("sandbox list-running selectSandboxContainer matches by candidate name (covers legacy '-')", async () => {

--- a/tests/integration/cli/sandbox-worktree-safety.test.ts
+++ b/tests/integration/cli/sandbox-worktree-safety.test.ts
@@ -265,7 +265,12 @@ test("worktree safety snapshot parses rename, delete, and conflict records", onP
     fs.writeFileSync(path.join(fixture.repo, "tracked.txt"), "main version\n", "utf8");
     git(fixture.repo, "add", "tracked.txt");
     git(fixture.repo, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "main");
-    assert.throws(() => git(fixture.worktree, "merge", "main"));
+    assert.throws(() => git(
+      fixture.worktree,
+      "-c", "user.name=Sandbox Test",
+      "-c", "user.email=sandbox@example.com",
+      "merge", "main"
+    ));
 
     const conflicted = safety.inspectWorktree(fixture.worktree);
     assert.equal(conflicted.status, "dirty");

--- a/tests/integration/cli/sandbox-worktree-safety.test.ts
+++ b/tests/integration/cli/sandbox-worktree-safety.test.ts
@@ -1,0 +1,600 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { SandboxConfig } from "../../../lib/sandbox/config.ts";
+import {
+  cliArgs,
+  envWithPrependedPath,
+  gitSafeEnv,
+  loadFreshEsm,
+  onPlatforms,
+  writeSandboxEngineFixture
+} from "../../helpers.ts";
+
+type SafetyModule = typeof import("../../../lib/sandbox/worktree-safety.ts");
+type ManagedFsModule = typeof import("../../../lib/sandbox/managed-fs.ts");
+type RmModule = typeof import("../../../lib/sandbox/commands/rm.ts");
+type PruneModule = typeof import("../../../lib/sandbox/commands/prune.ts");
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    env: gitSafeEnv(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function createLinkedWorktree(): {
+  root: string;
+  repo: string;
+  base: string;
+  worktree: string;
+  cleanup(): void;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-worktree-safety-"));
+  const repo = path.join(root, "repo");
+  const base = path.join(root, "worktrees");
+  const worktree = path.join(base, "feature..safe-delete");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(base, { recursive: true });
+  git(repo, "init", "-q", "-b", "main");
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "initial\n", "utf8");
+  git(repo, "add", "tracked.txt");
+  git(repo, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "initial");
+  git(repo, "worktree", "add", "-q", "-b", "feature/safe-delete", worktree, "HEAD");
+  return {
+    root,
+    repo,
+    base,
+    worktree,
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+}
+
+function addFixtureWorktree(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  branch: string,
+  project = "demo"
+): string {
+  try {
+    git(fixture.repoDir, "rev-parse", "--verify", "HEAD");
+  } catch {
+    fs.writeFileSync(path.join(fixture.repoDir, "tracked.txt"), "initial\n", "utf8");
+    git(fixture.repoDir, "add", "tracked.txt");
+    git(fixture.repoDir, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "initial");
+  }
+  const worktree = path.join(tmpDir, ".agent-infra", "worktrees", project, branch.replaceAll("/", ".."));
+  fs.mkdirSync(path.dirname(worktree), { recursive: true });
+  git(fixture.repoDir, "worktree", "add", "-q", "-b", branch, worktree, "HEAD");
+  return worktree;
+}
+
+function spawnSandboxCli(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  args: string[]
+) {
+  return spawnSync(process.execPath, cliArgs("sandbox", ...args), {
+    cwd: fixture.repoDir,
+    env: {
+      ...envWithPrependedPath(gitSafeEnv(), fixture.binDir),
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      DOCKER_LOG_PATH: fixture.logPath
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 15_000
+  });
+}
+
+function rmOneConfig(fixture: ReturnType<typeof writeSandboxEngineFixture>, tmpDir: string): SandboxConfig {
+  return {
+    repoRoot: fixture.repoDir,
+    configPath: path.join(fixture.repoDir, ".agents", ".airc.json"),
+    project: "demo",
+    org: "fitlab-ai",
+    home: tmpDir,
+    containerPrefix: "demo-dev",
+    imageName: "demo-sandbox:latest",
+    worktreeBase: path.join(tmpDir, ".agent-infra", "worktrees", "demo"),
+    shareBase: path.join(tmpDir, ".agent-infra", "share", "demo"),
+    shellConfigBase: path.join(tmpDir, ".agent-infra", "config", "demo"),
+    workspaceViewBase: path.join(tmpDir, ".agent-infra", "workspace-views"),
+    controlBase: path.join(tmpDir, ".agent-infra", "sandbox-control"),
+    dotfilesDir: path.join(tmpDir, ".agent-infra", "dotfiles"),
+    engine: "docker-desktop",
+    runtimes: ["node22"],
+    tools: [],
+    customTools: [],
+    agentClientState: {
+      "antigravity-cli": { enabled: false, installInSandbox: false },
+      "claude-code": { enabled: false, installInSandbox: false },
+      codex: { enabled: false, installInSandbox: false },
+      opencode: { enabled: false, installInSandbox: false }
+    },
+    agentClientSource: "canonical",
+    refreshIntervalDays: 7,
+    dockerfile: null,
+    vm: { cpu: null, memory: null, disk: null }
+  };
+}
+
+async function cleanRmOneFixture(
+  rm: RmModule,
+  safety: SafetyModule,
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  tmpDir: string,
+  branch: string,
+  prompt: NonNullable<Parameters<RmModule["rmOne"]>[3]>["prompt"]
+): Promise<{ worktree: string; share: string }> {
+  const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+  const share = path.join(tmpDir, ".agent-infra", "share", "demo", "branches", branch.replaceAll("/", ".."));
+  fs.mkdirSync(share, { recursive: true });
+  const inspected = safety.inspectWorktree(worktree);
+  assert.equal(inspected.status, "clean");
+  const permit = safety.createCleanPermit(inspected.snapshot);
+  await rm.rmOne(rmOneConfig(fixture, tmpDir), [], branch, {
+    target: {
+      branch,
+      effectiveBranch: branch,
+      engine: "docker-desktop",
+      matchedContainers: [],
+      existingWorktrees: [worktree],
+      toolCandidates: []
+    },
+    permits: new Map([[path.resolve(worktree), permit]]),
+    prompt
+  });
+  return { worktree, share };
+}
+
+test("worktree safety snapshot binds staged, unstaged, and unusual untracked content", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const fixture = createLinkedWorktree();
+  try {
+    const clean = safety.inspectWorktree(fixture.worktree);
+    assert.equal(clean.status, "clean");
+
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "first change\n", "utf8");
+    const first = safety.inspectWorktree(fixture.worktree);
+    assert.equal(first.status, "dirty");
+    assert.ok(first.snapshot.changes.some((change) => change.path === "tracked.txt" && change.worktreeStatus === "M"));
+
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "second change\n", "utf8");
+    const second = safety.inspectWorktree(fixture.worktree);
+    assert.equal(second.status, "dirty");
+    assert.notEqual(second.snapshot.identity, first.snapshot.identity);
+
+    git(fixture.worktree, "add", "tracked.txt");
+    const staged = safety.inspectWorktree(fixture.worktree);
+    assert.equal(staged.status, "dirty");
+    assert.ok(staged.snapshot.changes.some((change) => change.path === "tracked.txt" && change.indexStatus === "M"));
+
+    const unusualPath = "line\nbreak.txt";
+    fs.writeFileSync(path.join(fixture.worktree, unusualPath), "untracked\n", "utf8");
+    fs.appendFileSync(path.join(fixture.repo, ".git", "info", "exclude"), "ignored.txt\n", "utf8");
+    fs.writeFileSync(path.join(fixture.worktree, "ignored.txt"), "ignored\n", "utf8");
+    const untracked = safety.inspectWorktree(fixture.worktree);
+    assert.equal(untracked.status, "dirty");
+    assert.ok(untracked.snapshot.changes.some((change) => change.path === unusualPath && change.indexStatus === "?"));
+    assert.equal(untracked.snapshot.changes.some((change) => change.path === "ignored.txt"), false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("worktree removal permit fails closed when content changes after authorization", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const fixture = createLinkedWorktree();
+  try {
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "authorized content\n", "utf8");
+    const inspected = safety.inspectWorktree(fixture.worktree);
+    assert.equal(inspected.status, "dirty");
+    const permit = safety.createDiscardPermit(inspected.snapshot);
+
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "changed after authorization\n", "utf8");
+
+    assert.throws(
+      () => safety.verifyWorktreePermit(permit),
+      /changed after authorization/
+    );
+    assert.equal(fs.existsSync(fixture.worktree), true);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("interactive single-worktree authorization uses a separate default-no discard confirmation", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const fixture = createLinkedWorktree();
+  try {
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "explicitly discarded\n", "utf8");
+    let confirmationCount = 0;
+    const permits = await rm.authorizeWorktrees(
+      [fixture.worktree],
+      { allowDirtyDiscard: true, assumeYes: false },
+      {
+        interactive: true,
+        confirm: async (options) => {
+          confirmationCount += 1;
+          assert.equal(options.initialValue, false);
+          assert.match(options.message, /Discard these exact uncommitted changes/);
+          return true;
+        }
+      }
+    );
+
+    assert.equal(confirmationCount, 1);
+    assert.equal(permits.get(path.resolve(fixture.worktree))?.mode, "discard");
+    assert.equal(fs.existsSync(fixture.worktree), true);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("worktree safety snapshot parses rename, delete, and conflict records", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const fixture = createLinkedWorktree();
+  try {
+    git(fixture.worktree, "mv", "tracked.txt", "renamed.txt");
+    const renamed = safety.inspectWorktree(fixture.worktree);
+    assert.equal(renamed.status, "dirty");
+    assert.ok(renamed.snapshot.changes.some((change) => (
+      change.indexStatus === "R" && change.path === "renamed.txt" && change.originalPath === "tracked.txt"
+    )));
+
+    git(fixture.worktree, "reset", "--hard", "HEAD");
+    fs.rmSync(path.join(fixture.worktree, "tracked.txt"));
+    const deleted = safety.inspectWorktree(fixture.worktree);
+    assert.equal(deleted.status, "dirty");
+    assert.ok(deleted.snapshot.changes.some((change) => change.path === "tracked.txt" && change.worktreeStatus === "D"));
+
+    git(fixture.worktree, "reset", "--hard", "HEAD");
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "feature version\n", "utf8");
+    git(fixture.worktree, "add", "tracked.txt");
+    git(fixture.worktree, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "feature");
+    fs.writeFileSync(path.join(fixture.repo, "tracked.txt"), "main version\n", "utf8");
+    git(fixture.repo, "add", "tracked.txt");
+    git(fixture.repo, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "main");
+    assert.throws(() => git(fixture.worktree, "merge", "main"));
+
+    const conflicted = safety.inspectWorktree(fixture.worktree);
+    assert.equal(conflicted.status, "dirty");
+    assert.ok(conflicted.snapshot.changes.some((change) => change.path === "tracked.txt" && change.indexStatus === "U"));
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("managed worktree removal requires a matching clean permit", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const managedFs = await loadFreshEsm<ManagedFsModule>("lib/sandbox/managed-fs.js");
+  const fixture = createLinkedWorktree();
+  try {
+    const inspected = safety.inspectWorktree(fixture.worktree);
+    assert.equal(inspected.status, "clean");
+    const permit = safety.createCleanPermit(inspected.snapshot);
+
+    managedFs.removeWorktreeDir(fixture.repo, fixture.base, fixture.worktree, permit);
+
+    assert.equal(fs.existsSync(fixture.worktree), false);
+    assert.equal(git(fixture.repo, "branch", "--list", "feature/safe-delete"), "feature/safe-delete");
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("managed worktree removal preserves a dirty target authorized as clean", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const managedFs = await loadFreshEsm<ManagedFsModule>("lib/sandbox/managed-fs.js");
+  const fixture = createLinkedWorktree();
+  try {
+    const inspected = safety.inspectWorktree(fixture.worktree);
+    assert.equal(inspected.status, "clean");
+    const permit = safety.createCleanPermit(inspected.snapshot);
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "do not delete\n", "utf8");
+
+    assert.throws(
+      () => managedFs.removeWorktreeDir(fixture.repo, fixture.base, fixture.worktree, permit),
+      /changed after authorization/
+    );
+    assert.equal(fs.readFileSync(path.join(fixture.worktree, "tracked.txt"), "utf8"), "do not delete\n");
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("managed worktree removal only uses the registered-path fallback when explicitly allowed", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const managedFs = await loadFreshEsm<ManagedFsModule>("lib/sandbox/managed-fs.js");
+  const fixture = createLinkedWorktree();
+  const calls: string[][] = [];
+  try {
+    const inspected = safety.inspectWorktree(fixture.worktree);
+    assert.equal(inspected.status, "clean");
+    const permit = safety.createCleanPermit(inspected.snapshot);
+
+    managedFs.removeWorktreeDir(fixture.repo, fixture.base, fixture.worktree, permit, {
+      allowRegisteredPathFallback: true,
+      runFn: (cmd, args) => {
+        calls.push([cmd, ...args]);
+        throw new Error("fatal: is not a working tree");
+      },
+      runSafeFn: (cmd, args) => {
+        calls.push([cmd, ...args]);
+        return "";
+      }
+    });
+
+    assert.equal(fs.existsSync(fixture.worktree), false);
+    assert.deepEqual(calls.at(-1), ["git", "-C", fixture.repo, "worktree", "prune"]);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("sandbox rm clean path uses injectable default-yes confirmations and removes selected state", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-clean-confirm-"));
+  const branch = "feature/clean-confirm";
+  const prompts: string[] = [];
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const { worktree, share } = await cleanRmOneFixture(rm, safety, fixture, tmpDir, branch, {
+      confirm: async (options) => {
+        assert.equal(options.initialValue, true);
+        prompts.push(options.message);
+        return true;
+      }
+    });
+
+    assert.deepEqual(prompts.map((message) => message.split(" ")[0]), ["Remove", "Also", "Remove"]);
+    assert.equal(fs.existsSync(worktree), false);
+    assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
+    assert.equal(fs.existsSync(share), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm negative confirmations preserve clean worktree, branch, and share", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-clean-negative-"));
+  const branch = "feature/clean-negative";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const { worktree, share } = await cleanRmOneFixture(rm, safety, fixture, tmpDir, branch, {
+      confirm: async () => false
+    });
+
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "show-ref", "--verify", `refs/heads/${branch}`), new RegExp(`refs/heads/${branch}$`));
+    assert.equal(fs.existsSync(share), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm cancellation at the worktree confirmation stops before every cleanup", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-clean-cancel-"));
+  const branch = "feature/clean-cancel";
+  const cancel = Symbol("cancel");
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const { worktree, share } = await cleanRmOneFixture(rm, safety, fixture, tmpDir, branch, {
+      confirm: async () => cancel,
+      isCancel: (value): value is symbol => value === cancel
+    });
+
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "show-ref", "--verify", `refs/heads/${branch}`), new RegExp(`refs/heads/${branch}$`));
+    assert.equal(fs.existsSync(share), true);
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --unbound --yes removes a real clean linked worktree and branch", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-unbound-clean-"));
+  const branch = "feature/clean-unbound";
+  const row = `demo-dev-${branch.replaceAll("/", "..")}\tUp 1 minute\tdemo.sandbox.branch=${branch},demo.sandbox=true`;
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: row });
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--yes"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(worktree), false);
+    assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox purge removes real clean linked worktrees after confirmation", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-purge-clean-"));
+  const branch = "feature/clean-purge-success";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const config = rmOneConfig(fixture, tmpDir);
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    const shellConfig = path.join(config.shellConfigBase, branch.replaceAll("/", ".."));
+    fs.mkdirSync(shellConfig, { recursive: true });
+    const confirmations: boolean[] = [];
+
+    await rm.rmPurge(config, [], {
+      confirm: async (options) => {
+        confirmations.push(Boolean(options.initialValue));
+        return Boolean(options.initialValue);
+      }
+    });
+
+    assert.deepEqual(confirmations, [true, true, false]);
+    assert.equal(fs.existsSync(worktree), false);
+    assert.match(git(fixture.repoDir, "show-ref", "--verify", `refs/heads/${branch}`), new RegExp(`refs/heads/${branch}$`));
+    assert.equal(fs.existsSync(shellConfig), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox prune removes a real clean orphan worktree after confirmation", onPlatforms("linux", "darwin", "win32"), async () => {
+  const prune = await loadFreshEsm<PruneModule>("lib/sandbox/commands/prune.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-prune-clean-"));
+  const branch = "feature/clean-prune-success";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const config = rmOneConfig(fixture, tmpDir);
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    let confirmationCount = 0;
+
+    await prune.prune([], {
+      config,
+      tools: [],
+      engine: "docker-desktop",
+      labelsOutput: "",
+      confirm: async (options) => {
+        confirmationCount += 1;
+        assert.equal(options.initialValue, true);
+        return true;
+      }
+    });
+
+    assert.equal(confirmationCount, 1);
+    assert.equal(fs.existsSync(worktree), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm fails closed when the managed worktree path is not a Git worktree", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-probe-failed-"));
+  const branch = "feature/probe-failed";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const worktree = path.join(tmpDir, ".agent-infra", "worktrees", "demo", branch.replaceAll("/", ".."));
+    const managedDir = path.join(tmpDir, ".agent-infra", "config", "demo", branch.replaceAll("/", ".."));
+    fs.mkdirSync(worktree, { recursive: true });
+    fs.mkdirSync(managedDir, { recursive: true });
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", branch]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /Unable to inspect worktree/);
+    assert.equal(fs.existsSync(worktree), true);
+    assert.equal(fs.existsSync(managedDir), true);
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm refuses a dirty linked worktree before container cleanup", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-dirty-"));
+  const branch = "feature/dirty-single";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    const managedDir = path.join(tmpDir, ".agent-infra", "shell-config", "demo", branch.replaceAll("/", ".."));
+    fs.mkdirSync(managedDir, { recursive: true });
+    fs.writeFileSync(path.join(worktree, "tracked.txt"), "keep this change\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", branch]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /Refusing to remove dirty worktree/);
+    assert.equal(fs.readFileSync(path.join(worktree, "tracked.txt"), "utf8"), "keep this change\n");
+    assert.match(git(fixture.repoDir, "show-ref", "--verify", `refs/heads/${branch}`), new RegExp(`refs/heads/${branch}$`));
+    assert.equal(fs.existsSync(managedDir), true);
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --unbound preflights all worktrees before deleting any sandbox", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-unbound-dirty-"));
+  const cleanBranch = "feature/clean-batch";
+  const dirtyBranch = "feature/dirty-batch";
+  const rows = [cleanBranch, dirtyBranch].map((branch) => (
+    `demo-dev-${branch.replaceAll("/", "..")}\tUp 1 minute\tdemo.sandbox.branch=${branch},demo.sandbox=true`
+  )).join("\n");
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: rows });
+    const cleanWorktree = addFixtureWorktree(fixture, tmpDir, cleanBranch);
+    const dirtyWorktree = addFixtureWorktree(fixture, tmpDir, dirtyBranch);
+    fs.writeFileSync(path.join(dirtyWorktree, "untracked.txt"), "keep this untracked file\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--yes"]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /worktree preflight found blocker/);
+    assert.equal(fs.existsSync(cleanWorktree), true);
+    assert.equal(fs.existsSync(path.join(dirtyWorktree, "untracked.txt")), true);
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --purge refuses dirty worktrees before stopping project containers", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-purge-dirty-"));
+  const cleanBranch = "feature/clean-purge";
+  const dirtyBranch = "feature/dirty-purge";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const cleanWorktree = addFixtureWorktree(fixture, tmpDir, cleanBranch);
+    const dirtyWorktree = addFixtureWorktree(fixture, tmpDir, dirtyBranch);
+    fs.writeFileSync(path.join(dirtyWorktree, "tracked.txt"), "purge must preserve this\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--purge"]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /worktree preflight found blocker/);
+    assert.equal(fs.existsSync(cleanWorktree), true);
+    assert.equal(fs.existsSync(dirtyWorktree), true);
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox prune preserves every orphan group when an orphan worktree is dirty", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-prune-dirty-"));
+  const cleanBranch = "feature/clean-prune";
+  const dirtyBranch = "feature/dirty-prune";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: "" });
+    const cleanWorktree = addFixtureWorktree(fixture, tmpDir, cleanBranch);
+    const dirtyWorktree = addFixtureWorktree(fixture, tmpDir, dirtyBranch);
+    const shellDir = path.join(tmpDir, ".agent-infra", "config", "demo", "orphan-shell");
+    fs.mkdirSync(shellDir, { recursive: true });
+    fs.writeFileSync(path.join(dirtyWorktree, "tracked.txt"), "prune must preserve this\n", "utf8");
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["prune"]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /worktree preflight found blocker/);
+    assert.equal(fs.existsSync(cleanWorktree), true);
+    assert.equal(fs.existsSync(dirtyWorktree), true);
+    assert.equal(fs.existsSync(shellDir), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #839

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

阻止 sandbox 的单项删除、批量删除、purge 和 prune 路径在 worktree 含 staged、unstaged 或 untracked 修改时强制清理，从机械上避免未提交代码永久丢失。

## 📋 主要变更 / Brief Changelog

- 将删除许可绑定到精确 worktree dirty snapshot，并在真正删除前复核 identity。
- 在 `rm`、`rm --unbound`、`rm --purge` 和 `prune` 的首个破坏性副作用前完成预检；批量操作先整批预检再逐项确认。
- 以 `rm --unbound` 替换语义误导的 `rm --all`，同步英文与中文文档及迁移提示。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run build`。
2. 运行 `npm run typecheck`。
3. 运行 `npm test`，确认 dirty worktree 拒绝、clean worktree 删除、批量预检及 WSL2 fallback 注入测试通过。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

自动化结果：2292 tests，2288 passed，4 skipped，0 failed。

## 📸 截图 / Screenshots

不适用；本次变更为 CLI 删除安全边界与文档更新。

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 代码检查通过 / Lint checks pass
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

### ✅ 已接受的剩余风险

- 未在真实 Windows + WSL2 + Docker Desktop 环境实机复现 registered-path mismatch；现有窄错误分类、permit 二次复核、注入测试及跨平台 CI 已覆盖安全语义。若真实 stderr 不匹配，clean 删除会安全失败并保留数据。该兼容性剩余风险已接受，不作为合并前人工校验门禁，也不表述为已完成实机验证。

`rm --all` 被直接移除并以 `rm --unbound` 取代；旧参数会在零删除副作用下失败并提示迁移。

Closes #839

---

**审查者注意事项 / Reviewer Notes:**

重点检查 snapshot-bound permit、授权后的 identity 复核、批量零副作用预检，以及 WSL2 fallback 的窄错误分类。

Generated with AI assistance
