### PR TITLE
fix(platform): 修正 GitHub CLI 版本门禁与依赖守卫

### DIFF
--- a/.agents/rules/pr-checks-commands.md
+++ b/.agents/rules/pr-checks-commands.md
@@ -2,7 +2,7 @@
 
 PR 全部 checks 的获取、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。SKILL/模型只负责失败分类、根因分析、最小修复和授权后的提交推送。
 
-GitHub adapter 要求 `gh >= 2.16.0`。平台上下文会在任何 GitHub API、PR 或 checks 操作前检查该依赖；未选择 GitHub 平台时不探测也不依赖 `gh`。
+GitHub adapter 要求 `gh >= 2.72.0`。平台上下文会在任何 GitHub API、PR 或 checks 操作前检查该依赖；未选择 GitHub 平台时不探测也不依赖 `gh`。
 
 ## 快照与监控
 

--- a/lib/platform/github-client.ts
+++ b/lib/platform/github-client.ts
@@ -23,7 +23,9 @@ type ClientOptions = {
   sleep?: (delayMs: number) => void;
 };
 
-const MINIMUM_GITHUB_CLI_VERSION = '2.16.0';
+// closingIssuesReferences (introduced in gh 2.72.0) is the highest-versioned gh feature
+// the platform layer depends on; see github-release-notes.ts:102.
+const MINIMUM_GITHUB_CLI_VERSION = '2.72.0';
 const GITHUB_CLI_MAX_BUFFER = 64 * 1024 * 1024;
 const ERROR_DETAIL_LIMIT = 4096;
 

--- a/templates/.agents/rules/pr-checks-commands.github.en.md
+++ b/templates/.agents/rules/pr-checks-commands.github.en.md
@@ -1,6 +1,6 @@
 # GitHub PR Readiness Intents
 
