### PR TITLE

fix(lifecycle): 修复生命周期 Hook 隐式切换本地 CLI


### DIFF
--- a/.agents/QUICKSTART.md
+++ b/.agents/QUICKSTART.md
@@ -20,14 +20,14 @@ git config core.hooksPath .git-hooks
 
 ## 开发检出中的 CLI 对齐
 
-从源码检出开发 agent-infra 时，请先安装依赖并重新构建本地 CLI，再运行生命周期编排：
+从源码检出开发 agent-infra CLI 时，请按需安装依赖并重新构建 CLI：
 
 ```bash
 npm install
 npm run build
 ```
 
-本地 `dist/bin/internal-cli.js` 存在时，生命周期 hook 会优先使用它；不存在时则回退到 `PATH` 上的 `agent-infra-internal`。修改 CLI 源码后需要重新构建。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
+生命周期 hook 始终通过 `PATH` 调用 `agent-infra-internal`，不会隐式切换到当前检出的 source 或 `dist`。在 Codex sandbox 中，controller 放在 `PATH` 首位的 shim 是权威入口，并绑定 controller 选定的 executable。skills、rules、hooks 和任务数据仍从当前检出读取。上面的命令只用于开发 CLI 本身，不会改变 hook 的 executable 选择。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
 
 ```bash
 npm link

--- a/.agents/hooks/lifecycle-delegation.js
+++ b/.agents/hooks/lifecycle-delegation.js
@@ -1,13 +1,9 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync } from 'node:fs';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const MAX_INPUT_BYTES = 64 * 1024;
-const repoPackageJson = fileURLToPath(new URL('../../package.json', import.meta.url));
-const sourceInternalCli = fileURLToPath(new URL('../../bin/internal-cli.ts', import.meta.url));
-const localInternalCli = fileURLToPath(new URL('../../dist/bin/internal-cli.js', import.meta.url));
 const codexHooks = fileURLToPath(new URL('../../.codex/hooks.json', import.meta.url));
 const clientIndex = process.argv.indexOf('--client');
 const client = clientIndex >= 0 ? process.argv[clientIndex + 1] : '';
@@ -17,22 +13,6 @@ if (client !== 'claude-code' && client !== 'codex') {
 }
 
 function internalCliInvocation(args) {
-  let isAgentInfraSourceCheckout = false;
-  try {
-    isAgentInfraSourceCheckout = JSON.parse(readFileSync(repoPackageJson, 'utf8')).name === '@fitlab-ai/agent-infra';
-  } catch {
-    // Installed project hooks do not require a repository package.json.
-  }
-  if (isAgentInfraSourceCheckout && existsSync(sourceInternalCli)) {
-    return {
-      command: process.execPath,
-      commandArgs: ['--experimental-strip-types', sourceInternalCli, ...args],
-      shell: false
-    };
-  }
-  if (existsSync(localInternalCli)) {
-    return { command: process.execPath, commandArgs: [localInternalCli, ...args], shell: false };
-  }
   return { command: 'agent-infra-internal', commandArgs: args, shell: process.platform === 'win32' };
 }
 

--- a/templates/.agents/QUICKSTART.en.md
+++ b/templates/.agents/QUICKSTART.en.md
@@ -20,14 +20,14 @@ This makes Git invoke the hooks in the project repository's `.git-hooks/` direct
 
 ## Development Checkout CLI Alignment
 
-When developing agent-infra from a source checkout, install dependencies and rebuild the local CLI before running lifecycle orchestration:
+When developing the agent-infra CLI from a source checkout, install dependencies and rebuild it as needed:
 
 ```bash
 npm install
 npm run build
 ```
 
-Lifecycle hooks prefer the checkout's `dist/bin/internal-cli.js` when it exists and fall back to `agent-infra-internal` on `PATH` otherwise. Rebuild after CLI source changes. If shell commands must also resolve to this checkout, link it and compare the active version with the package version:
+Lifecycle hooks always invoke `agent-infra-internal` through `PATH`; they do not implicitly switch to checkout source or `dist`. In a Codex sandbox, the controller's `PATH`-first shim is authoritative and binds the controller's selected executable. Skills, rules, hooks, and task data continue to come from the current checkout. The commands above develop the CLI itself and do not change hook executable selection. If shell commands must also resolve to this checkout, link it and compare the active version with the package version:
 
 ```bash
 npm link

--- a/templates/.agents/QUICKSTART.zh-CN.md
+++ b/templates/.agents/QUICKSTART.zh-CN.md
@@ -20,14 +20,14 @@ git config core.hooksPath .git-hooks
 
 ## 开发检出中的 CLI 对齐
 
