### PR TITLE
fix(git): 修复提交器无法暂存已忽略目录内的删除文件


### DIFF
--- a/lib/git/workflow.ts
+++ b/lib/git/workflow.ts
@@ -20,6 +20,10 @@ function value(runner: GitRunner, cwd: string, args: readonly string[], trim = t
   return result.status === 0 ? (trim ? result.stdout.trim() : result.stdout.replace(/\n$/, '')) : null;
 }
 
+function nulPaths(output: string): string[] {
+  return output.split('\0').filter(Boolean);
+}
+
 function cleanMessage(message: string): string {
   return message.replace(/(https?:\/\/)[^\s/@:]+(?::[^\s/@]*)?@/gi, '$1***@').trim();
 }
@@ -68,8 +72,27 @@ function commitExplicitPaths(input: { cwd: string; paths: readonly string[]; mes
   const selected = new Set(input.paths);
   const unrelatedStaged = before.snapshot.staged.filter((candidate) => !selected.has(candidate));
   if (unrelatedStaged.length > 0) return { status: 'failed' as const, changed: false, snapshot: before.snapshot, operations: [], error: { code: 'GIT_STAGED_SCOPE_MISMATCH', message: `Unrelated staged paths: ${unrelatedStaged.join(', ')}` } };
-  const add = run(runner, input.cwd, ['add', '--', ...input.paths]);
-  if (add.status !== 0) return { status: 'failed' as const, changed: false, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'stage', status: 'failed' as const, message: add.stderr.trim() }], error: { code: 'GIT_STAGE_FAILED', message: add.stderr.trim() } };
+  const stageFailure = (message: string) => ({ status: 'failed' as const, changed: false, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'stage', status: 'failed' as const, message }], error: { code: 'GIT_STAGE_FAILED', message } });
+  const indexed = run(runner, input.cwd, ['ls-files', '-z', '--', ...input.paths]);
+  if (indexed.status !== 0) return stageFailure(indexed.stderr.trim());
+  const headed = run(runner, input.cwd, ['ls-tree', '-r', '--name-only', '-z', 'HEAD', '--', ...input.paths]);
+  if (headed.status !== 0) return stageFailure(headed.stderr.trim());
+  const indexedPaths = new Set(nulPaths(indexed.stdout));
+  const headPaths = new Set(nulPaths(headed.stdout));
+  const trackedPaths: string[] = [];
+  const addPaths: string[] = [];
+  for (const candidate of input.paths) {
+    if (indexedPaths.has(candidate)) trackedPaths.push(candidate);
+    else if (!headPaths.has(candidate) || fs.existsSync(path.join(input.cwd, candidate))) addPaths.push(candidate);
+  }
+  if (trackedPaths.length > 0) {
+    const update = run(runner, input.cwd, ['add', '-u', '--', ...trackedPaths]);
+    if (update.status !== 0) return stageFailure(update.stderr.trim());
+  }
+  if (addPaths.length > 0) {
+    const add = run(runner, input.cwd, ['add', '--', ...addPaths]);
+    if (add.status !== 0) return stageFailure(add.stderr.trim());
+  }
   const staged = run(runner, input.cwd, ['diff', '--cached', '--quiet', '--']);
   if (staged.status === 0) return { status: 'no-op' as const, changed: false, snapshot: inspectGitWorkflow(input.cwd, runner).snapshot, operations: [{ name: 'stage', status: 'no-op' as const }], error: null };
   if (input.expectedTree) {

--- a/tests/unit/git/workflow.test.ts
+++ b/tests/unit/git/workflow.test.ts
@@ -18,6 +18,31 @@ function fixture(): string {
   return root;
 }
 
+function ignoredTrackedFixture(): string {
+  const root = fixture();
+  fs.mkdirSync(path.join(root, 'ignored'));
+  fs.writeFileSync(path.join(root, 'ignored', 'file.txt'), 'one\n');
+  execFileSync('git', ['add', 'ignored/file.txt'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'track ignored file'], { cwd: root });
+  fs.writeFileSync(path.join(root, '.gitignore'), 'ignored/\n');
+  return root;
+}
+
+function gitOutput(root: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function stageIgnoredSnapshot(root: string): { head: string; tree: string } {
+  const head = gitOutput(root, ['rev-parse', 'HEAD']);
+  execFileSync('git', ['add', '-u', '--', 'ignored/file.txt'], { cwd: root });
+  execFileSync('git', ['add', '--', '.gitignore'], { cwd: root });
+  return { head, tree: gitOutput(root, ['write-tree']) };
+}
+
+function resetIgnoredSnapshot(root: string): void {
+  execFileSync('git', ['reset', '-q', 'HEAD', '--', 'ignored/file.txt', '.gitignore'], { cwd: root });
+}
+
 test('commitExplicitPaths commits only explicitly selected paths', () => {
   const root = fixture();
   fs.writeFileSync(path.join(root, 'tracked.txt'), 'two\n');
@@ -26,6 +51,102 @@ test('commitExplicitPaths commits only explicitly selected paths', () => {
   assert.equal(result.status, 'applied');
   assert.deepEqual(execFileSync('git', ['show', '--pretty=', '--name-only', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim(), 'tracked.txt');
   assert.match(execFileSync('git', ['status', '--short'], { cwd: root, encoding: 'utf8' }), /unrelated\.txt/);
+});
+
+test('commitExplicitPaths handles clean and modified tracked files under a newly ignored parent', () => {
+  for (const state of ['clean', 'modified'] as const) {
+    const root = ignoredTrackedFixture();
+    if (state === 'modified') fs.writeFileSync(path.join(root, 'ignored', 'file.txt'), 'two\n');
+    const { head, tree } = stageIgnoredSnapshot(root);
+    resetIgnoredSnapshot(root);
+
+    const result = commitExplicitPaths({
+      cwd: root,
+      paths: ['ignored/file.txt', '.gitignore'],
+      message: `fix: commit ${state} ignored tracked path`,
+      expectedHead: head,
+      expectedTree: tree
+    });
+
+    assert.equal(result.status, 'applied', `${state}: ${result.error?.code} ${result.error?.message}`);
+    assert.equal(gitOutput(root, ['rev-parse', 'HEAD^{tree}']), tree);
+    assert.equal(fs.readFileSync(path.join(root, 'ignored', 'file.txt'), 'utf8'), state === 'modified' ? 'two\n' : 'one\n');
+  }
+});
+
+test('commitExplicitPaths stages a tracked deletion under a newly ignored parent', () => {
+  const root = ignoredTrackedFixture();
+  fs.rmSync(path.join(root, 'ignored', 'file.txt'));
+  const { head, tree } = stageIgnoredSnapshot(root);
+  resetIgnoredSnapshot(root);
+
+  const result = commitExplicitPaths({
+    cwd: root,
+    paths: ['ignored/file.txt', '.gitignore'],
+    message: 'fix: delete ignored tracked path',
+    expectedHead: head,
+    expectedTree: tree
+  });
+
+  assert.equal(result.status, 'applied', `${result.error?.code} ${result.error?.message}`);
+  assert.equal(gitOutput(root, ['rev-parse', 'HEAD^{tree}']), tree);
+  assert.equal(gitOutput(root, ['show', '--pretty=', '--name-status', 'HEAD']), 'A\t.gitignore\nD\tignored/file.txt');
+});
+
+test('commitExplicitPaths accepts an already staged deletion under an ignored parent', () => {
+  const root = ignoredTrackedFixture();
+  fs.rmSync(path.join(root, 'ignored', 'file.txt'));
+  const { head, tree } = stageIgnoredSnapshot(root);
+
+  const result = commitExplicitPaths({
+    cwd: root,
+    paths: ['ignored/file.txt', '.gitignore'],
+    message: 'fix: commit staged ignored deletion',
+    expectedHead: head,
+    expectedTree: tree
+  });
+
+  assert.equal(result.status, 'applied', `${result.error?.code} ${result.error?.message}`);
+  assert.equal(gitOutput(root, ['rev-parse', 'HEAD^{tree}']), tree);
+});
+
+test('commitExplicitPaths rejects a recreated ignored file after its deletion was staged', () => {
+  const root = ignoredTrackedFixture();
+  fs.rmSync(path.join(root, 'ignored', 'file.txt'));
+  const { head } = stageIgnoredSnapshot(root);
+  fs.writeFileSync(path.join(root, 'ignored', 'file.txt'), 'recreated\n');
+
+  const result = commitExplicitPaths({
+    cwd: root,
+    paths: ['ignored/file.txt', '.gitignore'],
+    message: 'fix: reject recreated ignored file',
+    expectedHead: head
+  });
+
+  assert.equal(result.error?.code, 'GIT_STAGE_FAILED');
+  assert.equal(gitOutput(root, ['rev-parse', 'HEAD']), head);
+});
+
+test('commitExplicitPaths keeps invalid paths and expected tree mismatches fail closed', () => {
+  const invalidRoot = fixture();
+  const invalidHead = gitOutput(invalidRoot, ['rev-parse', 'HEAD']);
+  const invalid = commitExplicitPaths({ cwd: invalidRoot, paths: ['missing.txt'], message: 'fix: missing path' });
+  assert.equal(invalid.error?.code, 'GIT_STAGE_FAILED');
+  assert.equal(gitOutput(invalidRoot, ['rev-parse', 'HEAD']), invalidHead);
+
+  const mismatchRoot = fixture();
+  const mismatchHead = gitOutput(mismatchRoot, ['rev-parse', 'HEAD']);
+  const originalTree = gitOutput(mismatchRoot, ['rev-parse', 'HEAD^{tree}']);
+  fs.writeFileSync(path.join(mismatchRoot, 'tracked.txt'), 'two\n');
+  const mismatch = commitExplicitPaths({
+    cwd: mismatchRoot,
+    paths: ['tracked.txt'],
+    message: 'fix: mismatched tree',
+    expectedHead: mismatchHead,
+    expectedTree: originalTree
+  });
+  assert.equal(mismatch.error?.code, 'GIT_TREE_MISMATCH');
+  assert.equal(gitOutput(mismatchRoot, ['rev-parse', 'HEAD']), mismatchHead);
 });
 
 test('commitExplicitPaths rejects escaping and sensitive paths', () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #862

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change that doesn't need an issue

Closes #862

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

Fix controlled commits that fail when an explicit tracked path is deleted while its parent directory becomes ignored in the same reviewed snapshot.

修复受控提交在同一审查快照中删除受跟踪文件、同时新增规则忽略其父目录时无法完成显式路径暂存的问题。

## 📋 主要变更 / Brief Changelog

- Classify explicit paths using their current index and HEAD identities.
- Stage tracked paths with path-scoped `git add -u`, while preserving ordinary add failures for untracked or recreated ignored paths.
- Add regression coverage for clean, modified, deleted, already-staged, recreated ignored, invalid-path, and expected-tree mismatch scenarios.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Run `npm run typecheck`.
2. Run `npm run test:core`.
3. Run `node scripts/run-tests.js tests/unit/git/workflow.test.ts`.

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有核心测试都通过 / All existing core tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Latest local results: target tests 13/13; core tests 2023 passed, 0 failed, 3 skipped; TypeScript typecheck passed.

## 📸 截图 / Screenshots

Not applicable; this change has no visual output.

## ✅ 贡献者检查清单 / Contributor Checklist

### 基本要求 / Basic Requirements

- [x] 确保有 GitHub Issue 对应这个变更 / A GitHub Issue exists for this change
- [x] 此 PR 只解决一个 Issue / This PR addresses one issue without unrelated changes
- [x] 每个 commit 都有有意义的主题和描述 / Each commit has a meaningful subject and body

### 代码质量 / Code Quality

- [x] 代码遵循项目规范 / The code follows project conventions
- [x] 已完成自我审查和独立代码审查 / Self-review and independent code review are complete

### 测试要求 / Testing Requirements

- [x] 已编写必要的单元测试 / Necessary unit tests are included
- [x] TypeScript 类型检查通过 / TypeScript typecheck passes
- [x] 核心测试通过 / Core tests pass

### 文档和兼容性 / Documentation and Compatibility

- [x] 该内部行为修复不需要公共文档更新 / No public documentation update is required for this internal behavior fix
- [x] 无破坏性变更 / No breaking change is introduced
- [x] 已保留向后兼容性 / Backward compatibility is preserved

## 📋 附加信息 / Additional Notes

### ⚠️ 待人工验证 / Manual Validation Required

- On a case-insensitive macOS or Windows filesystem, stage deletion of `ignored/README.md`, recreate a case-variant `ignored/readme.md`, and add a rule ignoring `ignored/`. Confirm `commitExplicitPaths` fails closed with `GIT_STAGE_FAILED` instead of silently committing or skipping the path. This requires a case-insensitive host filesystem and cannot be completed in the current Linux environment.

## 审查者注意事项 / Reviewer Notes

- Verify that staging remains limited to the explicit path list.
- Confirm that sensitive-path, expected HEAD/tree, unrelated-staged-path, and checkpoint gates remain unchanged.
- Pay particular attention to the recreated ignored-file fail-closed regression test.

Generated with AI assistance