-The GitHub adapter requires `gh >= 2.16.0`. Platform context checks this dependency before any GitHub API, PR, or checks operation. Projects that do not select GitHub neither probe nor depend on `gh`.
+The GitHub adapter requires `gh >= 2.72.0`. Platform context checks this dependency before any GitHub API, PR, or checks operation. Projects that do not select GitHub neither probe nor depend on `gh`.
 
 ```bash
 agent-infra-internal platform-checks inspect {task-id}

--- a/templates/.agents/rules/pr-checks-commands.github.zh-CN.md
+++ b/templates/.agents/rules/pr-checks-commands.github.zh-CN.md
@@ -2,7 +2,7 @@
 
 PR 全部 checks 的获取、轮询 deadline、失败 run/job 定位和日志获取统一由 typed internal intent 执行。SKILL/模型只负责失败分类、根因分析、最小修复和授权后的提交推送。
 
-GitHub adapter 要求 `gh >= 2.16.0`。平台上下文会在任何 GitHub API、PR 或 checks 操作前检查该依赖；未选择 GitHub 平台时不探测也不依赖 `gh`。
+GitHub adapter 要求 `gh >= 2.72.0`。平台上下文会在任何 GitHub API、PR 或 checks 操作前检查该依赖；未选择 GitHub 平台时不探测也不依赖 `gh`。
 
 ## 快照与监控
 

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -53,7 +53,7 @@ if (process.env.GH_FAKE_FAIL) {
 }
 
 if (args.length === 1 && args[0] === "--version") {
-  process.stdout.write(`gh version ${process.env.GH_FAKE_VERSION || "2.16.0"}\n`);
+  process.stdout.write(`gh version ${process.env.GH_FAKE_VERSION || "2.72.0"}\n`);
   process.exit(0);
 }
 

--- a/tests/unit/platform/context.test.ts
+++ b/tests/unit/platform/context.test.ts
@@ -24,7 +24,7 @@ test('platform context resolves fork parent and separated capabilities', () => {
     cwd: root,
     gitRemote: () => 'git@github.com:contributor/widgets.git',
     client: {
-      version() { return { ok: true, value: '2.16.0' }; },
+      version() { return { ok: true, value: '2.72.0' }; },
       json(args) {
         requested.push(args.join(' '));
         if (args[1] === 'graphql') {
@@ -54,7 +54,7 @@ test('platform context reports a fully resolved read-only probe as no-op', () =>
     platformType: 'github',
     gitRemote: () => 'https://github.com/acme/widgets.git',
     client: {
-      version() { return { ok: true, value: '2.16.0' }; },
+      version() { return { ok: true, value: '2.72.0' }; },
       json(args) {
         if (args[1] === 'graphql') {
           return { ok: true, value: { data: { viewer: { login: 'maintainer' } } } };
@@ -100,7 +100,7 @@ test('non-GitHub platform does not probe gh', () => {
     client: {
       version() {
         versionCalls += 1;
-        return { ok: true, value: '2.16.0' };
+        return { ok: true, value: '2.72.0' };
       },
       json() { throw new Error('GitHub API must not be called'); }
     }

--- a/tests/unit/platform/github-client.test.ts
+++ b/tests/unit/platform/github-client.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyGitHubFailure, createGitHubClient } from '../../../lib/platform/github-client.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import semver from 'semver';
+
+import { classifyGitHubFailure, createGitHubClient, MINIMUM_GITHUB_CLI_VERSION } from '../../../lib/platform/github-client.ts';
 
 test('GitHub client reads the CLI version without shell parsing', () => {
   const calls: string[][] = [];
@@ -84,4 +89,29 @@ test('GitHub client retries reads but does not blindly replay posts', () => {
   const post = client.json(['api', 'repos/o/r/issues/1/comments', '-X', 'POST'], { method: 'POST' });
   assert.equal(post.ok, false);
   assert.equal(attempts, 1);
+});
+
+test('the declared gh floor covers every gh flag the platform layer uses', () => {
+  // Registry of gh features the platform layer depends on, mapped to the gh release
+  // that introduced them. Only register unconditional, must-pass dependencies here —
+  // self-gated fallback paths (e.g. --allow-escape-sequences) must not be added, or
+  // the floor will be tightened unnecessarily.
+  const flagFloors: Record<string, string> = {
+    '--slurp': '2.48.0',
+    closingIssuesReferences: '2.72.0'
+  };
+  const dir = path.join(import.meta.dirname, '..', '..', '..', 'lib', 'platform');
+  // github-client.ts declares the floor itself; scanning it would match its own annotation.
+  const callers = fs.readdirSync(dir).filter((entry) => entry.endsWith('.ts') && entry !== 'github-client.ts');
+  assert.ok(callers.length > 0);
+  for (const name of callers) {
+    const source = fs.readFileSync(path.join(dir, name), 'utf8');
+    for (const [flag, floor] of Object.entries(flagFloors)) {
+      if (!source.includes(flag)) continue;
+      assert.ok(
+        semver.gte(MINIMUM_GITHUB_CLI_VERSION, floor),
+        `lib/platform/${name} uses '${flag}' (gh >= ${floor}) but the declared floor is ${MINIMUM_GITHUB_CLI_VERSION}`
+      );
+    }
+  }
 });

--- a/tests/unit/platform/github-release-notes.test.ts
+++ b/tests/unit/platform/github-release-notes.test.ts
@@ -25,7 +25,7 @@ test('GitHub actors prefer platform users, then no-reply identities, without gue
 test('publishing edits an existing published release and creates a missing release', () => {
   const calls: string[][] = [];
   const existing: GitHubClient = {
-    version: () => ({ ok: true, value: '2.16.0' }),
+    version: () => ({ ok: true, value: '2.72.0' }),
     json: () => ({ ok: true, value: { tagName: 'v1.0.0', url: 'https://example/release' } }) as never,
     text(args) {
       calls.push(args);
@@ -52,7 +52,7 @@ test('publishing edits an existing published release and creates a missing relea
 
 test('dry-run plans publishing without invoking a write', () => {
   const client: GitHubClient = {
-    version: () => ({ ok: true, value: '2.16.0' }),
+    version: () => ({ ok: true, value: '2.72.0' }),
     json: () => ({ ok: true, value: { tagName: 'v1.0.0', url: 'https://example/release' } }) as never,
     text() {
       throw new Error('write must not be called');

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -126,7 +126,7 @@ test('comment sync creates once and becomes a no-op on replay', () => {
   const root = syncFixture();
   const comments: Array<{ id: number; body: string; user: { login: string } }> = [];
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[], options?: { input?: string }) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -156,7 +156,7 @@ test('comment sync refuses duplicate registered markers without writing', () => 
   const root = syncFixture();
   const marker = MARKERS.task('TASK-20260101-000001');
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[]) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: {} } };
@@ -179,7 +179,7 @@ test('artifact sync isolates sibling stems and becomes a no-op on replay', () =>
   const siblingBody = `${MARKERS.artifact('TASK-20260101-000001', 'analysis-r2')}\nexisting sibling`;
   const comments = [{ id: 20, body: siblingBody, user: { login: 'codex' } }];
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[], options?: { input?: string }) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -211,7 +211,7 @@ test('artifact backfill creates a missing comment with a timeline hint', () => {
   const root = syncFixture();
   const comments: Array<{ id: number; body: string; user: { login: string } }> = [];
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[], options?: { input?: string }) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -242,7 +242,7 @@ test('artifact backfill preserves an existing normal comment without remote writ
   const marker = MARKERS.artifact('TASK-20260101-000001', 'analysis');
   const comments = [{ id: 31, body: `${marker}\nexisting normal-stage body`, user: { login: 'codex' } }];
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[]) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -269,7 +269,7 @@ test('artifact backfill preserves an existing valid chunk set without remote wri
     { id: 33, body: `${MARKERS.artifactChunk('TASK-20260101-000001', 'analysis', 2, 2)}\nold part 2`, user: { login: 'codex' } }
   ];
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[]) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -295,7 +295,7 @@ test('normal artifact sync still updates an existing comment when content change
   const comments = [{ id: 34, body: `${marker}\nstale body`, user: { login: 'codex' } }];
   let patchCount = 0;
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[], options?: { input?: string }) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { triage: true } } };
@@ -324,7 +324,7 @@ test('artifact sync refuses duplicate base markers without writing', () => {
   const root = syncFixture();
   const marker = MARKERS.artifact('TASK-20260101-000001', 'analysis');
   const client = {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[]) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: {} } };

--- a/tests/unit/platform/issues.test.ts
+++ b/tests/unit/platform/issues.test.ts
@@ -26,7 +26,7 @@ function fixture(issueNumber = '') {
 
 function clientFor(handler: (args: string[], input?: string, method?: string) => unknown): GitHubClient {
   return {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args, options = {}) {
       const value = handler(args, options.input, options.method);
       return { ok: true, value } as never;

--- a/tests/unit/platform/pr-checks.test.ts
+++ b/tests/unit/platform/pr-checks.test.ts
@@ -34,7 +34,7 @@ test('PR readiness watcher reaches injected deadline and preserves the observed 
     fs.writeFileSync(path.join(root, '.agents', '.airc.json'), '{"platform":{"type":"github"}}');
     fs.writeFileSync(path.join(taskDir, 'task.md'), ['---', `id: ${taskId}`, 'status: active', 'pr_number: 5', '---', ''].join('\n'));
     const client = {
-      version() { return { ok: true as const, value: '2.16.0' }; },
+      version() { return { ok: true as const, value: '2.72.0' }; },
       json(args: string[]) {
         const joined = args.join(' ');
         if (args[1] === 'graphql' && args.some((arg) => arg.includes('viewer { login }'))) {

--- a/tests/unit/platform/pr-review.test.ts
+++ b/tests/unit/platform/pr-review.test.ts
@@ -62,7 +62,7 @@ function mockClient(options: {
   };
 
   const client = {
-    version() { return { ok: true as const, value: '2.16.0' }; },
+    version() { return { ok: true as const, value: '2.72.0' }; },
     json,
     text() { return { ok: true as const, value: '' }; }
   };
@@ -158,7 +158,7 @@ test('publishPrReview blocks when a retryable POST cannot be reconciled', () => 
     const mock = mockClient(); // POST succeeds, so simulate unknown by never writing: use a failing version below
     // Force the POST to fail transiently without recording the review.
     const client = {
-      version() { return { ok: true as const, value: '2.16.0' }; },
+      version() { return { ok: true as const, value: '2.72.0' }; },
       json: (args: string[], request: { method?: string; input?: string } = {}) => {
         const joined = args.join(' ');
         if (joined.includes('api --paginate --slurp repos/acme/widgets/pulls/') && joined.includes('/reviews')) {

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -80,7 +80,7 @@ function prByNumberFixture() {
 
 function mockPrByNumberClient(pullRequest: unknown): GitHubClient {
   return {
-    version() { return { ok: true, value: '2.16.0' }; },
+    version() { return { ok: true, value: '2.72.0' }; },
     json(args: string[]) {
       const joined = args.join(' ');
       if (/api repos\/o\/r\/pulls\/42/.test(joined)) return { ok: true, value: pullRequest };

--- a/tests/unit/platform/release-notes.test.ts
+++ b/tests/unit/platform/release-notes.test.ts
@@ -139,7 +139,7 @@ test('publish accepts a matching digest and rejects unreadable files before plat
   const digest = `sha256:${createHash('sha256').update('Notes\n').digest('hex')}`;
   const writes: string[][] = [];
   const client: GitHubClient = {
-    version: () => ({ ok: true, value: '2.16.0' }),
+    version: () => ({ ok: true, value: '2.72.0' }),
     json(args) {
       if (args[0] === 'api' && args[1] === 'graphql') {
         return { ok: true, value: { data: { viewer: { login: 'tester' } } } } as never;

--- a/tests/unit/platform/releases.test.ts
+++ b/tests/unit/platform/releases.test.ts
@@ -18,7 +18,7 @@ function fixture() {
 
 function client(release: Record<string, unknown> | null, options: { blocked?: boolean; calls?: string[][] } = {}): GitHubClient {
   return {
-    version: () => ({ ok: true, value: '2.16.0' }),
+    version: () => ({ ok: true, value: '2.72.0' }),
     json(args) {
       options.calls?.push(args);
       if (args.some((arg) => arg === 'repos/acme/widgets')) {
@@ -108,7 +108,7 @@ test('release milestone reconciliation closes current and ensures planning miles
   const patchCalls: string[][] = [];
   const postFields: Array<Record<string, string>> = [];
   const mutable: GitHubClient = {
-    version: () => ({ ok: true, value: '2.16.0' }),
+    version: () => ({ ok: true, value: '2.72.0' }),
     json(args) {
       const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? '';
       if (endpoint === 'repos/acme/widgets') return { ok: true, value: { full_name: 'acme/widgets', permissions: { admin: true } } } as never;


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #875

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小修改，不需要 Issue / This is a trivial change that does not need an issue

Closes #875

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / New feature
- [ ] 💥 破坏性变更 / Breaking change
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade
- [ ] 🚀 功能增强 / Feature enhancement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

平台层声明的 GitHub CLI 版本门禁（`MINIMUM_GITHUB_CLI_VERSION`）与代码实际依赖的 gh 特性脱节：门禁原值 `2.16.0` 过低，无法在前置检查阶段拦截缺少 `gh api --slurp`（2.48.0 引入）、`gh pr list --json closingIssuesReferences`（2.72.0 引入）的旧版本 gh，导致这些版本能通过前置检查、却在运行时报 `unknown flag` / `unknown JSON field`。本 PR 把门禁值改为通过 GitHub 官方 release notes 独立验证的正确上确界 `2.72.0`，同步三处文档声明，并按人工裁决（详见任务产物）修正、扩展了此前引入但基于错误事实的守卫测试。

The platform layer's declared GitHub CLI version floor (`MINIMUM_GITHUB_CLI_VERSION`) had drifted from what the code actually depends on: the original value `2.16.0` was too low to reject gh versions missing `gh api --slurp` (introduced in 2.48.0) or `gh pr list --json closingIssuesReferences` (introduced in 2.72.0) at the pre-flight check, letting those versions pass the gate only to fail at runtime with `unknown flag` / `unknown JSON field` errors. This PR corrects the floor to `2.72.0` — the actual upper bound, independently verified against GitHub CLI's official release notes — syncs the three doc declarations, and fixes/extends a previously introduced guard test that was based on incorrect assumptions (per human decision, see task artifacts).

## 📋 主要变更 / Brief Changelog

- 把 `lib/platform/github-client.ts` 的 `MINIMUM_GITHUB_CLI_VERSION` 从 `2.16.0` 改为 `2.72.0`，注释指向决定性依赖 `closingIssuesReferences`（`github-release-notes.ts:102`）。
- 同步 `.agents/rules/pr-checks-commands.md` 及 en/zh-CN 两份模板中的 gh 版本声明。
- 修正并扩展 `tests/unit/platform/github-client.test.ts` 的守卫测试字典，同时覆盖 `--slurp`（2.48.0）与 `closingIssuesReferences`（2.72.0），并显式注释排除自门控 fallback（如 `--allow-escape-sequences`），已通过 RED/GREEN 独立验证。
- 批量更新 10 个测试文件共 22 处 stub 版本字面量，与新门禁值保持一致。

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 运行 `npm run typecheck`（通过，无错误）。
2. 临时把 `MINIMUM_GITHUB_CLI_VERSION` 改回 `2.53.0`，运行 `node --experimental-strip-types --no-warnings --test tests/unit/platform/github-client.test.ts`，确认扩展后的守卫测试正确报红并指向 `closingIssuesReferences`（RED）。
3. 改回 `2.72.0` 复跑同一命令，确认转绿（GREEN）。
4. 运行完整 `npm test`，确认 `2391 tests / 2387 pass / 0 fail / 4 skipped`，与既有基线逐位一致。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [x] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（门禁抬升会拦截 `[2.16.0, 2.72.0)` 区间的 gh 版本，此前这批版本处于"能通过门禁、但运行时报错"的坏状态；按人工裁决判断为修复而非新增限制，不需要发布说明或宽限期）

## 📋 附加信息 / Additional Notes

门禁值、守卫测试处理方式等关键设计决策均已经过人工裁决确认，详见任务工作区产物（`analysis-r3.md`「人工裁决待办」与 `task.md`「人工裁决」段）。

---

**审查者注意事项 / Reviewer Notes:**

改动严格限定在常量值、文档文本和测试字面量层面，`lib/platform/context.ts` 的门禁判断逻辑本身未被触碰。

Generated with AI assistance
