### PR TITLE
feat(data): 建立过程数据增量快照与检查点


### DIFF
--- a/docs/en/process-data.md
+++ b/docs/en/process-data.md
@@ -1,57 +1,44 @@
 # Process Data Archive
 
-The `ai data` command family preserves development-process evidence as append-only, verifiable snapshots. It captures the local task workspace and currently visible GitHub Issue and pull-request data without changing either source.
+`ai data` records GitHub process evidence as append-only, verified snapshots. The new capture path is GitHub-only: local task files, Activity Logs, and receipts are already normalized locally and are not collected by this command.
 
 ## Commands
 
 ```bash
-ai data capture [--source all|local|github] [--root <dir>] [--include-excerpts]
+ai data capture [--source github] [--root <dir>] [--full-reconcile]
 ai data verify <snapshot-id> [--root <dir>]
 ai data audit <snapshot-id> [--root <dir>] [--format json|text]
 ai data repair <snapshot-id> [--root <dir>] [--apply]
-ai data export <snapshot-id> [--root <dir>] [--repairs none|applied] [--output <file|->]
+ai data export <snapshot-id> [--root <dir>] [--as-of <ISO>] [--repairs none|applied] [--output <file|->]
 ```
 
-The default root is `.agents/workspace/process-data/`. A custom root must stay inside the repository and cannot overlap a task directory. Exit code `0` means success or an idempotent no-op, `1` means invalid input or failed integrity verification, and `2` means a required source was incomplete or blocked.
+`--source github` is the default. `--source local`, `--source all`, and `--include-excerpts` fail closed; they do not create a data root, checkpoint, or snapshot. Existing `raw-manifest/v1` local, all, and GitHub snapshots remain readable by `verify`, `audit`, `repair`, and `export`.
 
-This default is host runtime state. Sandboxes do not mount it writable; a default-path capture attempted inside a sandbox therefore fails closed.
+## Observation and lineage
 
-`capture` defaults to `--source all`. A local-only or GitHub-only capture is explicitly marked as partial and must not be presented as a complete baseline.
+The first successful capture is a `base` snapshot. Later captures are `delta` snapshots linked through one parent and a checkpoint at `checkpoints/github/`. A checkpoint advances only after CAS writes, snapshot publication, and verification succeed.
 
-## Storage and Integrity
+Each run performs a GitHub response-date preflight and records an observation cutoff `F`. For endpoints with a documented strict `since` parameter, an incremental run requests `W - 1 second` and accepts objects in `[W, F)`. The one-second reread closes the inclusive checkpoint boundary. Objects older than `W` are overlap evidence; objects at or after `F` are deferred to a later observation. Endpoints without a documented `since` contract, including issue timelines, are fully paginated.
+
+HTTP `Date`, page evidence, and the checkpoint prove the observed request and local lineage only. They do not claim that GitHub has exposed every historical object by `F`. Use `--full-reconcile` to enumerate all endpoints without `since` and correct delayed visibility. Scheduling repeated full reconciliation is outside this task.
+
+## Storage and verification
 
 ```text
 process-data/
   objects/sha256/<prefix>/<digest>
   snapshots/YYYY/MM/DD/<snapshot-id>/
+  checkpoints/github/<repository-key>.json
   repairs/<snapshot-id>/<repair-id>/
   .staging/
 ```
 
-Content is stored in a SHA-256 content-addressed store. Capture writes to staging and publishes a snapshot with one filesystem rename only after every required source is complete. Existing objects and snapshots are verified and reused; they are never overwritten.
+Page evidence and resource objects are separate CAS entries. Page hashes prove pagination and request metadata; resource hashes are the only hashes used for stable delta equality. Resource identities do not contain page numbers. Issues, pull requests, comments, reviews, commits, and timeline events are projected through an allowlist.
 
-GitHub REST arrays are requested explicitly with `per_page=100&page=N`. Every request page records an item count and `canonicalSha256`. Canonical JSON recursively sorts object keys, preserves array order, and hashes its UTF-8 bytes. This is a semantic JSON representation, not the original HTTP response bytes. Empty terminal pages count as requests and page evidence, but not as data pages.
+`verify` checks manifest hashes, lineage, observation-window arithmetic, query evidence, operation counts, normalized records, and CAS objects. It never upgrades an HTTP `Date` into a completeness proof. `export --as-of` materializes only a verified v2 lineage whose observation watermark is no later than the requested time.
 
-`verify` recomputes manifest, object, page, and byte-count evidence. `audit` reads the deterministic quality baseline only after verification succeeds.
+## Privacy, recovery, and repair
 
-## Privacy Boundary
+Sensitive GitHub text is excluded by policy and is never restored by repair. Network, permission, identity, missing-time, response-boundary, and pagination failures stop the run before checkpoint advancement. Checkpoint locks are single-writer, host-bound, and owner-specific; unknown ownership or ambiguous recovery fails closed.
 
-Task artifacts and allowlisted GitHub fields are process evidence. Credentials, private keys, bearer tokens, and credential-shaped values are excluded; the manifest keeps only their hash, size, policy rule, and exclusion reason.
-
-Structured telemetry comes from task Activity Logs and recognized delegation or orchestration receipts. Entropy reports remain operational reports. Unknown log formats produce unknown observations instead of guessed telemetry.
-
-Session and tool bodies are unavailable by default. `--include-excerpts` is an explicit opt-in for bounded, redacted excerpts; it never authorizes internal reasoning or secret material.
-
-## Reconciliation and Repair
-
-Quality findings distinguish missing records, duplicate identities, binding conflicts, content differences, schema differences, mutable remote records, unrecoverable history, and privacy exclusions.
-
-`ai data repair` is a dry run. `--apply` may append an overlay only when the relationship is unique, the evidence is complete and non-sensitive, and its precondition is fixed. It never patches or deletes local tasks, GitHub comments, or snapshot objects. Repeating the same repair is a no-op.
-
-Use `ai data export ... --repairs applied` to compose verified overlays with normalized records. The base snapshot remains unchanged.
-
-## Scheduling, Backup, and Recovery
-
-Run capture and verify periodically from cron or CI with a credential that has read-only repository access. Treat exit code `2` as an incomplete observation, not a successful baseline.
-
-The default root is Git-ignored and is the local authoritative copy. Checksums detect damage but do not provide disaster recovery. Back up the directory independently with encryption and access controls, organize backup packages by year and month, and regularly restore a copy into a temporary repository before running `ai data verify`.
+`ai data repair` remains append-only and does not delete source records or snapshots. `--apply` writes a verified overlay only when its precondition is fixed. Historical v1 overlays continue to work without rewriting v1 data.

--- a/docs/zh-CN/process-data.md
+++ b/docs/zh-CN/process-data.md
@@ -1,57 +1,44 @@
 # 过程数据归档
 
-`ai data` 命令族把开发过程证据保存为只追加、可校验的快照。它采集本地任务工作区以及 GitHub 当前可见的 Issue 和 Pull Request 数据，不修改任何来源。
+`ai data` 把 GitHub 过程证据保存为只追加、可验证的快照。新的采集路径只收集 GitHub：本地任务文件、Activity Log 和 receipt 已经在本地规范化，不由该命令再次收集。
 
 ## 命令
 
 ```bash
-ai data capture [--source all|local|github] [--root <dir>] [--include-excerpts]
+ai data capture [--source github] [--root <dir>] [--full-reconcile]
 ai data verify <snapshot-id> [--root <dir>]
 ai data audit <snapshot-id> [--root <dir>] [--format json|text]
 ai data repair <snapshot-id> [--root <dir>] [--apply]
-ai data export <snapshot-id> [--root <dir>] [--repairs none|applied] [--output <file|->]
+ai data export <snapshot-id> [--root <dir>] [--as-of <ISO>] [--repairs none|applied] [--output <file|->]
 ```
 
-默认根目录为 `.agents/workspace/process-data/`。自定义根目录必须位于仓库内，且不能与任务目录重叠。退出码 `0` 表示成功或幂等 no-op，`1` 表示输入非法或完整性校验失败，`2` 表示必需来源不完整或被阻塞。
+`--source github` 是默认值。`--source local`、`--source all` 和 `--include-excerpts` 会失败关闭，不创建 data root、checkpoint 或 snapshot。历史 `raw-manifest/v1` 的 local、all、GitHub 快照仍可由 `verify`、`audit`、`repair` 和 `export` 读取。
 
-该默认目录属于宿主运行时状态。沙箱不会以可写方式挂载它，因此在沙箱内尝试写入默认路径会失败关闭。
+## 观察边界与 lineage
 
-`capture` 默认使用 `--source all`。只采集 local 或 GitHub 时，快照会明确标记为 partial，不得作为完整基线对外宣称。
+第一次成功采集生成 `base` 快照，后续采集生成沿单父节点连接的 `delta` 快照，并在 `checkpoints/github/` 保存 checkpoint。只有 CAS 写入、快照发布和校验全部成功后，checkpoint 才会推进。
 
-## 存储与完整性
+每轮先执行 GitHub response `Date` 预检，形成观察截止点 `F`。对官方契约明确支持严格 `since` 的 endpoint，增量请求使用 `W - 1 秒`，客户端接纳 `[W, F)` 内的对象；一秒边界重读保证 checkpoint 起点不因严格 after 语义被漏掉。早于 `W` 的对象只作为 overlap 证据，`>= F` 的对象延后到下一轮。没有正式 `since` 契约的 endpoint（包括 issue timeline）完整分页。
+
+HTTP `Date`、页面证据和 checkpoint 只证明本轮观察请求及本地 lineage，不声称 GitHub 在 `F` 前已经暴露全部历史对象。使用 `--full-reconcile` 可对所有 endpoint 做不带 `since` 的完整枚举并纠正延迟可见对象；持续调度不属于本任务。
+
+## 存储与校验
 
 ```text
 process-data/
   objects/sha256/<prefix>/<digest>
   snapshots/YYYY/MM/DD/<snapshot-id>/
+  checkpoints/github/<repository-key>.json
   repairs/<snapshot-id>/<repair-id>/
   .staging/
 ```
 
-内容写入 SHA-256 CAS。采集先写 staging，只有全部必需来源完成后才通过一次文件系统 rename 发布快照。已有对象和快照会先校验再复用，绝不覆盖。
+页面证据和资源对象分别写入 CAS。页面 hash 用于证明分页和请求 metadata；增量相等性只比较资源 hash，资源 identity 不包含页码。Issue、Pull Request、评论、Review、commit 和 timeline event 都经过 allowlist 投影。
 
-GitHub REST 数组使用 `per_page=100&page=N` 显式逐页请求。每个请求页记录条目数和 `canonicalSha256`。Canonical JSON 会递归排序对象键、保持数组顺序并对 UTF-8 字节计算哈希；它表达 JSON 语义，不冒充 HTTP 原始响应字节。空终止页计入请求和页证据，但不计入数据页。
+`verify` 校验 manifest hash、lineage、观察窗口算术、查询证据、操作计数、规范记录和 CAS 对象，但不会把 HTTP `Date` 提升为完整性证明。`export --as-of` 只物化已验证且 observation watermark 不晚于目标时间的 v2 lineage。
 
-`verify` 重算 manifest、对象、页面和字节数证据。`audit` 只有在校验通过后才读取确定性的质量基线。
+## 隐私、恢复与修复
 
-## 隐私边界
+敏感 GitHub 文本按策略排除，repair 不会恢复原文。网络、权限、identity、时间缺失、观察边界和分页失败都会在推进 checkpoint 前停止。checkpoint 锁采用同机单写者和 owner 绑定；owner 不明或恢复候选有歧义时失败关闭。
 
-任务产物和 GitHub allowlist 字段属于过程证据。凭据、私钥、Bearer token 和疑似凭据值会被排除；manifest 只保留其哈希、大小、策略规则和排除原因。
-
-结构化遥测只来自 task Activity Log 与可识别的 delegation/orchestration receipt。Entropy 报告仍是普通运行报告。未知日志格式只产生 unknown observation，不猜测为遥测。
-
-会话和工具正文默认 unavailable。`--include-excerpts` 仅表示显式允许保存限长、脱敏摘录，永远不授权保存内部思维或密钥材料。
-
-## 对账与修复
-
-质量发现区分本地/远端缺失、重复 identity、绑定冲突、内容差异、schema 差异、远端可变记录、不可恢复历史和隐私排除。
-
-`ai data repair` 默认为 dry-run。只有关系唯一、证据完整且非敏感、前置条件固定时，`--apply` 才能追加 overlay。它不会 patch 或删除本地任务、GitHub 评论或 snapshot 对象；重复执行相同修复为 no-op。
-
-使用 `ai data export ... --repairs applied` 将已验证 overlay 与规范记录合成导出，基础快照保持不变。
-
-## 周期执行、备份与恢复
-
-可在 cron 或 CI 中使用只读仓库凭据周期执行 capture 和 verify。退出码 `2` 表示观察不完整，不能当作成功基线。
-
-默认根目录被 Git 忽略，并作为本机权威副本。校验和只能发现损坏，不能提供灾备。请使用独立加密备份和访问控制，按年月组织备份包，并定期恢复到临时仓库后执行 `ai data verify` 演练。
+`ai data repair` 仍然只追加，不删除来源记录或快照。`--apply` 只有在前置条件固定时才写入已验证 overlay。历史 v1 overlay 继续可用，且不会改写 v1 数据。

--- a/lib/platform/github-client.ts
+++ b/lib/platform/github-client.ts
@@ -10,10 +10,18 @@ type RunOptions = { cwd?: string; input?: string };
 type Runner = (args: string[], options: RunOptions) => RunResult;
 type RequestOptions = RunOptions & { method?: 'GET' | 'PATCH' | 'POST' | 'DELETE' };
 type ClientResult<T> = { ok: true; value: T } | { ok: false; error: PlatformError };
+type ResponseMetadata = {
+  status: number;
+  requestUrl: string;
+  date?: string;
+  links: string[];
+};
+type JsonResponse<T> = { value: T; metadata: ResponseMetadata };
 
 type GitHubClient = {
   version(options?: RunOptions): ClientResult<string>;
   json<T = unknown>(args: string[], options?: RequestOptions): ClientResult<T>;
+  jsonWithMetadata?<T = unknown>(args: string[], options?: RequestOptions): ClientResult<JsonResponse<T>>;
   text(args: string[], options?: RequestOptions): ClientResult<string>;
 };
 
@@ -101,6 +109,39 @@ function classifyGitHubFailure(result: RunResult): PlatformError {
   return { code: 'PLATFORM_REQUEST_FAILED', message: detail || 'GitHub request failed', retryable: false };
 }
 
+function responseUrl(args: string[]): string {
+  const endpoint = args.find((arg, index) => index > 0 && !arg.startsWith('-')) || '';
+  return endpoint.startsWith('http') ? endpoint : `https://api.github.com/${endpoint.replace(/^\//, '')}`;
+}
+
+function parseIncludedResponse<T>(stdout: string, args: string[]): JsonResponse<T> | null {
+  const statusBlocks = [...stdout.matchAll(/^HTTP\/[^\r\n]+/gim)];
+  const headerStart = statusBlocks.at(-1)?.index;
+  if (headerStart === undefined) return null;
+  const response = stdout.slice(headerStart);
+  const separator = response.match(/\r?\n\r?\n/);
+  if (!separator || separator.index === undefined) return null;
+  const header = response.slice(0, separator.index);
+  const body = response.slice(separator.index + separator[0].length);
+  const status = header.match(/^HTTP\/[^ ]+\s+(\d{3})/mi)?.[1];
+  if (!status) return null;
+  const date = header.match(/^Date:\s*(.+)$/mi)?.[1]?.trim();
+  const links = [...header.matchAll(/^Link:\s*(.+)$/gim)].flatMap((match) => match[1]!.split(',').map((value) => value.trim()));
+  try {
+    return {
+      value: JSON.parse(body || 'null') as T,
+      metadata: {
+        status: Number(status),
+        requestUrl: responseUrl(args),
+        ...(date ? { date } : {}),
+        links
+      }
+    };
+  } catch {
+    return null;
+  }
+}
+
 function createGitHubClient(options: ClientOptions = {}): GitHubClient {
   const runner = options.runner || defaultRunner;
   const delays = options.retryDelaysMs || retryDelaysFromEnvironment();
@@ -156,9 +197,24 @@ function createGitHubClient(options: ClientOptions = {}): GitHubClient {
           error: { code: 'INVALID_PLATFORM_RESPONSE', message: 'GitHub returned invalid JSON', retryable: true }
         };
       }
+    },
+    jsonWithMetadata<T>(args: string[], request: RequestOptions = {}): ClientResult<JsonResponse<T>> {
+      const includeArgs = args[0] === 'api' && args[1] !== '--include'
+        ? [args[0], '--include', ...args.slice(1)]
+        : args;
+      const result = run(includeArgs, request);
+      if (!result.ok) return result;
+      const parsed = parseIncludedResponse<T>(result.value, args);
+      if (!parsed) {
+        return {
+          ok: false,
+          error: { code: 'INVALID_PLATFORM_RESPONSE', message: 'GitHub response metadata or JSON is invalid', retryable: true }
+        };
+      }
+      return { ok: true, value: parsed };
     }
   };
 }
 
-export { classifyGitHubFailure, createGitHubClient, MINIMUM_GITHUB_CLI_VERSION };
-export type { ClientResult, GitHubClient, RequestOptions, RunOptions, RunResult, Runner };
+export { classifyGitHubFailure, createGitHubClient, MINIMUM_GITHUB_CLI_VERSION, parseIncludedResponse };
+export type { ClientResult, GitHubClient, JsonResponse, RequestOptions, ResponseMetadata, RunOptions, RunResult, Runner };

