### PR TITLE
fix(cli): 修复 restore-task 无法执行的生命周期门禁

### DIFF
--- a/lib/internal/task-lifecycle.ts
+++ b/lib/internal/task-lifecycle.ts
@@ -1,7 +1,7 @@
 import { normalizeAgentToken, AGENT_USAGE_HINT } from '../agent-clients/tokens.ts';
 import { applyTaskLifecycle, lifecycleIntentCatalog } from '../task/lifecycle.ts';
 import type { TaskLifecycleRequest } from '../task/lifecycle.ts';
-import { resolveTaskRef } from '../task/resolve-ref.ts';
+import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
 
 const USAGE = `Usage: agent-infra-internal task-lifecycle <N | TASK-id> <intent> --agent <agent> [intent flags] [--dry-run]\n\nIntents: ${lifecycleIntentCatalog.join(', ')}\n`;
@@ -39,17 +39,35 @@ function taskLifecycle(args: string[] = []): void {
   const agent = normalizeAgentToken(String(values.agent ?? ''));
   if (!agent) { usageFailure(`invalid --agent '${values.agent}': ${AGENT_USAGE_HINT}`); return; }
   values.agent = agent;
-  const resolved = resolveTaskRef(String(values.taskRef));
-  if (!resolved.ok) {
-    process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: resolved.code, message: resolved.message } })}\n`);
-    process.exitCode = 1;
-    return;
+  let repoRoot: string;
+  let taskId: string;
+  if (values.intent === 'restore') {
+    // restore's precondition is that the task does NOT exist locally yet (it only lives
+    // in a staging dir), so resolveTaskRef's existence check is inapplicable here; identity
+    // is guaranteed by applyTaskLifecycle's own full-TASK-id check plus staging validation.
+    try {
+      repoRoot = detectRepoRoot();
+    } catch (error) {
+      process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'REPO_ROOT_NOT_FOUND', message: error instanceof Error ? error.message : String(error) } })}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    taskId = String(values.taskRef);
+  } else {
+    const resolved = resolveTaskRef(String(values.taskRef));
+    if (!resolved.ok) {
+      process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: resolved.code, message: resolved.message } })}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    repoRoot = resolved.repoRoot;
+    taskId = resolved.taskId;
   }
   let result: ReturnType<typeof applyTaskLifecycle>;
   try {
     result = withTaskExecutionLock(
-      resolved.repoRoot,
-      resolved.taskId,
+      repoRoot,
+      taskId,
       `task-lifecycle.${String(values.intent)}`,
       () => applyTaskLifecycle(values as TaskLifecycleRequest)
     );

--- a/tests/integration/cli/task-lifecycle.test.ts
+++ b/tests/integration/cli/task-lifecycle.test.ts
@@ -67,3 +67,42 @@ test('task-lifecycle CLI rejects unknown and duplicate options as one JSON failu
     assert.equal(JSON.parse(result.stdout).error.code, 'LIFECYCLE_PAYLOAD_INVALID');
   }
 });
+
+const RESTORE_TASK_ID = 'TASK-20260202-000002';
+
+function stagingFixture({ initGit = true } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-lifecycle-restore-cli-'));
+  if (initGit) spawnSync('git', ['init', '-q'], { cwd: root });
+  const staging = path.join(root, '.agents', 'workspace', '.restore-staging-1');
+  fs.mkdirSync(staging, { recursive: true });
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ task: { shortIdLength: 2 } }));
+  fs.writeFileSync(path.join(staging, 'task.md'), `---\nid: ${RESTORE_TASK_ID}\nissue_number: 42\nstatus: active\ncurrent_step: requirement-analysis\nupdated_at: old\nagent_infra_version: old\n---\n\n# Task\n\n## Activity Log\n\n`);
+  return { root, staging };
+}
+
+test('task-lifecycle CLI restore applies staging for a task that does not exist locally', () => {
+  const f = stagingFixture();
+  const result = run(f.root, [RESTORE_TASK_ID, 'restore', '--agent', 'codex', '--staging-dir', f.staging, '--issue-number', '42']);
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, 'applied');
+  assert.equal(parsed.shortId.shortId, '01');
+  assert.equal(fs.existsSync(path.join(f.root, '.agents', 'workspace', 'active', RESTORE_TASK_ID, 'task.md')), true);
+  assert.equal(fs.existsSync(f.staging), false);
+});
+
+test('task-lifecycle CLI restore rejects short ids and malformed TASK-ids with LIFECYCLE_IDENTITY_INVALID', () => {
+  const f = stagingFixture();
+  for (const ref of ['1', 'not-a-task-id']) {
+    const result = run(f.root, [ref, 'restore', '--agent', 'codex', '--staging-dir', f.staging, '--issue-number', '42']);
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error.code, 'LIFECYCLE_IDENTITY_INVALID');
+  }
+});
+
+test('task-lifecycle CLI restore fails closed with REPO_ROOT_NOT_FOUND outside a git repository', () => {
+  const f = stagingFixture({ initGit: false });
+  const result = run(f.root, [RESTORE_TASK_ID, 'restore', '--agent', 'codex', '--staging-dir', f.staging, '--issue-number', '42']);
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).error.code, 'REPO_ROOT_NOT_FOUND');
+});


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