-从源码检出开发 agent-infra 时，请先安装依赖并重新构建本地 CLI，再运行生命周期编排：
+从源码检出开发 agent-infra CLI 时，请按需安装依赖并重新构建 CLI：
 
 ```bash
 npm install
 npm run build
 ```
 
-本地 `dist/bin/internal-cli.js` 存在时，生命周期 hook 会优先使用它；不存在时则回退到 `PATH` 上的 `agent-infra-internal`。修改 CLI 源码后需要重新构建。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
+生命周期 hook 始终通过 `PATH` 调用 `agent-infra-internal`，不会隐式切换到当前检出的 source 或 `dist`。在 Codex sandbox 中，controller 放在 `PATH` 首位的 shim 是权威入口，并绑定 controller 选定的 executable。skills、rules、hooks 和任务数据仍从当前检出读取。上面的命令只用于开发 CLI 本身，不会改变 hook 的 executable 选择。如果 shell 命令也必须解析到当前检出，请建立链接并比较当前版本与包版本：
 
 ```bash
 npm link

--- a/templates/.agents/hooks/lifecycle-delegation.js
+++ b/templates/.agents/hooks/lifecycle-delegation.js
@@ -1,13 +1,9 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync } from 'node:fs';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const MAX_INPUT_BYTES = 64 * 1024;
-const repoPackageJson = fileURLToPath(new URL('../../package.json', import.meta.url));
-const sourceInternalCli = fileURLToPath(new URL('../../bin/internal-cli.ts', import.meta.url));
-const localInternalCli = fileURLToPath(new URL('../../dist/bin/internal-cli.js', import.meta.url));
 const codexHooks = fileURLToPath(new URL('../../.codex/hooks.json', import.meta.url));
 const clientIndex = process.argv.indexOf('--client');
 const client = clientIndex >= 0 ? process.argv[clientIndex + 1] : '';
@@ -17,22 +13,6 @@ if (client !== 'claude-code' && client !== 'codex') {
 }
 
 function internalCliInvocation(args) {
-  let isAgentInfraSourceCheckout = false;
-  try {
-    isAgentInfraSourceCheckout = JSON.parse(readFileSync(repoPackageJson, 'utf8')).name === '@fitlab-ai/agent-infra';
-  } catch {
-    // Installed project hooks do not require a repository package.json.
-  }
-  if (isAgentInfraSourceCheckout && existsSync(sourceInternalCli)) {
-    return {
-      command: process.execPath,
-      commandArgs: ['--experimental-strip-types', sourceInternalCli, ...args],
-      shell: false
-    };
-  }
-  if (existsSync(localInternalCli)) {
-    return { command: process.execPath, commandArgs: [localInternalCli, ...args], shell: false };
-  }
   return { command: 'agent-infra-internal', commandArgs: args, shell: process.platform === 'win32' };
 }
 

--- a/tests/integration/cli/orchestration-hooks.test.ts
+++ b/tests/integration/cli/orchestration-hooks.test.ts
@@ -22,6 +22,11 @@ interface RunOptions {
   hook?: string;
 }
 
+interface HookFixtureOptions {
+  pathCli?: boolean;
+  pathSource?: 'path' | 'controller-path';
+}
+
 type LocalCliState = 'missing' | 'working' | 'broken' | 'source-with-stale-dist';
 
 function run(input: string, options: RunOptions = {}) {
@@ -33,19 +38,22 @@ function run(input: string, options: RunOptions = {}) {
     hook = HOOK
   } = options;
   const args = [hook, '--client', client, ...(event ? ['--event', event] : [])];
-  return spawnSync('node', args, { cwd, input, encoding: 'utf8', env });
+  return spawnSync(process.execPath, args, { cwd, input, encoding: 'utf8', env });
 }
 
-function createHookFixture(localCliState: LocalCliState) {
+function createHookFixture(localCliState: LocalCliState, options: HookFixtureOptions = {}) {
+  const { pathCli: pathCliEnabled = true, pathSource = 'path' } = options;
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lifecycle-hook-'));
   fixtureRoots.add(root);
   const repoDir = path.join(root, 'repo');
   const hook = path.join(repoDir, '.agents', 'hooks', 'lifecycle-delegation.js');
   const cwd = path.join(repoDir, 'nested');
   const binDir = path.join(root, 'bin');
-  const pathCli = path.join(root, 'path-internal-cli.mjs');
+  const emptyBinDir = path.join(root, 'empty-bin');
+  const pathCliScript = path.join(root, 'path-internal-cli.mjs');
   fs.mkdirSync(path.dirname(hook), { recursive: true });
   fs.mkdirSync(cwd, { recursive: true });
+  fs.mkdirSync(emptyBinDir, { recursive: true });
   fs.copyFileSync(HOOK, hook);
   fs.writeFileSync(
     path.join(repoDir, 'package.json'),
@@ -54,8 +62,10 @@ function createHookFixture(localCliState: LocalCliState) {
       ...(localCliState === 'source-with-stale-dist' ? { name: '@fitlab-ai/agent-infra' } : {})
     })
   );
-  fs.writeFileSync(pathCli, "let input=''; process.stdin.setEncoding('utf8'); process.stdin.on('data',c=>input+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify({ source: 'path', args: process.argv.slice(2), ...(input ? { input: JSON.parse(input) } : {}) })))\n");
-  writeNodeCommandShim(path.join(binDir, 'agent-infra-internal'), pathCli);
+  if (pathCliEnabled) {
+    fs.writeFileSync(pathCliScript, `let input=''; process.stdin.setEncoding('utf8'); process.stdin.on('data',c=>input+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify({ source: '${pathSource}', args: process.argv.slice(2), ...(input ? { input: JSON.parse(input) } : {}) })))\n`);
+    writeNodeCommandShim(path.join(binDir, 'agent-infra-internal'), pathCliScript);
+  }
 
   if (localCliState !== 'missing') {
     const localCli = path.join(repoDir, 'dist', 'bin', 'internal-cli.js');
@@ -75,7 +85,13 @@ function createHookFixture(localCliState: LocalCliState) {
   fs.mkdirSync(path.join(repoDir, '.codex'), { recursive: true });
   fs.copyFileSync(path.resolve('.codex/hooks.json'), path.join(repoDir, '.codex', 'hooks.json'));
 
-  return { cwd, env: envWithPrependedPath(process.env, binDir), hook };
+  return {
+    cwd,
+    env: pathCliEnabled
+      ? envWithPrependedPath(process.env, binDir)
+      : { ...process.env, PATH: emptyBinDir },
+    hook
+  };
 }
 
 test('lifecycle hook ignores unrelated subagents without touching orchestration state', () => {
@@ -124,7 +140,7 @@ test('lifecycle hook falls back to PATH and maps native Claude payloads', () => 
   });
 });
 
-test('lifecycle hook prefers the repository-local CLI independently of cwd', () => {
+test('lifecycle hook uses the PATH CLI independently of cwd', () => {
   const fixture = createHookFixture('working');
 
   const start = run(
@@ -132,7 +148,7 @@ test('lifecycle hook prefers the repository-local CLI independently of cwd', () 
     fixture
   );
   assert.equal(start.status, 0, start.stderr);
-  assert.equal(JSON.parse(start.stdout).source, 'local');
+  assert.equal(JSON.parse(start.stdout).source, 'path');
 
   const stop = run(
     fs.readFileSync(path.join(FIXTURES, 'claude-subagent-stop.json'), 'utf8'),
@@ -140,7 +156,7 @@ test('lifecycle hook prefers the repository-local CLI independently of cwd', () 
   );
   assert.equal(stop.status, 0, stop.stderr);
   assert.deepEqual(JSON.parse(stop.stdout), {
-    source: 'local',
+    source: 'path',
     args: [
       'task-orchestration', 'auto', 'hook-stop',
       '--client', 'claude-code',
@@ -180,7 +196,7 @@ test('lifecycle hook forwards real-shaped stop-side model and effort evidence (n
 
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    source: 'local',
+    source: 'path',
     args: [
       'task-orchestration', 'auto', 'hook-stop',
       '--client', 'claude-code',
@@ -192,19 +208,18 @@ test('lifecycle hook forwards real-shaped stop-side model and effort evidence (n
   });
 });
 
-test('lifecycle hook fails closed when the repository-local CLI fails', () => {
+test('lifecycle hook uses PATH when the repository-local CLI fails', () => {
   const fixture = createHookFixture('broken');
 
   const result = run(
     fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'),
     fixture
   );
-  assert.equal(result.status, 23);
-  assert.equal(result.stdout, '');
-  assert.equal(result.stderr, 'Local lifecycle CLI failed\n');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).source, 'path');
 });
 
-test('lifecycle hook prefers checkout source over a stale dist CLI', () => {
+test('lifecycle hook uses PATH when checkout source and stale dist coexist', () => {
   const fixture = createHookFixture('source-with-stale-dist');
 
   const result = run(
@@ -213,7 +228,7 @@ test('lifecycle hook prefers checkout source over a stale dist CLI', () => {
   );
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(JSON.parse(result.stdout).source, 'source');
+  assert.equal(JSON.parse(result.stdout).source, 'path');
 });
 
 test('lifecycle hook rejects malformed payloads before invoking core', () => {
@@ -258,6 +273,28 @@ test('lifecycle hook normalizes Codex spawn and child events through stdin', () 
   assert.equal(childParsed.input.sessionId, 'codex-parent');
   assert.equal(childParsed.input.turnId, 'codex-child-turn');
   assert.equal(childParsed.input.childThreadId, 'codex-child');
+});
+
+test('Codex lifecycle hook uses the controller PATH shim when local source and dist coexist', () => {
+  const fixture = createHookFixture('source-with-stale-dist', { pathSource: 'controller-path' });
+  const result = run(
+    fs.readFileSync(path.join(FIXTURES, 'codex-lifecycle-start.json'), 'utf8'),
+    { ...fixture, client: 'codex', event: 'pre-tool', hook: fixture.hook }
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.source, 'controller-path');
+  assert.deepEqual(parsed.args, ['codex-lifecycle', 'hook-event', '--event', 'pre-tool', '--bridge', 'true']);
+});
+
+test('lifecycle hook fails closed when PATH has no internal CLI', () => {
+  const fixture = createHookFixture('source-with-stale-dist', { pathCli: false });
+  const result = run(
+    fs.readFileSync(path.join(FIXTURES, 'claude-subagent-start.json'), 'utf8'),
+    fixture
+  );
+  assert.notEqual(result.status, 0);
+  assert.equal(result.stdout, '');
 });
 
 test('lifecycle hook forwards completed Codex waits and ignores timed out waits', () => {

--- a/tests/unit/core/codex-sandbox-controller.test.ts
+++ b/tests/unit/core/codex-sandbox-controller.test.ts
@@ -91,8 +91,13 @@ test('sandbox controller prepares an isolated allowlisted home and fixed launch 
   assert.equal(prepared.env.HOME, prepared.home);
   assert.equal(prepared.env.UNRELATED_CONTROLLER_SECRET, undefined);
   assert.equal(prepared.env.AGENT_INFRA_CONTROL_TOKEN, 'control-token');
-  assert.match(fs.readFileSync(path.join(prepared.home, 'bin', 'agent-infra-internal'), 'utf8'), /"\$@"/u);
-  assert.doesNotMatch(fs.readFileSync(path.join(prepared.home, 'bin', 'agent-infra-internal'), 'utf8'), /"\\\$@"/u);
+  assert.equal(prepared.env.PATH?.split(path.delimiter)[0], path.join(prepared.home, 'bin'));
+  const shim = fs.readFileSync(path.join(prepared.home, 'bin', 'agent-infra-internal'), 'utf8');
+  const expectedExecutable = path.resolve(process.argv[1] ?? path.join(f.root, 'bin', 'internal-cli.ts'));
+  assert.equal(shim.includes(expectedExecutable), true);
+  if (expectedExecutable.endsWith('.ts')) assert.match(shim, /--experimental-strip-types/u);
+  assert.match(shim, /"\$@"/u);
+  assert.doesNotMatch(shim, /"\\\$@"/u);
   const homeStat = fs.lstatSync(prepared.home);
   const authStat = fs.lstatSync(path.join(prepared.home, 'auth.json'));
   assert.equal(homeStat.isDirectory(), true);


### PR DESCRIPTION

## 摘要

- 将 lifecycle delegation hook 的内部 CLI 调用统一为 PATH 中的 `agent-infra-internal`，移除对当前仓库 source/dist CLI 的隐式优先选择。
- 保持 Codex sandbox controller 的 PATH 首位 shim、启动 executable identity、payload、超时、Windows shell 与项目协作资产读取边界不变。
- 同步项目 hook、模板 hook、双语 Quick Start 文档及回归测试。

## 验证

- 聚焦生命周期集成测试：16/16 通过。
- `npm run test:core`：2186 passed，3 skipped，0 failed。
- `npm test`：2503 passed，4 skipped，0 failed。
- `git diff --check`、模板 hook parity 检查及提交前检查通过。

## 审查

- `review-code.md`：Approved；0 阻塞项、0 主要问题、0 次要问题、无需人工校验。

## 关联 Issue

Closes #893

Generated with AI assistance