--- a/lib/process-data/checkpoint.ts
+++ b/lib/process-data/checkpoint.ts
@@ -1,0 +1,335 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { verifySnapshot } from './store.ts';
+import type { GitHubCheckpoint, CheckpointOwner, ProcessResult, RecoveryReport } from './types.ts';
+
+type CheckpointPaths = { directory: string; checkpoint: string; lock: string };
+type CheckpointCandidate = {
+  schema: 'github-checkpoint/v1';
+  candidateSchema: 'github-checkpoint-candidate/v1';
+  ownerId: string;
+  expectedOld: { snapshotId: string | null; manifestSha256: string | null };
+  repository: string;
+  snapshotId: string;
+  watermark: string;
+  manifestSha256: string;
+  committedAt: string;
+};
+type CheckpointLease = {
+  paths: CheckpointPaths;
+  repository: string;
+  owner: CheckpointOwner;
+  recovery: RecoveryReport;
+  expectedOld: GitHubCheckpoint | null;
+};
+
+function repositoryKey(repository: string): string {
+  return crypto.createHash('sha256').update(repository).digest('hex').slice(0, 32);
+}
+
+function checkpointPaths(root: string, repository: string): CheckpointPaths {
+  const directory = path.join(root, 'checkpoints', 'github');
+  const base = path.join(directory, repositoryKey(repository));
+  return { directory, checkpoint: `${base}.json`, lock: `${base}.lock` };
+}
+
+function processStartToken(pid: number): string | null {
+  if (process.platform === 'linux') {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const closing = stat.lastIndexOf(')');
+      const fields = stat.slice(closing + 2).split(' ');
+      return fields[19] ?? null;
+    } catch {
+      return null;
+    }
+  }
+  return pid === process.pid ? `self:${process.pid}` : null;
+}
+
+function fsyncDirectory(directory: string): void {
+  if (process.platform === 'win32') return;
+  const fd = fs.openSync(directory, 'r');
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  const missing: string[] = [];
+  let current = path.resolve(directory);
+  while (!fs.existsSync(current)) {
+    missing.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`cannot create directory tree: ${directory}`);
+    current = parent;
+  }
+  for (const target of missing.reverse()) {
+    fs.mkdirSync(target, { mode: 0o700 });
+    if (process.platform !== 'win32') fs.chmodSync(target, 0o700);
+    fsyncDirectory(path.dirname(target));
+  }
+}
+
+function writeTemporary(filePath: string, value: unknown): string {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const temporary = `${filePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  const fd = fs.openSync(temporary, 'wx', 0o600);
+  try {
+    fs.writeFileSync(fd, `${JSON.stringify(value)}\n`);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return temporary;
+}
+
+function validCheckpoint(value: unknown, repository: string): value is GitHubCheckpoint {
+  if (!value || typeof value !== 'object') return false;
+  const checkpoint = value as GitHubCheckpoint;
+  return checkpoint.schema === 'github-checkpoint/v1'
+    && checkpoint.repository === repository
+    && Boolean(checkpoint.snapshotId)
+    && Boolean(checkpoint.watermark)
+    && Boolean(checkpoint.committedAt)
+    && /^[a-f0-9]{64}$/.test(checkpoint.manifestSha256);
+}
+
+function checkpointMatchesSnapshot(root: string, value: GitHubCheckpoint): boolean {
+  const verified = verifySnapshot(root, value.snapshotId);
+  return verified.ok
+    && verified.manifest?.schema === 'raw-manifest/v2'
+    && verified.manifest.snapshotId === value.snapshotId
+    && verified.manifest.repository === value.repository
+    && verified.manifest.manifestSha256 === value.manifestSha256
+    && verified.manifest.watermark === value.watermark;
+}
+
+function checkpointState(value: GitHubCheckpoint | null): { snapshotId: string | null; manifestSha256: string | null } {
+  return { snapshotId: value?.snapshotId ?? null, manifestSha256: value?.manifestSha256 ?? null };
+}
+
+function readGitHubCheckpoint(root: string, repository: string): ProcessResult<GitHubCheckpoint | null> {
+  const target = checkpointPaths(root, repository).checkpoint;
+  if (!fs.existsSync(target)) return { ok: true, value: null };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8')) as GitHubCheckpoint;
+    const value: GitHubCheckpoint = {
+      schema: parsed.schema,
+      repository: parsed.repository,
+      snapshotId: parsed.snapshotId,
+      watermark: parsed.watermark,
+      manifestSha256: parsed.manifestSha256,
+      committedAt: parsed.committedAt
+    };
+    if (!validCheckpoint(value, repository)) {
+      return { ok: false, error: { code: 'CHECKPOINT_INVALID', message: 'GitHub checkpoint schema or identity is invalid' } };
+    }
+    return { ok: true, value };
+  } catch {
+    return { ok: false, error: { code: 'CHECKPOINT_INVALID', message: 'GitHub checkpoint is not valid JSON' } };
+  }
+}
+
+function quarantine(lockPath: string): string {
+  const target = `${lockPath}.orphaned-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+  fs.renameSync(lockPath, target);
+  return target;
+}
+
+function acquireGitHubCheckpoint(root: string, repository: string): ProcessResult<CheckpointLease> {
+  const paths = checkpointPaths(root, repository);
+  ensurePrivateDirectory(paths.directory);
+  const recovery: RecoveryReport = { recovered: false, quarantined: [] };
+  const owner: CheckpointOwner = {
+    schema: 'checkpoint-owner/v1',
+    ownerId: crypto.randomUUID(),
+    pid: process.pid,
+    host: os.hostname(),
+    processStartToken: processStartToken(process.pid) ?? '',
+    createdAt: new Date().toISOString()
+  };
+  if (!owner.processStartToken) {
+    return { ok: false, error: { code: 'CHECKPOINT_TOPOLOGY_UNSUPPORTED', message: 'Process liveness cannot be verified on this host' } };
+  }
+  let recoveredOwnerId: string | null = null;
+  if (fs.existsSync(paths.lock)) {
+    let previous: CheckpointOwner;
+    try {
+      previous = JSON.parse(fs.readFileSync(paths.lock, 'utf8')) as CheckpointOwner;
+    } catch {
+      return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint lock is unreadable' } };
+    }
+    if (previous.host !== owner.host || !previous.ownerId || !previous.processStartToken) {
+      return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint lock owner topology is unknown' } };
+    }
+    const currentToken = processStartToken(previous.pid);
+    if (currentToken && currentToken === previous.processStartToken) {
+      return { ok: false, error: { code: 'CHECKPOINT_BUSY', message: 'Checkpoint is held by a live process' } };
+    }
+    if (process.platform !== 'linux') {
+      return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint owner liveness cannot be proven on this host' } };
+    }
+    try {
+      recoveredOwnerId = previous.ownerId;
+      recovery.quarantined.push(quarantine(paths.lock));
+      recovery.recovered = true;
+    } catch {
+      return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Unable to quarantine an orphaned checkpoint lock' } };
+    }
+  }
+  try {
+    const fd = fs.openSync(paths.lock, 'wx', 0o600);
+    try { fs.writeFileSync(fd, `${JSON.stringify(owner)}\n`); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+    fsyncDirectory(paths.directory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { ok: false, error: { code: 'CHECKPOINT_BUSY', message: 'Checkpoint lock was acquired by another process' } };
+    }
+    return { ok: false, error: { code: 'CHECKPOINT_LOCK_FAILED', message: String(error) } };
+  }
+
+  const releaseOwnedLock = () => {
+    try {
+      fs.unlinkSync(paths.lock);
+      fsyncDirectory(paths.directory);
+    } catch {
+      // Preserve the original recovery error; a remaining lock will fail closed next time.
+    }
+  };
+  const beforeResult = readGitHubCheckpoint(root, repository);
+  if (!beforeResult.ok) {
+    releaseOwnedLock();
+    return beforeResult;
+  }
+  let checkpointBefore = beforeResult.value;
+  const temporaryCandidates = fs.readdirSync(paths.directory)
+    .filter((entry) => entry.startsWith(path.basename(paths.checkpoint) + '.') && entry.endsWith('.tmp'))
+    .map((entry) => path.join(paths.directory, entry));
+  if (temporaryCandidates.length > 1) {
+    releaseOwnedLock();
+    return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Multiple checkpoint recovery candidates exist' } };
+  }
+  if (temporaryCandidates.length === 1) {
+    const candidate = temporaryCandidates[0]!;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8')) as CheckpointCandidate | GitHubCheckpoint;
+      const isCandidate = parsed && typeof parsed === 'object' && 'candidateSchema' in parsed
+        && parsed.candidateSchema === 'github-checkpoint-candidate/v1';
+      if (isCandidate) {
+        const candidateValue = parsed as CheckpointCandidate;
+        const value: GitHubCheckpoint = candidateValue;
+        const expected = checkpointState(checkpointBefore);
+        const candidateExpected = candidateValue.expectedOld;
+        if (!recoveredOwnerId || candidateValue.ownerId !== recoveredOwnerId) {
+          recovery.quarantined.push(quarantine(candidate));
+          releaseOwnedLock();
+          return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint candidate owner proof does not match the recovered lock owner' } };
+        }
+        if (!validCheckpoint(value, repository)
+          || candidateExpected?.snapshotId !== expected.snapshotId
+          || candidateExpected?.manifestSha256 !== expected.manifestSha256) {
+          releaseOwnedLock();
+          return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint candidate does not match the current head' } };
+        }
+        if (!checkpointMatchesSnapshot(root, value)) {
+          recovery.quarantined.push(quarantine(candidate));
+          releaseOwnedLock();
+          return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint candidate snapshot failed full verification' } };
+        }
+        if (process.platform === 'win32' && checkpointBefore) {
+          releaseOwnedLock();
+          return { ok: false, error: { code: 'CHECKPOINT_TOPOLOGY_UNSUPPORTED', message: 'Checkpoint replacement durability cannot be proven on this host' } };
+        }
+        fs.renameSync(candidate, paths.checkpoint);
+        recovery.recovered = true;
+        fsyncDirectory(paths.directory);
+        const recovered = readGitHubCheckpoint(root, repository);
+        if (!recovered.ok) {
+          releaseOwnedLock();
+          return recovered;
+        }
+        checkpointBefore = recovered.value;
+      } else {
+        recovery.quarantined.push(quarantine(candidate));
+        releaseOwnedLock();
+        return { ok: false, error: { code: 'CHECKPOINT_RECOVERY_REQUIRED', message: 'Checkpoint candidate lacks owner proof' } };
+      }
+    } catch {
+      recovery.quarantined.push(quarantine(candidate));
+    }
+  }
+  return { ok: true, value: { paths, repository, owner, recovery, expectedOld: checkpointBefore } };
+}
+
+function commitGitHubCheckpoint(lease: CheckpointLease, value: GitHubCheckpoint): ProcessResult<void> {
+  try {
+    const current = JSON.parse(fs.readFileSync(lease.paths.lock, 'utf8')) as CheckpointOwner;
+    if (current.ownerId !== lease.owner.ownerId) {
+      return { ok: false, error: { code: 'CHECKPOINT_OWNER_MISMATCH', message: 'Checkpoint lock ownership changed' } };
+    }
+    if (value.repository !== lease.repository || !validCheckpoint(value, lease.repository)) {
+      return { ok: false, error: { code: 'CHECKPOINT_INVALID', message: 'Checkpoint value is invalid' } };
+    }
+    const root = path.dirname(path.dirname(lease.paths.directory));
+    if (!checkpointMatchesSnapshot(root, value)) {
+      return { ok: false, error: { code: 'CHECKPOINT_INVALID', message: 'Checkpoint snapshot does not match a verified v2 manifest' } };
+    }
+    const currentCheckpoint = readGitHubCheckpoint(root, lease.repository);
+    if (!currentCheckpoint.ok) return currentCheckpoint;
+    if (checkpointState(currentCheckpoint.value).snapshotId !== checkpointState(lease.expectedOld).snapshotId
+      || checkpointState(currentCheckpoint.value).manifestSha256 !== checkpointState(lease.expectedOld).manifestSha256) {
+      return { ok: false, error: { code: 'CHECKPOINT_CONFLICT', message: 'Checkpoint head changed before commit' } };
+    }
+    const candidate: CheckpointCandidate = {
+      ...value,
+      candidateSchema: 'github-checkpoint-candidate/v1',
+      ownerId: lease.owner.ownerId,
+      expectedOld: checkpointState(lease.expectedOld)
+    };
+    const temporary = writeTemporary(lease.paths.checkpoint, candidate);
+    const rechecked = readGitHubCheckpoint(root, lease.repository);
+    if (!rechecked.ok) {
+      fs.unlinkSync(temporary);
+      return rechecked;
+    }
+    if (checkpointState(rechecked.value).snapshotId !== checkpointState(lease.expectedOld).snapshotId
+      || checkpointState(rechecked.value).manifestSha256 !== checkpointState(lease.expectedOld).manifestSha256) {
+      fs.unlinkSync(temporary);
+      return { ok: false, error: { code: 'CHECKPOINT_CONFLICT', message: 'Checkpoint head changed during commit' } };
+    }
+    if (process.platform === 'win32' && fs.existsSync(lease.paths.checkpoint)) {
+      fs.unlinkSync(temporary);
+      return { ok: false, error: { code: 'CHECKPOINT_TOPOLOGY_UNSUPPORTED', message: 'Checkpoint replacement durability cannot be proven on this host' } };
+    }
+    fs.renameSync(temporary, lease.paths.checkpoint);
+    if (process.platform !== 'win32') fs.chmodSync(lease.paths.checkpoint, 0o600);
+    fsyncDirectory(lease.paths.directory);
+    return { ok: true, value: undefined };
+  } catch (error) {
+    return { ok: false, error: { code: 'CHECKPOINT_COMMIT_FAILED', message: String(error) } };
+  }
+}
+
+function releaseGitHubCheckpoint(lease: CheckpointLease): void {
+  try {
+    const current = JSON.parse(fs.readFileSync(lease.paths.lock, 'utf8')) as CheckpointOwner;
+    if (current.ownerId === lease.owner.ownerId) {
+      fs.unlinkSync(lease.paths.lock);
+      fsyncDirectory(lease.paths.directory);
+    }
+  } catch {
+    // The next invocation will fail closed and report recovery if the lock remains.
+  }
+}
+
+export {
+  acquireGitHubCheckpoint,
+  checkpointPaths,
+  commitGitHubCheckpoint,
+  processStartToken,
+  readGitHubCheckpoint,
+  releaseGitHubCheckpoint
+};
+export type { CheckpointLease, CheckpointPaths };

--- a/lib/process-data/index.ts
+++ b/lib/process-data/index.ts
@@ -1,24 +1,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
 
 import { detectRepoRoot } from '../task/resolve-ref.ts';
-import { normalizeObjects } from './normalize.ts';
-import { reconcileRecords } from './reconcile.ts';
+import { acquireGitHubCheckpoint, commitGitHubCheckpoint, readGitHubCheckpoint, releaseGitHubCheckpoint } from './checkpoint.ts';
+import { materializeJson, materializeSnapshot } from './materialize.ts';
+import { normalizeResources } from './normalize.ts';
+import { reconcileRecords, reconcileResourceRecords } from './reconcile.ts';
 import { readAppliedOverlays, repairSnapshot } from './repair.ts';
-import { collectGitHubObjects, collectLocalObjects } from './sources.ts';
-import { canonicalJsonBytes, createObjectStore, publishSnapshot, verifySnapshot } from './store.ts';
+import { collectGitHubBoundary, resolveGitHubRepository } from './sources.ts';
+import { canonicalJsonBytes, createObjectStore, findSnapshot, publishSnapshotV2, verifySnapshot } from './store.ts';
+import { createGitHubClient } from '../platform/github-client.ts';
 
-import type { CapturedObject, NormalizedRecord, RestCollectionEvidence } from './types.ts';
+import type { NormalizedRecord } from './types.ts';
 
 const USAGE = `Usage: ai data <command> [options]
 
 Commands:
-  capture [--source all|local|github] [--root <dir>] [--include-excerpts]
+  capture [--source github] [--root <dir>] [--full-reconcile]
   verify <snapshot-id> [--root <dir>]
   audit <snapshot-id> [--root <dir>] [--format json|text]
   repair <snapshot-id> [--root <dir>] [--apply]
-  export <snapshot-id> [--root <dir>] [--repairs none|applied] [--output <file|->]
+  export <snapshot-id> [--root <dir>] [--repairs none|applied] [--as-of <ISO>] [--output <file|->]
 `;
 
 type ParsedArgs = { positionals: string[]; options: Map<string, string | true> };
@@ -64,14 +66,6 @@ function dataRoot(repoRoot: string, requested?: string): string {
   return resolved;
 }
 