**Issue 链接 / Issue Link:** #877

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

Closes #877

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📦 依赖升级 / Dependency upgrade (update dependencies to newer versions)
- [ ] 🚀 功能增强 / Feature enhancement (improve existing functionality without breaking changes)
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

`task-lifecycle` internal CLI 的 `restore` intent 在分发前被 `resolveTaskRef` 的任务存在性校验无条件挡住，而 restore 的合法前提恰恰是"本地任务不存在、只存在于 staging 目录"，两者结构性矛盾导致该 intent 经 CLI 入口永远返回 `TASK_NOT_FOUND`、结构性不可达，`restore-task` 技能完全无法完成。核心 `applyTaskLifecycle` 本身早已正确实现了 staging 恢复路径（`lib/task/lifecycle.ts:289-296`），缺陷只存在于 CLI 分发层；现有 restore 单元测试直接调用核心函数、绕过了该门禁，因此测试全绿也看不见这个缺陷。本 PR 让 CLI 分发层为 restore intent 增加与核心对称的分支。

The `restore` intent of the `task-lifecycle` internal CLI was unconditionally blocked by `resolveTaskRef`'s existence check before dispatch, while restore's valid precondition is exactly the opposite — the task does NOT exist locally yet, only in a staging directory. This structural contradiction made the intent return `TASK_NOT_FOUND` and become permanently unreachable through the CLI, so the `restore-task` skill could never complete. The core `applyTaskLifecycle` had already implemented the staging-restore path correctly (`lib/task/lifecycle.ts:289-296`); the defect was isolated to the CLI dispatch layer. Existing restore unit tests called the core function directly, bypassing this gate, so the defect stayed invisible even with a fully green test suite. This PR adds a dispatch branch for the restore intent that is symmetric with the core's existing handling.

## 📋 主要变更 / Brief Changelog

- `lib/internal/task-lifecycle.ts`：为 `restore` intent 新增独立分支——跳过 `resolveTaskRef` 的存在性前置检查，改用已导出的 `detectRepoRoot()` 单独获取 `repoRoot`，`taskId` 直接透传原始 `taskRef`；身份/存在性判断完全交给核心 `applyTaskLifecycle`（`TASK_ID_RE` 完整 TASK-id 校验 + `validateRestoreStaging` + `LIFECYCLE_SOURCE_INVALID` 二次防线均未改动）；其余 6 个 intent 的 `resolveTaskRef` 路径不变
- `tests/integration/cli/task-lifecycle.test.ts`：新增经真实 CLI 子进程调用的 restore 回归测试——成功落位并分配短号、短号/非完整 TASK-id 拒绝（`LIFECYCLE_IDENTITY_INVALID`）、非 git 仓库环境下 fail closed（`REPO_ROOT_NOT_FOUND`）

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. 修复前手工复现：restore 经 internal CLI 入口确定性返回 `error.code: TASK_NOT_FOUND`（RED）。
2. 应用修复后重跑同一场景与新增测试，均转绿；`task-lifecycle` 相关全部 20 条测试通过。
3. 运行完整 `npm test`，确认 `2440 tests / 2436 pass / 0 fail / 4 skipped`。
4. 使用现存 staging 目录对真实任务 `TASK-20260818-234614` 执行一次修复后的 restore，确认原子落位 `active/` 并分配短号，staging 目录与生命周期 journal 均已被原子清理。

### 测试覆盖 / Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## ✅ 贡献者检查清单 / Contributor Checklist

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更 / Make sure there is a Github issue filed for the change
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [x] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [x] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 单元测试通过 / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation（本次改动局限于 CLI 分发逻辑与测试，未涉及面向用户的文档）
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility（其余 6 个 intent 的 `resolveTaskRef` 存在性校验路径完全未改动；restore 的身份/staging 校验强度未削弱）

## 📋 附加信息 / Additional Notes

本 PR 顺带修复了同一个真实待恢复任务（`TASK-20260818-234614`，源自 #869）——使用修复后的 CLI 完成了一次真实恢复，不属于代码改动，但作为本 Issue 验收标准之一记录在此。

---

**审查者注意事项 / Reviewer Notes:**

改动严格限定在 `lib/internal/task-lifecycle.ts` 一个函数内的一处分支新增，未触碰核心生命周期（`lib/task/lifecycle.ts`）、身份/staging 校验逻辑或其余 6 个 intent 的既有代码路径。

Generated with AI assistance
