### PR TITLE
fix(task): 修复任务产物同步破坏时间线导致完成门禁误报

### DIFF
--- a/.agents/skills/code-task/reference/dual-mode.md
+++ b/.agents/skills/code-task/reference/dual-mode.md
@@ -10,6 +10,8 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 
 核心扫描任务目录中的 `plan.md` / `plan-r{N}.md`、`review-plan.md` / `review-plan-r{N}.md`、`code.md` / `code-r{N}.md` 和 `review-code.md` / `review-code-r{N}.md`。
 
+`code.started` 会在 task.md frontmatter 中绑定本轮方案文件及其 SHA-256。`code.completed` 必须从实现报告的“方案输入”/“Plan Input”字段读取 canonical plan，并同时匹配该开始上下文和当前最新 plan；缺失、身份不一致或内容变化均失败关闭。
+
 ## 8 个分支
 
 > 分支按表中自上而下的顺序评估，命中即返回；后续分支不再判定。
@@ -17,7 +19,7 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 | 条件 | mode | exit | 行为 |
 |---|---|---:|---|
 | 无 code 产物，且最新 review-plan 精确为 `Approved` 并引用最新 plan | `init` | 0 | 初次实现，产物为 `code.md`；缺少匹配审批或为 `Approved-with-issues` 时返回 error |