-function repositoryIdentity(repoRoot: string): string {
-  try {
-    return execFileSync('git', ['config', '--get', 'remote.origin.url'], { cwd: repoRoot, encoding: 'utf8' }).trim() || path.basename(repoRoot);
-  } catch {
-    return path.basename(repoRoot);
-  }
-}
-
 function writeJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value)}\n`);
 }
@@ -82,54 +76,106 @@ function optionString(parsed: ParsedArgs, name: string): string | undefined {
 }
 
 function capture(args: string[]): number {
-  const parsed = parseArgs(args, new Set(['--source', '--root']), new Set(['--include-excerpts']));
+  const parsed = parseArgs(args, new Set(['--source', '--root']), new Set(['--full-reconcile', '--include-excerpts']));
   if (parsed.positionals.length > 0) throw new Error('capture does not accept positional arguments');
-  const scope = optionString(parsed, '--source') ?? 'all';
-  if (!['all', 'local', 'github'].includes(scope)) throw new Error('--source must be all, local, or github');
+  const scope = optionString(parsed, '--source') ?? 'github';
+  if (scope !== 'github') throw new Error('new process-data capture only supports --source github; local data is already normalized and --source all is retired');
+  if (parsed.options.has('--include-excerpts')) throw new Error('--include-excerpts is not supported for GitHub-only capture');
   const repoRoot = detectRepoRoot();
   const root = dataRoot(repoRoot, optionString(parsed, '--root'));
-  const observedFrom = new Date().toISOString();
-  const objects: CapturedObject[] = [];
-  const endpoints: RestCollectionEvidence[] = [];
-  let repository = repositoryIdentity(repoRoot);
-
-  if (scope === 'all' || scope === 'local') {
-    const local = collectLocalObjects(repoRoot, { includeExcerpts: parsed.options.has('--include-excerpts') });
-    if (!local.ok) { writeJson({ ok: false, error: local.error }); return 2; }
-    objects.push(...local.value);
-  }
-  if (scope === 'all' || scope === 'github') {
-    const github = collectGitHubObjects(repoRoot);
+  const client = createGitHubClient();
+  const repositoryResult = resolveGitHubRepository(repoRoot, client);
+  if (!repositoryResult.ok) { writeJson({ ok: false, error: repositoryResult.error }); return 2; }
+  const repository = repositoryResult.value;
+  const leaseResult = acquireGitHubCheckpoint(root, repository);
+  if (!leaseResult.ok) { writeJson({ ok: false, error: leaseResult.error }); return 2; }
+  const lease = leaseResult.value;
+  try {
+    const checkpointResult = readGitHubCheckpoint(root, repository);
+    if (!checkpointResult.ok) { writeJson({ ok: false, error: checkpointResult.error }); return 2; }
+    const checkpoint = checkpointResult.value;
+    const full = parsed.options.has('--full-reconcile');
+    const observedFrom = new Date().toISOString();
+    const github = collectGitHubBoundary(repoRoot, {
+      client,
+      fromInclusive: full ? null : checkpoint?.watermark ?? null,
+      reconciliation: full ? 'full' : 'incremental'
+    });
     if (!github.ok) { writeJson({ ok: false, error: github.error }); return 2; }
-    objects.push(...github.value.objects);
-    endpoints.push(...github.value.endpoints);
-    repository = github.value.repository;
-  }
-
-  const store = createObjectStore(root);
-  for (const object of objects) {
-    if (object.content !== undefined && object.disposition?.state === 'included') {
-      const stored = store.put(Buffer.from(object.content, 'utf8'));
-      if (stored.sha256 !== object.sha256) throw new Error(`source hash mismatch: ${object.sourceIdentity}`);
+    const store = createObjectStore(root);
+    for (const object of github.value.objects) {
+      if (object.content !== undefined && object.disposition?.state === 'included') {
+        const stored = store.put(Buffer.from(object.content, 'utf8'));
+        if (stored.sha256 !== object.sha256) throw new Error(`source hash mismatch: ${object.sourceIdentity}`);
+      }
     }
+    let parent: NormalizedRecord[] = [];
+    if (checkpoint) {
+      const parentPath = findSnapshot(root, checkpoint.snapshotId);
+      if (!parentPath) throw new Error(`checkpoint head snapshot is missing: ${checkpoint.snapshotId}`);
+      const materialized = materializeSnapshot(root, checkpoint.snapshotId);
+      if (!materialized.manifest || materialized.manifest.manifestSha256 !== checkpoint.manifestSha256 || materialized.manifest.watermark !== checkpoint.watermark) {
+        throw new Error('checkpoint does not match its verified snapshot head');
+      }
+      parent = materialized.records;
+    }
+    const current = normalizeResources(github.value.objects);
+    const reconciliation = reconcileResourceRecords(current, {
+      parent,
+      full,
+      deferred: github.value.deferred,
+      unavailable: github.value.unavailable
+    });
+    const quality = reconcileRecords(reconciliation.records, 'github');
+    const fromInclusive = checkpoint?.watermark ?? null;
+    const hasStrictSinceEndpoint = github.value.endpoints.some((endpoint) => endpoint.queryMode === 'strict-since');
+    const queryAfter = !full && fromInclusive && hasStrictSinceEndpoint
+      ? new Date(new Date(fromInclusive).getTime() - 1000).toISOString()
+      : null;
+    const responseDates = github.value.responseDates;
+    const published = publishSnapshotV2(root, {
+      scope: 'github',
+      repository,
+      observedFrom,
+      observedTo: github.value.watermark,
+      objects: github.value.objects.map(({ content: _content, ...object }) => object),
+      endpoints: github.value.endpoints,
+      excerptsEnabled: false,
+      records: reconciliation.records,
+      quality: quality.findings,
+      repairs: quality.repairs,
+      snapshotKind: checkpoint ? 'delta' : 'base',
+      parentSnapshotId: checkpoint?.snapshotId ?? null,
+      checkpointBefore: checkpoint?.snapshotId ?? null,
+      watermark: github.value.watermark,
+      window: { fromInclusive, queryAfter, toExclusive: github.value.watermark, precision: 'second' },
+      observation: {
+        cutoffSource: 'github-response-date',
+        preflightDate: github.value.preflightDate,
+        responseDates
+      },
+      coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false },
+      reconciliation: full ? 'full' : 'incremental',
+      operations: reconciliation.operations
+    });
+    const verified = verifySnapshot(root, published.snapshotId);
+    if (!verified.ok || !verified.manifest || verified.manifest.schema !== 'raw-manifest/v2') {
+      throw new Error(`published snapshot failed verification: ${verified.errors.join('; ')}`);
+    }
+    const committed = commitGitHubCheckpoint(lease, {
+      schema: 'github-checkpoint/v1',
+      repository,
+      snapshotId: published.snapshotId,
+      watermark: github.value.watermark,
+      manifestSha256: verified.manifest.manifestSha256,
+      committedAt: new Date().toISOString()
+    });
+    if (!committed.ok) { writeJson({ ok: false, error: committed.error }); return 2; }
+    writeJson({ ok: true, snapshotId: published.snapshotId, scope, snapshotKind: checkpoint ? 'delta' : 'base', reconciliation: full ? 'full' : 'incremental', created: published.created, objects: github.value.objects.length, records: reconciliation.records.length, watermark: github.value.watermark, deferred: github.value.deferred.length });
+    return 0;
+  } finally {
+    releaseGitHubCheckpoint(lease);
   }
-  const records = normalizeObjects(objects);
-  const reconciliation = reconcileRecords(records, scope as 'all' | 'local' | 'github');
-  const observedTo = new Date().toISOString();
-  const published = publishSnapshot(root, {
-    scope: scope as 'all' | 'local' | 'github',
-    repository,
-    observedFrom,
-    observedTo,
-    objects: objects.map(({ content: _content, ...object }) => object),
-    endpoints,
-    excerptsEnabled: parsed.options.has('--include-excerpts'),
-    records,
-    quality: reconciliation.findings,
-    repairs: reconciliation.repairs
-  });
-  writeJson({ ok: true, snapshotId: published.snapshotId, scope, created: published.created, objects: objects.length, records: records.length });
-  return 0;
 }
 
 function verify(args: string[]): number {
@@ -175,7 +221,7 @@ function repair(args: string[]): number {
 }
 
 function exportSnapshot(args: string[]): number {
-  const parsed = parseArgs(args, new Set(['--root', '--repairs', '--output']), new Set());
+  const parsed = parseArgs(args, new Set(['--root', '--repairs', '--output', '--as-of']), new Set());
   if (parsed.positionals.length !== 1) throw new Error('export requires one snapshot id');
   const repairMode = optionString(parsed, '--repairs') ?? 'none';
   if (!['none', 'applied'].includes(repairMode)) throw new Error('--repairs must be none or applied');
@@ -184,7 +230,13 @@ function exportSnapshot(args: string[]): number {
   const root = dataRoot(repoRoot, optionString(parsed, '--root'));
   const verified = verifySnapshot(root, parsed.positionals[0]!);
   if (!verified.ok || !verified.snapshotPath) { writeJson(verified); return 1; }
-  let content = fs.readFileSync(path.join(verified.snapshotPath, 'normalized.jsonl'), 'utf8');
+  let content: string;
+  if (verified.manifest?.schema === 'raw-manifest/v2') {
+    content = materializeJson(root, parsed.positionals[0]!, { asOf: optionString(parsed, '--as-of') });
+  } else {
+    if (optionString(parsed, '--as-of')) throw new Error('--as-of is only supported for v2 GitHub snapshots');
+    content = fs.readFileSync(path.join(verified.snapshotPath, 'normalized.jsonl'), 'utf8');
+  }
   if (repairMode === 'applied') content += readAppliedOverlays(root, parsed.positionals[0]!);
   if (output === '-') process.stdout.write(content);
   else {

--- a/lib/process-data/materialize.ts
+++ b/lib/process-data/materialize.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { findSnapshot, verifySnapshot } from './store.ts';
+import type { NormalizedRecord, SnapshotManifestV2 } from './types.ts';
+
+type MaterializeOptions = { asOf?: string };
+type MaterializeResult = { snapshotId: string; records: NormalizedRecord[]; manifest: SnapshotManifestV2 | null };
+
+function readRecords(snapshotPath: string, schema: 'normalized/v1' | 'normalized/v2'): NormalizedRecord[] {
+  const file = path.join(snapshotPath, 'normalized.jsonl');
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).flatMap((line) => {
+    const value = JSON.parse(line) as { schema?: string } & NormalizedRecord;
+    if (value.schema !== schema) return [];
+    const { schema: _schema, ...record } = value;
+    return [record];
+  });
+}
+
+function materializeSnapshot(root: string, snapshotId: string, options: MaterializeOptions = {}): MaterializeResult {
+  const target = options.asOf ? new Date(options.asOf) : null;
+  if (target && !Number.isFinite(target.getTime())) throw new Error('as-of must be an ISO timestamp');
+  const chain: Array<{ id: string; path: string; manifest: SnapshotManifestV2 }> = [];
+  let currentId: string | null = snapshotId;
+  let repository: string | null = null;
+  while (currentId) {
+    const currentPath = findSnapshot(root, currentId);
+    if (!currentPath) throw new Error(`snapshot not found: ${currentId}`);
+    const verified = verifySnapshot(root, currentId);
+    if (!verified.ok || !verified.manifest) throw new Error(`snapshot is not verified: ${currentId}`);
+    if (verified.manifest.schema !== 'raw-manifest/v2') {
+      if (chain.length > 0) throw new Error('v1 and v2 snapshots cannot share a lineage');
+      return { snapshotId, records: readRecords(currentPath, 'normalized/v1'), manifest: null };
+    }
+    const manifest = verified.manifest;
+    if (repository && manifest.repository !== repository) throw new Error('snapshot lineage repository mismatch');
+    repository = manifest.repository;
+    chain.push({ id: currentId, path: currentPath, manifest });
+    currentId = manifest.parentSnapshotId;
+  }
+  if (chain.length === 0) throw new Error('snapshot lineage is empty');
+  const chronological = [...chain].reverse();
+  for (let index = 1; index < chronological.length; index += 1) {
+    if (new Date(chronological[index - 1]!.manifest.watermark).getTime() >= new Date(chronological[index]!.manifest.watermark).getTime()) {
+      throw new Error('snapshot watermark is not monotonic');
+    }
+  }
+  const view = new Map<string, NormalizedRecord>();
+  let appliedManifest: SnapshotManifestV2 | null = null;
+  for (const entry of chronological) {
+    if (target && new Date(entry.manifest.watermark).getTime() > target.getTime()) continue;
+    appliedManifest = entry.manifest;
+    for (const record of readRecords(entry.path, 'normalized/v2')) {
+      const identity = record.resourceIdentity ?? record.sourceIdentity;
+      switch (record.operation) {
+        case 'tombstone':
+          view.delete(identity);
+          break;
+        case 'unavailable':
+          view.set(identity, record);
+          break;
+        default:
+          view.set(identity, { ...record, operation: undefined });
+          break;
+      }
+    }
+  }
+  if (target && !appliedManifest) throw new Error('no verified snapshot is available at the requested as-of time');
+  return {
+    snapshotId,
+    records: [...view.values()].sort((left, right) => left.recordId.localeCompare(right.recordId)),
+    manifest: appliedManifest
+  };
+}
+
+function materializeJson(root: string, snapshotId: string, options: MaterializeOptions = {}): string {
+  const result = materializeSnapshot(root, snapshotId, options);
+  return result.records.map((record) => JSON.stringify({ schema: 'normalized/v2', ...record })).join('\n') + (result.records.length ? '\n' : '');
+}
+
+export { materializeJson, materializeSnapshot };
+export type { MaterializeOptions, MaterializeResult };

--- a/lib/process-data/normalize.ts
+++ b/lib/process-data/normalize.ts
@@ -199,4 +199,32 @@ function normalizeObjects(objects: CapturedObject[]): NormalizedRecord[] {
   return records.sort((left, right) => left.recordId.localeCompare(right.recordId));
 }
 
-export { normalizeObjects };
+function normalizeResources(objects: CapturedObject[]): NormalizedRecord[] {
+  const records: NormalizedRecord[] = [];
+  for (const object of objects) {
+    if (object.role !== 'resource') continue;
+    const identity = object.resourceIdentity ?? object.sourceIdentity;
+    let data: JsonValue = { availability: 'unknown' };
+    try { data = JSON.parse(object.content ?? '{}') as JsonValue; } catch { data = { availability: 'unavailable', reason: 'invalid resource JSON' }; }
+    const binding = typeof data === 'object' && data !== null && !Array.isArray(data) && typeof data.body === 'string'
+      ? data.body.match(TASK_ID_RE)?.[0]
+      : undefined;
+    records.push({
+      recordId: recordId('platform-resource', identity),
+      kind: 'platform-resource',
+      sourceIdentity: identity,
+      resourceIdentity: identity,
+      sourceSha256: object.sha256,
+      ...(binding ? { binding } : {}),
+      ...(object.eventTime ? { observedAt: { state: 'known', value: object.eventTime } } : {}),
+      ...(object.parentIdentity ? { parentIdentity: object.parentIdentity } : {}),
+      ...(object.pageSha256 ? {
+        evidence: [{ resourceIdentity: identity, resourceSha256: object.sha256, pageSha256: object.pageSha256 }]
+      } : {}),
+      data
+    });
+  }
+  return records.sort((left, right) => left.recordId.localeCompare(right.recordId));
+}
+
+export { normalizeObjects, normalizeResources };

--- a/lib/process-data/reconcile.ts
+++ b/lib/process-data/reconcile.ts
@@ -1,6 +1,6 @@
 import { sha256 } from './store.ts';
 
-import type { NormalizedRecord, QualityFinding, RepairAction, SnapshotManifest } from './types.ts';
+import type { NormalizedRecord, QualityFinding, RepairAction, SnapshotManifest, SnapshotOperations } from './types.ts';
 
 function reconcileRecords(
   records: NormalizedRecord[],
@@ -107,4 +107,66 @@ function reconcileRecords(
   };
 }
 
-export { reconcileRecords };
+type ResourceReconcileOptions = {
+  parent?: NormalizedRecord[];
+  full: boolean;
+  deferred?: Iterable<string>;
+  unavailable?: Iterable<string>;
+};
+
+function reconcileResourceRecords(
+  current: NormalizedRecord[],
+  options: ResourceReconcileOptions
+): { records: NormalizedRecord[]; operations: SnapshotOperations } {
+  const parent = new Map((options.parent ?? []).filter((record) => record.resourceIdentity).map((record) => [record.resourceIdentity!, record]));
+  const currentMap = new Map(current.filter((record) => record.resourceIdentity).map((record) => [record.resourceIdentity!, record]));
+  const deferred = new Set(options.deferred ?? []);
+  const unavailable = new Set(options.unavailable ?? []);
+  const records: NormalizedRecord[] = [];
+  const operations: SnapshotOperations = { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 };
+  for (const record of currentMap.values()) {
+    const identity = record.resourceIdentity!;
+    const previous = parent.get(identity);
+    if (!previous) {
+      records.push({ ...record, operation: 'upsert' });
+      operations.upsert += 1;
+    } else if (previous.sourceSha256 !== record.sourceSha256) {
+      records.push({ ...record, operation: 'supersede' });
+      operations.supersede += 1;
+    }
+  }
+  if (options.full) {
+    for (const [identity, previous] of parent) {
+      if (currentMap.has(identity) || deferred.has(identity) || unavailable.has(identity)
+        || (previous.parentIdentity && deferred.has(previous.parentIdentity))
+        || (previous.parentIdentity && unavailable.has(previous.parentIdentity))) continue;
+      records.push({
+        recordId: previous.recordId,
+        kind: 'platform-resource',
+        sourceIdentity: identity,
+        resourceIdentity: identity,
+        sourceSha256: previous.sourceSha256,
+        operation: 'tombstone',
+        data: { availability: 'tombstone', previousSha256: previous.sourceSha256 }
+      });
+      operations.tombstone += 1;
+    }
+  }
+  for (const identity of unavailable) {
+    if (!parent.has(identity) && !currentMap.has(identity)) continue;
+    const previous = parent.get(identity) ?? currentMap.get(identity)!;
+    records.push({
+      recordId: previous.recordId,
+      kind: 'platform-resource',
+      sourceIdentity: identity,
+      resourceIdentity: identity,
+      sourceSha256: previous.sourceSha256,
+      operation: 'unavailable',
+      data: { availability: 'unavailable', reason: 'source-unavailable' }
+    });
+    operations.unavailable += 1;
+  }
+  return { records: records.sort((left, right) => left.recordId.localeCompare(right.recordId)), operations };
+}
+
+export { reconcileRecords, reconcileResourceRecords };

--- a/lib/process-data/sources.ts
+++ b/lib/process-data/sources.ts
@@ -9,6 +9,7 @@ import { canonicalJsonBytes, sha256 } from './store.ts';
 import type { GitHubClient } from '../platform/github-client.ts';
 import type {
   CapturedObject,
+  EndpointQueryMode,
   ProcessResult,
   RestCollectionEvidence,
   RestPageEvidence
@@ -29,6 +30,33 @@ type GitHubCapture = {
   repository: string;
   objects: CapturedObject[];
   endpoints: RestCollectionEvidence[];
+};
+
+type GitHubBoundaryCapture = {
+  repository: string;
+  preflightDate: string;
+  watermark: string;
+  objects: CapturedObject[];
+  endpoints: RestCollectionEvidence[];
+  responseDates: string[];
+  deferred: string[];
+  unavailable: string[];
+};
+
+type BoundaryCaptureOptions = {
+  client?: GitHubClient;
+  fromInclusive?: string | null;
+  reconciliation?: 'incremental' | 'full';
+};
+
+type EndpointDescriptor = {
+  path: string;
+  queryMode: EndpointQueryMode;
+  eventTime: (item: unknown) => string | undefined;
+  identity: (item: unknown) => string;
+  parentIdentity?: string;
+  maxItems?: number;
+  includeResource?: (item: unknown) => boolean;
 };
 
 function endpointForPage(endpoint: string, page: number, perPage: number): string {
@@ -294,6 +322,38 @@ function projectGitHubItem(item: unknown): unknown {
   return output;
 }
 
+function projectGitHubTimelineItem(item: unknown): unknown {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) throw new Error('GitHub timeline item must be an object');
+  const source = item as Record<string, unknown>;
+  if (typeof source.event !== 'string' || source.event.length === 0) throw new Error('GitHub timeline event type is missing');
+  const output: Record<string, unknown> = {};
+  for (const field of [
+    'id', 'node_id', 'event', 'created_at', 'updated_at', 'submitted_at', 'commit_id', 'sha', 'state',
+    'lock_reason', 'ref', 'ref_type'
+  ]) {
+    if (source[field] !== undefined) output[field] = jsonClone(source[field]);
+  }
+  for (const field of ['actor', 'user', 'assignee', 'assigner', 'reviewer', 'requested_reviewer']) {
+    const projected = projectFields(source[field], ['id', 'login', 'name']);
+    if (projected) output[field] = projected;
+  }
+  const nestedFields: Record<string, string[]> = {
+    label: ['id', 'name', 'color'],
+    milestone: ['id', 'number', 'title', 'state'],
+    rename: ['from', 'to'],
+    source: ['id', 'node_id', 'number', 'title', 'ref', 'sha'],
+    dismissed_review: ['state', 'review_id', 'dismissal_commit_id'],
+    project_card: ['id', 'project_id', 'column_name']
+  };
+  for (const [field, fields] of Object.entries(nestedFields)) {
+    const projected = projectFields(source[field], fields);
+    if (projected) output[field] = projected;
+  }
+  const body = projectSensitiveText(source.body);
+  if (body !== undefined) output.body = body;
+  return output;
+}
+
 function collectGitHubObjects(repoRoot: string, client: GitHubClient = createGitHubClient()): ProcessResult<GitHubCapture> {
   const repoResult = client.json<{ nameWithOwner?: string }>(['repo', 'view', '--json', 'nameWithOwner'], { cwd: repoRoot });
   if (!repoResult.ok) return { ok: false, error: repoResult.error };
@@ -350,5 +410,392 @@ function collectGitHubObjects(repoRoot: string, client: GitHubClient = createGit
   return { ok: true, value: { repository, objects, endpoints: evidence } };
 }
 
-export { collectGitHubObjects, collectLocalObjects, fetchRestCollection, projectGitHubItem };
-export type { FetchRestCollectionOptions, GitHubCapture, RestCollection };
+function resolveGitHubRepository(repoRoot: string, client: GitHubClient = createGitHubClient()): ProcessResult<string> {
+  const result = client.json<{ nameWithOwner?: string }>(['repo', 'view', '--json', 'nameWithOwner'], { cwd: repoRoot });
+  if (!result.ok) return { ok: false, error: result.error };
+  if (!result.value.nameWithOwner || !/^[^/]+\/[^/]+$/.test(result.value.nameWithOwner)) {
+    return { ok: false, error: { code: 'INVALID_PLATFORM_RESPONSE', message: 'GitHub repository identity is missing' } };
+  }
+  return { ok: true, value: result.value.nameWithOwner };
+}
+
+function truncateSecond(date: Date): string {
+  return new Date(Math.floor(date.getTime() / 1000) * 1000).toISOString();
+}
+
+function validDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function queryEndpoint(endpoint: string, page: number, perPage: number, queryMode: EndpointQueryMode, queryAfter: string | null): string {
+  const parsed = new URL(endpoint, 'https://api.github.invalid/');
+  parsed.searchParams.set('per_page', String(perPage));
+  parsed.searchParams.set('page', String(page));
+  if (queryMode === 'strict-since' && queryAfter) parsed.searchParams.set('since', queryAfter);
+  return `${parsed.pathname.replace(/^\//, '')}${parsed.search}`;
+}
+
+function resourceIdentity(prefix: string, item: unknown): string {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+  const value = item as Record<string, unknown>;
+  if (typeof value.id === 'number' || typeof value.id === 'string') return `${prefix}:${String(value.id)}`;
+  if (typeof value.node_id === 'string') return `${prefix}:${value.node_id}`;
+  if (typeof value.sha === 'string') return `${prefix}:${value.sha}`;
+  if (typeof value.number === 'number') return `${prefix}:${value.number}`;
+  return '';
+}
+
+function issueOrPullIdentity(item: unknown): string {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+  const value = item as Record<string, unknown>;
+  const prefix = value.pull_request ? 'pr' : 'issue';
+  return resourceIdentity(prefix, item);
+}
+
+function isPullRequestIssue(item: unknown): boolean {
+  return Boolean(item && typeof item === 'object' && !Array.isArray(item) && (item as Record<string, unknown>).pull_request);
+}
+
+function itemEventTime(item: unknown): string | undefined {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return undefined;
+  const value = item as Record<string, unknown>;
+  for (const key of ['updated_at', 'created_at', 'submitted_at']) {
+    if (typeof value[key] === 'string') return value[key];
+  }
+  const commit = value.commit as Record<string, unknown> | undefined;
+  const author = commit?.author as Record<string, unknown> | undefined;
+  const committer = commit?.committer as Record<string, unknown> | undefined;
+  if (typeof author?.date === 'string') return author.date;
+  if (typeof committer?.date === 'string') return committer.date;
+  return undefined;
+}
+
+function timelineIdentity(item: unknown, parentNumber?: string): string {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+  const value = item as Record<string, unknown>;
+  if (typeof value.id === 'number' || typeof value.id === 'string') return `timeline:${String(value.id)}`;
+  const actor = value.actor as Record<string, unknown> | undefined;
+  const target = value.issue as Record<string, unknown> | undefined;
+  const tuple = [parentNumber, value.event, value.created_at ?? value.updated_at, actor?.id ?? actor?.login, target?.id ?? value.commit_id];
+  return tuple.every((part) => part !== undefined && part !== null && String(part) !== '') ? `timeline:${tuple.join(':')}` : '';
+}
+
+function descriptor(
+  pathname: string,
+  queryMode: EndpointQueryMode,
+  prefix: string,
+  identity?: (item: unknown) => string,
+  options: Pick<EndpointDescriptor, 'parentIdentity' | 'maxItems' | 'includeResource'> = {}
+): EndpointDescriptor {
+  return {
+    path: pathname,
+    queryMode,
+    eventTime: itemEventTime,
+    identity: identity ?? ((item) => resourceIdentity(prefix, item)),
+    ...options
+  };
+}
+
+function responseDateOrError(value: string | undefined): ProcessResult<{ date: Date; iso: string }> {
+  const date = validDate(value);
+  if (!date) return { ok: false, error: { code: 'OBSERVATION_BOUNDARY_INVALID', message: 'GitHub response Date is missing or invalid' } };
+  return { ok: true, value: { date, iso: date.toISOString() } };
+}
+
+function collectBoundaryCollection(
+  client: GitHubClient,
+  endpoint: EndpointDescriptor,
+  preflight: Date,
+  fromInclusive: Date | null,
+  watermark: Date,
+  reconciliation: 'incremental' | 'full',
+  addResource: (object: CapturedObject, identity: string, eventTime: string) => ProcessResult<void>,
+  deferred: Set<string>,
+  responseDates: string[]
+): ProcessResult<RestCollectionEvidence> {
+  const perPage = 100;
+  const queryMode = reconciliation === 'full' ? 'full-enumeration' : (fromInclusive ? endpoint.queryMode : 'full-enumeration');
+  const queryAfter = queryMode === 'strict-since' && fromInclusive
+    ? new Date(fromInclusive.getTime() - 1000).toISOString()
+    : null;
+  const pages: RestPageEvidence[] = [];
+  const objects: CapturedObject[] = [];
+  const identities = new Set<string>();
+  let previousHash: string | null = null;
+
+  for (let page = 1; ; page += 1) {
+    const url = queryEndpoint(endpoint.path, page, perPage, queryMode, queryAfter);
+    if (!client.jsonWithMetadata) {
+      return { ok: false, error: { code: 'PLATFORM_METADATA_UNAVAILABLE', message: 'GitHub response metadata boundary is unavailable' } };
+    }
+    const response = client.jsonWithMetadata<unknown>(['api', url]);
+    if (!response.ok) return { ok: false, error: response.error };
+    const dateResult = responseDateOrError(response.value.metadata.date);
+    if (!dateResult.ok) return dateResult;
+    if (dateResult.value.date.getTime() < preflight.getTime()) {
+      return { ok: false, error: { code: 'OBSERVATION_BOUNDARY_INVALID', message: `Response Date precedes preflight for ${endpoint.path}` } };
+    }
+    responseDates.push(dateResult.value.iso);
+    const actualUrl = response.value.metadata.requestUrl;
+    if (queryAfter && (!actualUrl.includes(`since=${encodeURIComponent(queryAfter)}`) && !actualUrl.includes(`since=${queryAfter}`))) {
+      return { ok: false, error: { code: 'QUERY_BOUNDARY_INVALID', message: `GitHub request did not include since=${queryAfter}` } };
+    }
+    if (!Array.isArray(response.value.value) || response.value.value.length > perPage) {
+      return { ok: false, error: { code: 'INVALID_PLATFORM_RESPONSE', message: `GitHub page ${page} is not a valid array page` } };
+    }
+    const selected = (response.value.value as unknown[]).map((item) => endpoint.path.includes('/timeline')
+      ? projectGitHubTimelineItem(item)
+      : projectGitHubItem(item));
+    const bytes = canonicalJsonBytes(selected);
+    const pageHash = sha256(bytes);
+    if (previousHash === pageHash && selected.length > 0) {
+      return { ok: false, error: { code: 'PAGINATION_UNSTABLE', message: `GitHub page ${page} repeats the previous page` } };
+    }
+    let overlapItemCount = 0;
+    let acceptedItemCount = 0;
+    let deferredItemCount = 0;
+    for (let index = 0; index < response.value.value.length; index += 1) {
+      const raw = response.value.value[index];
+      const projected = selected[index];
+      const identity = endpoint.identity(raw);
+      const eventTime = endpoint.eventTime(raw);
+      if (!identity) return { ok: false, error: { code: endpoint.path.includes('/timeline') ? 'TIMELINE_IDENTITY_UNAVAILABLE' : 'RESOURCE_IDENTITY_UNAVAILABLE', message: `Stable identity is missing for ${endpoint.path}` } };
+      if (!eventTime || !validDate(eventTime)) return { ok: false, error: { code: 'RESOURCE_TIME_UNAVAILABLE', message: `Event time is missing for ${identity}` } };
+      if (identities.has(identity)) return { ok: false, error: { code: 'PAGINATION_UNSTABLE', message: `duplicate identity on ${endpoint.path}` } };
+      identities.add(identity);
+      const observed = validDate(eventTime)!;
+      if (fromInclusive && observed.getTime() < fromInclusive.getTime()) {
+        overlapItemCount += 1;
+      } else if (observed.getTime() >= watermark.getTime()) {
+        deferredItemCount += 1;
+        if (endpoint.includeResource?.(raw) !== false) deferred.add(identity);
+      } else {
+        acceptedItemCount += 1;
+        if (endpoint.includeResource?.(raw) === false) continue;
+        const resourceBytes = canonicalJsonBytes(projected);
+        const rawRecord = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, unknown> : {};
+        const routeNumber = typeof rawRecord.number === 'number' ? rawRecord.number : undefined;
+        const added = addResource({
+          sourceKind: 'github-rest',
+          sourceIdentity: identity,
+          resourceIdentity: identity,
+          sha256: sha256(resourceBytes),
+          bytes: resourceBytes.length,
+          content: resourceBytes.toString('utf8'),
+          disposition: { state: 'included' },
+          role: 'resource',
+          eventTime,
+          ...(routeNumber !== undefined ? { routeNumber } : {}),
+          ...(endpoint.parentIdentity ? { parentIdentity: endpoint.parentIdentity } : {}),
+          pageSha256: pageHash
+        }, identity, eventTime);
+        if (!added.ok) return added;
+      }
+    }
+    const pageEvidence: RestPageEvidence = {
+      index: page,
+      itemCount: response.value.value.length,
+      canonicalSha256: pageHash,
+      queryMode,
+      ...(queryAfter ? { requestedSince: queryAfter } : {}),
+      responseDate: dateResult.value.iso,
+      overlapItemCount,
+      acceptedItemCount,
+      deferredItemCount
+    };
+    pages.push(pageEvidence);
+    objects.push({
+      sourceKind: 'github-rest',
+      sourceIdentity: `${endpoint.path}#page=${page}`,
+      sha256: pageHash,
+      bytes: bytes.length,
+      content: bytes.toString('utf8'),
+      disposition: { state: 'included' },
+      role: 'page-evidence',
+      endpoint: endpoint.path,
+      page,
+      queryMode,
+      ...(queryAfter ? { requestedSince: queryAfter } : {}),
+      responseDate: dateResult.value.iso
+    });
+    previousHash = pageHash;
+    const links = response.value.metadata.links.join(' ');
+    if (response.value.value.length < perPage) {
+      if (/rel=["']next["']/.test(links)) return { ok: false, error: { code: 'PAGINATION_UNSTABLE', message: `short page ${page} has a next link` } };
+      break;
+    }
+  }
+  const accepted = pages.reduce((sum, page) => sum + (page.acceptedItemCount ?? 0), 0);
+  const observed = pages.reduce((sum, page) => sum + page.itemCount, 0);
+  if (endpoint.maxItems !== undefined && observed >= endpoint.maxItems) {
+    return { ok: false, error: { code: 'PLATFORM_LIMIT_REACHED', message: `GitHub endpoint ${endpoint.path} reached its documented ${endpoint.maxItems}-item limit` } };
+  }
+  const evidence: RestCollectionEvidence = {
+    endpoint: endpoint.path,
+    requestCount: pages.length,
+    dataPageCount: pages.filter((page) => page.itemCount > 0).length,
+    itemCount: accepted,
+    termination: 'short-page',
+    pages,
+    queryMode,
+    ...(queryAfter ? { requestedSince: queryAfter } : {})
+  };
+  // The caller adds these after all resources are known so page evidence stays separate from resource hashes.
+  for (const object of objects) {
+    const added = addResource(object, object.sourceIdentity, object.eventTime ?? watermark.toISOString());
+    if (!added.ok) return added;
+  }
+  return { ok: true, value: evidence };
+}
+
+function collectGitHubBoundary(repoRoot: string, options: BoundaryCaptureOptions = {}): ProcessResult<GitHubBoundaryCapture> {
+  const client = options.client ?? createGitHubClient();
+  const repoResult = client.json<{ nameWithOwner?: string }>(['repo', 'view', '--json', 'nameWithOwner'], { cwd: repoRoot });
+  if (!repoResult.ok) return { ok: false, error: repoResult.error };
+  const repository = repoResult.value.nameWithOwner;
+  if (!repository || !/^[^/]+\/[^/]+$/.test(repository) || !client.jsonWithMetadata) {
+    return { ok: false, error: { code: 'INVALID_PLATFORM_RESPONSE', message: 'GitHub repository identity or response metadata is missing' } };
+  }
+  const preflightResult = client.jsonWithMetadata<unknown>(['api', `repos/${repository}`]);
+  if (!preflightResult.ok) return { ok: false, error: preflightResult.error };
+  const preflightDate = responseDateOrError(preflightResult.value.metadata.date);
+  if (!preflightDate.ok) return preflightDate;
+  const watermark = new Date(truncateSecond(preflightDate.value.date));
+  const fromInclusive = options.fromInclusive ? validDate(options.fromInclusive) : null;
+  if (options.fromInclusive && !fromInclusive) return { ok: false, error: { code: 'CHECKPOINT_INVALID', message: 'Checkpoint watermark is invalid' } };
+  if (fromInclusive && watermark.getTime() <= fromInclusive.getTime()) {
+    return { ok: false, error: { code: 'OBSERVATION_BOUNDARY_INVALID', message: 'Observation cutoff is not after checkpoint watermark' } };
+  }
+  const reconciliation = options.reconciliation ?? 'incremental';
+  const allObjects: CapturedObject[] = [];
+  const resources = new Map<string, CapturedObject>();
+  const pageObjects: CapturedObject[] = [];
+  const endpoints: RestCollectionEvidence[] = [];
+  const deferred = new Set<string>();
+  const unavailable = new Set<string>();
+  const responseDates = [preflightDate.value.iso];
+  const addResource = (object: CapturedObject, identity: string): ProcessResult<void> => {
+    if (object.role === 'page-evidence') {
+      pageObjects.push(object);
+      return { ok: true, value: undefined };
+    }
+    if (identity) {
+      const existing = resources.get(identity);
+      if (existing && (existing.sha256 !== object.sha256 || existing.parentIdentity !== object.parentIdentity)) {
+        return { ok: false, error: { code: 'RESOURCE_IDENTITY_COLLISION', message: `Conflicting GitHub resources share identity ${identity}` } };
+      }
+      if (!existing) resources.set(identity, object);
+    }
+    return { ok: true, value: undefined };
+  };
+  const collect = (endpoint: EndpointDescriptor): ProcessResult<void> => {
+    const result = collectBoundaryCollection(client, endpoint, preflightDate.value.date, fromInclusive, watermark, reconciliation, addResource, deferred, responseDates);
+    if (!result.ok) return result;
+    endpoints.push(result.value);
+    return { ok: true, value: undefined };
+  };
+  const issueEndpoint = `repos/${repository}/issues?state=all&sort=created&direction=asc`;
+  const pullEndpoint = `repos/${repository}/pulls?state=all&sort=created&direction=asc`;
+  for (const endpoint of [
+    descriptor(issueEndpoint, 'strict-since', 'issue', issueOrPullIdentity, { includeResource: (item) => !isPullRequestIssue(item) }),
+    descriptor(pullEndpoint, 'full-enumeration', 'pr')
+  ]) {
+    const result = collect(endpoint);
+    if (!result.ok) return result;
+  }
+  const issueNumbers = new Set<string>();
+  const pullNumbers = new Set<string>();
+  const issueRoots = new Map<string, CapturedObject>();
+  const pullRoots = new Map<string, CapturedObject>();
+  for (const resource of resources.values()) {
+    if (resource.routeNumber === undefined || !resource.resourceIdentity) continue;
+    if (resource.resourceIdentity.startsWith('pr:')) {
+      const number = String(resource.routeNumber);
+      pullNumbers.add(number);
+      pullRoots.set(number, resource);
+    } else if (resource.resourceIdentity.startsWith('issue:')) {
+      const number = String(resource.routeNumber);
+      issueNumbers.add(number);
+      issueRoots.set(number, resource);
+    }
+  }
+  for (const number of issueNumbers) {
+    const parentIdentity = issueRoots.get(number)?.resourceIdentity;
+    const result = collect(descriptor(`repos/${repository}/issues/${number}/comments`, 'strict-since', 'comment', undefined, { parentIdentity }));
+    if (!result.ok) return result;
+    const timeline = collect(descriptor(
+      `repos/${repository}/issues/${number}/timeline`,
+      'full-enumeration',
+      'timeline',
+      (item) => timelineIdentity(item, number),
+      { parentIdentity }
+    ));
+    if (!timeline.ok) return timeline;
+  }
+  for (const number of pullNumbers) {
+    const expected = pullRoots.get(number);
+    let expectedHead: string | undefined;
+    if (expected?.content) {
+      try {
+        expectedHead = ((JSON.parse(expected.content) as Record<string, unknown>).head as Record<string, unknown> | undefined)?.sha as string | undefined;
+      } catch {
+        expectedHead = undefined;
+      }
+    }
+    const current = client.jsonWithMetadata<unknown>(['api', `repos/${repository}/pulls/${number}`]);
+    if (!current.ok) return { ok: false, error: current.error };
+    const currentDate = responseDateOrError(current.value.metadata.date);
+    if (!currentDate.ok) return currentDate;
+    if (currentDate.value.date.getTime() < preflightDate.value.date.getTime()) {
+      return { ok: false, error: { code: 'OBSERVATION_BOUNDARY_INVALID', message: `Response Date precedes preflight for pull request ${number}` } };
+    }
+    responseDates.push(currentDate.value.iso);
+    const currentProjected = projectGitHubItem(current.value.value) as Record<string, unknown>;
+    const currentHead = (currentProjected.head as Record<string, unknown> | undefined)?.sha;
+    if (expectedHead && currentHead !== expectedHead) {
+      return { ok: false, error: { code: 'SOURCE_DRIFT', message: `Pull request ${number} head changed during capture` } };
+    }
+    const parentIdentity = expected?.resourceIdentity;
+    const conversationComments = collect(descriptor(`repos/${repository}/issues/${number}/comments`, 'strict-since', 'comment', undefined, { parentIdentity }));
+    if (!conversationComments.ok) return conversationComments;
+    for (const suffix of ['comments', 'reviews', 'commits']) {
+      const mode: EndpointQueryMode = suffix === 'reviews' || suffix === 'commits' ? 'full-enumeration' : 'strict-since';
+      const prefix = suffix === 'comments' ? 'review-comment' : suffix === 'reviews' ? 'review' : 'commit';
+      const result = collect(descriptor(
+        `repos/${repository}/pulls/${number}/${suffix}`,
+        mode,
+        prefix,
+        undefined,
+        { parentIdentity, ...(suffix === 'commits' ? { maxItems: 250 } : {}) }
+      ));
+      if (!result.ok) return result;
+    }
+    const timeline = collect(descriptor(
+      `repos/${repository}/issues/${number}/timeline`,
+      'full-enumeration',
+      'timeline',
+      (item) => timelineIdentity(item, number),
+      { parentIdentity }
+    ));
+    if (!timeline.ok) return timeline;
+  }
+  allObjects.push(...pageObjects, ...resources.values());
+  return {
+    ok: true,
+    value: {
+      repository,
+      preflightDate: preflightDate.value.iso,
+      watermark: watermark.toISOString(),
+      objects: allObjects,
+      endpoints,
+      responseDates: [...new Set(responseDates)].sort(),
+      deferred: [...deferred].sort(),
+      unavailable: [...unavailable].sort()
+    }
+  };
+}
+
+export { collectGitHubBoundary, collectGitHubObjects, collectLocalObjects, fetchRestCollection, projectGitHubItem, projectGitHubTimelineItem, resolveGitHubRepository };
+export type { BoundaryCaptureOptions, FetchRestCollectionOptions, GitHubBoundaryCapture, GitHubCapture, RestCollection };

--- a/lib/process-data/store.ts
+++ b/lib/process-data/store.ts
@@ -9,6 +9,9 @@ import type {
   RepairAction,
   RestCollectionEvidence,
   SnapshotManifest,
+  SnapshotManifestV1,
+  SnapshotManifestV2,
+  SnapshotOperations,
   StoredObjectEvidence
 } from './types.ts';
 
@@ -26,6 +29,18 @@ type PublishInput = {
   records: NormalizedRecord[];
   quality: QualityFinding[];
   repairs: RepairAction[];
+};
+
+type PublishV2Input = PublishInput & {
+  snapshotKind: 'base' | 'delta';
+  parentSnapshotId: string | null;
+  checkpointBefore: string | null;
+  watermark: string;
+  window: SnapshotManifestV2['window'];
+  observation: SnapshotManifestV2['observation'];
+  coverage: SnapshotManifestV2['coverage'];
+  reconciliation: 'incremental' | 'full';
+  operations: SnapshotOperations;
 };
 
 type VerificationResult = {
@@ -82,12 +97,32 @@ function canonicalJsonBytes(value: JsonValue | unknown): Buffer {
 }
 
 function ensurePrivateDirectory(directory: string): void {
-  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
-  if (process.platform !== 'win32') fs.chmodSync(directory, 0o700);
+  const missing: string[] = [];
+  let current = path.resolve(directory);
+  while (!fs.existsSync(current)) {
+    missing.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`cannot create directory tree: ${directory}`);
+    current = parent;
+  }
+  for (const target of missing.reverse()) {
+    fs.mkdirSync(target, { mode: 0o700 });
+    if (process.platform !== 'win32') fs.chmodSync(target, 0o700);
+    fsyncDirectory(path.dirname(target));
+  }
+}
+
+function fsyncDirectory(directory: string): void {
+  if (process.platform === 'win32') return;
+  const fd = fs.openSync(directory, 'r');
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
 }
 
 function writeExclusive(filePath: string, bytes: Buffer): boolean {
-  ensurePrivateDirectory(path.dirname(filePath));
+  const directory = path.dirname(filePath);
+  const directoryExisted = fs.existsSync(directory);
+  ensurePrivateDirectory(directory);
+  if (!directoryExisted) fsyncDirectory(path.dirname(directory));
   try {
     const fd = fs.openSync(filePath, 'wx', 0o600);
     try {
@@ -96,6 +131,7 @@ function writeExclusive(filePath: string, bytes: Buffer): boolean {
     } finally {
       fs.closeSync(fd);
     }
+    fsyncDirectory(directory);
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
@@ -133,11 +169,17 @@ function jsonLine(value: JsonValue | unknown): string {
 }
 
 function writePrivateFile(filePath: string, content: string | Buffer): void {
-  fs.writeFileSync(filePath, content, { mode: 0o600, flag: 'wx' });
+  const fd = fs.openSync(filePath, 'wx', 0o600);
+  try {
+    fs.writeFileSync(fd, content);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
   if (process.platform !== 'win32') fs.chmodSync(filePath, 0o600);
 }
 
-function manifestDigest(manifest: Omit<SnapshotManifest, 'manifestSha256'>): string {
+function manifestDigest(manifest: Record<string, unknown>): string {
   return sha256(canonicalJsonBytes(manifest));
 }
 
@@ -163,7 +205,7 @@ function publishSnapshot(root: string, input: PublishInput): { snapshotId: strin
   const identityDigest = sha256(canonicalJsonBytes(identity));
   const stamp = input.observedTo.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
   const snapshotId = `${stamp}-${identityDigest.slice(0, 12)}`;
-  const partialManifest: Omit<SnapshotManifest, 'manifestSha256'> = {
+  const partialManifest: Omit<SnapshotManifestV1, 'manifestSha256'> = {
     schema: 'raw-manifest/v1',
     snapshotId,
     ...identity,
@@ -200,9 +242,79 @@ function publishSnapshot(root: string, input: PublishInput): { snapshotId: strin
       const existing = fs.readFileSync(path.join(destination, 'manifest.json'), 'utf8');
       if (existing !== jsonLine(manifest)) throw new Error(`snapshot collision: ${snapshotId}`);
       fs.rmSync(staging, { recursive: true, force: true });
+      fsyncDirectory(stagingRoot);
       return { snapshotId, path: destination, created: false };
     }
+    fsyncDirectory(staging);
     fs.renameSync(staging, destination);
+    fsyncDirectory(stagingRoot);
+    fsyncDirectory(path.dirname(destination));
+    return { snapshotId, path: destination, created: true };
+  } catch (error) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function publishSnapshotV2(root: string, input: PublishV2Input): { snapshotId: string; path: string; created: boolean } {
+  ensurePrivateDirectory(root);
+  ensurePrivateDirectory(path.join(root, 'repairs'));
+  const date = new Date(input.observedTo);
+  if (!Number.isFinite(date.getTime())) throw new Error('observedTo must be an ISO timestamp');
+  const identity = {
+    scope: 'github' as const,
+    repository: input.repository,
+    observedFrom: input.observedFrom,
+    observedTo: input.observedTo,
+    objects: input.objects,
+    endpoints: input.endpoints,
+    excerptsEnabled: false,
+    dispositionCounts: dispositionCounts(input.objects),
+    recordCount: input.records.length,
+    findingCount: input.quality.length,
+    repairCount: input.repairs.length,
+    snapshotKind: input.snapshotKind,
+    parentSnapshotId: input.parentSnapshotId,
+    checkpointBefore: input.checkpointBefore,
+    watermark: input.watermark,
+    window: input.window,
+    observation: input.observation,
+    coverage: input.coverage,
+    reconciliation: input.reconciliation,
+    operations: input.operations
+  };
+  const snapshotId = `${input.watermark.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')}-${sha256(canonicalJsonBytes(identity)).slice(0, 12)}`;
+  const partialManifest = {
+    schema: 'raw-manifest/v2' as const,
+    snapshotId,
+    ...identity,
+    observedFrom: input.observedFrom,
+    observedTo: input.observedTo,
+    privacyPolicyVersion: 'process-data-privacy/v1' as const
+  };
+  const manifest: SnapshotManifestV2 = { ...partialManifest, manifestSha256: manifestDigest(partialManifest) };
+  const stagingRoot = path.join(root, '.staging');
+  ensurePrivateDirectory(stagingRoot);
+  const staging = fs.mkdtempSync(path.join(stagingRoot, `${snapshotId}-`));
+  if (process.platform !== 'win32') fs.chmodSync(staging, 0o700);
+  try {
+    writePrivateFile(path.join(staging, 'manifest.json'), jsonLine(manifest));
+    writePrivateFile(path.join(staging, 'normalized.jsonl'), input.records.map((record) => jsonLine({ schema: 'normalized/v2', ...record })).join(''));
+    writePrivateFile(path.join(staging, 'quality.json'), jsonLine({ schema: 'quality/v1', findings: input.quality }));
+    writePrivateFile(path.join(staging, 'repair-manifest.jsonl'), input.repairs.map((repair) => jsonLine({ schema: 'repair/v1', ...repair })).join(''));
+    const destination = path.join(root, 'snapshots', String(date.getUTCFullYear()), String(date.getUTCMonth() + 1).padStart(2, '0'), String(date.getUTCDate()).padStart(2, '0'), snapshotId);
+    ensurePrivateDirectory(path.dirname(destination));
+    if (fs.existsSync(destination)) {
+      const existing = fs.readFileSync(path.join(destination, 'manifest.json'), 'utf8');
+      if (existing !== jsonLine(manifest)) throw new Error(`snapshot collision: ${snapshotId}`);
+      fs.rmSync(staging, { recursive: true, force: true });
+      fsyncDirectory(stagingRoot);
+      return { snapshotId, path: destination, created: false };
+    }
+    fsyncDirectory(staging);
+    fs.renameSync(staging, destination);
+    fsyncDirectory(stagingRoot);
+    fsyncDirectory(path.dirname(destination));
     return { snapshotId, path: destination, created: true };
   } catch (error) {
     fs.rmSync(staging, { recursive: true, force: true });
@@ -226,7 +338,181 @@ function findSnapshot(root: string, snapshotId: string): string | null {
   return null;
 }
 
-function verifySnapshot(root: string, snapshotId: string): VerificationResult {
+function verifyV2Snapshot(root: string, snapshotId: string, snapshotPath: string, manifest: SnapshotManifestV2, seen: Set<string>): VerificationResult {
+  const errors: string[] = [];
+  if (seen.has(snapshotId)) return { ok: false, snapshotId, snapshotPath, errors: ['snapshot lineage cycle detected'], manifest };
+  seen.add(snapshotId);
+  if (manifest.snapshotId !== snapshotId) errors.push('snapshot identity mismatch');
+  if (manifest.scope !== 'github') errors.push('v2 snapshot scope must be github');
+  if (manifest.snapshotKind === 'base' && manifest.parentSnapshotId !== null) errors.push('base snapshot must not have a parent');
+  if (manifest.snapshotKind === 'delta' && !manifest.parentSnapshotId) errors.push('delta snapshot must have a parent');
+  if (manifest.checkpointBefore !== manifest.parentSnapshotId) errors.push('checkpoint and parent lineage mismatch');
+  if (manifest.parentSnapshotId) {
+    const parentPath = findSnapshot(root, manifest.parentSnapshotId);
+    if (!parentPath) errors.push('parent snapshot is missing');
+    else {
+      const parentVerification = verifySnapshot(root, manifest.parentSnapshotId, seen);
+      if (!parentVerification.ok || !parentVerification.manifest) {
+        errors.push(`parent snapshot is invalid: ${parentVerification.errors.join('; ')}`);
+      } else if (parentVerification.manifest.schema !== 'raw-manifest/v2') {
+        errors.push('v2 snapshot parent is not v2');
+      } else {
+        const parent = parentVerification.manifest;
+        if (parent.repository !== manifest.repository) errors.push('parent repository mismatch');
+        if (new Date(parent.watermark).getTime() >= new Date(manifest.watermark).getTime()) errors.push('snapshot watermark is not monotonic');
+      }
+    }
+  }
+  if (manifest.watermark !== manifest.window.toExclusive) errors.push('watermark and window cutoff mismatch');
+  const watermark = new Date(manifest.watermark);
+  const from = manifest.window.fromInclusive ? new Date(manifest.window.fromInclusive) : null;
+  const queryAfter = manifest.window.queryAfter ? new Date(manifest.window.queryAfter) : null;
+  if (!Number.isFinite(watermark.getTime()) || (from && !Number.isFinite(from.getTime())) || (queryAfter && !Number.isFinite(queryAfter.getTime()))) {
+    errors.push('v2 observation window contains an invalid timestamp');
+  }
+  if (from && queryAfter && queryAfter.getTime() !== from.getTime() - 1000) errors.push('queryAfter does not equal watermark minus one second');
+  if (!from && queryAfter) errors.push('base/full window cannot have queryAfter without fromInclusive');
+  const strictSinceEndpoints = manifest.endpoints.filter((endpoint) => endpoint.queryMode === 'strict-since');
+  const expectedQueryAfter = from && Number.isFinite(from.getTime()) ? new Date(from.getTime() - 1000).toISOString() : null;
+  if (manifest.snapshotKind === 'base' && from) errors.push('base snapshot must not have fromInclusive');
+  if (queryAfter && strictSinceEndpoints.length === 0) errors.push('queryAfter requires a strict-since endpoint');
+  if (strictSinceEndpoints.length > 0 && (manifest.snapshotKind !== 'delta' || manifest.reconciliation !== 'incremental')) {
+    errors.push('strict-since is only valid for incremental delta snapshots');
+  }
+  if (strictSinceEndpoints.length > 0 && manifest.window.queryAfter !== expectedQueryAfter) {
+    errors.push('incremental strict-since queryAfter proof is invalid');
+  }
+  if (manifest.coverage.mode !== 'boundary-reread-with-full-reconcile' || manifest.coverage.absoluteCompleteness !== false) errors.push('coverage declaration is invalid');
+  const preflight = new Date(manifest.observation.preflightDate);
+  if (!Number.isFinite(preflight.getTime())) errors.push('preflight Date is invalid');
+  for (const responseDate of manifest.observation.responseDates) {
+    const parsed = new Date(responseDate);
+    if (!Number.isFinite(parsed.getTime()) || parsed.getTime() < preflight.getTime()) errors.push('response Date evidence is invalid');
+  }
+  for (const endpoint of manifest.endpoints) {
+    if (!endpoint.queryMode) errors.push(`endpoint query mode missing: ${endpoint.endpoint}`);
+    if (endpoint.queryMode !== 'strict-since' && endpoint.queryMode !== 'full-enumeration') {
+      errors.push(`endpoint query mode is invalid: ${endpoint.endpoint}`);
+    } else if (endpoint.queryMode === 'strict-since') {
+      if (endpoint.requestedSince !== expectedQueryAfter) errors.push(`endpoint since proof mismatch: ${endpoint.endpoint}`);
+    } else if (endpoint.requestedSince !== undefined) {
+      errors.push(`full-enumeration endpoint has requestedSince: ${endpoint.endpoint}`);
+    }
+    for (const page of endpoint.pages) {
+      if (page.queryMode !== 'strict-since' && page.queryMode !== 'full-enumeration') {
+        errors.push(`page query mode is invalid: ${endpoint.endpoint}#${page.index}`);
+      }
+      if (page.queryMode !== endpoint.queryMode) errors.push(`page query mode mismatch: ${endpoint.endpoint}#${page.index}`);
+      if (endpoint.queryMode === 'strict-since') {
+        if (page.requestedSince !== expectedQueryAfter) errors.push(`page since proof mismatch: ${endpoint.endpoint}#${page.index}`);
+      } else if (page.requestedSince !== undefined) {
+        errors.push(`full-enumeration page has requestedSince: ${endpoint.endpoint}#${page.index}`);
+      }
+      if (page.responseDate && new Date(page.responseDate).getTime() < preflight.getTime()) errors.push(`page Date precedes preflight: ${endpoint.endpoint}#${page.index}`);
+    }
+  }
+  for (const endpoint of manifest.endpoints) {
+    for (const page of endpoint.pages) {
+      const matches = manifest.objects.filter((object) => object.role === 'page-evidence'
+        && object.endpoint === endpoint.endpoint
+        && object.page === page.index
+        && object.sha256 === page.canonicalSha256);
+      if (matches.length !== 1) {
+        errors.push(`page evidence CAS reference is missing or ambiguous: ${endpoint.endpoint}#${page.index}`);
+        continue;
+      }
+      const object = matches[0]!;
+      if (object.queryMode !== 'strict-since' && object.queryMode !== 'full-enumeration') {
+        errors.push(`page evidence query mode is invalid: ${endpoint.endpoint}#${page.index}`);
+      }
+      if (object.queryMode !== page.queryMode
+        || object.requestedSince !== page.requestedSince
+        || object.responseDate !== page.responseDate) {
+        errors.push(`page evidence metadata mismatch: ${endpoint.endpoint}#${page.index}`);
+      }
+      if (endpoint.queryMode === 'strict-since' && object.requestedSince !== expectedQueryAfter) {
+        errors.push(`page evidence since proof mismatch: ${endpoint.endpoint}#${page.index}`);
+      }
+    }
+  }
+  const { manifestSha256, ...partial } = manifest;
+  if (manifestDigest(partial) !== manifestSha256) errors.push('manifest hash mismatch');
+  const checkMode = (target: string, expected: number, label: string) => {
+    if (process.platform === 'win32' || !fs.existsSync(target)) return;
+    const actual = fs.statSync(target).mode & 0o777;
+    if (actual !== expected) errors.push(`${label} permission mismatch: expected ${expected.toString(8)}, got ${actual.toString(8)}`);
+  };
+  checkMode(snapshotPath, 0o700, 'snapshot directory');
+  for (const file of ['manifest.json', 'normalized.jsonl', 'quality.json', 'repair-manifest.jsonl']) checkMode(path.join(snapshotPath, file), 0o600, file);
+  const store = createObjectStore(root);
+  const normalizedEvidence: Array<{ resourceIdentity: string; resourceSha256: string; pageSha256: string }> = [];
+  try {
+    const lines = fs.readFileSync(path.join(snapshotPath, 'normalized.jsonl'), 'utf8').split('\n').filter(Boolean);
+    const ids = new Set<string>();
+    const operationCounts: SnapshotOperations = { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 };
+    for (const line of lines) {
+      const record = JSON.parse(line) as {
+        schema?: string;
+        recordId?: string;
+        resourceIdentity?: string;
+        sourceSha256?: string;
+        operation?: keyof SnapshotOperations;
+        evidence?: Array<{ resourceIdentity?: string; resourceSha256?: string; pageSha256?: string }>;
+      };
+      if (record.schema !== 'normalized/v2' || typeof record.recordId !== 'string') errors.push('normalized v2 record schema is invalid');
+      if (typeof record.recordId === 'string' && ids.has(record.recordId)) errors.push(`duplicate normalized record: ${record.recordId}`);
+      if (typeof record.recordId === 'string') ids.add(record.recordId);
+      if (!record.operation || !(record.operation in operationCounts)) errors.push('normalized v2 operation is invalid');
+      else operationCounts[record.operation] += 1;
+      if ((record.operation === 'upsert' || record.operation === 'supersede')
+        && (!Array.isArray(record.evidence) || record.evidence.length !== 1)) {
+        errors.push(`resource evidence is required for ${record.operation}: ${record.recordId ?? 'unknown'}`);
+      }
+      for (const evidence of record.evidence ?? []) {
+        if (typeof evidence.resourceIdentity === 'string' && typeof evidence.resourceSha256 === 'string' && typeof evidence.pageSha256 === 'string') {
+          if (record.resourceIdentity !== evidence.resourceIdentity || record.sourceSha256 !== evidence.resourceSha256) {
+            errors.push(`normalized v2 evidence does not match record source: ${record.recordId ?? 'unknown'}`);
+          }
+          normalizedEvidence.push({ resourceIdentity: evidence.resourceIdentity, resourceSha256: evidence.resourceSha256, pageSha256: evidence.pageSha256 });
+        } else {
+          errors.push('normalized v2 evidence reference is invalid');
+        }
+      }
+    }
+    if (lines.length !== manifest.recordCount) errors.push('normalized record count mismatch');
+    if (canonicalJsonBytes(operationCounts).toString('utf8') !== canonicalJsonBytes(manifest.operations).toString('utf8')) errors.push('operation count mismatch');
+    const quality = JSON.parse(fs.readFileSync(path.join(snapshotPath, 'quality.json'), 'utf8')) as { schema?: string; findings?: unknown[] };
+    if (quality.schema !== 'quality/v1' || !Array.isArray(quality.findings)) errors.push('quality schema is invalid');
+    else if (quality.findings.length !== manifest.findingCount) errors.push('quality finding count mismatch');
+    const repairLines = fs.readFileSync(path.join(snapshotPath, 'repair-manifest.jsonl'), 'utf8').split('\n').filter(Boolean);
+    if (repairLines.length !== manifest.repairCount) errors.push('repair manifest count mismatch');
+    for (const line of repairLines) if ((JSON.parse(line) as { schema?: string }).schema !== 'repair/v1') errors.push('repair manifest schema is invalid');
+  } catch {
+    errors.push('snapshot derived files are missing or invalid');
+  }
+  for (const object of manifest.objects) {
+    if (object.role !== 'page-evidence' && object.role !== 'resource') errors.push(`object role is invalid: ${object.sourceIdentity}`);
+    if (object.disposition?.state && object.disposition.state !== 'included') continue;
+    try {
+      const objectPath = store.pathFor(object.sha256);
+      const bytes = fs.readFileSync(objectPath);
+      if (sha256(bytes) !== object.sha256 || bytes.length !== object.bytes) errors.push(`object integrity mismatch: ${object.sourceIdentity}`);
+    } catch {
+      errors.push(`object missing: ${object.sourceIdentity}`);
+    }
+  }
+  for (const evidence of normalizedEvidence) {
+    const resources = manifest.objects.filter((object) => object.role === 'resource'
+      && object.resourceIdentity === evidence.resourceIdentity
+      && object.sha256 === evidence.resourceSha256);
+    const pages = manifest.objects.filter((object) => object.role === 'page-evidence' && object.sha256 === evidence.pageSha256);
+    if (resources.length !== 1) errors.push(`resource evidence reference is missing or ambiguous: ${evidence.resourceIdentity}`);
+    if (pages.length === 0) errors.push(`resource page evidence reference is missing: ${evidence.resourceIdentity}`);
+  }
+  return { ok: errors.length === 0, snapshotId, snapshotPath, errors, manifest };
+}
+
+function verifySnapshot(root: string, snapshotId: string, seen: Set<string> = new Set()): VerificationResult {
   const snapshotPath = findSnapshot(root, snapshotId);
   if (!snapshotPath) return { ok: false, snapshotId, snapshotPath: null, errors: ['snapshot not found'] };
   const errors: string[] = [];
@@ -239,13 +525,19 @@ function verifySnapshot(root: string, snapshotId: string): VerificationResult {
   for (const file of ['manifest.json', 'normalized.jsonl', 'quality.json', 'repair-manifest.jsonl']) {
     checkMode(path.join(snapshotPath, file), 0o600, file);
   }
-  let manifest: SnapshotManifest;
+  let rawManifest: { schema?: unknown };
   try {
-    manifest = JSON.parse(fs.readFileSync(path.join(snapshotPath, 'manifest.json'), 'utf8')) as SnapshotManifest;
+    rawManifest = JSON.parse(fs.readFileSync(path.join(snapshotPath, 'manifest.json'), 'utf8')) as { schema?: unknown };
   } catch {
     return { ok: false, snapshotId, snapshotPath, errors: ['manifest is invalid JSON'] };
   }
-  if (manifest.schema !== 'raw-manifest/v1') errors.push(`unsupported manifest schema: ${manifest.schema}`);
+  if (rawManifest.schema === 'raw-manifest/v2') {
+    return verifyV2Snapshot(root, snapshotId, snapshotPath, rawManifest as SnapshotManifestV2, seen);
+  }
+  if (rawManifest.schema !== 'raw-manifest/v1') {
+    return { ok: false, snapshotId, snapshotPath, errors: [`unsupported manifest schema: ${String(rawManifest.schema)}`] };
+  }
+  const manifest = rawManifest as SnapshotManifestV1;
   if (manifest.snapshotId !== snapshotId) errors.push('snapshot identity mismatch');
   if (typeof manifest.excerptsEnabled !== 'boolean') errors.push('manifest excerpts opt-in is invalid');
   if (!manifest.dispositionCounts || canonicalJsonBytes(manifest.dispositionCounts).toString('utf8') !== canonicalJsonBytes(dispositionCounts(manifest.objects)).toString('utf8')) {
@@ -309,7 +601,8 @@ export {
   createObjectStore,
   findSnapshot,
   publishSnapshot,
+  publishSnapshotV2,
   sha256,
   verifySnapshot
 };
-export type { ObjectStore, ObjectWrite, PublishInput, VerificationResult };
+export type { ObjectStore, ObjectWrite, PublishInput, PublishV2Input, VerificationResult };

--- a/lib/process-data/types.ts
+++ b/lib/process-data/types.ts
@@ -7,6 +7,9 @@ type Availability<T> =
 
 type SourceKind = 'local-file' | 'github-rest' | 'operational-report' | 'structured-telemetry';
 
+type CaptureObjectRole = 'page-evidence' | 'resource';
+type EndpointQueryMode = 'strict-since' | 'full-enumeration';
+
 type PrivacyDisposition =
   | { state: 'included' }
   | { state: 'excluded-sensitive'; ruleId: string }
@@ -19,14 +22,37 @@ type CapturedObject = {
   bytes: number;
   content?: string;
   disposition?: PrivacyDisposition;
+  role?: CaptureObjectRole;
+  resourceIdentity?: string;
+  routeNumber?: number;
+  eventTime?: string;
+  endpoint?: string;
+  page?: number;
+  queryMode?: EndpointQueryMode;
+  requestedSince?: string;
+  responseDate?: string;
+  pageSha256?: string;
+  parentIdentity?: string;
 };
 
 type StoredObjectEvidence = Omit<CapturedObject, 'content'>;
+
+type ResourceEvidenceRef = {
+  resourceIdentity: string;
+  resourceSha256: string;
+  pageSha256: string;
+};
 
 type RestPageEvidence = {
   index: number;
   itemCount: number;
   canonicalSha256: string;
+  queryMode?: EndpointQueryMode;
+  requestedSince?: string;
+  responseDate?: string;
+  overlapItemCount?: number;
+  acceptedItemCount?: number;
+  deferredItemCount?: number;
 };
 
 type RestCollectionEvidence = {
@@ -36,6 +62,8 @@ type RestCollectionEvidence = {
   itemCount: number;
   termination: 'short-page';
   pages: RestPageEvidence[];
+  queryMode?: EndpointQueryMode;
+  requestedSince?: string;
 };
 
 type NormalizedKind =
@@ -58,6 +86,10 @@ type NormalizedRecord = {
   binding?: string;
   observedAt?: Availability<string>;
   data?: JsonValue;
+  resourceIdentity?: string;
+  parentIdentity?: string;
+  evidence?: ResourceEvidenceRef[];
+  operation?: 'upsert' | 'supersede' | 'tombstone' | 'unavailable' | 'unchanged';
 };
 
 type QualityCategory =
@@ -88,10 +120,12 @@ type RepairAction = {
   preconditionSha256: string;
 };
 
-type SnapshotManifest = {
+type SnapshotScope = 'all' | 'local' | 'github';
+
+type SnapshotManifestV1 = {
   schema: 'raw-manifest/v1';
   snapshotId: string;
-  scope: 'all' | 'local' | 'github';
+  scope: SnapshotScope;
   repository: string;
   observedFrom: string;
   observedTo: string;
@@ -104,6 +138,80 @@ type SnapshotManifest = {
   excerptsEnabled: boolean;
   dispositionCounts: Record<'included' | 'excluded-sensitive' | 'unavailable', number>;
   manifestSha256: string;
+};
+
+type SnapshotWindow = {
+  fromInclusive: string | null;
+  queryAfter: string | null;
+  toExclusive: string;
+  precision: 'second';
+};
+
+type ObservationEvidence = {
+  cutoffSource: 'github-response-date';
+  preflightDate: string;
+  responseDates: string[];
+};
+
+type CoverageEvidence = {
+  mode: 'boundary-reread-with-full-reconcile';
+  absoluteCompleteness: false;
+};
+
+type SnapshotOperations = {
+  upsert: number;
+  supersede: number;
+  tombstone: number;
+  unavailable: number;
+};
+
+type SnapshotManifestV2 = Omit<SnapshotManifestV1, 'schema' | 'observedFrom' | 'observedTo'> & {
+  schema: 'raw-manifest/v2';
+  snapshotKind: 'base' | 'delta';
+  parentSnapshotId: string | null;
+  checkpointBefore: string | null;
+  watermark: string;
+  window: SnapshotWindow;
+  observation: ObservationEvidence;
+  coverage: CoverageEvidence;
+  reconciliation: 'incremental' | 'full';
+  operations: SnapshotOperations;
+  observedFrom: string;
+  observedTo: string;
+};
+
+type SnapshotManifest = SnapshotManifestV1 | SnapshotManifestV2;
+
+type CheckpointOwner = {
+  schema: 'checkpoint-owner/v1';
+  ownerId: string;
+  pid: number;
+  host: string;
+  processStartToken: string;
+  createdAt: string;
+};
+
+type GitHubCheckpoint = {
+  schema: 'github-checkpoint/v1';
+  repository: string;
+  snapshotId: string;
+  watermark: string;
+  manifestSha256: string;
+  committedAt: string;
+};
+
+type DeltaOperation = {
+  operation: 'upsert' | 'supersede' | 'tombstone' | 'unavailable';
+  resourceIdentity: string;
+  previousSha256?: string;
+  resourceSha256?: string;
+  reason?: string;
+};
+
+type RecoveryReport = {
+  recovered: boolean;
+  quarantined: string[];
+  reason?: string;
 };
 
 type ProcessDataError = {
@@ -127,9 +235,23 @@ export type {
   QualityCategory,
   QualityFinding,
   RepairAction,
+  CaptureObjectRole,
+  CheckpointOwner,
+  CoverageEvidence,
+  DeltaOperation,
+  EndpointQueryMode,
+  GitHubCheckpoint,
+  ObservationEvidence,
+  RecoveryReport,
+  ResourceEvidenceRef,
   RestCollectionEvidence,
   RestPageEvidence,
   SnapshotManifest,
+  SnapshotManifestV1,
+  SnapshotManifestV2,
+  SnapshotOperations,
+  SnapshotScope,
+  SnapshotWindow,
   SourceKind,
   StoredObjectEvidence
 };

--- a/tests/integration/cli/process-data.test.ts
+++ b/tests/integration/cli/process-data.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 import { CLI_PATH } from '../../helpers.ts';
+import { createObjectStore, publishSnapshot } from '../../../lib/process-data/store.ts';
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-cli-'));
@@ -22,14 +23,24 @@ function run(root: string, args: string[], env: NodeJS.ProcessEnv = process.env)
   return spawnSync('node', [CLI_PATH, 'data', ...args], { cwd: root, encoding: 'utf8', env });
 }
 
-test('local capture, verify, audit, repair dry-run and export form a read-only evidence lifecycle', () => {
+test('historical v1 snapshots remain readable while local capture is retired', () => {
   const root = fixture();
-  const capture = run(root, ['capture', '--source', 'local']);
-  assert.equal(capture.status, 0, `${capture.stderr}\n${capture.stdout}`);
-  const captured = JSON.parse(capture.stdout);
-  assert.equal(captured.ok, true);
-  assert.equal(captured.scope, 'local');
-  const snapshotId = captured.snapshotId as string;
+  const dataRoot = path.join(root, '.agents', 'workspace', 'process-data');
+  const store = createObjectStore(dataRoot);
+  const object = store.put(Buffer.from('legacy evidence'));
+  const published = publishSnapshot(dataRoot, {
+    scope: 'local',
+    repository: 'example/repo',
+    observedFrom: '2026-01-01T00:00:00.000Z',
+    observedTo: '2026-01-01T00:00:01.000Z',
+    objects: [{ sourceKind: 'local-file', sourceIdentity: 'task.md', sha256: object.sha256, bytes: object.path ? 15 : 15 }],
+    endpoints: [],
+    excerptsEnabled: false,
+    records: [{ recordId: 'legacy', kind: 'artifact', sourceIdentity: 'task.md', sourceSha256: object.sha256 }],
+    quality: [],
+    repairs: []
+  });
+  const snapshotId = published.snapshotId;
 
   const verify = run(root, ['verify', snapshotId]);
   assert.equal(verify.status, 0, verify.stderr);
@@ -51,6 +62,15 @@ test('local capture, verify, audit, repair dry-run and export form a read-only e
   assert.match(exported.stdout, /"schema":"normalized\/v1"/);
 });
 
+test('local, all and excerpt capture options fail before creating the data root', () => {
+  for (const args of [['capture', '--source', 'local'], ['capture', '--source', 'all'], ['capture', '--include-excerpts']]) {
+    const root = fixture();
+    const result = run(root, args);
+    assert.equal(result.status, 1);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'process-data')), false);
+  }
+});
+
 test('unknown data subcommand fails without creating the default root', () => {
   const root = fixture();
   const result = run(root, ['unknown']);
@@ -58,22 +78,30 @@ test('unknown data subcommand fails without creating the default root', () => {
   assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'process-data')), false);
 });
 
+test('data help exposes the v2 export as-of option', () => {
+  const root = fixture();
+  const result = run(root, ['--help']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /export .*--as-of <ISO>/);
+});
+
 test('full capture uses explicit GitHub pages through a fake gh boundary', () => {
   const root = fixture();
   const fake = path.join(root, 'fake-gh.mjs');
   fs.writeFileSync(fake, `
-import fs from 'node:fs';
 const args = process.argv.slice(2);
 if (args[0] === 'repo' && args[1] === 'view') {
   process.stdout.write(JSON.stringify({ nameWithOwner: 'acme/demo' }));
   process.exit(0);
 }
 if (args[0] === 'api') {
-  const endpoint = args[1] || '';
+  const endpoint = args.find((value) => value.startsWith('repos/')) || '';
+  const date = 'Thu, 20 Aug 2026 00:00:00 GMT';
+  const respond = (value) => process.stdout.write('HTTP/2 200 OK\\r\\nDate: ' + date + '\\r\\n\\r\\n' + JSON.stringify(value));
   if (endpoint.includes('/issues?state=all')) {
-    fs.writeFileSync(1, JSON.stringify([{ id: 101, number: 1, body: 'TASK-20260101-000001', title: 'x'.repeat(3 * 1024 * 1024) }]));
+    respond([{ id: 101, number: 1, body: 'TASK-20260101-000001', title: 'evidence', updated_at: '2026-08-19T00:00:00Z' }]);
   } else {
-    process.stdout.write('[]');
+    respond(endpoint.includes('/acme/demo') && !endpoint.includes('?') ? { id: 1 } : []);
   }
   process.exit(0);
 }
@@ -88,7 +116,7 @@ process.exit(1);
   });
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const output = JSON.parse(result.stdout);
-  assert.equal(output.scope, 'all');
+  assert.equal(output.scope, 'github');
   const manifestFiles: string[] = [];
   const visit = (directory: string) => {
     for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
@@ -99,6 +127,7 @@ process.exit(1);
   };
   visit(path.join(root, '.agents', 'workspace', 'process-data', 'snapshots'));
   const manifest = JSON.parse(fs.readFileSync(manifestFiles[0]!, 'utf8'));
-  assert.equal(manifest.endpoints.length, 3);
+  assert.equal(manifest.schema, 'raw-manifest/v2');
+  assert.equal(manifest.endpoints.length, 4);
   assert.equal(manifest.endpoints.every((endpoint: { pages: unknown[] }) => endpoint.pages.length === 1), true);
 });

--- a/tests/unit/platform/github-client.test.ts
+++ b/tests/unit/platform/github-client.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyGitHubFailure, createGitHubClient } from '../../../lib/platform/github-client.ts';
+import { classifyGitHubFailure, createGitHubClient, parseIncludedResponse } from '../../../lib/platform/github-client.ts';
 
 test('GitHub client reads the CLI version without shell parsing', () => {
   const calls: string[][] = [];
@@ -84,4 +84,30 @@ test('GitHub client retries reads but does not blindly replay posts', () => {
   const post = client.json(['api', 'repos/o/r/issues/1/comments', '-X', 'POST'], { method: 'POST' });
   assert.equal(post.ok, false);
   assert.equal(attempts, 1);
+});
+
+test('metadata JSON boundary returns the final successful attempt and parses the final response block', () => {
+  let attempts = 0;
+  const client = createGitHubClient({
+    runner(args) {
+      attempts += 1;
+      if (attempts === 1) return { status: 1, stdout: '', stderr: 'HTTP 503: unavailable' };
+      return {
+        status: 0,
+        stdout: 'HTTP/2 302 Found\r\nDate: Thu, 20 Aug 2026 00:00:00 GMT\r\n\r\nHTTP/2 200 OK\r\nDate: Thu, 20 Aug 2026 00:00:01 GMT\r\nLink: <https://api.github.com/repos/o/r?page=2>; rel="next"\r\n\r\n[]',
+        stderr: ''
+      };
+    },
+    retryDelaysMs: [0],
+    sleep() {}
+  });
+  const result = client.jsonWithMetadata?.(['api', 'repos/o/r']);
+  assert.equal(result?.ok, true);
+  if (result?.ok) {
+    assert.equal(result.value.metadata.status, 200);
+    assert.equal(result.value.metadata.date, 'Thu, 20 Aug 2026 00:00:01 GMT');
+    assert.equal(result.value.metadata.links.length, 1);
+  }
+  assert.equal(attempts, 2);
+  assert.deepEqual(parseIncludedResponse('HTTP/2 200 OK\r\n\r\n{}', ['api', 'repos/o/r'])?.value, {});
 });

--- a/tests/unit/process-data/checkpoint.test.ts
+++ b/tests/unit/process-data/checkpoint.test.ts
@@ -1,0 +1,262 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  acquireGitHubCheckpoint,
+  commitGitHubCheckpoint,
+  checkpointPaths,
+  readGitHubCheckpoint,
+  releaseGitHubCheckpoint
+} from '../../../lib/process-data/checkpoint.ts';
+import { publishSnapshotV2 } from '../../../lib/process-data/store.ts';
+
+function publishEmptyBase(root: string) {
+  return publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+}
+
+function writeStaleOwner(paths: ReturnType<typeof checkpointPaths>, ownerId: string): void {
+  fs.writeFileSync(paths.lock, `${JSON.stringify({
+    schema: 'checkpoint-owner/v1',
+    ownerId,
+    pid: process.pid,
+    host: os.hostname(),
+    processStartToken: 'stale-process-token',
+    createdAt: '2026-08-20T00:00:00.000Z'
+  })}\n`);
+}
+
+test('checkpoint is single-writer, owner-specific, and committed atomically', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-'));
+  const published = publishEmptyBase(root);
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  const first = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  const busy = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(busy.ok, false);
+  if (!busy.ok) assert.equal(busy.error.code, 'CHECKPOINT_BUSY');
+  const committed = commitGitHubCheckpoint(first.value, {
+    schema: 'github-checkpoint/v1',
+    repository: 'acme/demo',
+    snapshotId: published.snapshotId,
+    watermark: '2026-08-20T00:00:01.000Z',
+    manifestSha256: manifest.manifestSha256,
+    committedAt: '2026-08-20T00:00:01.000Z'
+  });
+  assert.equal(committed.ok, true);
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), {
+    ok: true,
+    value: {
+      schema: 'github-checkpoint/v1',
+      repository: 'acme/demo',
+      snapshotId: published.snapshotId,
+      watermark: '2026-08-20T00:00:01.000Z',
+      manifestSha256: manifest.manifestSha256,
+      committedAt: '2026-08-20T00:00:01.000Z'
+    }
+  });
+  releaseGitHubCheckpoint(first.value);
+  const second = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(second.ok, true);
+  if (second.ok) releaseGitHubCheckpoint(second.value);
+});
+
+test('checkpoint recovery promotes a verified candidate over an existing expected-old head', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-recovery-'));
+  const paths = checkpointPaths(root, 'acme/demo');
+  const published = publishEmptyBase(root);
+  const old = {
+    schema: 'github-checkpoint/v1' as const,
+    repository: 'acme/demo',
+    snapshotId: 'old-snapshot',
+    watermark: '2026-08-20T00:00:00.000Z',
+    manifestSha256: 'a'.repeat(64),
+    committedAt: '2026-08-20T00:00:01.000Z'
+  };
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  const next = { ...old, snapshotId: published.snapshotId, manifestSha256: manifest.manifestSha256, watermark: '2026-08-20T00:00:01.000Z' };
+  fs.mkdirSync(paths.directory, { recursive: true });
+  fs.writeFileSync(paths.checkpoint, `${JSON.stringify(old)}\n`);
+  writeStaleOwner(paths, 'crashed-owner');
+  const candidatePath = `${paths.checkpoint}.crashed-owner.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    ...next,
+    candidateSchema: 'github-checkpoint-candidate/v1',
+    ownerId: 'crashed-owner',
+    expectedOld: { snapshotId: old.snapshotId, manifestSha256: old.manifestSha256 }
+  })}\n`);
+  const acquired = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(acquired.ok, true);
+  if (!acquired.ok) return;
+  assert.equal(acquired.value.recovery.recovered, true);
+  assert.equal(fs.existsSync(candidatePath), false);
+  const recovered = readGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(recovered.ok, true);
+  if (recovered.ok) assert.deepEqual(recovered.value, next);
+  releaseGitHubCheckpoint(acquired.value);
+});
+
+test('checkpoint recovery rejects a candidate whose derived snapshot is corrupt', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-corrupt-recovery-'));
+  const paths = checkpointPaths(root, 'acme/demo');
+  const published = publishEmptyBase(root);
+  fs.appendFileSync(path.join(published.path, 'normalized.jsonl'), '{"schema":"normalized/v2","recordId":"corrupt"}\n');
+  const old = {
+    schema: 'github-checkpoint/v1' as const,
+    repository: 'acme/demo', snapshotId: 'old-snapshot', watermark: '2026-08-20T00:00:00.000Z', manifestSha256: 'a'.repeat(64), committedAt: '2026-08-20T00:00:01.000Z'
+  };
+  fs.mkdirSync(paths.directory, { recursive: true });
+  fs.writeFileSync(paths.checkpoint, `${JSON.stringify(old)}\n`);
+  writeStaleOwner(paths, 'corrupt-owner');
+  const candidatePath = `${paths.checkpoint}.corrupt-owner.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    ...old, snapshotId: published.snapshotId, manifestSha256: (JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string }).manifestSha256, watermark: '2026-08-20T00:00:02.000Z',
+    candidateSchema: 'github-checkpoint-candidate/v1', ownerId: 'corrupt-owner', expectedOld: { snapshotId: old.snapshotId, manifestSha256: old.manifestSha256 }
+  })}\n`);
+
+  const acquired = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(acquired.ok, false);
+  if (!acquired.ok) assert.equal(acquired.error.code, 'CHECKPOINT_RECOVERY_REQUIRED');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: old });
+  assert.equal(fs.existsSync(candidatePath), false);
+});
+
+test('checkpoint recovery rejects a verified snapshot with a mismatched watermark', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-watermark-recovery-'));
+  const paths = checkpointPaths(root, 'acme/demo');
+  const published = publishEmptyBase(root);
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  const old = {
+    schema: 'github-checkpoint/v1' as const, repository: 'acme/demo', snapshotId: 'old-snapshot', watermark: '2026-08-20T00:00:00.000Z', manifestSha256: 'a'.repeat(64), committedAt: '2026-08-20T00:00:01.000Z'
+  };
+  fs.mkdirSync(paths.directory, { recursive: true });
+  fs.writeFileSync(paths.checkpoint, `${JSON.stringify(old)}\n`);
+  writeStaleOwner(paths, 'mismatched-watermark');
+  const candidatePath = `${paths.checkpoint}.mismatched-watermark.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    ...old, snapshotId: published.snapshotId, watermark: '2099-01-01T00:00:00.000Z', manifestSha256: manifest.manifestSha256,
+    candidateSchema: 'github-checkpoint-candidate/v1', ownerId: 'mismatched-watermark', expectedOld: { snapshotId: old.snapshotId, manifestSha256: old.manifestSha256 }
+  })}\n`);
+
+  const acquired = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(acquired.ok, false);
+  if (!acquired.ok) assert.equal(acquired.error.code, 'CHECKPOINT_RECOVERY_REQUIRED');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: old });
+  assert.equal(fs.existsSync(candidatePath), false);
+});
+
+test('checkpoint recovery rejects a candidate owned by a different stale lock', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-owner-recovery-'));
+  const paths = checkpointPaths(root, 'acme/demo');
+  const published = publishEmptyBase(root);
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  const old = {
+    schema: 'github-checkpoint/v1' as const,
+    repository: 'acme/demo',
+    snapshotId: 'old-snapshot',
+    watermark: '2026-08-20T00:00:00.000Z',
+    manifestSha256: 'a'.repeat(64),
+    committedAt: '2026-08-20T00:00:01.000Z'
+  };
+  const next = { ...old, snapshotId: published.snapshotId, manifestSha256: manifest.manifestSha256, watermark: '2026-08-20T00:00:01.000Z' };
+  fs.mkdirSync(paths.directory, { recursive: true });
+  fs.writeFileSync(paths.checkpoint, `${JSON.stringify(old)}\n`);
+  writeStaleOwner(paths, 'stale-owner');
+  const candidatePath = `${paths.checkpoint}.different-owner.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    ...next,
+    candidateSchema: 'github-checkpoint-candidate/v1',
+    ownerId: 'different-owner',
+    expectedOld: { snapshotId: old.snapshotId, manifestSha256: old.manifestSha256 }
+  })}\n`);
+
+  const acquired = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(acquired.ok, false);
+  if (!acquired.ok) assert.equal(acquired.error.code, 'CHECKPOINT_RECOVERY_REQUIRED');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: old });
+  assert.equal(fs.existsSync(candidatePath), false);
+});
+
+test('checkpoint recovery rejects an ownerless legacy candidate without a canonical head', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-ownerless-recovery-'));
+  const paths = checkpointPaths(root, 'acme/demo');
+  const published = publishEmptyBase(root);
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  fs.mkdirSync(paths.directory, { recursive: true });
+  writeStaleOwner(paths, 'dead-owner');
+  const candidatePath = `${paths.checkpoint}.legacy-owner.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    schema: 'github-checkpoint/v1',
+    repository: 'acme/demo',
+    snapshotId: published.snapshotId,
+    watermark: '2026-08-20T00:00:01.000Z',
+    manifestSha256: manifest.manifestSha256,
+    committedAt: '2026-08-20T00:00:01.000Z'
+  })}\n`);
+
+  const acquired = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(acquired.ok, false);
+  if (!acquired.ok) assert.equal(acquired.error.code, 'CHECKPOINT_RECOVERY_REQUIRED');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: null });
+  assert.equal(fs.existsSync(candidatePath), false);
+});
+
+test('checkpoint commit rejects an invalid or mismatched watermark', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-watermark-commit-'));
+  const published = publishEmptyBase(root);
+  const first = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as { manifestSha256: string };
+  const committed = commitGitHubCheckpoint(first.value, {
+    schema: 'github-checkpoint/v1', repository: 'acme/demo', snapshotId: published.snapshotId, watermark: 'not-an-iso-timestamp',
+    manifestSha256: manifest.manifestSha256, committedAt: '2026-08-20T00:00:01.000Z'
+  });
+  assert.equal(committed.ok, false);
+  if (!committed.ok) assert.equal(committed.error.code, 'CHECKPOINT_INVALID');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: null });
+  releaseGitHubCheckpoint(first.value);
+});
+
+test('busy checkpoint acquisition does not promote a recovery candidate', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-busy-recovery-'));
+  const first = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  const paths = checkpointPaths(root, 'acme/demo');
+  const old = {
+    schema: 'github-checkpoint/v1' as const,
+    repository: 'acme/demo',
+    snapshotId: 'old-snapshot',
+    watermark: '2026-08-20T00:00:00.000Z',
+    manifestSha256: 'a'.repeat(64),
+    committedAt: '2026-08-20T00:00:01.000Z'
+  };
+  const next = { ...old, snapshotId: 'new-snapshot', manifestSha256: 'b'.repeat(64), watermark: '2026-08-20T00:00:02.000Z' };
+  fs.mkdirSync(path.join(root, 'snapshots', '2026', '08', '20', 'new-snapshot'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'snapshots', '2026', '08', '20', 'new-snapshot', 'manifest.json'), JSON.stringify({ manifestSha256: next.manifestSha256 }));
+  fs.writeFileSync(paths.checkpoint, `${JSON.stringify(old)}\n`);
+  const candidatePath = `${paths.checkpoint}.live-owner.random.tmp`;
+  fs.writeFileSync(candidatePath, `${JSON.stringify({
+    ...next,
+    candidateSchema: 'github-checkpoint-candidate/v1',
+    ownerId: 'live-owner',
+    expectedOld: { snapshotId: old.snapshotId, manifestSha256: old.manifestSha256 }
+  })}\n`);
+
+  const busy = acquireGitHubCheckpoint(root, 'acme/demo');
+  assert.equal(busy.ok, false);
+  if (!busy.ok) assert.equal(busy.error.code, 'CHECKPOINT_BUSY');
+  assert.deepEqual(readGitHubCheckpoint(root, 'acme/demo'), { ok: true, value: old });
+  assert.equal(fs.existsSync(candidatePath), true);
+  releaseGitHubCheckpoint(first.value);
+});

--- a/tests/unit/process-data/checkpoint.test.ts
+++ b/tests/unit/process-data/checkpoint.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { onPlatforms } from '../../helpers.ts';
 import {
   acquireGitHubCheckpoint,
   commitGitHubCheckpoint,
@@ -70,7 +71,7 @@ test('checkpoint is single-writer, owner-specific, and committed atomically', ()
   if (second.ok) releaseGitHubCheckpoint(second.value);
 });
 
-test('checkpoint recovery promotes a verified candidate over an existing expected-old head', () => {
+test('checkpoint recovery promotes a verified candidate over an existing expected-old head', onPlatforms('linux'), () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-recovery-'));
   const paths = checkpointPaths(root, 'acme/demo');
   const published = publishEmptyBase(root);
@@ -105,7 +106,7 @@ test('checkpoint recovery promotes a verified candidate over an existing expecte
   releaseGitHubCheckpoint(acquired.value);
 });
 
-test('checkpoint recovery rejects a candidate whose derived snapshot is corrupt', () => {
+test('checkpoint recovery rejects a candidate whose derived snapshot is corrupt', onPlatforms('linux'), () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-corrupt-recovery-'));
   const paths = checkpointPaths(root, 'acme/demo');
   const published = publishEmptyBase(root);
@@ -130,7 +131,7 @@ test('checkpoint recovery rejects a candidate whose derived snapshot is corrupt'
   assert.equal(fs.existsSync(candidatePath), false);
 });
 
-test('checkpoint recovery rejects a verified snapshot with a mismatched watermark', () => {
+test('checkpoint recovery rejects a verified snapshot with a mismatched watermark', onPlatforms('linux'), () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-watermark-recovery-'));
   const paths = checkpointPaths(root, 'acme/demo');
   const published = publishEmptyBase(root);
@@ -154,7 +155,7 @@ test('checkpoint recovery rejects a verified snapshot with a mismatched watermar
   assert.equal(fs.existsSync(candidatePath), false);
 });
 
-test('checkpoint recovery rejects a candidate owned by a different stale lock', () => {
+test('checkpoint recovery rejects a candidate owned by a different stale lock', onPlatforms('linux'), () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-owner-recovery-'));
   const paths = checkpointPaths(root, 'acme/demo');
   const published = publishEmptyBase(root);
@@ -186,7 +187,7 @@ test('checkpoint recovery rejects a candidate owned by a different stale lock', 
   assert.equal(fs.existsSync(candidatePath), false);
 });
 
-test('checkpoint recovery rejects an ownerless legacy candidate without a canonical head', () => {
+test('checkpoint recovery rejects an ownerless legacy candidate without a canonical head', onPlatforms('linux'), () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-checkpoint-ownerless-recovery-'));
   const paths = checkpointPaths(root, 'acme/demo');
   const published = publishEmptyBase(root);

--- a/tests/unit/process-data/materialize.test.ts
+++ b/tests/unit/process-data/materialize.test.ts
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { materializeJson, materializeSnapshot } from '../../../lib/process-data/materialize.ts';
+import { createObjectStore, publishSnapshotV2, verifySnapshot } from '../../../lib/process-data/store.ts';
+
+function snapshotInput(root: string, content: string, identity: string) {
+  const store = createObjectStore(root);
+  const bytes = Buffer.from(content);
+  const object = store.put(bytes);
+  const pageBytes = Buffer.from(`[${content}]`);
+  const page = store.put(pageBytes);
+  const endpoint = {
+    endpoint: 'repos/acme/demo/issues', requestCount: 1, dataPageCount: 1, itemCount: 1, termination: 'short-page' as const, queryMode: 'full-enumeration' as const,
+    pages: [{ index: 1, itemCount: 1, canonicalSha256: page.sha256, queryMode: 'full-enumeration' as const, responseDate: '2026-08-20T00:00:02.000Z' }]
+  };
+  return {
+    object: { sourceKind: 'github-rest' as const, sourceIdentity: identity, resourceIdentity: identity, role: 'resource' as const, sha256: object.sha256, bytes: bytes.length },
+    pageObject: { sourceKind: 'github-rest' as const, sourceIdentity: `${identity}#page=1`, role: 'page-evidence' as const, endpoint: endpoint.endpoint, page: 1, queryMode: 'full-enumeration' as const, responseDate: '2026-08-20T00:00:02.000Z', sha256: page.sha256, bytes: pageBytes.length },
+    endpoint,
+    sha256: object.sha256,
+    pageSha256: page.sha256
+  };
+}
+
+test('materialize follows one verified v2 lineage and supports as-of observation views', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-materialize-'));
+  const baseObject = snapshotInput(root, '{"number":1}', 'issue:1');
+  const base = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [baseObject.object, baseObject.pageObject], endpoints: [baseObject.endpoint], excerptsEnabled: false,
+    records: [{ recordId: 'r1', kind: 'platform-resource', sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: baseObject.sha256, operation: 'upsert', evidence: [{ resourceIdentity: 'issue:1', resourceSha256: baseObject.sha256, pageSha256: baseObject.pageSha256 }], data: { number: 1 } }],
+    quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 1, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  assert.equal(verifySnapshot(root, base.snapshotId).ok, true);
+  const deltaObject = snapshotInput(root, '{"number":2}', 'issue:1');
+  const delta = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:02.000Z', observedTo: '2026-08-20T00:00:03.000Z',
+    objects: [deltaObject.object, deltaObject.pageObject], endpoints: [deltaObject.endpoint], excerptsEnabled: false,
+    records: [{ recordId: 'r1', kind: 'platform-resource', sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: deltaObject.sha256, operation: 'supersede', evidence: [{ resourceIdentity: 'issue:1', resourceSha256: deltaObject.sha256, pageSha256: deltaObject.pageSha256 }], data: { number: 2 } }],
+    quality: [], repairs: [], snapshotKind: 'delta', parentSnapshotId: base.snapshotId, checkpointBefore: base.snapshotId,
+    watermark: '2026-08-20T00:00:03.000Z', window: { fromInclusive: '2026-08-20T00:00:01.000Z', queryAfter: null, toExclusive: '2026-08-20T00:00:03.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:02.000Z', responseDates: ['2026-08-20T00:00:02.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 0, supersede: 1, tombstone: 0, unavailable: 0 }
+  });
+  assert.equal(verifySnapshot(root, delta.snapshotId).ok, true);
+  assert.deepEqual(materializeSnapshot(root, delta.snapshotId).records[0]!.data, { number: 2 });
+  assert.deepEqual(materializeSnapshot(root, delta.snapshotId, { asOf: '2026-08-20T00:00:02.000Z' }).records[0]!.data, { number: 1 });
+  assert.match(materializeJson(root, delta.snapshotId), /"number":2/);
+});
+
+test('materialize keeps unchanged ancestors when as-of is later than the head', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-materialize-late-asof-'));
+  const baseObject = snapshotInput(root, '{"number":1}', 'issue:1');
+  const base = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [baseObject.object, baseObject.pageObject], endpoints: [baseObject.endpoint], excerptsEnabled: false,
+    records: [{ recordId: 'r1', kind: 'platform-resource', sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: baseObject.sha256, operation: 'upsert', evidence: [{ resourceIdentity: 'issue:1', resourceSha256: baseObject.sha256, pageSha256: baseObject.pageSha256 }], data: { number: 1 } }],
+    quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 1, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  const deltaObject = snapshotInput(root, '{"number":2}', 'issue:2');
+  const delta = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:02.000Z', observedTo: '2026-08-20T00:00:03.000Z',
+    objects: [deltaObject.object, deltaObject.pageObject], endpoints: [deltaObject.endpoint], excerptsEnabled: false,
+    records: [{ recordId: 'r2', kind: 'platform-resource', sourceIdentity: 'issue:2', resourceIdentity: 'issue:2', sourceSha256: deltaObject.sha256, operation: 'upsert', evidence: [{ resourceIdentity: 'issue:2', resourceSha256: deltaObject.sha256, pageSha256: deltaObject.pageSha256 }], data: { number: 2 } }],
+    quality: [], repairs: [], snapshotKind: 'delta', parentSnapshotId: base.snapshotId, checkpointBefore: base.snapshotId,
+    watermark: '2026-08-20T00:00:03.000Z', window: { fromInclusive: '2026-08-20T00:00:01.000Z', queryAfter: null, toExclusive: '2026-08-20T00:00:03.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:02.000Z', responseDates: ['2026-08-20T00:00:02.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 1, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  assert.equal(verifySnapshot(root, delta.snapshotId).ok, true);
+  const records = materializeSnapshot(root, delta.snapshotId, { asOf: '2026-08-20T00:00:04.000Z' }).records;
+  assert.deepEqual(records.map((record) => record.resourceIdentity), ['issue:1', 'issue:2']);
+});

--- a/tests/unit/process-data/normalize.test.ts
+++ b/tests/unit/process-data/normalize.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeObjects } from '../../../lib/process-data/normalize.ts';
+import { normalizeObjects, normalizeResources } from '../../../lib/process-data/normalize.ts';
 import { reconcileRecords } from '../../../lib/process-data/reconcile.ts';
 import type { CapturedObject } from '../../../lib/process-data/types.ts';
 
@@ -95,4 +95,24 @@ test('normalization preserves repeated historical rows with unique deterministic
   assert.deepEqual(second, first);
   const quality = reconcileRecords(first, 'local').findings;
   assert.equal(quality.filter((finding) => finding.category === 'duplicate-identity').length, 2);
+});
+
+test('resource normalization uses stable resource identity instead of page identity', () => {
+  const records = normalizeResources([{
+    sourceKind: 'github-rest',
+    sourceIdentity: 'issue:7',
+    resourceIdentity: 'issue:7',
+    role: 'resource',
+    sha256: 'a'.repeat(64),
+    bytes: 2,
+    eventTime: '2026-08-20T00:00:00.000Z',
+    pageSha256: 'b'.repeat(64),
+    content: '{"number":7}'
+  }]);
+  assert.equal(records.length, 1);
+  assert.equal(records[0]!.sourceIdentity, 'issue:7');
+  assert.equal(records[0]!.recordId, normalizeResources([{
+    sourceKind: 'github-rest', sourceIdentity: 'issue:7#page=2', resourceIdentity: 'issue:7', role: 'resource', sha256: 'a'.repeat(64), bytes: 2, content: '{"number":7}'
+  }])[0]!.recordId);
+  assert.deepEqual(records[0]!.evidence, [{ resourceIdentity: 'issue:7', resourceSha256: 'a'.repeat(64), pageSha256: 'b'.repeat(64) }]);
 });

--- a/tests/unit/process-data/reconcile.test.ts
+++ b/tests/unit/process-data/reconcile.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { reconcileRecords } from '../../../lib/process-data/reconcile.ts';
+import { reconcileRecords, reconcileResourceRecords } from '../../../lib/process-data/reconcile.ts';
 
 test('reconciliation proposes only unique deterministic links and keeps conflicts manual', () => {
   const result = reconcileRecords([
@@ -99,4 +99,29 @@ test('reconciliation does not report cross-source gaps for partial snapshots', (
     { recordId: 'issue', kind: 'platform-resource', sourceIdentity: 'issue:800', sourceSha256: 'b'.repeat(64), binding: 'TASK-1' }
   ], 'github');
   assert.equal(github.findings.some((finding) => finding.category === 'missing-local'), false);
+});
+
+test('resource reconciliation defers unknown visibility and tombstones only during complete full reconciliation', () => {
+  const parent = [{
+    recordId: 'old', kind: 'platform-resource' as const, sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: 'a'.repeat(64)
+  }];
+  const changed = { recordId: 'new', kind: 'platform-resource' as const, sourceIdentity: 'issue:2', resourceIdentity: 'issue:2', sourceSha256: 'b'.repeat(64) };
+  const incremental = reconcileResourceRecords([changed], { parent, full: false, deferred: ['issue:1'] });
+  assert.equal(incremental.records.some((record) => record.operation === 'tombstone'), false);
+  assert.equal(incremental.operations.upsert, 1);
+  const full = reconcileResourceRecords([], { parent, full: true, deferred: ['issue:1'] });
+  assert.equal(full.operations.tombstone, 0);
+  const reconciled = reconcileResourceRecords([], { parent, full: true });
+  assert.equal(reconciled.operations.tombstone, 1);
+  assert.equal(reconciled.records[0]!.operation, 'tombstone');
+});
+
+test('resource reconciliation suppresses child tombstones when a parent scope is deferred', () => {
+  const parent = [
+    { recordId: 'root', kind: 'platform-resource' as const, sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: 'a'.repeat(64) },
+    { recordId: 'child', kind: 'platform-resource' as const, sourceIdentity: 'issue-comment:9', resourceIdentity: 'issue-comment:9', sourceSha256: 'b'.repeat(64), parentIdentity: 'issue:1' }
+  ];
+  const result = reconcileResourceRecords([], { parent, full: true, deferred: ['issue:1'] });
+  assert.equal(result.operations.tombstone, 0);
+  assert.deepEqual(result.records, []);
 });

--- a/tests/unit/process-data/sources.test.ts
+++ b/tests/unit/process-data/sources.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { redactExcerpt } from '../../../lib/process-data/privacy.ts';
-import { collectLocalObjects, fetchRestCollection, projectGitHubItem } from '../../../lib/process-data/sources.ts';
+import { collectGitHubBoundary, collectLocalObjects, fetchRestCollection, projectGitHubItem, projectGitHubTimelineItem } from '../../../lib/process-data/sources.ts';
 import { enumerateAllTaskDirs } from '../../../lib/task/resolve-ref.ts';
 import type { GitHubClient } from '../../../lib/platform/github-client.ts';
 
@@ -73,6 +73,24 @@ test('GitHub commit projection retains the approved nested commit metadata', () 
   });
 });
 
