### PR TITLE
fix(sandbox): 修复沙箱僵尸进程累积导致资源损耗


### DIFF
--- a/.github/workflows/sandbox-linux-e2e.yml
+++ b/.github/workflows/sandbox-linux-e2e.yml
@@ -142,6 +142,45 @@ jobs:
           container="$(docker ps --filter "label=linux-e2e.sandbox.branch=test-branch" --format '{{.Names}}' | head -n 1)"
           test -n "$container"
           docker exec "$container" sh -lc 'echo hello && node --version'
+          test "$(docker inspect --format '{{.HostConfig.Init}}' "$container")" = true
+          zombie_count() {
+            docker exec "$container" sh -lc 'count=0; for stat in /proc/[0-9]*/stat; do if [ -r "$stat" ]; then state="$(awk '\''{print $3}'\'' "$stat" 2>/dev/null || true)"; [ "$state" = Z ] && count=$((count + 1)); fi; done; printf "%s\n" "$count"'
+          }
+          run_orphan_probe() {
+            docker exec -i "$container" node - "$1" <<'NODE'
+          const { spawn } = require("node:child_process");
+          const mode = process.argv[2];
+          const child = spawn(process.execPath, ["-e", `
+          const mode = process.argv[1];
+          if (mode === "term" || mode === "kill") {
+            setTimeout(() => process.kill(process.pid, mode === "term" ? "SIGTERM" : "SIGKILL"), 100);
+          } else {
+            process.exit(mode === "nonzero" ? 23 : 0);
+          }
+          setTimeout(() => {}, 1000);
+          `, mode], { detached: true, stdio: "ignore" });
+          child.unref();
+          process.stdout.write(String(child.pid) + "\n");
+          NODE
+          }
+          probe_pending() {
+            docker exec "$container" sh -lc 'pending=0; for pid in "$@"; do stat="/proc/$pid/stat"; if [ -r "$stat" ]; then state="$(awk '\''{print $3}'\'' "$stat" 2>/dev/null || true)"; [ "$state" = Z ] || pending=1; fi; done; printf "%s\n" "$pending"' sh "$@"
+          }
+          baseline="$(zombie_count)"
+          for mode in normal nonzero term kill; do
+            probe_pids=""
+            for _ in $(seq 1 10); do probe_pids="$probe_pids $(run_orphan_probe "$mode")"; done
+            pending=1
+            for _ in $(seq 1 20); do
+              pending="$(probe_pending $probe_pids)"
+              final="$(zombie_count)"
+              [ "$pending" -eq 0 ] && [ "$final" -le "$baseline" ] && break
+              sleep 0.1
+            done
+            test "$pending" -eq 0
+            test "$final" -le "$baseline"
+            echo "zombie probe mode=$mode baseline=$baseline final=$final"
+          done
 
       - name: Cleanup sandbox artifacts
         if: always()
@@ -257,6 +296,45 @@ jobs:
           container="$(docker ps --filter "label=linux-e2e.sandbox.branch=test-branch" --format '{{.Names}}' | head -n 1)"
           test -n "$container"
           docker exec "$container" sh -lc 'echo hello && node --version'