-| 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，mtime 又晚于最新 code | `init` | 0 | plan 已在 code 之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准 |
+| 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，而最新 code 的完成 receipt 未绑定相同 plan 摘要 | `init` | 0 | plan 内容在 code 输入之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准；缺失或无效 receipt 失败关闭 |
 | `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
 | 最新 review-code 为 Approved 且存在审查完成后产生的 pending 实现输入 | `decision` | 0 | 选择最早 `II-N`，进入裁决驱动实现；false/not-required 与 consumed 输入不触发 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |

--- a/lib/task/artifact-lifecycle.ts
+++ b/lib/task/artifact-lifecycle.ts
@@ -7,6 +7,7 @@ import { locateActivityLog } from './activity-log.ts';
 import { parseImplementationInputs, selectPendingImplementationInput } from './implementation-inputs.ts';
 import { parseVerdict } from './review-artifacts.ts';
 import { extractSection, findSectionHeading } from './sections.ts';
+import { receiptForOutput, sha256File } from './artifact-receipts.ts';
 
 const artifactFamilyCatalog = [
   { family: 'analysis', sectionAliases: ['分析', 'Analysis'], heading: '分析', labels: ['需求分析报告', 'Requirements Analysis'] },
@@ -218,11 +219,7 @@ function resolveReviewedInput(
     diagnostics.push(diagnostic('BROKEN_REFERENCE', review.family, review.name, String(error)));
     return null;
   }
-  const lines = content.split(/\r?\n/);
-  const header = lines.findIndex((line) => /\*\*(?:审查输入|Review Input)\*\*[:：]/.test(line));
-  const referenceBlock = header >= 0 ? lines.slice(header, header + 12).join('\n') : '';
-  const candidates = [...referenceBlock.matchAll(/`([^`]+\.md)`/g)].map((match) => match[1]!);
-  const parsed = candidates.map((name) => parseArtifactName(name)).find((item) => item?.family === expectedFamily);
+  const parsed = parseReviewedInputReference(content, expectedFamily);
   if (!parsed) {
     diagnostics.push(diagnostic('BROKEN_REFERENCE', review.family, review.name, `${review.name} does not reference a canonical ${expectedFamily} artifact`));
     return null;
@@ -231,15 +228,70 @@ function resolveReviewedInput(
   try {
     const stat = fs.lstatSync(abs);
     if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('referenced input is not a regular file');
-    if (stat.mtimeMs > review.mtimeMs) {
-      diagnostics.push(diagnostic('BROKEN_REFERENCE', review.family, review.name, `${parsed.name} is newer than ${review.name}`));
-      return null;
+    const taskContent = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+    const receipt = receiptForOutput(taskContent, review.name);
+    if (!receipt) throw new Error(`receipt for ${review.name} is missing`);
+    const expectedEvent = reviewEventName(review.family);
+    if (receipt.event !== expectedEvent || receipt.input !== parsed.name) {
+      throw new Error(`receipt for ${review.name} does not match ${parsed.name}`);
+    }
+    const actualSha256 = sha256File(abs);
+    if (actualSha256 !== receipt.inputSha256) {
+      throw new Error(`${parsed.name} content digest does not match receipt`);
     }
     return { ...parsed, path: abs, size: stat.size, mtimeMs: stat.mtimeMs };
   } catch (error) {
     diagnostics.push(diagnostic('BROKEN_REFERENCE', review.family, review.name, `${parsed.name}: ${String(error)}`));
     return null;
   }
+}
+
+function parseReviewedInputReference(content: string, expectedFamily: ArtifactFamily): { family: ArtifactFamily; round: number; name: string } | null {
+  const lines = content.split(/\r?\n/);
+  const header = lines.findIndex((line) => /\*\*(?:审查输入|Review Input)\*\*[:：]/.test(line));
+  const referenceBlock = header >= 0 ? lines.slice(header, header + 12).join('\n') : '';
+  const candidates = [...referenceBlock.matchAll(/`([^`]+\.md)`/g)].map((match) => match[1]!);
+  return candidates
+    .map((name) => parseArtifactName(name))
+    .find((item) => item?.family === expectedFamily) ?? null;
+}
+
+function parseCodePlanInputReference(content: string): { family: 'plan'; round: number; name: string } | null {
+  const lines = content.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => /^##\s+(?:实现输入|Implementation Input)\s*$/.test(line.trim()));
+  if (sectionStart < 0) return null;
+  const bodyLines = lines.slice(sectionStart + 1);
+  const nextSection = bodyLines.findIndex((line) => /^##\s+/.test(line.trim()));
+  const body = (nextSection < 0 ? bodyLines : bodyLines.slice(0, nextSection)).join('\n');
+  const match = body.match(/\*\*(?:方案输入|Plan Input)\*\*[:：]\s*`([^`]+\.md)`/);
+  if (!match) return null;
+  const parsed = parseArtifactName(match[1]!);
+  return parsed?.family === 'plan' ? { ...parsed, family: 'plan' } : null;
+}
+
+function reviewEventName(family: ArtifactFamily): 'review-analysis.completed' | 'review-plan.completed' | 'review-code.completed' {
+  if (family === 'review-analysis') return 'review-analysis.completed';
+  if (family === 'review-plan') return 'review-plan.completed';
+  if (family === 'review-code') return 'review-code.completed';
+  throw new Error(`unsupported review family '${family}'`);
+}
+
+function resolveCodeInputReceipt(taskDir: string, code: ArtifactIdentity): { input: ArtifactIdentity; inputSha256: string } | null {
+  let taskContent: string;
+  try { taskContent = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8'); }
+  catch { return null; }
+  let receipt;
+  try { receipt = receiptForOutput(taskContent, code.name); }
+  catch { return null; }
+  if (!receipt || receipt.event !== 'code.completed') return null;
+  const plan = inspectArtifactDirectory(taskDir, 'plan');
+  if (plan.status !== 'ready') return null;
+  const input = plan.artifacts.find((artifact) => artifact.name === receipt.input);
+  return input ? { input, inputSha256: receipt.inputSha256 } : null;
+}
+
+function resolveCodePlanInput(taskDir: string, code: ArtifactIdentity): { input: ArtifactIdentity; inputSha256: string } | null {
+  return resolveCodeInputReceipt(taskDir, code);
 }
 
 function assertWritableInventory(inventory: ArtifactInventoryResult): ArtifactError | null {
@@ -312,11 +364,21 @@ function resolveCodeContext(inventory: ArtifactInventoryResult, options: Inspect
     return withCodeMode(inventory, inputs, 'ready', 'init', codeMax, reviewMax, null, null,
       'No prior code artifact. Starting initial implementation (round 1 -> code.md).');
   }
+  const codePlanInput = resolveCodePlanInput(inventory.taskDir!, latestCode);
+  if (!codePlanInput) {
+    return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', `code completion receipt for ${latestCode.name} is missing or does not match the current plan`, latestCode.name);
+  }
+  if (reviewPlan.latest && !reviewPlan.reviewedInput) {
+    return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', `${reviewPlan.latest.name} has no valid reviewed input`, reviewPlan.latest.name);
+  }
   if (reviewPlan.latest && reviewPlan.reviewedInput?.name === plan.latest.name) {
     const verdict = parseVerdict(reviewPlan.latest.path);
-    if (verdict.ok && verdict.verdict === 'Approved' && reviewPlan.latest.mtimeMs > latestCode.mtimeMs) {
+    const reviewedPlanSha256 = sha256File(reviewPlan.reviewedInput.path);
+    if (verdict.ok && verdict.verdict === 'Approved' && (
+      codePlanInput.input.name !== plan.latest.name || codePlanInput.inputSha256 !== reviewedPlanSha256
+    )) {
       return withCodeMode(inventory, inputs, 'ready', 'init', codeMax, reviewMax, verdict.verdict, reviewPlan.latest.name,
-        `Latest ${reviewPlan.latest.name} is approved and newer than the latest code artifact. Entering replan-driven init.`);
+        `Latest ${reviewPlan.latest.name} approves plan content not captured by the latest code input receipt. Entering replan-driven init.`);
     }
   }
   if (reviewMax < codeMax) {
@@ -440,6 +502,7 @@ function buildArtifactLinkSection(content: string, artifact: ArtifactIdentity): 
 export {
   artifactFamilyCatalog, artifactName, parseArtifactName, familySpec,
   inspectTaskArtifacts, inspectArtifactDirectory, resolveArtifactContext,
+  parseReviewedInputReference, parseCodePlanInputReference, resolveCodePlanInput, reviewEventName,
   assertWritableInventory, validateCompletedArtifact, buildArtifactLinkSection
 };
 export type {

--- a/lib/task/artifact-receipts.ts
+++ b/lib/task/artifact-receipts.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+
+import { extractSection, findSectionHeading, parseTable } from './sections.ts';
+
+const RECEIPT_SECTION_ALIASES = ['产物生命周期收据', 'Artifact Lifecycle Receipts'] as const;
+const RECEIPT_COLUMNS = ['event', 'output', 'input', 'input_sha256', 'completed_at'] as const;
+const RECEIPT_EVENTS = new Set([
+  'review-analysis.completed',
+  'review-plan.completed',
+  'review-code.completed',
+  'code.completed'
+]);
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const ARTIFACT_NAME_RE = /^(analysis|review-analysis|plan|review-plan|code|review-code|manual-validation|validation-run|pr-review)(?:-r([2-9]|[1-9]\d+))?\.md$/;
+const RECEIPT_SHAPES = {
+  'review-analysis.completed': { output: 'review-analysis', input: 'analysis' },
+  'review-plan.completed': { output: 'review-plan', input: 'plan' },
+  'review-code.completed': { output: 'review-code', input: 'code' },
+  'code.completed': { output: 'code', input: 'plan' }
+} as const;
+
+type ArtifactReceiptEvent =
+  | 'review-analysis.completed'
+  | 'review-plan.completed'
+  | 'review-code.completed'
+  | 'code.completed';
+type ArtifactReceipt = {
+  event: ArtifactReceiptEvent;
+  output: string;
+  input: string;
+  inputSha256: string;
+  completedAt: string;
+};
+type ArtifactReceiptParseResult = {
+  present: boolean;
+  rows: readonly ArtifactReceipt[];
+};
+type ReceiptSectionMutation = {
+  aliases: readonly string[];
+  heading: string;
+  body: string;
+};
+
+class ArtifactReceiptError extends Error {
+  readonly code = 'ARTIFACT_RECEIPT_INVALID';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArtifactReceiptError';
+  }
+}
+
+function sha256Bytes(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function sha256File(filePath: string): string {
+  return sha256Bytes(fs.readFileSync(filePath));
+}
+
+function parseReceiptArtifactName(name: string): { family: string } | null {
+  const match = ARTIFACT_NAME_RE.exec(name);
+  if (!match) return null;
+  const roundText = match[2];
+  if (roundText !== undefined) {
+    const round = Number(roundText);
+    if (!Number.isSafeInteger(round) || String(round) !== roundText) return null;
+  }
+  return { family: match[1]! };
+}
+
+function validateReceiptShape(event: ArtifactReceiptEvent, output: string, input: string): void {
+  const outputIdentity = parseReceiptArtifactName(output);
+  const inputIdentity = parseReceiptArtifactName(input);
+  if (!outputIdentity || !inputIdentity) throw new ArtifactReceiptError(`receipt artifact identity is invalid: ${output} -> ${input}`);
+  const shape = RECEIPT_SHAPES[event];
+  if (outputIdentity.family !== shape.output || inputIdentity.family !== shape.input) {
+    throw new ArtifactReceiptError(`receipt event '${event}' does not match ${output} -> ${input}`);
+  }
+}
+
+function parseArtifactReceipts(content: string): ArtifactReceiptParseResult {
+  const section = extractSection(content, [...RECEIPT_SECTION_ALIASES]);
+  if (!section) return { present: false, rows: [] };
+
+  let table;
+  try {
+    table = parseTable(content, {
+      sectionAliases: [...RECEIPT_SECTION_ALIASES],
+      columns: [...RECEIPT_COLUMNS],
+      keyColumn: 'output'
+    });
+  } catch (error) {
+    throw new ArtifactReceiptError(error instanceof Error ? error.message : String(error));
+  }
+  if (!table) throw new ArtifactReceiptError('receipt section has no receipt table');
+
+  const rows = table.rows.map((row) => {
+    const event = row.values.event ?? '';
+    const output = row.values.output ?? '';
+    const input = row.values.input ?? '';
+    const inputSha256 = row.values.input_sha256 ?? '';
+    const completedAt = row.values.completed_at ?? '';
+    if (!RECEIPT_EVENTS.has(event)) throw new ArtifactReceiptError(`unknown receipt event '${event}'`);
+    if (!output || !input) throw new ArtifactReceiptError('receipt output and input are required');
+    validateReceiptShape(event as ArtifactReceiptEvent, output, input);
+    if (!SHA256_RE.test(inputSha256)) throw new ArtifactReceiptError(`receipt digest for '${output}' is invalid`);
+    if (!completedAt || Number.isNaN(Date.parse(completedAt.replace(' ', 'T')))) {
+      throw new ArtifactReceiptError(`receipt completion time for '${output}' is invalid`);
+    }
+    return {
+      event: event as ArtifactReceiptEvent,
+      output,
+      input,
+      inputSha256,
+      completedAt
+    };
+  });
+  return { present: true, rows };
+}
+
+function receiptForOutput(content: string, output: string): ArtifactReceipt | null {
+  const parsed = parseArtifactReceipts(content);
+  return parsed.rows.find((row) => row.output === output) ?? null;
+}
+
+function upsertArtifactReceipt(content: string, receipt: ArtifactReceipt): ReceiptSectionMutation {
+  if (!RECEIPT_EVENTS.has(receipt.event)) throw new ArtifactReceiptError(`unknown receipt event '${receipt.event}'`);
+  if (!receipt.output || !receipt.input) throw new ArtifactReceiptError('receipt output and input are required');
+  validateReceiptShape(receipt.event, receipt.output, receipt.input);
+  if (!SHA256_RE.test(receipt.inputSha256)) throw new ArtifactReceiptError(`receipt digest for '${receipt.output}' is invalid`);
+  if (!receipt.completedAt || Number.isNaN(Date.parse(receipt.completedAt.replace(' ', 'T')))) {
+    throw new ArtifactReceiptError(`receipt completion time for '${receipt.output}' is invalid`);
+  }
+
+  const existing = parseArtifactReceipts(content).rows;
+  const previous = existing.find((row) => row.output === receipt.output);
+  if (previous && JSON.stringify(previous) !== JSON.stringify(receipt)) {
+    throw new ArtifactReceiptError(`receipt for '${receipt.output}' already exists with different evidence`);
+  }
+  const rows = previous ? existing : [...existing, receipt];
+  const heading = findSectionHeading(content, [...RECEIPT_SECTION_ALIASES]);
+  const body = [
+    `| ${RECEIPT_COLUMNS.join(' | ')} |`,
+    `| ${RECEIPT_COLUMNS.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.event} | ${row.output} | ${row.input} | ${row.inputSha256} | ${row.completedAt} |`)
+  ].join('\n');
+  return { aliases: [...RECEIPT_SECTION_ALIASES], heading, body };
+}
+
+export {
+  ArtifactReceiptError,
+  RECEIPT_SECTION_ALIASES,
+  parseArtifactReceipts,
+  receiptForOutput,
+  sha256Bytes,
+  sha256File,
+  upsertArtifactReceipt
+};
+export type { ArtifactReceipt, ArtifactReceiptEvent, ArtifactReceiptParseResult, ReceiptSectionMutation };

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -4,11 +4,16 @@ import { appendActivityEntry, locateActivityLog, pairEntries } from './activity-
 import {
   buildArtifactLinkSection,
   artifactName,
+  inspectArtifactDirectory,
+  parseReviewedInputReference,
+  parseCodePlanInputReference,
   parseArtifactName,
   resolveArtifactContext,
   validateCompletedArtifact
 } from './artifact-lifecycle.ts';
 import type { ArtifactContextResult, ArtifactErrorCode, ArtifactFamily, ArtifactIdentity } from './artifact-lifecycle.ts';
+import { ArtifactReceiptError, sha256File, upsertArtifactReceipt } from './artifact-receipts.ts';
+import type { ArtifactReceipt } from './artifact-receipts.ts';
 import { parseTypedTaskFrontmatter } from './frontmatter.ts';
 import {
   consumeImplementationInput,
@@ -273,6 +278,80 @@ function openStartedIdentity(rows: ReturnType<typeof pairEntries>, family: Event
   return matches.length === 1 ? matches[0] : matches.length > 1 ? { conflict: true as const } : null;
 }
 
+function reviewInputFamily(family: EventFamily): ArtifactFamily {
+  return family === 'review-analysis' ? 'analysis' : family === 'review-plan' ? 'plan' : 'code';
+}
+
+function buildCompletionReceipt(
+  taskDir: string,
+  family: EventFamily,
+  artifact: ArtifactIdentity,
+  completedAt: string,
+  frontmatter: Record<string, unknown>
+): { ok: true; receipt: ArtifactReceipt } | { ok: false; message: string } | null {
+  if (family === 'code') {
+    let content: string;
+    try { content = fs.readFileSync(artifact.path, 'utf8'); }
+    catch (error) { return { ok: false, message: `cannot read ${artifact.name}: ${String(error)}` }; }
+    const input = parseCodePlanInputReference(content);
+    if (!input) return { ok: false, message: `${artifact.name} does not reference a canonical plan artifact` };
+    const startedInput = typeof frontmatter.code_input_artifact === 'string' ? frontmatter.code_input_artifact : '';
+    const startedSha256 = typeof frontmatter.code_input_sha256 === 'string' ? frontmatter.code_input_sha256 : '';
+    if (!startedInput || !startedSha256) return { ok: false, message: 'code.started plan input context is missing' };
+    if (input.name !== startedInput) return { ok: false, message: `${artifact.name} plan input '${input.name}' does not match code.started input '${startedInput}'` };
+    const plan = inspectArtifactDirectory(taskDir, 'plan');
+    if (plan.status !== 'ready' || !plan.latest || plan.latest.name !== input.name) {
+      return { ok: false, message: `code input '${input.name}' is not the latest plan artifact` };
+    }
+    try {
+      const inputSha256 = sha256File(plan.latest.path);
+      if (inputSha256 !== startedSha256) return { ok: false, message: `code input ${input.name} changed after code.started` };
+      return {
+        ok: true,
+        receipt: {
+          event: 'code.completed', output: artifact.name, input: input.name,
+          inputSha256, completedAt
+        }
+      };
+    } catch (error) {
+      return { ok: false, message: `cannot hash code input plan: ${error instanceof Error ? error.message : String(error)}` };
+    }
+  }
+  if (!family.startsWith('review-')) return null;
+  const expectedFamily = reviewInputFamily(family);
+  let content: string;
+  try { content = fs.readFileSync(artifact.path, 'utf8'); }
+  catch (error) { return { ok: false, message: `cannot read ${artifact.name}: ${String(error)}` }; }
+  const input = parseReviewedInputReference(content, expectedFamily);
+  if (!input) return { ok: false, message: `${artifact.name} does not reference a canonical ${expectedFamily} artifact` };
+  const startedInput = typeof frontmatter.review_input_artifact === 'string' ? frontmatter.review_input_artifact : '';
+  const startedSha256 = typeof frontmatter.review_input_sha256 === 'string' ? frontmatter.review_input_sha256 : '';
+  if (!startedInput || !startedSha256) return { ok: false, message: 'review started input context is missing' };
+  if (input.name !== startedInput) return { ok: false, message: `${artifact.name} input '${input.name}' does not match review.started input '${startedInput}'` };
+  const current = inspectArtifactDirectory(taskDir, expectedFamily);
+  if (current.status !== 'ready' || !current.latest || current.latest.name !== input.name) {
+    return { ok: false, message: `review input '${input.name}' is not the latest ${expectedFamily} artifact` };
+  }
+  const event = family === 'review-analysis'
+    ? 'review-analysis.completed' as const
+    : family === 'review-plan' ? 'review-plan.completed' as const : 'review-code.completed' as const;
+  try {
+    const stat = fs.lstatSync(current.latest.path);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('review input is not a regular file');
+    const inputSha256 = sha256File(current.latest.path);
+    if (inputSha256 !== startedSha256) return { ok: false, message: `review input ${input.name} changed after review.started` };
+    return {
+      ok: true,
+      receipt: {
+        event, output: artifact.name, input: input.name,
+        inputSha256, completedAt
+      }
+    };
+  } catch (error) {
+    return { ok: false, message: `cannot hash review input ${input.name}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
 function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOptions = {}): TaskEventResult {
   const invalid = validateTaskEventRequest(request);
   if (invalid) return failed(request, invalid);
@@ -371,17 +450,59 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
   let metadata;
   try { metadata = (options.metadataProvider ?? captureTaskWriteMetadata)(); }
   catch (error) { return failed(normalized, { code: 'METADATA_CAPTURE_FAILED', message: String(error) }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath }); }
+  let completionReceipt: ArtifactReceipt | null = null;
+  if (eventIdentity.phase === 'completed' && completedArtifact) {
+    const receipt = buildCompletionReceipt(resolved.taskDir, eventIdentity.family, completedArtifact, metadata.timestamp, frontmatter);
+    if (receipt && !receipt.ok) {
+      return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: receipt.message }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+    }
+    completionReceipt = receipt?.receipt ?? null;
+  }
   const step = eventIdentity.phase === 'started' || eventIdentity.target === null ? currentStep : eventIdentity.target;
   const logStep = eventIdentity.phase === 'started' ? `${eventIdentity.action} [started]` : eventIdentity.action;
   const body = appendActivityEntry(section, { time: metadata.timestamp, step: logStep, agent: normalized.agent, note: eventIdentity.note });
   const frontmatterSet: Record<string, string> = { current_step: step, assigned_to: normalized.agent };
+  let frontmatterRemove: string[] | undefined;
+  if (eventIdentity.phase === 'started' && eventIdentity.family === 'code') {
+    const planInput = artifactContext?.inputs.find((input) => input.family === 'plan');
+    if (!planInput) return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: 'code.started plan input context is unavailable' }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
+    try {
+      frontmatterSet.code_input_artifact = planInput.name;
+      frontmatterSet.code_input_sha256 = sha256File(planInput.path);
+    } catch (error) {
+      return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot hash code.started plan input: ${error instanceof Error ? error.message : String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
+    }
+  } else if (eventIdentity.phase === 'completed' && eventIdentity.family === 'code') {
+    frontmatterRemove = ['code_input_artifact', 'code_input_sha256'];
+  } else if (eventIdentity.phase === 'started' && eventIdentity.family.startsWith('review-')) {
+    const expectedFamily = reviewInputFamily(eventIdentity.family);
+    const input = artifactContext?.inputs.find((candidate) => candidate.family === expectedFamily);
+    if (!input) return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `review.started ${expectedFamily} input context is unavailable` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
+    try {
+      frontmatterSet.review_input_artifact = input.name;
+      frontmatterSet.review_input_sha256 = sha256File(input.path);
+    } catch (error) {
+      return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot hash review.started input: ${error instanceof Error ? error.message : String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
+    }
+  } else if (eventIdentity.phase === 'completed' && eventIdentity.family.startsWith('review-')) {
+    frontmatterRemove = ['review_input_artifact', 'review_input_sha256'];
+  }
   if (eventIdentity.phase === 'started' && normalized.implementationInput) frontmatterSet.last_reviewed_commit = '';
   const mutations: Parameters<typeof writeTask>[0]['mutations'][number][] = [
-    { kind: 'frontmatter', set: frontmatterSet }
+    { kind: 'frontmatter', set: frontmatterSet, remove: frontmatterRemove }
   ];
   if (completedArtifact) {
     const link = buildArtifactLinkSection(content, completedArtifact);
     mutations.push({ kind: 'section', aliases: link.aliases, heading: link.heading, body: link.body });
+  }
+  if (completionReceipt) {
+    try {
+      const receiptSection = upsertArtifactReceipt(content, completionReceipt);
+      mutations.push({ kind: 'section', aliases: receiptSection.aliases, heading: receiptSection.heading, body: receiptSection.body });
+    } catch (error) {
+      const message = error instanceof ArtifactReceiptError ? error.message : String(error);
+      return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+    }
   }
   if (eventIdentity.phase === 'completed' && normalized.implementationInput) {
     let implementationRows;

--- a/lib/task/sections.ts
+++ b/lib/task/sections.ts
@@ -73,7 +73,7 @@ class DocumentMutationError extends Error {
 
 function parseTable(
   content: string,
-  input: { sectionAliases: readonly string[]; columns: readonly string[] }
+  input: { sectionAliases: readonly string[]; columns: readonly string[]; keyColumn?: string }
 ): ParsedTable | null {
   validateAliases(input.sectionAliases, 'table section aliases');
   if (
@@ -82,6 +82,10 @@ function parseTable(
     new Set(input.columns).size !== input.columns.length
   ) {
     throw new DocumentMutationError('MUTATION_INVALID', 'table columns are invalid');
+  }
+  const keyColumn = input.keyColumn ?? input.columns[0]!;
+  if (!input.columns.includes(keyColumn)) {
+    throw new DocumentMutationError('MUTATION_INVALID', 'table key column is invalid');
   }
   const sections = matchingSections(content, input.sectionAliases);
   if (sections.length === 0) return null;
@@ -125,7 +129,7 @@ function parseTable(
       column,
       decodeCell(parsed.cells[columnIndex]!).trim()
     ]));
-    const key = values[input.columns[0]!]!;
+    const key = values[keyColumn]!;
     if (seen.has(key)) {
       throw new DocumentMutationError('TABLE_DUPLICATE_KEY', `duplicate table key '${key}'`);
     }

--- a/templates/.agents/skills/code-task/reference/dual-mode.en.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.en.md
@@ -10,6 +10,8 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 
 The core scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N}.md`, `code.md` / `code-r{N}.md`, and `review-code.md` / `review-code-r{N}.md` in the task directory.
 
+`code.started` persists the plan identity and SHA-256 for the round in task.md frontmatter. `code.completed` must read the canonical plan from the implementation report's `Plan Input` field and match both that start context and the current latest plan; missing, mismatched, or changed input fails closed.
+
 ## Eight Branches
 
 > Branches are evaluated top-down in this table; the first match returns and skips later rows.
@@ -17,7 +19,7 @@ The core scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N}.
 | Condition | mode | exit | Behavior |
 |---|---|---:|---|
 | no code artifact, and the latest review-plan is exactly `Approved` and references the latest plan | `init` | 0 | initial implementation, output `code.md`; a missing matching approval or `Approved-with-issues` returns an error |
-| latest review-plan is exactly `Approved`, references the latest plan, and is newer than the latest code | `init` | 0 | enter a new implementation round. `Approved-with-issues` remains parse-compatible for history but is not cross-stage approval |
+| latest review-plan is exactly `Approved`, references the latest plan, and the latest code completion receipt does not bind the same plan digest | `init` | 0 | enter a new implementation round. `Approved-with-issues` remains parse-compatible for history but is not cross-stage approval; missing or invalid receipts fail closed |
 | `rev_max < code_max` | `error` | 2 | latest code round is unreviewed; run `review-code` first |
 | latest review-code is Approved and a pending implementation input was decided after that review completed | `decision` | 0 | select the earliest `II-N` and enter decision-driven implementation; false/not-required and consumed inputs do not trigger |
 | latest review-code is Approved with 0/0/0 | `refused` | 1 | already approved; do not run `code-task` again |

--- a/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
@@ -10,6 +10,8 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 
 核心扫描任务目录中的 `plan.md` / `plan-r{N}.md`、`review-plan.md` / `review-plan-r{N}.md`、`code.md` / `code-r{N}.md` 和 `review-code.md` / `review-code-r{N}.md`。
 
+`code.started` 会在 task.md frontmatter 中绑定本轮方案文件及其 SHA-256。`code.completed` 必须从实现报告的“方案输入”/“Plan Input”字段读取 canonical plan，并同时匹配该开始上下文和当前最新 plan；缺失、身份不一致或内容变化均失败关闭。
+
 ## 8 个分支
 
 > 分支按表中自上而下的顺序评估，命中即返回；后续分支不再判定。
@@ -17,7 +19,7 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 | 条件 | mode | exit | 行为 |
 |---|---|---:|---|
 | 无 code 产物，且最新 review-plan 精确为 `Approved` 并引用最新 plan | `init` | 0 | 初次实现，产物为 `code.md`；缺少匹配审批或为 `Approved-with-issues` 时返回 error |
-| 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，mtime 又晚于最新 code | `init` | 0 | plan 已在 code 之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准 |
+| 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，而最新 code 的完成 receipt 未绑定相同 plan 摘要 | `init` | 0 | plan 内容在 code 输入之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准；缺失或无效 receipt 失败关闭 |
 | `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
 | 最新 review-code 为 Approved 且存在审查完成后产生的 pending 实现输入 | `decision` | 0 | 选择最早 `II-N`，进入裁决驱动实现；false/not-required 与 consumed 输入不触发 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |

--- a/tests/e2e/core/code-task-dual-mode.test.ts
+++ b/tests/e2e/core/code-task-dual-mode.test.ts
@@ -6,6 +6,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { INTERNAL_CLI_PATH } from "../../helpers.ts";
+import { sha256File, upsertArtifactReceipt } from "../../../lib/task/artifact-receipts.ts";
+import { upsertSection } from "../../../lib/task/sections.ts";
 
 const TASK_ID = "TASK-20260101-000001";
 
@@ -17,7 +19,37 @@ function makeFixture(files: Record<string, string>) {
   fs.writeFileSync(path.join(taskDir, "task.md"), `---\nid: ${TASK_ID}\ncurrent_step: technical-design-review\n---\n\n# Task\n`);
   const withPlan = files["plan.md"] ? files : { "plan.md": "# plan", ...files };
   for (const [name, content] of Object.entries(withPlan)) fs.writeFileSync(path.join(taskDir, name), content);
+  seedLifecycleReceipts(taskDir);
   return { root, taskDir };
+}
+
+function addReceipt(taskDir: string, receipt: Parameters<typeof upsertArtifactReceipt>[1]) {
+  const taskPath = path.join(taskDir, "task.md");
+  const content = fs.readFileSync(taskPath, "utf8");
+  const mutation = upsertArtifactReceipt(content, receipt);
+  fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
+}
+
+function seedLifecycleReceipts(taskDir: string) {
+  const completedAt = "2026-01-01 00:00:00+00:00";
+  const entries = fs.readdirSync(taskDir).filter((name) => /^review-plan(?:-r[2-9]\d*)?\.md$/.test(name));
+  for (const output of entries) {
+    const content = fs.readFileSync(path.join(taskDir, output), "utf8");
+    const input = content.match(/`((?:plan|plan-r[2-9]\d*)\.md)`/)?.[1];
+    if (!input || !fs.existsSync(path.join(taskDir, input))) continue;
+    addReceipt(taskDir, {
+      event: "review-plan.completed", output, input,
+      inputSha256: sha256File(path.join(taskDir, input)), completedAt
+    });
+  }
+  const codeOutputs = fs.readdirSync(taskDir).filter((name) => /^code(?:-r[2-9]\d*)?\.md$/.test(name));
+  for (const output of codeOutputs) {
+    if (!fs.existsSync(path.join(taskDir, "plan.md"))) continue;
+    addReceipt(taskDir, {
+      event: "code.completed", output, input: "plan.md",
+      inputSha256: sha256File(path.join(taskDir, "plan.md")), completedAt
+    });
+  }
 }
 
 function runDetect(files: Record<string, string>) {
@@ -312,7 +344,8 @@ test("code-task dual-mode: parsing failure returns error", () => {
 // branch 4 (Approved 0/0/0 with no plan iteration → `refused`) remains the regression baseline for
 // the new replan branch; we don't duplicate it here.
 
-function runDetectWithMtimes(
+// File times model transport noise only; receipt-backed identity and SHA-256 drive routing.
+function runDetectWithTransportTimes(
   files: Record<string, string>,
   mtimes: Record<string, number> = {}
 ) {
@@ -330,7 +363,7 @@ function runDetectWithMtimes(
 
 test("code-task dual-mode: branch 2 (replan) - new plan-r2 after code triggers init", () => {
   const nowSec = Math.floor(Date.now() / 1000);
-  const result = runDetectWithMtimes(
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),
@@ -356,12 +389,39 @@ test("code-task dual-mode: branch 2 (replan) - new plan-r2 after code triggers i
   assert.equal(result.output.review_artifact, "review-plan-r2.md");
 });
 
+test("code-task dual-mode: transport time reordering does not change receipt-backed routing", () => {
+  const files = {
+    "code.md": "# code",
+    "review-code.md": zhReview("通过"),
+    "plan.md": "# plan",
+    "review-plan.md": zhReviewPlan("plan.md", "通过"),
+    "plan-r2.md": "# plan-r2",
+    "review-plan-r2.md": zhReviewPlan("plan-r2.md", "通过")
+  };
+  const first = runDetectWithTransportTimes(files, {
+    "plan-r2.md": 2000,
+    "review-plan-r2.md": 2030
+  });
+  const reordered = runDetectWithTransportTimes(files, {
+    "plan-r2.md": 2030,
+    "review-plan-r2.md": 2000
+  });
+  const routing = (result: ReturnType<typeof runDetectWithTransportTimes>) => ({
+    status: result.status,
+    mode: result.output.mode,
+    next_round: result.output.next_round,
+    next_artifact: result.output.next_artifact,
+    review_artifact: result.output.review_artifact
+  });
+  assert.deepEqual(routing(reordered), routing(first));
+});
+
 test("code-task dual-mode: branch 2 (replan) - unreviewed latest plan does not fire", () => {
   const nowSec = Math.floor(Date.now() / 1000);
   // plan iterated to r2 but the only review-plan (review-plan.md) still references plan.md;
   // checkPlanAheadOfCode sees the latest plan (plan-r2.md) is unreviewed and skips replan,
   // falling through to the existing Approved 0/0/0 → refused branch.
-  const result = runDetectWithMtimes(
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),
@@ -385,8 +445,8 @@ test("code-task dual-mode: branch 2 (replan) - unreviewed latest plan does not f
 test("code-task dual-mode: branch 2 (replan) - precedes unreviewed-code error", () => {
   const nowSec = Math.floor(Date.now() / 1000);
   // code-r2 has no matching review-code-r2 (would normally hit branch 3: error).
-  // But review-plan-r2 (mtime > code-r2) should win and force a new init round.
-  const result = runDetectWithMtimes(
+  // The approved review-plan-r2 receipt and plan identity should win and force a new init round.
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),
@@ -417,7 +477,7 @@ test("code-task dual-mode: branch 2 (replan) - precedes unreviewed-code error", 
 test("code-task dual-mode: branch 2 (replan) - review-plan Approved-with-issues does not trigger init", () => {
   const nowSec = Math.floor(Date.now() / 1000);
   // review-plan-r2 has Approved + 1 major → normalizes to Approved-with-issues.
-  const result = runDetectWithMtimes(
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),
@@ -447,7 +507,7 @@ test("code-task dual-mode: branch 2 (replan) - off-number plan/review-plan linke
   // Real workflow shape from TASK-20260608-230434: plan-r5 was approved by review-plan-r4.
   // Round numbers are independent counters; checkPlanAheadOfCode must read the
   // "审查输入" of the latest review-plan to verify it actually reviewed the latest plan.
-  const result = runDetectWithMtimes(
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),
@@ -480,7 +540,7 @@ test("code-task dual-mode: branch 2 (replan) - latest plan unreviewed (review-pl
   const nowSec = Math.floor(Date.now() / 1000);
   // review-plan-r2 explicitly references plan-r2.md, but plan-r3.md exists (unreviewed).
   // checkPlanAheadOfCode must NOT replan because the maintainer hasn't approved plan-r3 yet.
-  const result = runDetectWithMtimes(
+  const result = runDetectWithTransportTimes(
     {
       "code.md": "# code",
       "review-code.md": zhReview("通过"),

--- a/tests/integration/cli/merge.test.ts
+++ b/tests/integration/cli/merge.test.ts
@@ -15,6 +15,9 @@ import {
   rebuildManifests,
   scanSourceTasks
 } from '../../../lib/merge.ts';
+import { sha256File, receiptForOutput, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { resolveArtifactContext } from '../../../lib/task/artifact-lifecycle.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 
 function makeTempRepo() {
   const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-merge-'));
@@ -454,6 +457,41 @@ test('merge workspace copies new mutable tasks and preserves archive behavior', 
     assert.match(output, /Archive\s+\(.agents\/workspace\/archive\/\):/);
     assert.match(output, /TASK-20260409-111111\s+active\s+copied/);
     assert.match(output, /TASK-20260409-121212\s+archive\s+copied/);
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('merge workspace transports receipt-backed review context across mtime changes', () => {
+  const repoDir = makeTempRepo();
+  const sourceWorkspace = makeTempWorkspace(repoDir);
+  const taskId = 'TASK-20260409-121313';
+
+  try {
+    const review = '# Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n';
+    const sourceTaskDir = writeFlatTask(sourceWorkspace, 'active', taskId, {
+      title: 'receipt-backed task',
+      updatedAt: '2026-04-09 12:13:13',
+      extraFiles: { 'plan.md': '# Plan\n', 'review-plan.md': review }
+    });
+    const taskPath = path.join(sourceTaskDir, 'task.md');
+    const content = fs.readFileSync(taskPath, 'utf8');
+    const mutation = upsertArtifactReceipt(content, {
+      event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+      inputSha256: sha256File(path.join(sourceTaskDir, 'plan.md')),
+      completedAt: '2026-04-09 12:13:13+00:00'
+    });
+    fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
+
+    execFileSync(process.execPath, cliArgs('merge', sourceWorkspace), { cwd: repoDir, encoding: 'utf8' });
+    const localTaskDir = path.join(repoDir, '.agents', 'workspace', 'active', taskId);
+    // Reproduce the original sync failure: the reviewed input is newer than its review.
+    fs.utimesSync(path.join(localTaskDir, 'plan.md'), new Date('2030-01-01T00:00:00Z'), new Date('2030-01-01T00:00:00Z'));
+    fs.utimesSync(path.join(localTaskDir, 'review-plan.md'), new Date('2000-01-01T00:00:00Z'), new Date('2000-01-01T00:00:00Z'));
+
+    const restored = fs.readFileSync(path.join(localTaskDir, 'task.md'), 'utf8');
+    assert.equal(receiptForOutput(restored, 'review-plan.md')?.input, 'plan.md');
+    assert.equal(resolveArtifactContext(taskId, 'review-plan', { repoRoot: repoDir }).status, 'ready');
   } finally {
     fs.rmSync(repoDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/platform-comment.test.ts
+++ b/tests/integration/cli/platform-comment.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 
 import { INTERNAL_CLI_PATH, filePath } from '../../helpers.ts';
+import { sha256File, receiptForOutput, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'platform-comment-cli-'));
@@ -56,6 +58,32 @@ test('platform internal commands expose stable JSON and idempotent task comment 
   assert.equal(second.status, 0, second.stderr);
   assert.equal(JSON.parse(second.stdout).status, 'no-op');
   assert.equal(JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')).length, 1);
+});
+
+test('platform task comment sync transports receipt evidence with the task document', () => {
+  const f = fixture();
+  try {
+    const taskDir = path.join(f.root, '.agents', 'workspace', 'active', f.taskId);
+    fs.writeFileSync(path.join(taskDir, 'plan.md'), '# Plan\n');
+    fs.writeFileSync(path.join(taskDir, 'review-plan.md'), '# Review\n\n- **审查输入**：`plan.md`\n');
+    const taskPath = path.join(taskDir, 'task.md');
+    const content = fs.readFileSync(taskPath, 'utf8');
+    const mutation = upsertArtifactReceipt(content, {
+      event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+      inputSha256: sha256File(path.join(taskDir, 'plan.md')),
+      completedAt: '2026-08-19 20:00:00+00:00'
+    });
+    fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
+
+    const synced = runComment(['sync', f.taskId, '--kind', 'task', '--agent', 'codex'], f);
+    assert.equal(synced.status, 0, synced.stderr || synced.stdout);
+    const comments = JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')) as Array<{ body: string }>;
+    assert.equal(comments.length, 1);
+    assert.equal(receiptForOutput(comments[0]!.body, 'review-plan.md')?.input, 'plan.md');
+    assert.equal(receiptForOutput(comments[0]!.body, 'review-plan.md')?.inputSha256, sha256File(path.join(taskDir, 'plan.md')));
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
 });
 
 test('platform internal commands reject invalid payloads with exit code 1', () => {

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -8,6 +9,8 @@ import { spawnSync } from 'node:child_process';
 import { INTERNAL_CLI_PATH, sandboxControlSafeEnv } from '../../helpers.ts';
 import { applyTaskEvent } from '../../../lib/task/events.ts';
 import { prepareOrchestrationDelegation } from '../../../lib/task/orchestration.ts';
+import { upsertArtifactReceipt, type ArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 
 function fixture(step = 'requirement-analysis-review') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-event-'));
@@ -39,6 +42,20 @@ function reviewArtifact(
   counts: ReviewCounts = { blockers: 0, major: 0, minor: 0 }
 ) {
   return `# ${title}\n\n- **审查输入**：\`${input}\`\n\n## 审查摘要\n\n- **总体结论**：${verdict}\n- **发现（AI 可处理）**：${counts.blockers} 阻塞项，${counts.major} 主要，${counts.minor} 次要 / **人工校验**：0\n`;
+}
+
+function sha256File(filePath: string) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function addReceipt(file: string, receipt: ArtifactReceipt) {
+  const content = fs.readFileSync(file, 'utf8');
+  const mutation = upsertArtifactReceipt(content, receipt);
+  fs.writeFileSync(file, upsertSection(content, mutation).content);
+}
+
+function codeReport(plan = 'plan.md') {
+  return `# Implementation Report\n\n## Implementation Input\n\n- **Plan Input**: \`${plan}\`\n`;
 }
 
 type ReviewCounts = { blockers: number; major: number; minor: number };
@@ -126,6 +143,12 @@ last_reviewed_commit: abcdef1234567890
 | id | ledger_id | decision_evidence | stage | needs_implementation | decided_at | status | consumed_by |
 |----|-----------|-------------------|-------|----------------------|------------|--------|-------------|
 | II-1 | CD-1 | task.md#HDR-1 | code | true | 2026-07-18 09:59:00+08:00 | pending | |
+
+## 产物生命周期收据
+
+| event | output | input | input_sha256 | completed_at |
+|-------|--------|-------|--------------|--------------|
+| code.completed | code.md | plan.md | ${sha256File(path.join(f.dir, 'plan.md'))} | 2026-07-18 09:58:00+08:00 |
 
 ## Activity Log
 
@@ -585,6 +608,35 @@ test('review-code event completes the regular code review path', () => {
 });
 
 for (const scenario of reviewScenarios) {
+  test(`${scenario.family} completion records the reviewed input digest receipt`, () => {
+    const f = prepareReview(scenario, []);
+    const startedContent = fs.readFileSync(f.file, 'utf8');
+    assert.match(startedContent, /^review_input_artifact: /m);
+    assert.match(startedContent, /^review_input_sha256: [a-f0-9]{64}$/m);
+    const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+    assert.equal(completed.status, 0, completed.stderr);
+    const digest = sha256File(path.join(f.dir, scenario.input));
+    const content = fs.readFileSync(f.file, 'utf8');
+    assert.match(content, new RegExp(`\\| ${scenario.family}\\.completed \\| ${scenario.artifact} \\| ${scenario.input} \\| ${digest} \\|`));
+  });
+}
+
+for (const scenario of reviewScenarios) {
+  test(`${scenario.family} rejects input changes after the review artifact is written`, () => {
+    const f = prepareReview(scenario, []);
+    fs.writeFileSync(path.join(f.dir, scenario.input), `# ${scenario.input} changed\n`);
+    const before = fs.readFileSync(f.file);
+    const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
+    const result = JSON.parse(completed.stdout);
+
+    assert.equal(completed.status, 1);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error.code, 'EVENT_ARTIFACT_CONFLICT');
+    assert.deepEqual(fs.readFileSync(f.file), before);
+  });
+}
+
+for (const scenario of reviewScenarios) {
   test(`${scenario.family} rejects approved finding counts that differ from the ${scenario.stage} ledger`, () => {
     const f = prepareReview(scenario, [
       `| ${scenario.findingId} | ${scenario.stage} | 1 | minor | open | ${scenario.artifact}#finding |`
@@ -784,10 +836,12 @@ test('decision code event clears the review baseline and consumes its input on c
   assert.equal(startedResult.implementationInput, 'II-1');
   let content = fs.readFileSync(f.file, 'utf8');
   assert.match(content, /Code Task \(Round 2, decision II-1\) \[started\]/);
+  assert.match(content, /^code_input_artifact: plan\.md$/m);
+  assert.match(content, /^code_input_sha256: [a-f0-9]{64}$/m);
   assert.match(content, /last_reviewed_commit:\s*$/m);
   assert.match(content, /\| II-1 .*\| pending \|\s*\|/);
 
-  fs.writeFileSync(path.join(f.dir, 'code-r2.md'), '# Code round 2\n');
+  fs.writeFileSync(path.join(f.dir, 'code-r2.md'), codeReport());
   const completed = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
     '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4'
@@ -797,10 +851,48 @@ test('decision code event clears the review baseline and consumes its input on c
   content = fs.readFileSync(f.file, 'utf8');
   assert.match(content, /\| II-1 .*\| consumed \| code-r2\.md \|/);
   assert.match(content, /Code Task \(Round 2, decision II-1\).*Code implemented/);
+  assert.match(content, new RegExp(`\\| code.completed \\| code-r2\\.md \\| plan\\.md \\| ${sha256File(path.join(f.dir, 'plan.md'))} \\|`));
 
   const repeated = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
     '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4'
   ]);
   assert.equal(JSON.parse(repeated.stdout).status, 'no-op');
+});
+
+test('code completion rejects a report without a canonical plan input', () => {
+  const f = decisionFixture();
+  const started = run(f.root, [f.id, 'code.started', '--agent', 'codex', '--implementation-input', 'II-1']);
+  assert.equal(started.status, 0, started.stderr);
+  fs.writeFileSync(path.join(f.dir, 'code-r2.md'), '# Code round 2\n');
+  const before = fs.readFileSync(f.file);
+  const completed = run(f.root, [
+    f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '1'
+  ]);
+  assert.equal(completed.status, 1);
+  assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('code completion rejects a plan changed after code started', () => {
+  const f = fixture('technical-design-review');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan v1\n');
+  fs.writeFileSync(path.join(f.dir, 'review-plan.md'), reviewArtifact('Plan Review', 'plan.md'));
+  addReceipt(f.file, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.dir, 'plan.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  const started = run(f.root, [f.id, 'code.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stderr);
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan v2\n');
+  fs.writeFileSync(path.join(f.dir, 'code.md'), codeReport());
+  const before = fs.readFileSync(f.file);
+  const completed = run(f.root, [
+    f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code.md',
+    '--files-modified', '1', '--tests-passed', '1'
+  ]);
+  assert.equal(completed.status, 1);
+  assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+  assert.deepEqual(fs.readFileSync(f.file), before);
 });

--- a/tests/integration/cli/task-orchestration.test.ts
+++ b/tests/integration/cli/task-orchestration.test.ts
@@ -6,6 +6,8 @@ import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 import { filePath, gitSafeEnv, INTERNAL_CLI_PATH, sandboxControlSafeEnv } from '../../helpers.ts';
+import { sha256File, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-orchestration-cli-'));
@@ -27,6 +29,13 @@ function run(root: string, args: string[], env?: NodeJS.ProcessEnv) {
     encoding: 'utf8',
     env: sandboxControlSafeEnv(gitSafeEnv(env))
   });
+}
+
+function addReceipt(taskDir: string, receipt: Parameters<typeof upsertArtifactReceipt>[1]) {
+  const taskPath = path.join(taskDir, 'task.md');
+  const content = fs.readFileSync(taskPath, 'utf8');
+  const mutation = upsertArtifactReceipt(content, receipt);
+  fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
 }
 
 function approvedRouteFixture(prFlow: 'required' | 'disabled' | undefined) {
@@ -52,6 +61,23 @@ function approvedRouteFixture(prFlow: 'required' | 'disabled' | undefined) {
   fs.writeFileSync(path.join(dir, 'review-plan.md'), '# Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
   fs.writeFileSync(path.join(dir, 'code.md'), '# Code\n');
   fs.writeFileSync(path.join(dir, 'review-code.md'), '# Review\n\n- **审查输入**：`code.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
+  const completedAt = '2026-01-01 00:00:00+00:00';
+  addReceipt(dir, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(dir, 'analysis.md')), completedAt
+  });
+  addReceipt(dir, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(dir, 'plan.md')), completedAt
+  });
+  addReceipt(dir, {
+    event: 'code.completed', output: 'code.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(dir, 'plan.md')), completedAt
+  });
+  addReceipt(dir, {
+    event: 'review-code.completed', output: 'review-code.md', input: 'code.md',
+    inputSha256: sha256File(path.join(dir, 'code.md')), completedAt
+  });
   const fake = path.join(root, 'fake-gh.cjs');
   const pr = path.join(root, 'pr.json');
   const calls = path.join(root, 'calls.jsonl');

--- a/tests/unit/cli/task-artifact-lifecycle.test.ts
+++ b/tests/unit/cli/task-artifact-lifecycle.test.ts
@@ -12,6 +12,8 @@ import {
   parseArtifactName,
   resolveArtifactContext
 } from '../../../lib/task/artifact-lifecycle.ts';
+import { sha256Bytes, sha256File, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
 
@@ -23,6 +25,13 @@ function fixture(files: Record<string, string> = {}) {
   fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${TASK_ID}\ncurrent_step: requirement-analysis\n---\n\n# Task\n`);
   for (const [name, content] of Object.entries(files)) fs.writeFileSync(path.join(taskDir, name), content);
   return { repoRoot, taskDir };
+}
+
+function addReceipt(f: ReturnType<typeof fixture>, receipt: Parameters<typeof upsertArtifactReceipt>[1]) {
+  const taskPath = path.join(f.taskDir, 'task.md');
+  const content = fs.readFileSync(taskPath, 'utf8');
+  const mutation = upsertArtifactReceipt(content, receipt);
+  fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
 }
 
 test('catalog exposes exactly the approved artifact families', () => {
@@ -97,6 +106,10 @@ test('context resolves required latest inputs and actual review references indep
     'plan-r2.md': '# plan 2',
     'review-plan.md': '**审查输入**：`plan-r2.md`\n'
   });
+  addReceipt(f, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan-r2.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan-r2.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
   const plan = resolveArtifactContext(TASK_ID, 'plan', { repoRoot: f.repoRoot });
   const review = resolveArtifactContext(TASK_ID, 'review-plan', { repoRoot: f.repoRoot });
   assert.equal(plan.status, 'ready');
@@ -104,6 +117,48 @@ test('context resolves required latest inputs and actual review references indep
   assert.equal(review.status, 'ready');
   assert.deepEqual(review.inputs.map((item) => item.name), ['plan-r2.md']);
   assert.equal(inspectTaskArtifacts(TASK_ID, 'review-plan', { repoRoot: f.repoRoot }).reviewedInput?.name, 'plan-r2.md');
+});
+
+test('review references ignore mtime order and fail closed on content changes', () => {
+  const f = fixture({
+    'analysis.md': '# analysis\n',
+    'review-analysis.md': '**审查输入**：`analysis.md`\n'
+  });
+  addReceipt(f, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'analysis.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  const old = new Date(Date.now() - 10_000);
+  const future = new Date(Date.now());
+  fs.utimesSync(path.join(f.taskDir, 'review-analysis.md'), old, old);
+  fs.utimesSync(path.join(f.taskDir, 'analysis.md'), future, future);
+
+  assert.equal(resolveArtifactContext(TASK_ID, 'analysis', { repoRoot: f.repoRoot }).status, 'ready');
+  fs.appendFileSync(path.join(f.taskDir, 'analysis.md'), 'changed\n');
+  const changed = resolveArtifactContext(TASK_ID, 'analysis', { repoRoot: f.repoRoot });
+  assert.equal(changed.status, 'failed');
+  assert.equal(changed.error?.code, 'ARTIFACT_REFERENCE_INVALID');
+});
+
+test('code replan routing compares plan content with the code input receipt', () => {
+  const f = fixture({
+    'plan.md': '# new plan\n',
+    'code.md': '# code\n',
+    'review-plan.md': '**审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n'
+  });
+  addReceipt(f, {
+    event: 'code.completed', output: 'code.md', input: 'plan.md',
+    inputSha256: sha256Bytes(Buffer.from('# old plan\n')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  addReceipt(f, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan.md')), completedAt: '2026-01-01 00:01:00+00:00'
+  });
+
+  const result = resolveArtifactContext(TASK_ID, 'code', { repoRoot: f.repoRoot });
+  assert.equal(result.status, 'ready');
+  assert.equal(result.codeMode?.mode, 'init');
+  assert.equal(result.codeMode?.reviewArtifact, 'review-plan.md');
 });
 
 test('revision context fails closed when a review points to a future input', () => {

--- a/tests/unit/cli/task-lifecycle.test.ts
+++ b/tests/unit/cli/task-lifecycle.test.ts
@@ -5,6 +5,9 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { applyTaskLifecycle, lifecycleIntentCatalog } from '../../../lib/task/lifecycle.ts';
+import { sha256File, receiptForOutput, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
+import { resolveArtifactContext } from '../../../lib/task/artifact-lifecycle.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
 const METADATA = {
@@ -140,6 +143,38 @@ test('restore validates staging before exposing active and allocates a short id'
   const target = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'task.md');
   assert.match(fs.readFileSync(target, 'utf8'), /status: active/);
   assert.equal(result.shortId.shortId, '01');
+});
+
+test('restore transports task receipts with artifacts without using mtime', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-restore-receipt-'));
+  const staging = path.join(repoRoot, '.agents', 'workspace', '.restore-staging-1');
+  fs.mkdirSync(staging, { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, '.agents', '.airc.json'), JSON.stringify({ task: { shortIdLength: 2 } }));
+  const taskPath = path.join(staging, 'task.md');
+  fs.writeFileSync(taskPath, `---\nid: ${TASK_ID}\nissue_number: 42\nstatus: completed\ncurrent_step: code-review\nupdated_at: old\nagent_infra_version: old\n---\n\n# Task\n\n## Activity Log\n\n`);
+  fs.writeFileSync(path.join(staging, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(staging, 'review-plan.md'), '# Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n');
+  let content = fs.readFileSync(taskPath, 'utf8');
+  const mutation = upsertArtifactReceipt(content, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(staging, 'plan.md')), completedAt: '2026-07-18 12:00:00+00:00'
+  });
+  content = upsertSection(content, mutation).content;
+  fs.writeFileSync(taskPath, content);
+
+  const result = applyTaskLifecycle(
+    { taskRef: TASK_ID, intent: 'restore', agent: 'codex', stagingDir: staging, issueNumber: 42 },
+    { repoRoot, metadataProvider: () => METADATA }
+  );
+  assert.equal(result.status, 'applied');
+  const targetTask = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'task.md');
+  const restored = fs.readFileSync(targetTask, 'utf8');
+  assert.deepEqual(receiptForOutput(restored, 'review-plan.md'), {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID, 'plan.md')),
+    completedAt: '2026-07-18 12:00:00+00:00'
+  });
+  assert.equal(resolveArtifactContext(TASK_ID, 'review-plan', { repoRoot }).status, 'ready');
 });
 
 test('registry failure leaves a recoverable journal and the same request converges after repair', () => {

--- a/tests/unit/core/task-orchestration.test.ts
+++ b/tests/unit/core/task-orchestration.test.ts
@@ -18,6 +18,8 @@ import {
   sealMatchingOrchestrationDelegation,
   sealOrchestrationDelegation
 } from '../../../lib/task/orchestration.ts';
+import { sha256File, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
+import { upsertSection } from '../../../lib/task/sections.ts';
 import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
 
 const snapshot = () => 'before-tree';
@@ -57,6 +59,33 @@ function fixture(step: string) {
   return { root, taskDir };
 }
 
+function addReceipt(taskDir: string, receipt: Parameters<typeof upsertArtifactReceipt>[1]) {
+  const taskPath = path.join(taskDir, 'task.md');
+  const content = fs.readFileSync(taskPath, 'utf8');
+  const mutation = upsertArtifactReceipt(content, receipt);
+  fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
+}
+
+function seedLifecycleReceipts(f: ReturnType<typeof fixture>) {
+  const completedAt = '2026-01-01 00:00:00+00:00';
+  addReceipt(f.taskDir, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'analysis.md')), completedAt
+  });
+  addReceipt(f.taskDir, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan.md')), completedAt
+  });
+  addReceipt(f.taskDir, {
+    event: 'code.completed', output: 'code.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan.md')), completedAt
+  });
+  addReceipt(f.taskDir, {
+    event: 'review-code.completed', output: 'review-code.md', input: 'code.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'code.md')), completedAt
+  });
+}
+
 test('dispatch respects the repository execution lock', () => {
   const f = fixture('requirement-analysis');
   beginOrResumeOrchestration('TASK-20260101-000001', { repoRoot: f.root });
@@ -85,6 +114,7 @@ function approvedCodeFixture(manualValidation = 0) {
   fs.writeFileSync(path.join(f.taskDir, 'review-plan.md'), '# Plan Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
   fs.writeFileSync(path.join(f.taskDir, 'code.md'), '# Code\n');
   fs.writeFileSync(path.join(f.taskDir, 'review-code.md'), `# Code Review\n\n- **审查输入**：\`code.md\`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：${manualValidation}\n`);
+  seedLifecycleReceipts(f);
   return f;
 }
 
@@ -94,6 +124,7 @@ function cleanCommitCandidateFixture(prFlow: unknown = 'required') {
   fs.mkdirSync(path.join(f.root, '.agents'), { recursive: true });
   fs.writeFileSync(path.join(f.root, '.agents', '.airc.json'), `${JSON.stringify({ prFlow })}\n`);
   fs.writeFileSync(path.join(f.taskDir, 'task.md'), `---\nid: TASK-20260101-000001\ncurrent_step: code-review\npr_number: 42\nlast_reviewed_commit: ${head}\n---\n\n# Task\n`);
+  seedLifecycleReceipts(f);
   beginOrResumeOrchestration('TASK-20260101-000001', {
     repoRoot: f.root,
     id: () => 'run-clean',
@@ -419,6 +450,14 @@ test('route selects one fresh role from existing lifecycle facts', () => {
   fs.writeFileSync(path.join(code.taskDir, 'review-analysis.md'), '# Analysis Review\n\n- **审查输入**：`analysis.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
   fs.writeFileSync(path.join(code.taskDir, 'plan.md'), '# Plan\n');
   fs.writeFileSync(path.join(code.taskDir, 'review-plan.md'), '# Plan Review\n\n- **审查输入**：`plan.md`\n\n## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n');
+  addReceipt(code.taskDir, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(code.taskDir, 'analysis.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  addReceipt(code.taskDir, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(code.taskDir, 'plan.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
   assert.deepEqual(routeOrchestration('TASK-20260101-000001', { repoRoot: code.root }).next, {
     action: 'code-task', role: 'executor', stage: 'code', round: 1, artifact: 'code.md',
     requestedModel: null, requestedReasoningEffort: null
@@ -531,6 +570,7 @@ test('route gates clean completion on an explicit required PR flow', () => {
 
   const missingPr = cleanCommitCandidateFixture();
   fs.writeFileSync(path.join(missingPr.taskDir, 'task.md'), `---\nid: TASK-20260101-000001\ncurrent_step: code-review\nlast_reviewed_commit: ${missingPr.head}\n---\n\n# Task\n`);
+  seedLifecycleReceipts(missingPr);
   let missingPrCaptures = 0;
   const routed = routeOrchestration('TASK-20260101-000001', {
     repoRoot: missingPr.root,

--- a/tests/unit/task/artifact-receipts.test.ts
+++ b/tests/unit/task/artifact-receipts.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ArtifactReceiptError,
+  parseArtifactReceipts,
+  receiptForOutput,
+  sha256Bytes,
+  upsertArtifactReceipt
+} from '../../../lib/task/artifact-receipts.ts';
+
+const RECEIPT = {
+  event: 'review-plan.completed' as const,
+  output: 'review-plan.md',
+  input: 'plan.md',
+  inputSha256: sha256Bytes(Buffer.from('plan\n')),
+  completedAt: '2026-08-19 20:00:00+00:00'
+};
+
+test('sha256Bytes hashes exact bytes and preserves newline sensitivity', () => {
+  assert.equal(sha256Bytes(Buffer.from('plan\n')), '1b4025dc7b8d27cf38df85e77b20ed44a00851a2c28b338560560d85deded8e3');
+  assert.notEqual(sha256Bytes(Buffer.from('plan\r\n')), sha256Bytes(Buffer.from('plan\n')));
+});
+
+test('receipt upsert creates a portable task section and parses it back', () => {
+  const content = '# Task\n';
+  const mutation = upsertArtifactReceipt(content, RECEIPT);
+  const updated = `${content}\n## ${mutation.heading}\n\n${mutation.body}\n`;
+  const parsed = parseArtifactReceipts(updated);
+
+  assert.equal(parsed.present, true);
+  assert.deepEqual(receiptForOutput(updated, 'review-plan.md'), RECEIPT);
+});
+
+test('receipt parsing fails closed for invalid digest and duplicate output', () => {
+  const invalid = `## 产物生命周期收据\n\n| event | output | input | input_sha256 | completed_at |\n|---|---|---|---|---|\n| review-plan.completed | review-plan.md | plan.md | invalid | 2026-08-19 20:00:00+00:00 |\n`;
+  assert.throws(() => parseArtifactReceipts(invalid), ArtifactReceiptError);
+
+  const first = upsertArtifactReceipt('# Task\n', RECEIPT);
+  const withSection = `## ${first.heading}\n\n${first.body}\n`;
+  const duplicate = `${withSection}| review-plan.completed | review-plan.md | plan.md | ${RECEIPT.inputSha256} | ${RECEIPT.completedAt} |\n`;
+  assert.throws(() => parseArtifactReceipts(duplicate), ArtifactReceiptError);
+});
+
+test('receipt parsing accepts multiple rounds but rejects noncanonical and mismatched identities', () => {
+  const first = upsertArtifactReceipt('# Task\n', RECEIPT);
+  const second = upsertArtifactReceipt(`## ${first.heading}\n\n${first.body}\n`, {
+    ...RECEIPT,
+    output: 'review-plan-r2.md',
+    input: 'plan-r2.md',
+    inputSha256: 'b'.repeat(64)
+  });
+  const content = `## ${second.heading}\n\n${second.body}\n`;
+  assert.equal(parseArtifactReceipts(content).rows.length, 2);
+  assert.throws(() => upsertArtifactReceipt('# Task\n', {
+    ...RECEIPT,
+    output: 'review-plan-r1.md'
+  }), ArtifactReceiptError);
+  assert.throws(() => upsertArtifactReceipt('# Task\n', {
+    ...RECEIPT,
+    output: 'review-code.md',
+    input: 'code.md'
+  }), ArtifactReceiptError);
+});
+
+test('receipt identity accepts canonical double- and triple-digit rounds', () => {
+  for (const round of [10, 19, 100, 200]) {
+    assert.doesNotThrow(() => upsertArtifactReceipt('# Task\n', {
+      ...RECEIPT,
+      output: `review-plan-r${round}.md`,
+      input: `plan-r${round}.md`
+    }));
+  }
+  assert.throws(() => upsertArtifactReceipt('# Task\n', {
+    ...RECEIPT,
+    output: 'review-plan-r01.md',
+    input: 'plan-r01.md'
+  }), ArtifactReceiptError);
+});
+
+test('receipt identity enforces the canonical safe-integer round boundary', () => {
+  const maxSafeRound = Number.MAX_SAFE_INTEGER;
+  assert.doesNotThrow(() => upsertArtifactReceipt('# Task\n', {
+    ...RECEIPT,
+    output: `review-plan-r${maxSafeRound}.md`,
+    input: `plan-r${maxSafeRound}.md`
+  }));
+  assert.throws(() => upsertArtifactReceipt('# Task\n', {
+    ...RECEIPT,
+    output: `review-plan-r${maxSafeRound + 1}.md`,
+    input: `plan-r${maxSafeRound + 1}.md`
+  }), ArtifactReceiptError);
+});
+
+test('receipt upsert rejects different evidence for an existing output', () => {
+  const first = upsertArtifactReceipt('# Task\n', RECEIPT);
+  const content = `## ${first.heading}\n\n${first.body}\n`;
+  assert.throws(() => upsertArtifactReceipt(content, {
+    ...RECEIPT,
+    inputSha256: 'f'.repeat(64)
+  }), ArtifactReceiptError);
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #837

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小修改，不需要 Issue / This is a trivial change that does not need an issue

Closes #837

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [x] 📚 文档更新 / Documentation update
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

任务产物跨工作树同步或恢复后，文件 `mtime` 可能被重排，导致完成门禁把内容未变化的已审查输入误判为审查后修改。本变更将审查因果证据迁移到 `task.md` 中的结构化生命周期 receipt 和输入文件原始字节 SHA-256，同时保持真实内容变化、证据缺失和身份不匹配时的失败关闭语义。

When task artifacts are synchronized or restored across worktrees, file `mtime` ordering can change and falsely report that an already-reviewed input was modified after review. This change moves review-causality evidence to structured lifecycle receipts in `task.md` and SHA-256 digests of the input bytes, while preserving fail-closed behavior for real content changes, missing evidence, and identity mismatches.

## 📋 主要变更 / Brief Changelog

- 新增 receipt schema、原始字节 SHA-256 计算和 canonical artifact family/round 校验；`Number.MAX_SAFE_INTEGER` 可接受，首个超界轮次拒绝。
  Added receipt schema validation, raw-byte SHA-256 hashing, and canonical artifact family/round checks; `Number.MAX_SAFE_INTEGER` is accepted and the first unsafe round is rejected.
- 让 `review-*.started/completed` 和 `code.started/completed` 绑定实际输入产物身份与摘要，并在同一次 `task.md` 原子写入中更新 receipt、Activity Log、frontmatter 和产物链接。
  Bind review and code started/completed events to the actual input artifact identity and digest, atomically updating receipts, Activity Log, frontmatter, and artifact links in `task.md`.
- 将生命周期消费和 code 双模式 replan 判断从 `mtime` 因果判断切换为 receipt + digest 比较；merge、restore、Issue comment 运输继续携带同一 `task.md` 证据。
  Replace mtime-based causality in lifecycle consumption and code dual-mode replan routing with receipt and digest comparisons; merge, restore, and Issue-comment transport continue to carry the same `task.md` evidence.
- 同步英文/中文 code-mode 说明，并增加 unit、integration、e2e、transport、orchestration 和安全整数边界回归测试。
  Synchronize the English/Chinese code-mode guidance and add unit, integration, e2e, transport, orchestration, and safe-integer boundary regression coverage.

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 `npm run build`。
3. 运行完整 `npm test`。
4. 检查 `git diff --check` 和提交前 reviewed snapshot tree 一致性。

### 测试覆盖 / Test Coverage

- [x] 已添加必要的单元、集成和端到端测试 / Unit, integration, and end-to-end tests added
- [x] 类型检查和构建通过 / Typecheck and build pass
- [x] 完整测试 2390 项：2386 通过、0 失败、4 跳过 / Full suite: 2386 passed, 0 failed, 4 skipped
- [x] 受影响专项测试 179 项全部通过 / All 179 affected tests pass
- [x] Round 5 代码审查通过，Blocker/Major/Minor 为 0/0/0 / Round 5 code review approved with 0/0/0 findings
- [x] 无需人工校验项 / No manual-validation items required

## 📸 截图 / Screenshots

不适用；本次变更为任务生命周期、receipt schema、门禁和文档行为修复，无可视化界面变化。

Not applicable; this change updates task lifecycle, receipt schema, gate behavior, and documentation rather than a visual interface.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只处理 Issue #837 / This PR addresses only Issue #837
- [x] Commit 具有清晰主题与说明 / Commit has a clear subject and body
- [x] 代码遵循项目规范并已完成自审 / Code follows project conventions and self-review is complete
- [x] 已完成 Round 5 独立代码审查 / Round 5 independent code review is approved
- [x] 已添加必要测试，类型检查、构建和完整测试通过 / Required tests, typecheck, build, and full suite pass
- [x] 已同步英文和中文文档 / English and Chinese documentation is synchronized
- [x] 无破坏性公共 API 变更 / No breaking public API changes

## 📋 附加信息 / Additional Notes

Receipt 是任务工作流中的可验证完整性证据，不是抗恶意篡改的密码学签名；该信任模型与已批准的技术方案一致。mtime 仍可用于展示，但不再参与审查因果判断。

Receipts provide workflow-verifiable integrity evidence, not a cryptographic signature against malicious tampering; this trust model follows the approved technical plan. `mtime` remains available for display but is no longer used for review-causality decisions.

---

Generated with AI assistance