+test('GitHub timeline projection preserves event semantics and stable actor identity', () => {
+  assert.deepEqual(projectGitHubTimelineItem({
+    id: 7,
+    event: 'renamed',
+    actor: { id: 4, login: 'octocat', avatar_url: 'ignored' },
+    rename: { from: 'old', to: 'new', issue: 'ignored' },
+    created_at: '2026-08-20T00:00:00Z',
+    body: 'public context'
+  }), {
+    id: 7,
+    event: 'renamed',
+    actor: { id: 4, login: 'octocat' },
+    rename: { from: 'old', to: 'new' },
+    created_at: '2026-08-20T00:00:00Z',
+    body: 'public context'
+  });
+});
+
 test('excerpt privacy rejects common cloud and messaging credentials', () => {
   assert.equal(redactExcerpt('AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'), null);
   const slackWebhook = `https://hooks.slack.com/services/${'T00000000'}/${'B00000000'}/${'X'.repeat(24)}`;
@@ -113,4 +131,172 @@ test('all-state enumeration includes the dated archive while local capture exclu
   if (!optedIn.ok) return;
   const excerpt = optedIn.value.find((object) => object.sourceIdentity.endsWith('logs/sessions/session.md#excerpt'));
   assert.equal(excerpt?.content, 'user-visible transcript');
+});
+
+test('GitHub boundary rereads W minus one second and accepts the inclusive W item', () => {
+  const calls: string[] = [];
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.80.0' }),
+    text: () => ({ ok: true, value: '' }),
+    json: <T>(args: string[]) => ({ ok: true, value: (args[0] === 'repo' ? { nameWithOwner: 'acme/demo' } : {}) as T }),
+    jsonWithMetadata: <T>(args: string[]) => {
+      const url = args.find((value) => value.startsWith('repos/'))!;
+      calls.push(url);
+      const page = new URL(url, 'https://api.github.test');
+      const value = url === 'repos/acme/demo'
+        ? { id: 1 }
+        : url.includes('/issues?')
+          ? [{ id: 1, number: 1, updated_at: '2026-08-19T00:00:00.000Z' }]
+          : [];
+      return {
+        ok: true,
+        value: {
+          value: value as T,
+          metadata: {
+            status: 200,
+            requestUrl: `https://api.github.com/${url}`,
+            date: page.pathname === '/repos/acme/demo' ? 'Thu, 20 Aug 2026 00:00:00 GMT' : 'Thu, 20 Aug 2026 00:00:01 GMT',
+            links: []
+          }
+        }
+      };
+    }
+  };
+  const result = collectGitHubBoundary('/tmp', { client, fromInclusive: '2026-08-19T00:00:00.000Z' });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  const issueEndpoint = result.value.endpoints.find((endpoint) => endpoint.endpoint.includes('/issues?'))!;
+  assert.equal(issueEndpoint.queryMode, 'strict-since');
+  assert.equal(issueEndpoint.requestedSince, '2026-08-18T23:59:59.000Z');
+  assert.equal(issueEndpoint.pages[0]!.acceptedItemCount, 1);
+  assert.ok(calls.some((url) => url.includes('since=2026-08-18T23%3A59%3A59.000Z')));
+  assert.equal(result.value.objects.some((object) => object.role === 'resource' && object.resourceIdentity === 'issue:1'), true);
+});
+
+test('GitHub boundary uses issue and pull numbers for all child routes', () => {
+  const calls: string[] = [];
+  const metadata = (value: unknown, url: string) => ({
+    ok: true as const,
+    value: {
+      value,
+      metadata: {
+        status: 200,
+        requestUrl: `https://api.github.com/${url}`,
+        date: 'Thu, 20 Aug 2026 00:00:01 GMT',
+        links: []
+      }
+    }
+  });
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.80.0' }),
+    text: () => ({ ok: true, value: '' }),
+    json: <T>(args: string[]) => ({ ok: true, value: (args[0] === 'repo' ? { nameWithOwner: 'acme/demo' } : {}) as T }),
+    jsonWithMetadata: <T>(args: string[]) => {
+      const url = args.find((value) => value.startsWith('repos/'))!;
+      calls.push(url);
+      if (url === 'repos/acme/demo') return metadata({ id: 1 }, url) as never;
+      if (url.includes('/issues?')) return metadata([{ id: 101, number: 1, updated_at: '2026-08-19T00:00:00Z' }], url) as never;
+      if (url.includes('/pulls?')) return metadata([{ id: 202, number: 2, head: { sha: 'head-2' }, updated_at: '2026-08-19T00:00:00Z' }], url) as never;
+      if (url === 'repos/acme/demo/pulls/2') return metadata({ id: 202, number: 2, head: { sha: 'head-2' }, updated_at: '2026-08-20T00:00:01Z' }, url) as never;
+      return metadata([], url) as never;
+    }
+  };
+  const result = collectGitHubBoundary('/tmp', { client, fromInclusive: '2026-08-19T00:00:00Z' });
+  assert.equal(result.ok, true);
+  assert.equal(calls.some((url) => url.includes('/issues/1/comments')), true);
+  assert.equal(calls.some((url) => url.includes('/issues/1/timeline')), true);
+  assert.equal(calls.some((url) => url.includes('/issues/2/comments')), true);
+  assert.equal(calls.some((url) => url.includes('/pulls/2/comments')), true);
+  assert.equal(calls.some((url) => url.includes('/issues/101/')), false);
+  assert.equal(calls.some((url) => url.includes('/pulls/202/')), false);
+});
+
+test('GitHub boundary keeps an issue-view PR as page evidence and uses the pull view as canonical', () => {
+  const metadata = (value: unknown, url: string) => ({
+    ok: true as const,
+    value: { value, metadata: { status: 200, requestUrl: `https://api.github.com/${url}`, date: 'Thu, 20 Aug 2026 00:00:01 GMT', links: [] } }
+  });
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.80.0' }),
+    text: () => ({ ok: true, value: '' }),
+    json: <T>(args: string[]) => ({ ok: true, value: (args[0] === 'repo' ? { nameWithOwner: 'acme/demo' } : {}) as T }),
+    jsonWithMetadata: <T>(args: string[]) => {
+      const url = args.find((value) => value.startsWith('repos/'))!;
+      if (url === 'repos/acme/demo') return metadata({ id: 1 }, url) as never;
+      if (url.includes('/issues?')) return metadata([{
+        id: 202, number: 2, pull_request: { url: 'https://api.github.com/repos/acme/demo/pulls/2' }, updated_at: '2026-08-19T00:00:00Z'
+      }], url) as never;
+      if (url.includes('/pulls?')) return metadata([{
+        id: 202, number: 2, head: { sha: 'head-2' }, base: { sha: 'base-2' }, updated_at: '2026-08-19T00:00:00Z'
+      }], url) as never;
+      if (url === 'repos/acme/demo/pulls/2') return metadata({
+        id: 202, number: 2, head: { sha: 'head-2' }, base: { sha: 'base-2' }, updated_at: '2026-08-19T00:00:01Z'
+      }, url) as never;
+      return metadata([], url) as never;
+    }
+  };
+  const result = collectGitHubBoundary('/tmp', { client });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  const resources = result.value.objects.filter((object) => object.role === 'resource');
+  assert.equal(resources.filter((object) => object.resourceIdentity === 'pr:202').length, 1);
+  assert.equal(resources.some((object) => object.resourceIdentity === 'issue:202'), false);
+  assert.equal(result.value.objects.some((object) => object.role === 'page-evidence' && object.endpoint?.includes('/issues?')), true);
+});
+
+test('GitHub timeline fallback identities include their parent issue number', () => {
+  const metadata = (value: unknown, url: string) => ({
+    ok: true as const,
+    value: { value, metadata: { status: 200, requestUrl: `https://api.github.com/${url}`, date: 'Thu, 20 Aug 2026 00:00:01 GMT', links: [] } }
+  });
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.80.0' }),
+    text: () => ({ ok: true, value: '' }),
+    json: <T>(args: string[]) => ({ ok: true, value: (args[0] === 'repo' ? { nameWithOwner: 'acme/demo' } : {}) as T }),
+    jsonWithMetadata: <T>(args: string[]) => {
+      const url = args.find((value) => value.startsWith('repos/'))!;
+      if (url === 'repos/acme/demo') return metadata({ id: 1 }, url) as never;
+      if (url.includes('/issues?')) return metadata([
+        { id: 1, number: 1, updated_at: '2026-08-19T00:00:00Z' },
+        { id: 2, number: 2, updated_at: '2026-08-19T00:00:00Z' }
+      ], url) as never;
+      if (url.includes('/timeline')) return metadata([{ event: 'closed', created_at: '2026-08-19T01:00:00Z', actor: { id: 9 }, issue: { id: 77 } }], url) as never;
+      return metadata([], url) as never;
+    }
+  };
+  const result = collectGitHubBoundary('/tmp', { client });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  const timelines = result.value.objects.filter((object) => object.role === 'resource' && object.resourceIdentity?.startsWith('timeline:'));
+  assert.equal(timelines.length, 2);
+  assert.deepEqual(new Set(timelines.map((object) => object.parentIdentity)), new Set(['issue:1', 'issue:2']));
+});
+
+test('GitHub pull commit collection fails closed at the documented endpoint limit', () => {
+  const metadata = (value: unknown, url: string) => ({
+    ok: true as const,
+    value: { value, metadata: { status: 200, requestUrl: `https://api.github.com/${url}`, date: 'Thu, 20 Aug 2026 00:00:01 GMT', links: [] } }
+  });
+  const client: GitHubClient = {
+    version: () => ({ ok: true, value: '2.80.0' }),
+    text: () => ({ ok: true, value: '' }),
+    json: <T>(args: string[]) => ({ ok: true, value: (args[0] === 'repo' ? { nameWithOwner: 'acme/demo' } : {}) as T }),
+    jsonWithMetadata: <T>(args: string[]) => {
+      const url = args.find((value) => value.startsWith('repos/'))!;
+      if (url === 'repos/acme/demo') return metadata({ id: 1 }, url) as never;
+      if (url.includes('/issues?')) return metadata([], url) as never;
+      if (url.includes('/pulls?')) return metadata([{ id: 202, number: 2, head: { sha: 'head-2' }, updated_at: '2026-08-19T00:00:00Z' }], url) as never;
+      if (url === 'repos/acme/demo/pulls/2') return metadata({ id: 202, number: 2, head: { sha: 'head-2' }, updated_at: '2026-08-20T00:00:01Z' }, url) as never;
+      if (url.includes('/pulls/2/commits')) {
+        const page = Number(new URL(url, 'https://api.github.test').searchParams.get('page'));
+        const start = (page - 1) * 100;
+        const count = page < 3 ? 100 : 50;
+        return metadata(Array.from({ length: count }, (_, index) => ({ sha: `commit-${start + index}`, commit: { committer: { date: '2026-08-19T00:00:00Z' } } })), url) as never;
+      }
+      return metadata([], url) as never;
+    }
+  };
+  const result = collectGitHubBoundary('/tmp', { client });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.error.code, 'PLATFORM_LIMIT_REACHED');
 });