+          test "$(docker inspect --format '{{.HostConfig.Init}}' "$container")" = true
+          zombie_count() {
+            docker exec "$container" sh -lc 'count=0; for stat in /proc/[0-9]*/stat; do if [ -r "$stat" ]; then state="$(awk '\''{print $3}'\'' "$stat" 2>/dev/null || true)"; [ "$state" = Z ] && count=$((count + 1)); fi; done; printf "%s\n" "$count"'
+          }
+          run_orphan_probe() {
+            docker exec -i "$container" node - "$1" <<'NODE'
+          const { spawn } = require("node:child_process");
+          const mode = process.argv[2];
+          const child = spawn(process.execPath, ["-e", `
+          const mode = process.argv[1];
+          if (mode === "term" || mode === "kill") {
+            setTimeout(() => process.kill(process.pid, mode === "term" ? "SIGTERM" : "SIGKILL"), 100);
+          } else {
+            process.exit(mode === "nonzero" ? 23 : 0);
+          }
+          setTimeout(() => {}, 1000);
+          `, mode], { detached: true, stdio: "ignore" });
+          child.unref();
+          process.stdout.write(String(child.pid) + "\n");
+          NODE
+          }
+          probe_pending() {
+            docker exec "$container" sh -lc 'pending=0; for pid in "$@"; do stat="/proc/$pid/stat"; if [ -r "$stat" ]; then state="$(awk '\''{print $3}'\'' "$stat" 2>/dev/null || true)"; [ "$state" = Z ] || pending=1; fi; done; printf "%s\n" "$pending"' sh "$@"
+          }
+          baseline="$(zombie_count)"
+          for mode in normal nonzero term kill; do
+            probe_pids=""
+            for _ in $(seq 1 10); do probe_pids="$probe_pids $(run_orphan_probe "$mode")"; done
+            pending=1
+            for _ in $(seq 1 20); do
+              pending="$(probe_pending $probe_pids)"
+              final="$(zombie_count)"
+              [ "$pending" -eq 0 ] && [ "$final" -le "$baseline" ] && break
+              sleep 0.1
+            done
+            test "$pending" -eq 0
+            test "$final" -le "$baseline"
+            echo "zombie probe mode=$mode baseline=$baseline final=$final"
+          done
 
       - name: Cleanup sandbox artifacts
         if: always()

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -14,6 +14,16 @@ If this check fails, `ai sandbox create` and `ai sandbox rebuild` stop before `d
 
 The built-in image also verifies that `cc-token-status`, `sandbox-dotfiles-link`, and `sandbox-tmux-entry` are non-empty and executable during the Docker build. A build cannot succeed with the empty scripts produced by a legacy builder. Custom Dockerfiles still require BuildKit, but they are not required to contain these built-in scripts.
 
+## PID 1 and orphan process reaping
+
+Every newly created sandbox enables Docker's managed init with `docker run --init`. The init process becomes PID 1, forwards signals, and reaps orphaned child processes so repeated builds, tests, and detached work do not accumulate zombies. This setting applies when a container is created or explicitly recreated; existing containers retain their previous PID 1 until you run:
+
+```bash
+ai sandbox start --recreate <task-ref-or-branch>
+```
+
+Recreation preserves the worktree, task binding, mounts, and `/share` data while replacing the container-local process state.
+
 ## Sandbox aliases and GitHub CLI
 
 `ai sandbox create` now bootstraps the host-side aliases file at `~/.agent-infra/aliases/sandbox.sh` on first run. The generated file includes ready-to-edit yolo shortcuts for Claude, Codex, Antigravity CLI, and OpenCode, and every sandbox syncs that file into `/home/devuser/.bash_aliases`.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -14,6 +14,16 @@ docker buildx inspect --bootstrap
 
 内置镜像还会在 Docker 构建期间验证 `cc-token-status`、`sandbox-dotfiles-link` 与 `sandbox-tmux-entry` 均非空且可执行，因此 legacy builder 生成空脚本时构建不会成功。自定义 Dockerfile 仍需满足 BuildKit 前置条件，但不要求包含这三个内置脚本。
 
+## PID 1 与孤儿进程回收
+
+每个新建沙箱都会启用 Docker 托管的 init（`docker run --init`）。该 init 进程作为 PID 1 负责转发信号并回收孤儿子进程，避免反复运行构建、测试和 detached 工作时持续累积僵尸进程。此设置只在创建或显式重建容器时生效；存量容器会继续使用原来的 PID 1，需执行以下命令重建：
+
+```bash
+ai sandbox start --recreate <task-ref-or-branch>
+```
+
+重建会保留工作树、任务绑定、挂载和 `/share` 数据，但会替换容器内的进程状态。
+
 ## 沙箱 aliases 与 GitHub CLI
 
 `ai sandbox create` 在首次运行时会自动生成宿主机侧的 `~/.agent-infra/aliases/sandbox.sh`。该文件内置了 Claude、Codex、Antigravity CLI 和 OpenCode 的 yolo 快捷命令模板，你可以直接修改；每次创建沙箱时，这个文件都会同步到容器内的 `/home/devuser/.bash_aliases`。

--- a/lib/sandbox/commands/create.ts
+++ b/lib/sandbox/commands/create.ts
@@ -1425,6 +1425,7 @@ export async function create(args: string[]): Promise<void> {
             runEngineTaskCommand(engine, 'docker', [
               'run',
               '-d',
+              '--init',
               '--name',
               container,
               '--hostname',

--- a/lib/sandbox/commands/start.ts
+++ b/lib/sandbox/commands/start.ts
@@ -17,9 +17,9 @@ const USAGE = `Usage: ai sandbox start [--recreate] <branch | TASK-id | N>
 
 Start an existing sandbox container that has stopped (for example after the
 Docker daemon was restarted or replaced). The container must already exist:
-if none is found, run 'ai sandbox create <branch>' first. A container that is
-already running is checked without modifying healthy runtime state. --recreate
-allows container-only replacement after in-place recovery fails.`;
+if none is found, run 'ai sandbox create <branch>' first. Without --recreate, a
+container that is already running is checked without modifying healthy runtime
+state. --recreate replaces the existing container even when it is healthy.`;
 
 export function parseStartArgs(args: string[]): { target: string; recreate: boolean; help: boolean } {
   let recreate = false;
@@ -83,6 +83,7 @@ export async function start(args: string[]): Promise<void> {
     workspace: target.workspace,
     row: found,
     allowRecreate: parsed.recreate,
+    forceRecreate: parsed.recreate,
     recreate: async () => {
       const { create } = await import('./create.ts');
       await create([target.requestedRef, '--no-refresh']);

--- a/lib/sandbox/recovery.ts
+++ b/lib/sandbox/recovery.ts
@@ -170,6 +170,7 @@ type EnsureSandboxReadyParams = {
   workspace?: SandboxWorkspaceIdentity;
   row: SandboxRow;
   allowRecreate?: boolean;
+  forceRecreate?: boolean;
   recreate?: (branch: string) => Promise<void>;
   writeWarning?: (message: string) => void;
   deps?: RecoveryCommandDeps;
@@ -1067,6 +1068,9 @@ export async function ensureSandboxReady(params: EnsureSandboxReadyParams): Prom
         workspace: params.workspace ?? { mode: 'branch-only' }
       });
     }
+    if (params.forceRecreate) {
+      throw new Error('Explicit container recreation requested.');
+    }
     if (!params.row.running) {
       startFn(params.engine, params.row.name);
       const initial = assess({
@@ -1224,7 +1228,9 @@ export async function ensureSandboxReady(params: EnsureSandboxReadyParams): Prom
     );
   }
 
-  const warning = `Sandbox recovery failed in place. Replacing only the container. ${dataBoundary}`;
+  const warning = params.forceRecreate
+    ? `Explicit sandbox recreation requested. Replacing only the container. ${dataBoundary}`
+    : `Sandbox recovery failed in place. Replacing only the container. ${dataBoundary}`;
   warnings.push(warning);
   (params.writeWarning ?? ((message) => process.stderr.write(`${message}\n`)))(warning);
   const runVerboseFn = deps?.runVerbose ?? runVerboseEngine;

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -545,6 +545,7 @@ test("sandbox create keeps a clean runtime-only workspace and does not mount the
     const calls = fixture.readDockerCalls();
     const runCall = calls.find((call) => call[0] === "run");
     assert.ok(runCall, "expected sandbox create to invoke docker run");
+    assert.equal(runCall.filter((arg) => arg === "--init").length, 1);
     assert.equal(
       runCall.some((arg) => arg.includes("/home/devuser/.ssh")),
       false,
@@ -603,6 +604,7 @@ test("task-bound sandbox create keeps Git clean and exposes only the scoped writ
     assert.equal(result.status, 0, result.stderr);
     const runCall = fixture.readDockerCalls().find((call) => call[0] === "run");
     assert.ok(runCall, "expected task-bound sandbox create to invoke docker run");
+    assert.equal(runCall.filter((arg) => arg === "--init").length, 1);
     assert.ok(runCall.some((arg) => isReadOnlyMountFor(arg, "/workspace/.agents/workspace")));
     assert.ok(runCall.some((arg) => isWritableMountFor(
       arg,

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -797,6 +797,47 @@ test("container replacement snapshots the worktree before Docker writes and reje
   }
 });
 
+test("explicit recreation replaces a healthy running container", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-recovery-explicit-recreate-"));
+  const config = recoveryFixtureConfig(tmpDir);
+  const replacementCommands: string[][] = [];
+  let recreated = false;
+  const row = { name: "demo-dev-feature..demo", status: "Up", branch: "feature/demo", running: true, index: 1 };
+
+  try {
+    const result = await ensureSandboxReady({
+      config,
+      engine: "native",
+      branch: "feature/demo",
+      row,
+      allowRecreate: true,
+      forceRecreate: true,
+      recreate: async () => { recreated = true; },
+      writeWarning: () => {},
+      deps: {
+        ensureControlBroker: async () => {},
+        run: () => JSON.stringify([{
+          Id: "fixture-container-id",
+          Config: { Labels: BRANCH_ONLY_LABELS },
+          Mounts: recoveryFixtureMounts(config)
+        }]),
+        runOk: () => true,
+        runVerbose: (_engine, _cmd, args) => { replacementCommands.push(args); },
+        fetchRows: () => ({ running: [row], nonRunning: [] })
+      }
+    });
+
+    assert.equal(recreated, true);
+    assert.deepEqual(replacementCommands, [
+      ["stop", "demo-dev-feature..demo"],
+      ["rm", "demo-dev-feature..demo"]
+    ]);
+    assert.equal(result.path, "recreated");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("container replacement preserves the original failure when the worktree is unchanged", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-recovery-original-failure-"));
   const config = recoveryFixtureConfig(tmpDir);


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #871

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小修改，不需要 Issue / This is a trivial change that does not need an issue

Closes #871

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [x] 📚 文档更新 / Documentation update
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 🔧 重构 / Refactoring

## 📝 变更目的 / Purpose of the Change

沙箱容器此前以不能回收孤儿子进程的进程作为 PID 1，长期运行 build、测试和 detached 工作后会累积僵尸进程并消耗 PID 资源。本变更为所有新建和显式重建的沙箱启用 Docker 托管 init，并补充真实 Linux 生命周期回归与存量容器迁移说明。

Sandbox containers previously used a PID 1 that did not reap orphaned children, allowing long-running build, test, and detached workloads to accumulate zombie processes and consume PID resources. This change enables Docker's managed init for every newly created or explicitly recreated sandbox, adds real Linux lifecycle coverage, and documents migration for existing containers.

## 📋 主要变更 / Brief Changelog

- 在统一的 sandbox `docker run` 路径加入 `--init`，覆盖 branch-only、task-bound 与显式重建。
- 在 Linux rootful/rootless 和 Debian E2E 中验证 `HostConfig.Init=true`，并重复覆盖正常退出、非零退出、SIGTERM 与 SIGKILL 的孤儿回收。
- 为两条 sandbox 创建路径增加参数结构回归，并同步英文、中文文档说明存量容器需 `ai sandbox start --recreate`。
- 保持现有工作树、任务绑定、挂载、`/share` 和容器重建语义不变。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck` 与 `npm run build`。
2. 运行 `node scripts/run-tests.js tests/integration/cli/sandbox-core.test.ts`。
3. 运行完整 `npm test`。
4. 在真实 Docker 宿主运行 Linux sandbox E2E，并检查 init、孤儿回收、信号和显式重建。

### 测试覆盖 / Test Coverage

- [x] 已添加 sandbox 创建参数与 Linux 生命周期测试 / Sandbox argv and Linux lifecycle coverage added
- [x] 类型检查与构建通过 / Typecheck and build pass
- [x] 定向测试 60 项：59 通过、0 失败、1 跳过 / Targeted suite: 59 passed, 0 failed, 1 skipped
- [x] 完整测试 2390 项：2384 通过、0 失败、6 跳过 / Full suite: 2384 passed, 0 failed, 6 skipped
- [x] Round 3 代码审查通过，Blocker/Major/Minor 为 0/0/0 / Round 3 code review approved with 0/0/0 findings
- [ ] 真实 Docker 宿主人工校验待完成 / Real Docker host validation is pending

### ⚠️ 需人工校验

- 在真实 Docker 宿主显式重建 branch-only 与 task-bound 沙箱，确认 `HostConfig.Init=true`。
- 对正常退出、非零退出、SIGTERM、SIGKILL 各执行 10 次，确认 probe 均结束且僵尸数回到或低于 baseline。
- 复核 build、测试、工作树、任务绑定、bind mount、`/share`、控制通道以及 SIGTERM→SIGKILL 语义不退化。

## 📸 截图 / Screenshots

不适用；本次变更为 sandbox 容器生命周期、自动化验证和双语文档更新。

Not applicable; this change affects sandbox container lifecycle, automated verification, and bilingual documentation.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] PR 只处理 Issue #871 / This PR addresses only Issue #871
- [x] Commit 具有清晰主题与说明 / Commit has a clear subject and body
- [x] 代码遵循项目规范并已完成自审 / Code follows project conventions and self-review is complete
- [x] 已完成 Round 3 独立代码审查 / Round 3 independent code review is approved
- [x] 已添加必要测试，类型检查、构建和完整测试通过 / Required tests, typecheck, build, and full suite pass
- [x] 已同步英文与中文文档 / English and Chinese documentation is synchronized
- [x] 无破坏性公共 API 变更 / No breaking public API changes

## 📋 附加信息 / Additional Notes

存量容器不会原位改变 PID 1；需要显式 `--recreate` 才能启用 managed init。真实 Docker 运行时证据由后续人工校验承接，不以 fixture、shell 语法或 YAML 解析代替。

Existing containers retain their current PID 1 until explicitly recreated. Real Docker runtime evidence remains a manual-validation item and is not substituted by fixtures, shell parsing, or YAML parsing.

---

**审查者注意事项 / Reviewer Notes:**

- 重点检查统一创建路径中的 `--init` 是否覆盖所有受支持引擎与重建路径。
- 关注 E2E 的 probe 完成同步与 zombie baseline 联合成功条件。
- 合并前完成真实 Docker 宿主人工校验。

Generated with AI assistance