--- a/tests/unit/process-data/store.test.ts
+++ b/tests/unit/process-data/store.test.ts
@@ -8,10 +8,53 @@ import {
   canonicalJsonBytes,
   createObjectStore,
   publishSnapshot,
+  publishSnapshotV2,
   sha256,
   verifySnapshot
 } from '../../../lib/process-data/store.ts';
 import { readAppliedOverlays, repairSnapshot } from '../../../lib/process-data/repair.ts';
+import { onPlatforms } from '../../helpers.ts';
+
+function publishBoundaryBase(root: string) {
+  return publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+}
+
+function publishBoundaryDelta(root: string, parentSnapshotId: string, options: {
+  snapshotKind?: 'base' | 'delta';
+  reconciliation?: 'incremental' | 'full';
+  queryAfter: string | null;
+  requestedSince?: string;
+  queryMode?: 'strict-since' | 'full-enumeration';
+  endpointQueryMode?: 'strict-since' | 'full-enumeration';
+  pageQueryMode?: 'strict-since' | 'full-enumeration';
+  objectQueryMode?: 'strict-since' | 'full-enumeration';
+}) {
+  const store = createObjectStore(root);
+  const pageBytes = Buffer.from('[]');
+  const page = store.put(pageBytes);
+  const queryMode = options.queryMode ?? 'strict-since';
+  const endpointQueryMode = options.endpointQueryMode ?? queryMode;
+  const pageQueryMode = options.pageQueryMode ?? queryMode;
+  const objectQueryMode = options.objectQueryMode ?? queryMode;
+  const endpoint = {
+    endpoint: 'repos/acme/demo/issues', requestCount: 1, dataPageCount: 0, itemCount: 0, termination: 'short-page' as const, queryMode: endpointQueryMode,
+    pages: [{ index: 1, itemCount: 0, canonicalSha256: page.sha256, queryMode: pageQueryMode, ...(options.requestedSince !== undefined ? { requestedSince: options.requestedSince } : {}), responseDate: '2026-08-20T00:00:02.000Z' }]
+  };
+  return publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:02.000Z', observedTo: '2026-08-20T00:00:03.000Z',
+    objects: [{ sourceKind: 'github-rest', sourceIdentity: 'repos/acme/demo/issues#page=1', role: 'page-evidence', endpoint: endpoint.endpoint, page: 1, queryMode: objectQueryMode, ...(options.requestedSince !== undefined ? { requestedSince: options.requestedSince } : {}), responseDate: '2026-08-20T00:00:02.000Z', sha256: page.sha256, bytes: pageBytes.length }],
+    endpoints: [endpoint], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: options.snapshotKind ?? 'delta', parentSnapshotId, checkpointBefore: parentSnapshotId,
+    watermark: '2026-08-20T00:00:03.000Z', window: { fromInclusive: '2026-08-20T00:00:01.000Z', queryAfter: options.queryAfter, toExclusive: '2026-08-20T00:00:03.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:02.000Z', responseDates: ['2026-08-20T00:00:02.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: options.reconciliation ?? 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+}
 
 test('canonical JSON sorts object keys recursively and preserves array order', () => {
   const left = canonicalJsonBytes({ b: 1, a: { z: '值', y: [2, 1] } });
@@ -60,6 +103,198 @@ test('CAS is idempotent and snapshot verification detects tampering', () => {
   const invalid = verifySnapshot(root, published.snapshotId);
   assert.equal(invalid.ok, false);
   assert.match(invalid.errors.join('\n'), /hash mismatch/);
+});
+
+test('snapshot verification rejects an unknown manifest schema instead of treating it as v1', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-unknown-schema-'));
+  const published = publishSnapshot(root, {
+    scope: 'local', repository: 'example/repo', observedFrom: '2026-01-01T00:00:00.000Z', observedTo: '2026-01-01T00:00:01.000Z',
+    objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: []
+  });
+  const manifest = JSON.parse(fs.readFileSync(path.join(published.path, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+  const { manifestSha256: _oldDigest, ...partial } = manifest;
+  const unknown = { ...partial, schema: 'raw-manifest/v999' };
+  fs.writeFileSync(path.join(published.path, 'manifest.json'), `${JSON.stringify({ ...unknown, manifestSha256: sha256(canonicalJsonBytes(unknown)) })}\n`);
+  const verified = verifySnapshot(root, published.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /unsupported manifest schema/);
+});
+
+test('v2 verification rejects an endpoint page without its page-evidence CAS object', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-page-'));
+  const published = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [],
+    endpoints: [{
+      endpoint: 'repos/acme/demo/issues', requestCount: 1, dataPageCount: 0, itemCount: 0, termination: 'short-page', queryMode: 'full-enumeration',
+      pages: [{ index: 1, itemCount: 0, canonicalSha256: 'f'.repeat(64), queryMode: 'full-enumeration', responseDate: '2026-08-20T00:00:00.000Z' }]
+    }],
+    excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  const verified = verifySnapshot(root, published.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /page evidence CAS reference/);
+});
+
+test('v2 verification requires strict-since query boundary proof on incremental deltas', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-proof-'));
+  const base = publishBoundaryBase(root);
+  const delta = publishBoundaryDelta(root, base.snapshotId, { queryAfter: null });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /strict-since|queryAfter|requestedSince/);
+});
+
+test('v2 verification rejects strict-since on full reconciliation', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-mode-'));
+  const base = publishBoundaryBase(root);
+  const queryAfter = '2026-08-20T00:00:00.000Z';
+  const delta = publishBoundaryDelta(root, base.snapshotId, {
+    queryAfter,
+    requestedSince: queryAfter,
+    reconciliation: 'full'
+  });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /strict-since|full reconciliation/);
+});
+
+test('v2 verification rejects a strict-since endpoint with mismatched requestedSince', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-mismatch-'));
+  const base = publishBoundaryBase(root);
+  const delta = publishBoundaryDelta(root, base.snapshotId, {
+    queryAfter: '2026-08-20T00:00:00.000Z',
+    requestedSince: '2026-08-20T00:00:02.000Z'
+  });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /since proof|query proof|requestedSince/);
+});
+
+test('v2 verification rejects an unknown query mode at the endpoint level', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-mode-endpoint-unknown-'));
+  const base = publishBoundaryBase(root);
+  const delta = publishBoundaryDelta(root, base.snapshotId, {
+    queryAfter: null,
+    queryMode: 'full-enumeration',
+    endpointQueryMode: 'future-mode' as never
+  });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /endpoint query mode is invalid/);
+});
+
+test('v2 verification rejects an unknown query mode at the page level', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-mode-page-unknown-'));
+  const base = publishBoundaryBase(root);
+  const delta = publishBoundaryDelta(root, base.snapshotId, {
+    queryAfter: null,
+    queryMode: 'full-enumeration',
+    pageQueryMode: 'future-mode' as never
+  });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /page query mode is invalid/);
+});
+
+test('v2 verification rejects an unknown query mode at the page-evidence object level', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-query-mode-object-unknown-'));
+  const base = publishBoundaryBase(root);
+  const delta = publishBoundaryDelta(root, base.snapshotId, {
+    queryAfter: null,
+    queryMode: 'full-enumeration',
+    objectQueryMode: 'future-mode' as never
+  });
+  const verified = verifySnapshot(root, delta.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /page evidence query mode is invalid/);
+});
+
+test('v2 verification requires evidence for every upsert resource', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-resource-evidence-'));
+  const store = createObjectStore(root);
+  const bytes = Buffer.from('{"number":1}');
+  const object = store.put(bytes);
+  const published = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [{ sourceKind: 'github-rest', sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', role: 'resource', sha256: object.sha256, bytes: bytes.length }],
+    endpoints: [], excerptsEnabled: false,
+    records: [{ recordId: 'r1', kind: 'platform-resource', sourceIdentity: 'issue:1', resourceIdentity: 'issue:1', sourceSha256: object.sha256, operation: 'upsert', data: { number: 1 } }],
+    quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental',
+    operations: { upsert: 1, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  const verified = verifySnapshot(root, published.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /resource evidence/);
+});
+
+test('v2 verification recursively verifies every snapshot ancestor', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-v2-ancestor-'));
+  const base = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+    objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+    watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  fs.appendFileSync(path.join(base.path, 'normalized.jsonl'), '{"schema":"normalized/v2","recordId":"corrupt"}\n');
+  const child = publishSnapshotV2(root, {
+    scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:02.000Z', observedTo: '2026-08-20T00:00:03.000Z',
+    objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'delta', parentSnapshotId: base.snapshotId, checkpointBefore: base.snapshotId,
+    watermark: '2026-08-20T00:00:03.000Z', window: { fromInclusive: '2026-08-20T00:00:01.000Z', queryAfter: '2026-08-20T00:00:00.000Z', toExclusive: '2026-08-20T00:00:03.000Z', precision: 'second' },
+    observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:02.000Z', responseDates: ['2026-08-20T00:00:02.000Z'] },
+    coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+  });
+  const verified = verifySnapshot(root, child.snapshotId);
+  assert.equal(verified.ok, false);
+  assert.match(verified.errors.join('\n'), /ancestor|normalized record count/);
+});
+
+test('snapshot publication uses file and directory fsync barriers', onPlatforms('linux', 'darwin'), () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'process-data-store-fsync-'));
+  const originalFsync = fs.fsyncSync;
+  const originalOpen = fs.openSync;
+  let calls = 0;
+  const opened = new Map<number, string>();
+  const fsyncedDirectories: string[] = [];
+  fs.openSync = ((...args: any[]) => {
+    const fd = (originalOpen as (...values: any[]) => number)(...args);
+    if (typeof args[0] === 'string') opened.set(fd, args[0]);
+    return fd;
+  }) as typeof fs.openSync;
+  fs.fsyncSync = ((fd: number) => {
+    calls += 1;
+    const target = opened.get(fd);
+    if (target) fsyncedDirectories.push(target);
+    return originalFsync(fd);
+  }) as typeof fs.fsyncSync;
+  try {
+    publishSnapshotV2(root, {
+      scope: 'github', repository: 'acme/demo', observedFrom: '2026-08-20T00:00:00.000Z', observedTo: '2026-08-20T00:00:01.000Z',
+      objects: [], endpoints: [], excerptsEnabled: false, records: [], quality: [], repairs: [], snapshotKind: 'base', parentSnapshotId: null, checkpointBefore: null,
+      watermark: '2026-08-20T00:00:01.000Z', window: { fromInclusive: null, queryAfter: null, toExclusive: '2026-08-20T00:00:01.000Z', precision: 'second' },
+      observation: { cutoffSource: 'github-response-date', preflightDate: '2026-08-20T00:00:00.000Z', responseDates: ['2026-08-20T00:00:00.000Z'] },
+      coverage: { mode: 'boundary-reread-with-full-reconcile', absoluteCompleteness: false }, reconciliation: 'incremental', operations: { upsert: 0, supersede: 0, tombstone: 0, unavailable: 0 }
+    });
+  } finally {
+    fs.openSync = originalOpen;
+    fs.fsyncSync = originalFsync;
+  }
+  assert.ok(calls >= 6, `expected publication fsync barriers, got ${calls}`);
+  const snapshots = path.join(root, 'snapshots');
+  const year = path.join(snapshots, '2026');
+  const month = path.join(year, '08');
+  const day = path.join(month, '20');
+  const order = [root, snapshots, year, month, day].map((directory) => fsyncedDirectories.indexOf(directory));
+  assert.ok(order.every((index) => index >= 0), `expected recursive directory barriers, got ${fsyncedDirectories.join(', ')}`);
+  assert.ok(order.every((index, position) => position === 0 || index > order[position - 1]!));
 });
 
 test('repair application is append-only and idempotent', () => {


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #807

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小修改，不需要 Issue / This is a trivial change that does not need an issue

Closes #807

## 📋 变更类型 / Type of Change

- [x] ✨ 新功能 / New feature
- [x] 📚 文档更新 / Documentation update
- [ ] 🐛 Bug 修复 / Bug fix
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

在现有不可变 GitHub 全量快照、CAS、verify、audit 和 export 基础上，增加可验证的 base + delta 谱系、可靠 checkpoint 与按时间点确定性合成导出，避免周期采集反复生成完整规范化副本，同时保留旧 full snapshot 的读取兼容性。

Build verifiable base-plus-delta lineage, reliable checkpoints, and deterministic as-of materialization on top of the existing immutable GitHub snapshots, CAS, verification, audit, and export pipeline. This avoids rebuilding complete normalized copies on every capture while preserving legacy full-snapshot compatibility.

## 📋 主要变更 / Brief Changelog

- 新增 `raw-manifest/v2` base/delta lineage、增量 operation 和严格 query evidence 校验，并保持 `raw-manifest/v1` 读取兼容。
- 新增 owner-specific、原子且失败关闭的 GitHub checkpoint 提交与恢复协议，只有完整发布并验证的 snapshot 才能推进 watermark。
- 新增按 `--as-of` 合成 base + delta 的确定性 materialization，覆盖 supersede、tombstone、unavailable 与 deferred 语义。
- 收窄公开 capture 为 GitHub-only，补充 timeline/分页证据、CLI 行为、双语文档以及单元和集成回归测试。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`。
2. 运行 process-data 相关单元与 CLI 集成测试。
3. 运行完整 `npm test`。
4. 检查 `git diff --check` 与 reviewed snapshot tree 一致性。

### 测试覆盖 / Test Coverage

- [x] 已添加必要的单元和集成测试 / Unit and integration tests added
- [x] 类型检查、构建及 56 项相关测试通过 / Typecheck, build, and all 56 affected tests passed
- [x] Linux 审查环境完整测试 2402 项：2398 通过、0 失败、4 跳过 / Linux review environment: 2398 passed, 0 failed, 4 skipped
- [x] Round 9 代码审查通过，Blocker/Major/Minor 为 0/0/0 / Round 9 code review approved with 0/0/0 findings
- [x] 无需人工校验项 / No manual-validation items required

宿主 macOS 复跑时，5 个仅允许 Linux stale-owner recovery 的用例因平台拓扑限制失败，另有 1 个无关 tmpfs 清理竞态；批准快照已在 Linux 完整通过，跨平台 CI 将继续验证平台门禁。

On the macOS host rerun, five Linux-only stale-owner recovery cases failed at the intentional topology boundary and one unrelated tmpfs cleanup race occurred. The approved snapshot passed the full Linux suite; cross-platform CI remains the authoritative platform gate.

## 📸 截图 / Screenshots

不适用；本次变更为数据归档、校验与 CLI 行为，无可视化界面变化。

Not applicable; this change affects data archival, verification, and CLI behavior rather than a visual interface.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只处理 Issue #807 / This PR addresses only Issue #807
- [x] Commit 具有清晰主题与说明 / Commit has a clear subject and body
- [x] 代码遵循项目规范并已完成自审 / Code follows project conventions and self-review is complete
- [x] 已完成 Round 9 独立代码审查 / Round 9 independent code review is approved
- [x] 已添加必要测试并通过 Linux 完整门禁 / Required tests pass the full Linux gate
- [x] 已同步英文和中文文档 / English and Chinese documentation is synchronized
- [x] 保留旧 snapshot 兼容性 / Legacy snapshot compatibility is preserved

## 📋 附加信息 / Additional Notes

Checkpoint 只在候选 snapshot 的 repository、manifest digest、watermark、owner proof 和完整 verify 结果全部匹配后推进；失败、阻塞或证据不完整均保留旧 checkpoint。公开 capture 入口为 GitHub-only，历史 local/all full snapshot 仅保留读取兼容。

Checkpoint advancement requires matching repository identity, manifest digest, watermark, owner proof, and full verification. Failures, blocked runs, or incomplete evidence preserve the previous checkpoint. New public capture is GitHub-only, while historical local/all full snapshots remain readable.

---

Generated with AI assistance
