### PR TITLE
fix(codex): 修复 capability 消费身份误判


### DIFF
--- a/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import semver from 'semver';
+
 const LIFECYCLE_PROTOCOL_VERSION = 3;
 
 type LifecycleBuildIdentity = Readonly<{
@@ -30,6 +32,14 @@ type IdentityVerification = Readonly<{
 
 function exactText(value: unknown): value is string {
   return typeof value === 'string' && value.trim() === value && value.length > 0;
+}
+
+function isCanonicalLifecyclePackageVersion(value: unknown): value is string {
+  return typeof value === 'string' && semver.valid(value) === value;
+}
+
+function isLifecycleProtocolVersion(value: unknown): value is typeof LIFECYCLE_PROTOCOL_VERSION {
+  return value === LIFECYCLE_PROTOCOL_VERSION;
 }
 
 function normalizeRelativePath(value: string): string {
@@ -215,6 +225,8 @@ function verifyLifecycleBuildIdentity(
 export {
   LIFECYCLE_PROTOCOL_VERSION,
   computeLifecycleBuildIdentity,
+  isCanonicalLifecyclePackageVersion,
+  isLifecycleProtocolVersion,
   readLifecycleManifestFiles,
   resolveLifecycleExecutableFiles,
   verifyLifecycleBuildIdentity

--- a/lib/agent-clients/adapters/codex-lifecycle/capability-store.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/capability-store.ts
@@ -2,7 +2,12 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { verifyLifecycleBuildIdentity } from './build-identity.ts';
+import {
+  isCanonicalLifecyclePackageVersion,
+  isLifecycleProtocolVersion,
+  LIFECYCLE_PROTOCOL_VERSION,
+  verifyLifecycleBuildIdentity
+} from './build-identity.ts';
 import type { LifecycleBuildIdentity } from './build-identity.ts';
 import { resolveAgentRuntimeStoreRoot } from '../../../runtime/agent-runtime.ts';
 
@@ -10,6 +15,36 @@ type CapabilityStatus = 'armed' | 'attested' | 'consumed' | 'expired';
 type CodexControllerBinding = Readonly<{
   instanceDigest: string;
   controlGeneration: string;
+}>;
+type CodexCapabilityProjection = Readonly<
+  | { kind: 'absent' }
+  | { kind: 'protocol-version'; value: typeof LIFECYCLE_PROTOCOL_VERSION }
+  | { kind: 'semver'; value: string }
+  | { kind: 'digest-prefix'; value: string }
+  | { kind: 'presence'; present: boolean }
+>;
+type CodexCapabilityProvenanceField = Readonly<{
+  matches: boolean;
+  expected: CodexCapabilityProjection;
+  actual: CodexCapabilityProjection;
+}>;
+type CodexCapabilityProvenanceDetail = Readonly<{
+  kind: 'codex-capability-provenance-mismatch';
+  version: 1;
+  fields: Readonly<{
+    taskId: CodexCapabilityProvenanceField;
+    hookDefinitionHash: CodexCapabilityProvenanceField;
+    buildIdentity: Readonly<{
+      protocolVersion: CodexCapabilityProvenanceField;
+      packageVersion: CodexCapabilityProvenanceField;
+      internalExecutableBuildHash: CodexCapabilityProvenanceField;
+      lifecycleContractHash: CodexCapabilityProvenanceField;
+    }>;
+    controller: Readonly<{
+      instanceDigest: CodexCapabilityProvenanceField;
+      controlGeneration: CodexCapabilityProvenanceField;
+    }>;
+  }>;
 }>;
 type CodexCapabilityRecord = Readonly<{
   schemaVersion: 1;
@@ -45,23 +80,222 @@ const DEFAULT_MAX_RECORDS = 128;
 const LOCK_RETRY_MS = 10;
 const LOCK_TIMEOUT_MS = 1_000;
 const LOCK_STALE_MS = 30_000;
+const DETAIL_DOMAIN = 'codex-capability-provenance/v1';
+const TASK_ID_PATTERN = /^TASK-[0-9]{8}-[0-9]{6}$/u;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const DIGEST_PREFIX_PATTERN = /^sha256:[0-9a-f]{16}$/u;
 
 function digest(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
 
-function capabilityError(code: string, message: string): Error {
+function capabilityError(code: string, message: string, detail?: CodexCapabilityProvenanceDetail): Error {
   const error = new Error(`${code}: ${message}`);
   error.name = code;
+  if (detail) (error as Error & { detail: CodexCapabilityProvenanceDetail }).detail = detail;
   return error;
 }
 
-function sameController(
-  left: CodexControllerBinding | null,
-  right: CodexControllerBinding | null
+function objectValue(value: unknown, key: string): unknown {
+  if (!value || typeof value !== 'object') return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function digestPrefix(fieldName: string, value: string): CodexCapabilityProjection {
+  return {
+    kind: 'digest-prefix',
+    value: `sha256:${crypto.createHash('sha256')
+      .update(`${DETAIL_DOMAIN}\0${fieldName}\0${value}`)
+      .digest('hex')
+      .slice(0, 16)}`
+  };
+}
+
+function projectDigest(fieldName: string, value: unknown, pattern: RegExp): CodexCapabilityProjection {
+  return typeof value === 'string' && pattern.test(value) ? digestPrefix(fieldName, value) : { kind: 'absent' };
+}
+
+function projectTaskId(value: unknown): CodexCapabilityProjection {
+  return projectDigest('taskId', value, TASK_ID_PATTERN);
+}
+
+function projectHash(fieldName: string, value: unknown): CodexCapabilityProjection {
+  return projectDigest(fieldName, value, SHA256_PATTERN);
+}
+
+function projectProtocol(value: unknown): CodexCapabilityProjection {
+  return isLifecycleProtocolVersion(value)
+    ? { kind: 'protocol-version', value: LIFECYCLE_PROTOCOL_VERSION }
+    : { kind: 'absent' };
+}
+
+function projectPackageVersion(value: unknown): CodexCapabilityProjection {
+  return isCanonicalLifecyclePackageVersion(value)
+    ? { kind: 'semver', value }
+    : { kind: 'absent' };
+}
+
+function projectPresence(value: unknown): CodexCapabilityProjection {
+  return { kind: 'presence', present: Boolean(value && typeof value === 'object') };
+}
+
+function field(matches: boolean, expected: CodexCapabilityProjection, actual: CodexCapabilityProjection): CodexCapabilityProvenanceField {
+  return { matches, expected, actual };
+}
+
+function provenanceDetail(
+  record: CodexCapabilityRecord,
+  expected: Readonly<{
+    taskId: string;
+    hookDefinitionHash: string;
+    buildIdentity: LifecycleBuildIdentity;
+    controller?: CodexControllerBinding;
+  }>
+): CodexCapabilityProvenanceDetail {
+  const actualBuild = record.buildIdentity;
+  const expectedBuild = expected.buildIdentity;
+  const actualController = record.controller;
+  const expectedController = expected.controller ?? null;
+  return {
+    kind: 'codex-capability-provenance-mismatch',
+    version: 1,
+    fields: {
+      taskId: field(
+        record.taskId === expected.taskId,
+        projectTaskId(expected.taskId),
+        projectTaskId(record.taskId)
+      ),
+      hookDefinitionHash: field(
+        record.hookDefinitionHash === expected.hookDefinitionHash,
+        projectHash('hookDefinitionHash', expected.hookDefinitionHash),
+        projectHash('hookDefinitionHash', record.hookDefinitionHash)
+      ),
+      buildIdentity: {
+        protocolVersion: field(
+          objectValue(actualBuild, 'protocolVersion') === objectValue(expectedBuild, 'protocolVersion'),
+          projectProtocol(objectValue(expectedBuild, 'protocolVersion')),
+          projectProtocol(objectValue(actualBuild, 'protocolVersion'))
+        ),
+        packageVersion: field(
+          objectValue(actualBuild, 'packageVersion') === objectValue(expectedBuild, 'packageVersion'),
+          projectPackageVersion(objectValue(expectedBuild, 'packageVersion')),
+          projectPackageVersion(objectValue(actualBuild, 'packageVersion'))
+        ),
+        internalExecutableBuildHash: field(
+          objectValue(actualBuild, 'internalExecutableBuildHash') === objectValue(expectedBuild, 'internalExecutableBuildHash'),
+          projectHash('buildIdentity.internalExecutableBuildHash', objectValue(expectedBuild, 'internalExecutableBuildHash')),
+          projectHash('buildIdentity.internalExecutableBuildHash', objectValue(actualBuild, 'internalExecutableBuildHash'))
+        ),
+        lifecycleContractHash: field(
+          objectValue(actualBuild, 'lifecycleContractHash') === objectValue(expectedBuild, 'lifecycleContractHash'),
+          projectHash('buildIdentity.lifecycleContractHash', objectValue(expectedBuild, 'lifecycleContractHash')),
+          projectHash('buildIdentity.lifecycleContractHash', objectValue(actualBuild, 'lifecycleContractHash'))
+        )
+      },
+      controller: {
+        instanceDigest: field(
+          sameControllerField(actualController, expectedController, 'instanceDigest'),
+          projectPresence(objectValue(expectedController, 'instanceDigest') === undefined ? null : expectedController),
+          projectPresence(objectValue(actualController, 'instanceDigest') === undefined ? null : actualController)
+        ),
+        controlGeneration: field(
+          sameControllerField(actualController, expectedController, 'controlGeneration'),
+          projectPresence(objectValue(expectedController, 'controlGeneration') === undefined ? null : expectedController),
+          projectPresence(objectValue(actualController, 'controlGeneration') === undefined ? null : actualController)
+        )
+      }
+    }
+  };
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function isCodexControllerBinding(value: unknown): value is CodexControllerBinding {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return exactKeys(record, ['instanceDigest', 'controlGeneration'])
+    && typeof record.instanceDigest === 'string'
+    && typeof record.controlGeneration === 'string';
+}
+
+function isProjection(value: unknown): value is CodexCapabilityProjection {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (record.kind === 'absent') return exactKeys(record, ['kind']);
+  if (record.kind === 'protocol-version') {
+    return exactKeys(record, ['kind', 'value']) && isLifecycleProtocolVersion(record.value);
+  }
+  if (record.kind === 'semver') {
+    return exactKeys(record, ['kind', 'value']) && isCanonicalLifecyclePackageVersion(record.value);
+  }
+  if (record.kind === 'digest-prefix') {
+    return exactKeys(record, ['kind', 'value'])
+      && typeof record.value === 'string'
+      && DIGEST_PREFIX_PATTERN.test(record.value);
+  }
+  if (record.kind === 'presence') {
+    return exactKeys(record, ['kind', 'present']) && typeof record.present === 'boolean';
+  }
+  return false;
+}
+
+function isProvenanceField(value: unknown): value is CodexCapabilityProvenanceField {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return exactKeys(record, ['matches', 'expected', 'actual'])
+    && typeof record.matches === 'boolean'
+    && isProjection(record.expected)
+    && isProjection(record.actual);
+}
+
+function isCodexCapabilityProvenanceDetail(value: unknown): value is CodexCapabilityProvenanceDetail {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (!exactKeys(record, ['kind', 'version', 'fields'])
+    || record.kind !== 'codex-capability-provenance-mismatch'
+    || record.version !== 1
+    || !record.fields || typeof record.fields !== 'object') return false;
+  const fields = record.fields as Record<string, unknown>;
+  if (!exactKeys(fields, ['taskId', 'hookDefinitionHash', 'buildIdentity', 'controller'])
+    || !isProvenanceField(fields.taskId)
+    || !isProvenanceField(fields.hookDefinitionHash)) return false;
+  const buildIdentity = fields.buildIdentity;
+  const controller = fields.controller;
+  if (!buildIdentity || typeof buildIdentity !== 'object' || !controller || typeof controller !== 'object') return false;
+  const build = buildIdentity as Record<string, unknown>;
+  const binding = controller as Record<string, unknown>;
+  return exactKeys(build, ['protocolVersion', 'packageVersion', 'internalExecutableBuildHash', 'lifecycleContractHash'])
+    && exactKeys(binding, ['instanceDigest', 'controlGeneration'])
+    && isProvenanceField(build.protocolVersion)
+    && isProvenanceField(build.packageVersion)
+    && isProvenanceField(build.internalExecutableBuildHash)
+    && isProvenanceField(build.lifecycleContractHash)
+    && isProvenanceField(binding.instanceDigest)
+    && isProvenanceField(binding.controlGeneration);
+}
+
+function sameControllerField(
+  left: unknown,
+  right: unknown,
+  key: keyof CodexControllerBinding
 ): boolean {
-  return left?.instanceDigest === right?.instanceDigest
-    && left?.controlGeneration === right?.controlGeneration;
+  if (left === null || right === null) return left === null && right === null;
+  return isCodexControllerBinding(left)
+    && isCodexControllerBinding(right)
+    && left[key] === right[key];
+}
+
+function sameController(
+  left: unknown,
+  right: unknown
+): boolean {
+  if (left === null || right === null) return left === null && right === null;
+  return isCodexControllerBinding(left)
+    && isCodexControllerBinding(right)
+    && left.instanceDigest === right.instanceDigest
+    && left.controlGeneration === right.controlGeneration;
 }
 
 function createCodexCapabilityStore(options: CodexCapabilityStoreOptions = {}) {
@@ -289,12 +523,18 @@ function createCodexCapabilityStore(options: CodexCapabilityStoreOptions = {}) {
     if (record.status !== 'attested') {
       throw capabilityError('CODEX_CAPABILITY_NOT_ATTESTED', 'capability token has no current-session hook attestation');
     }
-    const identity = verifyLifecycleBuildIdentity(record.buildIdentity, expected.buildIdentity);
+    const identity = record.buildIdentity && typeof record.buildIdentity === 'object'
+      ? verifyLifecycleBuildIdentity(record.buildIdentity, expected.buildIdentity)
+      : { ok: false };
     if (!identity.ok
       || record.taskId !== expected.taskId
       || record.hookDefinitionHash !== expected.hookDefinitionHash
       || !sameController(record.controller, expected.controller ?? null)) {
-      throw capabilityError('CODEX_CAPABILITY_PROVENANCE_MISMATCH', 'capability consumption identity does not match');
+      throw capabilityError(
+        'CODEX_CAPABILITY_PROVENANCE_MISMATCH',
+        'capability consumption identity does not match',
+        provenanceDetail(record, expected)
+      );
     }
     const next: CodexCapabilityRecord = Object.freeze({
       ...record,
@@ -316,7 +556,10 @@ function createCodexCapabilityStore(options: CodexCapabilityStoreOptions = {}) {
 export { createCodexCapabilityStore };
 export type {
   CapabilityStatus,
+  CodexCapabilityProjection,
+  CodexCapabilityProvenanceDetail,
   CodexCapabilityRecord,
   CodexCapabilityStoreOptions,
   CodexControllerBinding
 };
+export { isCodexCapabilityProvenanceDetail };

--- a/lib/agent-clients/adapters/codex-lifecycle/controller-context.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/controller-context.ts
@@ -1,0 +1,181 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { getProcessIdentityState, type ProcessIdentity } from '../../../server/process-state.ts';
+import type { CodexControllerLeaseProofV1, CodexControllerLeaseV1 } from '../../../sandbox/control/controller-registration.ts';
+import { computeLifecycleBuildIdentity, type LifecycleBuildIdentity } from './build-identity.ts';
+
+const HEX_256 = /^[a-f0-9]{64}$/u;
+
+export type CodexSandboxControllerContextV2 = Readonly<{
+  version: 2;
+  taskId: string;
+  controlGeneration: string;
+  controllerInstanceDigest: string;
+  controllerProcess: ProcessIdentity;
+  controllerLease: Readonly<{ version: 1; leaseId: string; leaseSecret: string }>;
+  issuedAt: number;
+  expiresAt: number;
+  buildIdentity: LifecycleBuildIdentity;
+  hookDefinitionHash: string;
+  lifecycleProfilesHash: string;
+}>;
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).sort().join(',') === [...keys].sort().join(',');
+}
+
+function digestProfiles(repoRoot: string): string {
+  const files = [
+    path.join(repoRoot, '.codex', 'agents', 'agent-infra-lifecycle-executor.toml'),
+    path.join(repoRoot, '.codex', 'agents', 'agent-infra-lifecycle-reviewer.toml')
+  ];
+  const hash = crypto.createHash('sha256');
+  for (const file of files.sort()) {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('CODEX_SANDBOX_CONTROLLER_BUNDLE_MISMATCH');
+    hash.update(path.basename(file));
+    hash.update('\0');
+    hash.update(fs.readFileSync(file));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+function validProcess(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const identity = value as Record<string, unknown>;
+  return exactKeys(identity, ['pid', 'startTime'])
+    && Number.isSafeInteger(identity.pid) && (identity.pid as number) > 0
+    && Number.isSafeInteger(identity.startTime) && (identity.startTime as number) >= 0;
+}
+
+function validBuildIdentity(value: unknown): value is LifecycleBuildIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const identity = value as Record<string, unknown>;
+  return exactKeys(identity, [
+    'internalExecutableBuildHash', 'lifecycleContractHash', 'packageVersion', 'protocolVersion'
+  ])
+    && identity.protocolVersion === 3
+    && typeof identity.packageVersion === 'string' && identity.packageVersion.length > 0
+    && typeof identity.internalExecutableBuildHash === 'string' && HEX_256.test(identity.internalExecutableBuildHash)
+    && typeof identity.lifecycleContractHash === 'string' && HEX_256.test(identity.lifecycleContractHash);
+}
+
+function validateContext(value: unknown): CodexSandboxControllerContextV2 {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  const context = value as Record<string, unknown>;
+  const lease = context.controllerLease as Record<string, unknown> | null;
+  if (!exactKeys(context, [
+    'buildIdentity', 'controlGeneration', 'controllerInstanceDigest', 'controllerLease',
+    'controllerProcess', 'expiresAt', 'hookDefinitionHash', 'issuedAt',
+    'lifecycleProfilesHash', 'taskId', 'version'
+  ])
+    || context.version !== 2
+    || typeof context.taskId !== 'string' || context.taskId.length === 0
+    || typeof context.controlGeneration !== 'string' || context.controlGeneration.length === 0
+    || typeof context.controllerInstanceDigest !== 'string' || !HEX_256.test(context.controllerInstanceDigest)
+    || !validProcess(context.controllerProcess)
+    || !lease || !exactKeys(lease, ['leaseId', 'leaseSecret', 'version'])
+    || lease.version !== 1
+    || typeof lease.leaseId !== 'string' || !HEX_256.test(lease.leaseId)
+    || typeof lease.leaseSecret !== 'string' || !HEX_256.test(lease.leaseSecret)
+    || !Number.isSafeInteger(context.issuedAt)
+    || !Number.isSafeInteger(context.expiresAt)
+    || (context.expiresAt as number) <= (context.issuedAt as number)
+    || !validBuildIdentity(context.buildIdentity)
+    || typeof context.hookDefinitionHash !== 'string' || !HEX_256.test(context.hookDefinitionHash)
+    || typeof context.lifecycleProfilesHash !== 'string' || !HEX_256.test(context.lifecycleProfilesHash)) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  return context as unknown as CodexSandboxControllerContextV2;
+}
+
+export function contextFromControllerLease(
+  lease: CodexControllerLeaseV1,
+  hashes: Readonly<{ hookDefinitionHash: string; lifecycleProfilesHash: string }>
+): CodexSandboxControllerContextV2 {
+  return Object.freeze({
+    version: 2,
+    taskId: lease.taskId,
+    controlGeneration: lease.controlGeneration,
+    controllerInstanceDigest: lease.controllerInstanceDigest,
+    controllerProcess: lease.controllerProcess,
+    controllerLease: Object.freeze({ version: 1, leaseId: lease.leaseId, leaseSecret: lease.leaseSecret }),
+    issuedAt: lease.issuedAt,
+    expiresAt: lease.expiresAt,
+    buildIdentity: lease.buildIdentity,
+    hookDefinitionHash: hashes.hookDefinitionHash,
+    lifecycleProfilesHash: hashes.lifecycleProfilesHash
+  });
+}
+
+export function writeCodexSandboxControllerContext(
+  contextPath: string,
+  context: CodexSandboxControllerContextV2
+): void {
+  validateContext(context);
+  fs.mkdirSync(path.dirname(contextPath), { recursive: true, mode: 0o700 });
+  const temporary = path.join(path.dirname(contextPath), `.${path.basename(contextPath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(context, null, 2)}\n`, { mode: 0o600, flag: 'wx' });
+    fs.chmodSync(temporary, 0o600);
+    fs.renameSync(temporary, contextPath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function verifyCodexSandboxControllerContext(
+  contextPath: string,
+  taskId: string,
+  options: Readonly<{
+    repoRoot?: string;
+    now?: number;
+    generation?: string;
+    probeProcess?: (identity: ProcessIdentity) => 'alive' | 'dead' | 'unknown';
+  }> = {}
+): CodexSandboxControllerContextV2 {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(contextPath);
+  } catch {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  let context: CodexSandboxControllerContextV2;
+  try {
+    context = validateContext(JSON.parse(fs.readFileSync(contextPath, 'utf8')));
+  } catch {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const generation = options.generation ?? process.env.AGENT_INFRA_CONTROL_GENERATION;
+  const state = (options.probeProcess ?? getProcessIdentityState)(context.controllerProcess);
+  if (context.taskId !== taskId
+    || context.controlGeneration !== generation
+    || context.expiresAt <= (options.now ?? Date.now())
+    || state !== 'alive') {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
+  }
+  if (JSON.stringify(computeLifecycleBuildIdentity(repoRoot)) !== JSON.stringify(context.buildIdentity)
+    || crypto.createHash('sha256').update(fs.readFileSync(path.join(repoRoot, '.codex', 'hooks.json'))).digest('hex') !== context.hookDefinitionHash
+    || digestProfiles(repoRoot) !== context.lifecycleProfilesHash) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_BUNDLE_MISMATCH');
+  }
+  return Object.freeze(context);
+}
+
+export function controllerProofFromContext(context: CodexSandboxControllerContextV2): CodexControllerLeaseProofV1 {
+  return Object.freeze({
+    version: 1,
+    leaseId: context.controllerLease.leaseId,
+    leaseSecret: context.controllerLease.leaseSecret,
+    controllerProcess: context.controllerProcess
+  });
+}

--- a/lib/agent-clients/adapters/codex-lifecycle/controller-context.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/controller-context.ts
@@ -145,7 +145,8 @@ export function verifyCodexSandboxControllerContext(
   } catch {
     throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
   }
-  if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
+  if (!stat.isFile() || stat.isSymbolicLink()
+    || (process.platform !== 'win32' && (stat.mode & 0o077) !== 0)) {
     throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
   }
   let context: CodexSandboxControllerContextV2;

--- a/lib/agent-clients/adapters/codex-lifecycle/manifest-files.json
+++ b/lib/agent-clients/adapters/codex-lifecycle/manifest-files.json
@@ -3,6 +3,7 @@
     "bin/internal-cli.ts",
     "lib/internal/codex-lifecycle.ts",
     "lib/internal/codex-sandbox-controller.ts",
+    "lib/internal/sandbox-control.ts",
     "lib/internal/task-orchestration.ts",
     "lib/task/codex-orchestration.ts",
     "lib/task/delegation-receipts.ts",
@@ -10,10 +11,17 @@
     "lib/agent-clients/adapters/codex-lifecycle/build-identity.ts",
     "lib/agent-clients/adapters/codex-lifecycle/capability-store.ts",
     "lib/agent-clients/adapters/codex-lifecycle/sandbox-controller.ts",
+    "lib/agent-clients/adapters/codex-lifecycle/controller-context.ts",
     "lib/agent-clients/adapters/codex-lifecycle/app-server.ts",
     "lib/agent-clients/adapters/codex-lifecycle/evidence.ts",
     "lib/agent-clients/adapters/codex-lifecycle/store.ts",
-    "lib/agent-clients/adapters/codex-lifecycle/manifest-files.json"
+    "lib/agent-clients/adapters/codex-lifecycle/manifest-files.json",
+    "lib/sandbox/control/protocol.ts",
+    "lib/sandbox/control/client.ts",
+    "lib/sandbox/control/executor.ts",
+    "lib/sandbox/control/controller-registration.ts",
+    "lib/server/process-state.ts",
+    "lib/sandbox/shell.ts"
   ],
   "contractFiles": [
     ".codex/hooks.json",

--- a/lib/agent-clients/adapters/codex-lifecycle/sandbox-controller.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/sandbox-controller.ts
@@ -6,11 +6,21 @@ import path from 'node:path';
 import semver from 'semver';
 import * as toml from 'smol-toml';
 
-import { requestSandboxControl } from '../../../sandbox/control/client.ts';
+import {
+  requestCodexControllerClose,
+  requestCodexControllerOpen,
+  requestSandboxControl
+} from '../../../sandbox/control/client.ts';
 import { readSandboxControlStatus } from '../../../sandbox/control/state.ts';
-import { getProcessStartTime, isProcessAlive } from '../../../server/process-state.ts';
+import { getProcessStartTime } from '../../../server/process-state.ts';
 import { computeLifecycleBuildIdentity } from './build-identity.ts';
-import type { LifecycleBuildIdentity } from './build-identity.ts';
+import {
+  contextFromControllerLease,
+  controllerProofFromContext,
+  verifyCodexSandboxControllerContext,
+  writeCodexSandboxControllerContext,
+  type CodexSandboxControllerContextV2
+} from './controller-context.ts';
 
 type ControllerControl = Readonly<{
   token: string;
@@ -18,20 +28,6 @@ type ControllerControl = Readonly<{
   channelDir: string;
   statusDir: string;
   runtimeDir: string;
-}>;
-
-type CodexSandboxControllerContext = Readonly<{
-  version: 1;
-  taskId: string;
-  controlGeneration: string;
-  controllerInstanceDigest: string;
-  parentPid: number;
-  parentStartTime: number;
-  issuedAt: number;
-  expiresAt: number;
-  buildIdentity: LifecycleBuildIdentity;
-  hookDefinitionHash: string;
-  lifecycleProfilesHash: string;
 }>;
 
 type ControllerInput = Readonly<{
@@ -51,6 +47,8 @@ type ControllerOptions = Readonly<{
   now?: () => number;
   codexVersion?: () => string;
   verifyTaskBinding?: (taskId: string, control: ControllerControl) => void;
+  openController?: typeof requestCodexControllerOpen;
+  closeController?: typeof requestCodexControllerClose;
   environment?: NodeJS.ProcessEnv;
 }>;
 
@@ -60,11 +58,9 @@ type PreparedCodexSandboxController = Readonly<{
   env: NodeJS.ProcessEnv;
   home: string;
   contextPath: string;
-  context: CodexSandboxControllerContext;
+  context: CodexSandboxControllerContextV2;
   cleanup: () => void;
 }>;
-
-const CONTEXT_TTL_MS = 4 * 60 * 60 * 1_000;
 
 function digestFiles(files: readonly string[]): string {
   const hash = crypto.createHash('sha256');
@@ -267,43 +263,30 @@ function prepareCodexSandboxController(
   const key = crypto.createHash('sha256')
     .update(`${input.taskId}\0${control.generation}`)
     .digest('hex');
-  const leasePath = path.join(runtimeRoot, `${key}.lease.json`);
-  if (fs.existsSync(leasePath)) {
-    const lease = JSON.parse(fs.readFileSync(leasePath, 'utf8')) as { pid?: number; startTime?: number };
-    if (Number.isSafeInteger(lease.pid) && typeof lease.startTime === 'number'
-      && getProcessStartTime(lease.pid!) === lease.startTime) {
-      throw new Error('CODEX_SANDBOX_CONTROLLER_BUSY');
-    }
-    fs.unlinkSync(leasePath);
-  }
-
   const parentStartTime = getProcessStartTime(process.pid);
   if (!parentStartTime) throw new Error('CODEX_SANDBOX_CONTROLLER_PROCESS_IDENTITY_INVALID');
-  const instanceDigest = crypto.randomBytes(32).toString('hex');
-  fs.writeFileSync(leasePath, `${JSON.stringify({
-    version: 1,
-    pid: process.pid,
-    startTime: parentStartTime,
-    taskId: input.taskId,
-    generation: control.generation,
-    instanceDigest
-  })}\n`, { mode: 0o600, flag: 'wx' });
-
   const home = fs.mkdtempSync(path.join(runtimeRoot, `${key}-`));
   fs.chmodSync(home, 0o700);
   let cleaned = false;
+  let context: CodexSandboxControllerContextV2 | null = null;
   const cleanup = () => {
     if (cleaned) return;
     cleaned = true;
+    if (context) {
+      try {
+        (options.closeController ?? requestCodexControllerClose)({
+          controllerProcess: context.controllerProcess,
+          controllerProof: controllerProofFromContext(context),
+          ...control,
+          timeoutMs: 30_000
+        });
+      } catch {
+        // The wrapper is exiting; dead-process recovery safely handles an unknown close result.
+      }
+    }
     const relative = path.relative(runtimeRoot, home);
     if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
       fs.rmSync(home, { recursive: true, force: true });
-    }
-    try {
-      const lease = JSON.parse(fs.readFileSync(leasePath, 'utf8')) as { instanceDigest?: string };
-      if (lease.instanceDigest === instanceDigest) fs.unlinkSync(leasePath);
-    } catch {
-      // A missing or replaced lease is owned by another cleanup path.
     }
   };
 
@@ -333,22 +316,24 @@ function prepareCodexSandboxController(
     }
 
     const buildIdentity = computeLifecycleBuildIdentity(repoRoot);
-    const now = (options.now ?? Date.now)();
-    const context: CodexSandboxControllerContext = Object.freeze({
-      version: 1,
-      taskId: input.taskId,
-      controlGeneration: control.generation,
-      controllerInstanceDigest: instanceDigest,
-      parentPid: process.pid,
-      parentStartTime,
-      issuedAt: now,
-      expiresAt: now + CONTEXT_TTL_MS,
-      buildIdentity,
+    const opened = (options.openController ?? requestCodexControllerOpen)({
+      controllerProcess: { pid: process.pid, startTime: parentStartTime },
+      ...control,
+      timeoutMs: 30_000
+    });
+    context = contextFromControllerLease(opened.lease, {
       hookDefinitionHash: crypto.createHash('sha256').update(fs.readFileSync(hooks)).digest('hex'),
       lifecycleProfilesHash: digestFiles([executor, reviewer])
     });
+    if (opened.lease.taskId !== input.taskId
+      || opened.lease.controlGeneration !== control.generation
+      || opened.lease.controllerProcess.pid !== process.pid
+      || opened.lease.controllerProcess.startTime !== parentStartTime
+      || JSON.stringify(opened.lease.buildIdentity) !== JSON.stringify(buildIdentity)) {
+      throw new Error('SANDBOX_CONTROL_RESULT_INVALID');
+    }
     const contextPath = path.join(home, 'controller-context.json');
-    fs.writeFileSync(contextPath, `${JSON.stringify(context, null, 2)}\n`, { mode: 0o600 });
+    writeCodexSandboxControllerContext(contextPath, context);
 
     const shimDir = path.join(home, 'bin');
     fs.mkdirSync(shimDir, { mode: 0o700 });
@@ -399,32 +384,6 @@ function prepareCodexSandboxController(
   }
 }
 
-function verifyCodexSandboxControllerContext(
-  contextPath: string,
-  taskId: string,
-  options: Readonly<{ repoRoot?: string; now?: number; generation?: string }> = {}
-): CodexSandboxControllerContext {
-  const stat = fs.lstatSync(contextPath);
-  if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
-    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
-  }
-  const context = JSON.parse(fs.readFileSync(contextPath, 'utf8')) as CodexSandboxControllerContext;
-  const generation = options.generation ?? process.env.AGENT_INFRA_CONTROL_GENERATION;
-  if (context.version !== 1
-    || context.taskId !== taskId
-    || context.controlGeneration !== generation
-    || context.expiresAt < (options.now ?? Date.now())
-    || getProcessStartTime(context.parentPid) !== context.parentStartTime
-    || !isProcessAlive(context.parentPid)) {
-    throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_INVALID');
-  }
-  const current = computeLifecycleBuildIdentity(options.repoRoot ?? process.cwd());
-  if (JSON.stringify(current) !== JSON.stringify(context.buildIdentity)) {
-    throw new Error('CODEX_SANDBOX_CONTROLLER_BUNDLE_MISMATCH');
-  }
-  return Object.freeze(context);
-}
-
 async function runCodexSandboxController(
   input: ControllerInput,
   options: ControllerOptions = {}
@@ -472,7 +431,7 @@ export {
   verifyCodexSandboxControllerContext
 };
 export type {
-  CodexSandboxControllerContext,
+  CodexSandboxControllerContextV2 as CodexSandboxControllerContext,
   ControllerControl,
   ControllerInput,
   ControllerOptions,

--- a/lib/internal/sandbox-control.ts
+++ b/lib/internal/sandbox-control.ts
@@ -1,6 +1,24 @@
-import { requestSandboxControl, SandboxControlClientError } from '../sandbox/control/client.ts';
+import {
+  requestSandboxControl,
+  requestSandboxTaskControl,
+  SandboxControlClientError
+} from '../sandbox/control/client.ts';
 import { serveSandboxControl } from '../sandbox/control/server.ts';
 import { runSandboxControlExecutor } from '../sandbox/control/executor.ts';
+import {
+  controllerProofFromContext,
+  verifyCodexSandboxControllerContext
+} from '../agent-clients/adapters/codex-lifecycle/controller-context.ts';
+
+function isCanonicalCodexPrepare(args: readonly string[]): boolean {
+  if (args[1] !== 'prepare') return false;
+  const clients: string[] = [];
+  for (let index = 2; index < args.length; index += 1) {
+    if (args[index] === '--client') clients.push(args[index + 1] ?? '');
+    else if (args[index]?.startsWith('--client=')) clients.push(args[index]!.slice('--client='.length));
+  }
+  return clients.length === 1 && clients[0] === 'codex';
+}
 
 async function sandboxControl(args: string[]): Promise<void> {
   const [operation, ...rest] = args;
@@ -33,7 +51,16 @@ async function sandboxControl(args: string[]): Promise<void> {
     const [family = '', ...commandArgs] = rest;
     let response;
     try {
-      response = requestSandboxControl({ family, args: commandArgs });
+      if (family === 'task-orchestration' && isCanonicalCodexPrepare(commandArgs)) {
+        const contextPath = process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT;
+        const taskId = process.env.AGENT_INFRA_TASK_ID;
+        const proof = contextPath && taskId
+          ? controllerProofFromContext(verifyCodexSandboxControllerContext(contextPath, taskId))
+          : null;
+        response = requestSandboxTaskControl({ family, args: commandArgs, controllerProof: proof });
+      } else {
+        response = requestSandboxControl({ family, args: commandArgs });
+      }
     } catch (error) {
       if (!(error instanceof SandboxControlClientError)) throw error;
       process.stderr.write(`${error.detail.message}\n`);

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -9,8 +9,15 @@ import {
   type SandboxControlError,
   type SandboxControlRequest,
   type SandboxControlResponse,
-  type SandboxTaskCreateRequest
+  type SandboxTaskCreateRequest,
+  type SandboxTaskCommandRequest,
+  type SandboxCodexControllerRequest
 } from './protocol.ts';
+import type {
+  CodexControllerLeaseProofV1,
+  CodexControllerOpened
+} from './controller-registration.ts';
+import type { ProcessIdentity } from '../../server/process-state.ts';
 import { readSandboxControlStatus } from './state.ts';
 import type { TaskCreateCandidateV1 } from '../../task/create.ts';
 
@@ -177,15 +184,179 @@ export function requestSandboxControl(params: Readonly<{
   token?: string; generation?: string; timeoutMs?: number;
 }>): SandboxControlResponse {
   if (!isSandboxControlFamily(params.family)) clientError('SANDBOX_CONTROL_COMMAND_DENIED', `'${params.family}' is not allowed`, false);
-  if (params.family === 'task-create') clientError('SANDBOX_CONTROL_COMMAND_DENIED', "'task-create' requires a typed candidate", false);
+  if (params.family === 'task-create' || params.family === 'codex-controller') {
+    clientError('SANDBOX_CONTROL_COMMAND_DENIED', `'${params.family}' requires a typed request`, false);
+  }
   const auth = authority(params);
   const issuedAt = Date.now();
   const request: SandboxControlRequest = {
-    version: 2, id: randomUUID(), ...auth, issuedAt,
+    version: 3, id: randomUUID(), ...auth, issuedAt,
     expiresAt: issuedAt + SANDBOX_CONTROL_ADMISSION_WINDOW_MS,
-    family: params.family, args: params.args
+    family: params.family as 'task-lifecycle' | 'task-orchestration', args: params.args,
+    controllerProcess: null,
+    controllerProof: null
   };
   return exchangeSandboxControl(request, params);
+}
+
+export function requestSandboxTaskControl(params: Readonly<{
+  family: 'task-lifecycle' | 'task-orchestration';
+  args: string[];
+  controllerProof: CodexControllerLeaseProofV1 | null;
+  channelDir?: string;
+  statusDir?: string;
+  token?: string;
+  generation?: string;
+  timeoutMs?: number;
+}>): SandboxControlResponse {
+  const auth = authority(params);
+  const issuedAt = Date.now();
+  const request: SandboxTaskCommandRequest = {
+    version: 3,
+    id: randomUUID(),
+    ...auth,
+    issuedAt,
+    expiresAt: issuedAt + SANDBOX_CONTROL_ADMISSION_WINDOW_MS,
+    family: params.family,
+    args: params.args,
+    controllerProcess: null,
+    controllerProof: params.controllerProof
+  };
+  return exchangeSandboxControl(request, params);
+}
+
+type CodexControllerClosed = Readonly<{
+  version: 1;
+  status: 'closed';
+  changed: boolean;
+  lease: null;
+  error: null;
+}>;
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).sort().join(',') === [...keys].sort().join(',');
+}
+
+function validProcess(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const identity = value as Record<string, unknown>;
+  return exactKeys(identity, ['pid', 'startTime'])
+    && Number.isSafeInteger(identity.pid) && (identity.pid as number) > 0
+    && Number.isSafeInteger(identity.startTime) && (identity.startTime as number) >= 0;
+}
+
+function validBuild(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const build = value as Record<string, unknown>;
+  return exactKeys(build, ['internalExecutableBuildHash', 'lifecycleContractHash', 'packageVersion', 'protocolVersion'])
+    && build.protocolVersion === 3
+    && typeof build.packageVersion === 'string' && build.packageVersion.length > 0
+    && typeof build.internalExecutableBuildHash === 'string' && /^[a-f0-9]{64}$/u.test(build.internalExecutableBuildHash)
+    && typeof build.lifecycleContractHash === 'string' && /^[a-f0-9]{64}$/u.test(build.lifecycleContractHash);
+}
+
+export function parseCodexControllerResult(response: SandboxControlResponse): CodexControllerOpened | CodexControllerClosed {
+  if (response.phase !== 'completed' || response.error !== null || response.stderr !== '') {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller result outer response is invalid', false, true);
+  }
+  let value: unknown;
+  try {
+    if (!response.stdout.endsWith('\n') || response.stdout.slice(0, -1).includes('\n')) throw new Error('not canonical');
+    value = JSON.parse(response.stdout);
+  } catch {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller result payload is invalid', false, true);
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller result payload is invalid', false, true);
+  }
+  const result = value as Record<string, unknown>;
+  if (!exactKeys(result, ['changed', 'error', 'lease', 'status', 'version'])
+    || result.version !== 1 || !['opened', 'closed', 'failed'].includes(result.status as string)) {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller result schema is invalid', false, true);
+  }
+  if (result.status === 'failed') {
+    const error = result.error as { code?: unknown; message?: unknown; retryable?: unknown } | null;
+    if (response.exitCode !== 1 || result.changed !== false || result.lease !== null
+      || !error || !exactKeys(error as Record<string, unknown>, ['code', 'message', 'retryable'])
+      || typeof error.code !== 'string' || !/^[A-Z][A-Z0-9_]+$/u.test(error.code)
+      || typeof error.message !== 'string' || error.retryable !== false) {
+      clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller failure result is invalid', false, true);
+    }
+    clientError(error.code, error.message, false, true);
+  }
+  if (response.exitCode !== 0 || result.error !== null) {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller success result is invalid', false, true);
+  }
+  if (result.status === 'closed') {
+    if (typeof result.changed !== 'boolean' || result.lease !== null) {
+      clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller close result is invalid', false, true);
+    }
+    return result as unknown as CodexControllerClosed;
+  }
+  const lease = result.lease as Record<string, unknown> | null;
+  if (result.changed !== true || !lease
+    || !exactKeys(lease, [
+      'buildIdentity', 'controlGeneration', 'controllerInstanceDigest', 'controllerProcess',
+      'expiresAt', 'issuedAt', 'leaseId', 'leaseSecret', 'taskId', 'version'
+    ])
+    || lease.version !== 1
+    || typeof lease.leaseId !== 'string' || !/^[a-f0-9]{64}$/u.test(lease.leaseId)
+    || typeof lease.leaseSecret !== 'string' || !/^[a-f0-9]{64}$/u.test(lease.leaseSecret)
+    || typeof lease.taskId !== 'string' || lease.taskId.length === 0
+    || typeof lease.controlGeneration !== 'string' || lease.controlGeneration.length === 0
+    || typeof lease.controllerInstanceDigest !== 'string' || !/^[a-f0-9]{64}$/u.test(lease.controllerInstanceDigest)
+    || !validProcess(lease.controllerProcess) || !validBuild(lease.buildIdentity)
+    || !Number.isSafeInteger(lease.issuedAt) || !Number.isSafeInteger(lease.expiresAt)
+    || (lease.expiresAt as number) <= (lease.issuedAt as number)) {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller open result is invalid', false, true);
+  }
+  return result as unknown as CodexControllerOpened | CodexControllerClosed;
+}
+
+function requestCodexController(params: Readonly<{
+  command: 'open' | 'close';
+  controllerProcess: ProcessIdentity;
+  controllerProof: CodexControllerLeaseProofV1 | null;
+  channelDir?: string;
+  statusDir?: string;
+  token?: string;
+  generation?: string;
+  timeoutMs?: number;
+}>): CodexControllerOpened | CodexControllerClosed {
+  const auth = authority(params);
+  const issuedAt = Date.now();
+  const request: SandboxCodexControllerRequest = {
+    version: 3,
+    id: randomUUID(),
+    ...auth,
+    issuedAt,
+    expiresAt: issuedAt + SANDBOX_CONTROL_ADMISSION_WINDOW_MS,
+    family: 'codex-controller',
+    command: params.command,
+    args: [],
+    controllerProcess: params.controllerProcess,
+    controllerProof: params.controllerProof
+  };
+  const result = parseCodexControllerResult(exchangeSandboxControl(request, params));
+  if (result.status === 'opened'
+    && (result.lease.controlGeneration !== auth.generation
+      || result.lease.controllerProcess.pid !== params.controllerProcess.pid
+      || result.lease.controllerProcess.startTime !== params.controllerProcess.startTime)) {
+    clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller result does not match the request', false, true);
+  }
+  return result;
+}
+
+export function requestCodexControllerOpen(params: Omit<Parameters<typeof requestCodexController>[0], 'command' | 'controllerProof'>): CodexControllerOpened {
+  const result = requestCodexController({ ...params, command: 'open', controllerProof: null });
+  if (result.status !== 'opened') clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller open returned the wrong result', false, true);
+  return result;
+}
+
+export function requestCodexControllerClose(params: Omit<Parameters<typeof requestCodexController>[0], 'command'>): CodexControllerClosed {
+  const result = requestCodexController({ ...params, command: 'close' });
+  if (result.status !== 'closed') clientError('SANDBOX_CONTROL_RESULT_INVALID', 'controller close returned the wrong result', false, true);
+  return result;
 }
 
 export function requestSandboxTaskCreate(params: Readonly<{
@@ -195,9 +366,11 @@ export function requestSandboxTaskCreate(params: Readonly<{
   const auth = authority(params);
   const issuedAt = Date.now();
   const request: SandboxTaskCreateRequest = {
-    version: 2, id: randomUUID(), ...auth, issuedAt,
+    version: 3, id: randomUUID(), ...auth, issuedAt,
     expiresAt: issuedAt + SANDBOX_CONTROL_ADMISSION_WINDOW_MS,
-    family: 'task-create', candidate: params.candidate
+    family: 'task-create', candidate: params.candidate,
+    controllerProcess: null,
+    controllerProof: null
   };
   return exchangeSandboxControl(request, { ...params, timeoutMs: params.timeoutMs ?? 120_000 });
 }

--- a/lib/sandbox/control/controller-registration.ts
+++ b/lib/sandbox/control/controller-registration.ts
@@ -137,7 +137,8 @@ function registrationPath(manifestPath: string): string {
 function readRaw(file: string): { raw: string; stat: fs.Stats } | null {
   try {
     const stat = fs.lstatSync(file);
-    if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o777) !== 0o600) {
+    if (!stat.isFile() || stat.isSymbolicLink()
+      || (process.platform !== 'win32' && (stat.mode & 0o777) !== 0o600)) {
       fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration file is unsafe');
     }
     return { raw: fs.readFileSync(file, 'utf8'), stat };

--- a/lib/sandbox/control/controller-registration.ts
+++ b/lib/sandbox/control/controller-registration.ts
@@ -1,0 +1,346 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { LifecycleBuildIdentity } from '../../agent-clients/adapters/codex-lifecycle/build-identity.ts';
+import { parseLinuxProcessStat, type ProcessIdentity, type ProcessIdentityState } from '../../server/process-state.ts';
+import { commandForEngine, runProbe } from '../shell.ts';
+import type { SandboxControlManifest } from './protocol.ts';
+
+const CONTROLLER_TTL_MS = 4 * 60 * 60 * 1_000;
+const HEX_256 = /^[a-f0-9]{64}$/u;
+const REGISTRATION_KEYS = [
+  'buildIdentity', 'containerId', 'controlGeneration', 'controllerInstanceDigest',
+  'controllerProcess', 'expiresAt', 'issuedAt', 'leaseId', 'leaseSecretHash',
+  'taskId', 'version'
+].sort().join(',');
+
+export type CodexControllerLeaseProofV1 = Readonly<{
+  version: 1;
+  leaseId: string;
+  leaseSecret: string;
+  controllerProcess: ProcessIdentity;
+}>;
+
+export type CodexControllerRegistrationV1 = Readonly<{
+  version: 1;
+  taskId: string;
+  controlGeneration: string;
+  containerId: string;
+  leaseId: string;
+  leaseSecretHash: string;
+  controllerInstanceDigest: string;
+  controllerProcess: ProcessIdentity;
+  buildIdentity: LifecycleBuildIdentity;
+  issuedAt: number;
+  expiresAt: number;
+}>;
+
+export type CodexControllerLeaseV1 = Readonly<{
+  version: 1;
+  leaseId: string;
+  leaseSecret: string;
+  taskId: string;
+  controlGeneration: string;
+  controllerInstanceDigest: string;
+  controllerProcess: ProcessIdentity;
+  buildIdentity: LifecycleBuildIdentity;
+  issuedAt: number;
+  expiresAt: number;
+}>;
+
+export type CodexControllerOpened = Readonly<{
+  version: 1;
+  status: 'opened';
+  changed: true;
+  lease: CodexControllerLeaseV1;
+  error: null;
+}>;
+
+type RegistrationOptions = Readonly<{
+  now?: () => number;
+  probeProcess?: (identity: ProcessIdentity) => ProcessIdentityState;
+  randomHex?: () => string;
+  beforeCommit?: () => void;
+}>;
+
+export class CodexControllerRegistrationError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(`${code}: ${message}`);
+    this.name = code;
+    this.code = code;
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new CodexControllerRegistrationError(code, message);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).sort().join(',') === [...keys].sort().join(',');
+}
+
+function validProcess(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const processValue = value as Record<string, unknown>;
+  return exactKeys(processValue, ['pid', 'startTime'])
+    && Number.isSafeInteger(processValue.pid) && (processValue.pid as number) > 0
+    && Number.isSafeInteger(processValue.startTime) && (processValue.startTime as number) >= 0;
+}
+
+function validBuild(value: unknown): value is LifecycleBuildIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const build = value as Record<string, unknown>;
+  return exactKeys(build, [
+    'internalExecutableBuildHash', 'lifecycleContractHash', 'packageVersion', 'protocolVersion'
+  ])
+    && build.protocolVersion === 3
+    && typeof build.packageVersion === 'string' && build.packageVersion.length > 0
+    && typeof build.internalExecutableBuildHash === 'string' && HEX_256.test(build.internalExecutableBuildHash)
+    && typeof build.lifecycleContractHash === 'string' && HEX_256.test(build.lifecycleContractHash);
+}
+
+function parseRegistration(raw: string): CodexControllerRegistrationV1 {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration is malformed');
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration is invalid');
+  }
+  const registration = value as Record<string, unknown>;
+  if (Object.keys(registration).sort().join(',') !== REGISTRATION_KEYS
+    || registration.version !== 1
+    || typeof registration.taskId !== 'string'
+    || typeof registration.controlGeneration !== 'string'
+    || typeof registration.containerId !== 'string'
+    || typeof registration.leaseId !== 'string' || !HEX_256.test(registration.leaseId)
+    || typeof registration.leaseSecretHash !== 'string' || !HEX_256.test(registration.leaseSecretHash)
+    || typeof registration.controllerInstanceDigest !== 'string' || !HEX_256.test(registration.controllerInstanceDigest)
+    || !validProcess(registration.controllerProcess)
+    || !validBuild(registration.buildIdentity)
+    || !Number.isSafeInteger(registration.issuedAt)
+    || !Number.isSafeInteger(registration.expiresAt)
+    || (registration.expiresAt as number) <= (registration.issuedAt as number)) {
+    fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration schema is invalid');
+  }
+  return registration as CodexControllerRegistrationV1;
+}
+
+function registrationPath(manifestPath: string): string {
+  return path.join(path.dirname(path.resolve(manifestPath)), 'codex-controller.json');
+}
+
+function readRaw(file: string): { raw: string; stat: fs.Stats } | null {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o777) !== 0o600) {
+      fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration file is unsafe');
+    }
+    return { raw: fs.readFileSync(file, 'utf8'), stat };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function sameFile(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode
+    && left.size === right.size && left.mtimeMs === right.mtimeMs;
+}
+
+function secretHash(secret: string): string {
+  return crypto.createHash('sha256')
+    .update('agent-infra/codex-controller-lease/v1\0')
+    .update(secret)
+    .digest('hex');
+}
+
+function safeEqual(left: string, right: string): boolean {
+  if (!HEX_256.test(left) || !HEX_256.test(right)) return false;
+  return crypto.timingSafeEqual(Buffer.from(left, 'hex'), Buffer.from(right, 'hex'));
+}
+
+function defaultProbe(manifest: SandboxControlManifest, identity: ProcessIdentity): ProcessIdentityState {
+  const command = commandForEngine(manifest.engine, 'docker', [
+    'exec', manifest.containerIdentity.id, 'cat', `/proc/${identity.pid}/stat`
+  ]);
+  const result = runProbe(command.cmd, command.args, { timeout: 2_000 });
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr : result.stderr?.toString('utf8') ?? '';
+    return /no such (?:file|container)|not found|does not exist/iu.test(stderr) ? 'dead' : 'unknown';
+  }
+  const stdout = typeof result.stdout === 'string' ? result.stdout : result.stdout?.toString('utf8') ?? '';
+  const stat = parseLinuxProcessStat(stdout);
+  if (!stat) return 'unknown';
+  if (stat.state === 'Z' || stat.startTime !== identity.startTime) return 'dead';
+  return 'alive';
+}
+
+function assertRegistrationBinding(
+  registration: CodexControllerRegistrationV1,
+  manifest: SandboxControlManifest,
+  buildIdentity: LifecycleBuildIdentity
+): void {
+  if (registration.taskId !== manifest.taskId
+    || registration.controlGeneration !== manifest.generation
+    || registration.containerId !== manifest.containerIdentity.id
+    || JSON.stringify(registration.buildIdentity) !== JSON.stringify(buildIdentity)) {
+    fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID', 'controller registration binding is invalid');
+  }
+}
+
+function atomicWrite(file: string, value: CodexControllerRegistrationV1): void {
+  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600, flag: 'wx' });
+    fs.chmodSync(temporary, 0o600);
+    fs.renameSync(temporary, file);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function readCodexControllerRegistration(manifestPath: string): CodexControllerRegistrationV1 {
+  const existing = readRaw(registrationPath(manifestPath));
+  if (!existing) fail('CODEX_SANDBOX_CONTROLLER_REGISTRATION_MISSING', 'controller registration is missing');
+  return parseRegistration(existing.raw);
+}
+
+export function openCodexControllerRegistration(params: Readonly<{
+  manifest: SandboxControlManifest;
+  manifestPath: string;
+  controllerProcess: ProcessIdentity;
+  buildIdentity: LifecycleBuildIdentity;
+}>, options: RegistrationOptions = {}): CodexControllerOpened {
+  if (params.manifest.mode !== 'task-bound' || !params.manifest.taskId) {
+    fail('SANDBOX_CONTROL_BRANCH_ONLY', 'branch-only sandboxes cannot register a Codex controller');
+  }
+  if (!validProcess(params.controllerProcess)) {
+    fail('CODEX_SANDBOX_CONTROLLER_PROCESS_INACTIVE', 'requested controller process is invalid');
+  }
+  const file = registrationPath(params.manifestPath);
+  const now = (options.now ?? Date.now)();
+  const initial = readRaw(file);
+  if (initial) {
+    const existing = parseRegistration(initial.raw);
+    assertRegistrationBinding(existing, params.manifest, params.buildIdentity);
+    if (existing.expiresAt > now) {
+      const oldState = (options.probeProcess ?? ((identity) => defaultProbe(params.manifest, identity)))(existing.controllerProcess);
+      if (oldState === 'alive') fail('CODEX_SANDBOX_CONTROLLER_BUSY', 'an active controller registration already exists');
+      if (oldState === 'unknown') fail('CODEX_SANDBOX_CONTROLLER_PROCESS_UNKNOWN', 'existing controller process state is unknown');
+    }
+  }
+  const requestedState = (options.probeProcess ?? ((identity) => defaultProbe(params.manifest, identity)))(params.controllerProcess);
+  if (requestedState === 'dead') fail('CODEX_SANDBOX_CONTROLLER_PROCESS_INACTIVE', 'requested controller process is not alive');
+  if (requestedState === 'unknown') fail('CODEX_SANDBOX_CONTROLLER_PROCESS_UNKNOWN', 'requested controller process state is unknown');
+
+  const randomHex = options.randomHex ?? (() => crypto.randomBytes(32).toString('hex'));
+  const leaseId = randomHex();
+  const leaseSecret = randomHex();
+  const controllerInstanceDigest = randomHex();
+  if (![leaseId, leaseSecret, controllerInstanceDigest].every((value) => HEX_256.test(value))) {
+    fail('CODEX_SANDBOX_CONTROLLER_CREDENTIAL_INVALID', 'generated controller credential is invalid');
+  }
+  const registration: CodexControllerRegistrationV1 = Object.freeze({
+    version: 1,
+    taskId: params.manifest.taskId!,
+    controlGeneration: params.manifest.generation,
+    containerId: params.manifest.containerIdentity.id,
+    leaseId,
+    leaseSecretHash: secretHash(leaseSecret),
+    controllerInstanceDigest,
+    controllerProcess: params.controllerProcess,
+    buildIdentity: params.buildIdentity,
+    issuedAt: now,
+    expiresAt: now + CONTROLLER_TTL_MS
+  });
+  options.beforeCommit?.();
+  const current = readRaw(file);
+  if ((!initial && current)
+    || (initial && (!current || current.raw !== initial.raw || !sameFile(current.stat, initial.stat)))) {
+    fail('CODEX_SANDBOX_CONTROLLER_OWNERSHIP_LOST', 'controller registration changed before commit');
+  }
+  atomicWrite(file, registration);
+  return Object.freeze({
+    version: 1,
+    status: 'opened',
+    changed: true,
+    lease: Object.freeze({
+      version: 1,
+      leaseId,
+      leaseSecret,
+      taskId: registration.taskId,
+      controlGeneration: registration.controlGeneration,
+      controllerInstanceDigest,
+      controllerProcess: registration.controllerProcess,
+      buildIdentity: registration.buildIdentity,
+      issuedAt: registration.issuedAt,
+      expiresAt: registration.expiresAt
+    }),
+    error: null
+  });
+}
+
+export function closeCodexControllerRegistration(params: Readonly<{
+  manifest: SandboxControlManifest;
+  manifestPath: string;
+  proof: CodexControllerLeaseProofV1;
+}>): Readonly<{ version: 1; status: 'closed'; changed: boolean; lease: null; error: null }> {
+  if (params.manifest.mode !== 'task-bound' || !params.manifest.taskId) {
+    fail('SANDBOX_CONTROL_BRANCH_ONLY', 'branch-only sandboxes cannot close a Codex controller registration');
+  }
+  const file = registrationPath(params.manifestPath);
+  const existingRaw = readRaw(file);
+  if (!existingRaw) return Object.freeze({ version: 1, status: 'closed', changed: false, lease: null, error: null });
+  const existing = parseRegistration(existingRaw.raw);
+  if (existing.taskId !== params.manifest.taskId
+    || existing.controlGeneration !== params.manifest.generation
+    || existing.containerId !== params.manifest.containerIdentity.id
+    || params.proof.version !== 1
+    || existing.leaseId !== params.proof.leaseId
+    || !safeEqual(existing.leaseSecretHash, secretHash(params.proof.leaseSecret))
+    || JSON.stringify(existing.controllerProcess) !== JSON.stringify(params.proof.controllerProcess)) {
+    fail('CODEX_SANDBOX_CONTROLLER_PROOF_INVALID', 'controller close proof is invalid');
+  }
+  const current = readRaw(file);
+  if (!current || current.raw !== existingRaw.raw || !sameFile(current.stat, existingRaw.stat)) {
+    fail('CODEX_SANDBOX_CONTROLLER_OWNERSHIP_LOST', 'controller registration changed before close');
+  }
+  fs.unlinkSync(file);
+  return Object.freeze({ version: 1, status: 'closed', changed: true, lease: null, error: null });
+}
+
+export function resolveCodexControllerBinding(params: Readonly<{
+  manifest: SandboxControlManifest;
+  manifestPath: string;
+  proof: CodexControllerLeaseProofV1;
+  buildIdentity: LifecycleBuildIdentity;
+  now?: number;
+  probeProcess?: (identity: ProcessIdentity) => ProcessIdentityState;
+}>): Readonly<{ instanceDigest: string; controlGeneration: string }> {
+  if (params.manifest.mode !== 'task-bound' || !params.manifest.taskId) {
+    fail('SANDBOX_CONTROL_BRANCH_ONLY', 'branch-only sandboxes cannot resolve a Codex controller registration');
+  }
+  const registration = readCodexControllerRegistration(params.manifestPath);
+  assertRegistrationBinding(registration, params.manifest, params.buildIdentity);
+  if (registration.expiresAt <= (params.now ?? Date.now())) {
+    fail('CODEX_SANDBOX_CONTROLLER_LEASE_EXPIRED', 'controller lease is expired');
+  }
+  if (params.proof.version !== 1
+    || registration.leaseId !== params.proof.leaseId
+    || !safeEqual(registration.leaseSecretHash, secretHash(params.proof.leaseSecret))
+    || JSON.stringify(registration.controllerProcess) !== JSON.stringify(params.proof.controllerProcess)) {
+    fail('CODEX_SANDBOX_CONTROLLER_PROOF_INVALID', 'controller proof is invalid');
+  }
+  const state = (params.probeProcess ?? ((identity) => defaultProbe(params.manifest, identity)))(registration.controllerProcess);
+  if (state === 'dead') fail('CODEX_SANDBOX_CONTROLLER_PROCESS_INACTIVE', 'controller process is not alive');
+  if (state === 'unknown') fail('CODEX_SANDBOX_CONTROLLER_PROCESS_UNKNOWN', 'controller process state is unknown');
+  return Object.freeze({
+    instanceDigest: registration.controllerInstanceDigest,
+    controlGeneration: registration.controlGeneration
+  });
+}

--- a/lib/sandbox/control/executor.ts
+++ b/lib/sandbox/control/executor.ts
@@ -6,6 +6,13 @@ import { getProcessStartTime } from '../../server/process-state.ts';
 import { createTask } from '../../task/create-service.ts';
 import { bindSandboxControlTask, type SandboxControlExecution, type SandboxControlManifest, type SandboxControlRequest } from './protocol.ts';
 import { atomicWriteJson, executionPath, terminateSandboxControlExecution } from './state.ts';
+import { computeLifecycleBuildIdentity } from '../../agent-clients/adapters/codex-lifecycle/build-identity.ts';
+import {
+  closeCodexControllerRegistration,
+  CodexControllerRegistrationError,
+  openCodexControllerRegistration,
+  resolveCodexControllerBinding
+} from './controller-registration.ts';
 
 export type SandboxControlExecutionResult = {
   exitCode: number;
@@ -132,7 +139,54 @@ function waitForGate(nonce: string, timeoutMs = 2_000): Promise<void> {
   });
 }
 
-function executeRequest(manifest: SandboxControlManifest, request: SandboxControlRequest): SandboxControlExecutionResult {
+function controllerFailure(error: unknown): SandboxControlExecutionResult {
+  const code = error instanceof CodexControllerRegistrationError
+    ? error.code
+    : /^([A-Z][A-Z0-9_]+)/u.exec(error instanceof Error ? error.message : String(error))?.[1]
+      ?? 'CODEX_SANDBOX_CONTROLLER_FAILED';
+  const payload = {
+    version: 1,
+    status: 'failed',
+    changed: false,
+    lease: null,
+    error: { code, message: `${code}: controller request failed`, retryable: false }
+  };
+  return { exitCode: 1, stdout: `${JSON.stringify(payload)}\n`, stderr: '' };
+}
+
+function orchestrationFailure(code: string, message: string): SandboxControlExecutionResult {
+  return {
+    exitCode: 1,
+    stdout: `${JSON.stringify({
+      status: 'failed', changed: false, taskId: null, run: null, next: null,
+      error: { code, message }
+    })}\n`,
+    stderr: ''
+  };
+}
+
+function isCodexPrepare(args: readonly string[]): boolean {
+  if (args[1] !== 'prepare') return false;
+  const values: string[] = [];
+  for (let index = 2; index < args.length; index += 1) {
+    if (args[index] === '--client') values.push(args[index + 1] ?? '');
+    else if (args[index]?.startsWith('--client=')) values.push(args[index]!.slice('--client='.length));
+  }
+  return values.length === 1 && values[0] === 'codex';
+}
+
+type ExecuteRequestOptions = Readonly<{
+  buildIdentity?: typeof computeLifecycleBuildIdentity;
+  resolveControllerBinding?: typeof resolveCodexControllerBinding;
+  spawnDomain?: typeof spawnSync;
+}>;
+
+export function executeRequest(
+  manifest: SandboxControlManifest,
+  manifestPath: string,
+  request: SandboxControlRequest,
+  options: ExecuteRequestOptions = {}
+): SandboxControlExecutionResult {
   if (request.family === 'task-create') {
     const result = createTask(request.candidate, { repoRoot: manifest.repoRoot });
     return {
@@ -141,15 +195,69 @@ function executeRequest(manifest: SandboxControlManifest, request: SandboxContro
       stderr: ''
     };
   }
+  if (request.family === 'codex-controller') {
+    try {
+      const result = request.command === 'open'
+        ? openCodexControllerRegistration({
+            manifest,
+            manifestPath,
+            controllerProcess: request.controllerProcess!,
+            buildIdentity: (options.buildIdentity ?? computeLifecycleBuildIdentity)(manifest.repoRoot)
+          })
+        : closeCodexControllerRegistration({
+            manifest,
+            manifestPath,
+            proof: request.controllerProof!
+          });
+      return { exitCode: 0, stdout: `${JSON.stringify(result)}\n`, stderr: '' };
+    } catch (error) {
+      return controllerFailure(error);
+    }
+  }
   const boundArgs = bindSandboxControlTask(request, manifest.taskId!);
-  if (request.family === 'task-orchestration') boundArgs.push('--git-worktree-root', manifest.worktreeRoot);
-  const result = spawnSync(
+  let controllerBinding: Readonly<{ instanceDigest: string; controlGeneration: string }> | null = null;
+  if (request.family === 'task-orchestration') {
+    if (isCodexPrepare(request.args)) {
+      if (!request.controllerProof) {
+        return orchestrationFailure(
+          'CODEX_SANDBOX_CONTROLLER_PROOF_REQUIRED',
+          'Codex prepare requires a current controller lease proof'
+        );
+      }
+      try {
+        controllerBinding = (options.resolveControllerBinding ?? resolveCodexControllerBinding)({
+          manifest,
+          manifestPath,
+          proof: request.controllerProof,
+          buildIdentity: (options.buildIdentity ?? computeLifecycleBuildIdentity)(manifest.repoRoot)
+        });
+      } catch (error) {
+        const code = error instanceof CodexControllerRegistrationError
+          ? error.code
+          : 'CODEX_SANDBOX_CONTROLLER_PROOF_INVALID';
+        return orchestrationFailure(code, `${code}: Codex controller proof was rejected`);
+      }
+    } else if (request.controllerProof !== null) {
+      return orchestrationFailure(
+        'CODEX_SANDBOX_CONTROLLER_PROOF_INVALID',
+        'Controller proof is only accepted for canonical Codex prepare'
+      );
+    }
+    boundArgs.push('--git-worktree-root', manifest.worktreeRoot);
+  }
+  const result = (options.spawnDomain ?? spawnSync)(
     process.execPath,
     nodeEntryArgs(process.argv[1]!, [request.family, ...boundArgs]),
     {
       cwd: manifest.repoRoot,
       encoding: 'utf8',
-      env: { ...safeEnv(process.env), AGENT_INFRA_RUNTIME_DIR: manifest.runtimeDir }
+      env: {
+        ...safeEnv(process.env),
+        AGENT_INFRA_RUNTIME_DIR: manifest.runtimeDir,
+        ...(controllerBinding
+          ? { AGENT_INFRA_CONTROL_CONTROLLER_BINDING: JSON.stringify(controllerBinding) }
+          : {})
+      }
     }
   );
   return { exitCode: result.status ?? 1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
@@ -164,7 +272,7 @@ export async function runSandboxControlExecutor(requestPath: string, nonce: stri
   if (!manifestPath) throw new Error('SANDBOX_CONTROL_EXECUTOR_MANIFEST_MISSING');
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as SandboxControlManifest;
   if (fs.realpathSync.native(manifest.repoRoot) !== root) throw new Error('SANDBOX_CONTROL_EXECUTOR_ROOT_INVALID');
-  const result = executeRequest(manifest, request);
+  const result = executeRequest(manifest, manifestPath, request);
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
   process.exitCode = result.exitCode;

--- a/lib/sandbox/control/protocol.ts
+++ b/lib/sandbox/control/protocol.ts
@@ -1,12 +1,13 @@
 import { validateTaskCreateCandidate, type TaskCreateCandidateV1 } from '../../task/create.ts';
 import type { ProcessIdentity } from '../../server/process-state.ts';
+import type { CodexControllerLeaseProofV1 } from './controller-registration.ts';
 
 export const SANDBOX_CONTROL_MAX_BYTES = 64 * 1024;
 export const SANDBOX_CONTROL_ADMISSION_WINDOW_MS = 2_000;
 export const SANDBOX_CONTROL_STATUS_INTERVAL_MS = 250;
 export const SANDBOX_CONTROL_STATUS_STALE_MS = 1_500;
 export const SANDBOX_CONTROL_FUTURE_SKEW_MS = 1_000;
-export const SANDBOX_CONTROL_FAMILIES = ['task-lifecycle', 'task-orchestration', 'task-create'] as const;
+export const SANDBOX_CONTROL_FAMILIES = ['task-lifecycle', 'task-orchestration', 'task-create', 'codex-controller'] as const;
 export type SandboxControlTimingPolicy = Readonly<{
   controlTickMs: number;
   parkedBindingInitialMs: number;
@@ -43,7 +44,9 @@ export type SandboxControlBrokerOwner = ProcessIdentity & Readonly<{
   generation: string;
 }>;
 type RequestBase = Readonly<{
-  version: 2; id: string; token: string; generation: string; issuedAt: number; expiresAt: number;
+  version: 3; id: string; token: string; generation: string; issuedAt: number; expiresAt: number;
+  controllerProcess: ProcessIdentity | null;
+  controllerProof: CodexControllerLeaseProofV1 | null;
 }>;
 export type SandboxTaskCommandRequest = RequestBase & Readonly<{
   family: 'task-lifecycle' | 'task-orchestration'; args: string[];
@@ -51,7 +54,12 @@ export type SandboxTaskCommandRequest = RequestBase & Readonly<{
 export type SandboxTaskCreateRequest = RequestBase & Readonly<{
   family: 'task-create'; candidate: TaskCreateCandidateV1;
 }>;
-export type SandboxControlRequest = SandboxTaskCommandRequest | SandboxTaskCreateRequest;
+export type SandboxCodexControllerRequest = RequestBase & Readonly<{
+  family: 'codex-controller';
+  command: 'open' | 'close';
+  args: [];
+}>;
+export type SandboxControlRequest = SandboxTaskCommandRequest | SandboxTaskCreateRequest | SandboxCodexControllerRequest;
 export type SandboxControlError = Readonly<{ code: string; message: string; retryable: boolean }>;
 export type SandboxControlResponse = Readonly<{
   version: 2; id: string; phase: 'accepted' | 'completed' | 'rejected'; exitCode: number | null;
@@ -101,7 +109,7 @@ export function validateSandboxControlRequest(
   }
   const request = value as Record<string, unknown>;
   if (
-    request.version !== 2 || typeof request.id !== 'string'
+    request.version !== 3 || typeof request.id !== 'string'
     || !/^[a-f0-9-]{16,64}$/.test(request.id) || request.token !== manifest.token
     || typeof request.family !== 'string' || !isSandboxControlFamily(request.family)
     || !Number.isSafeInteger(request.issuedAt) || !Number.isSafeInteger(request.expiresAt)
@@ -120,13 +128,31 @@ export function validateSandboxControlRequest(
     fail('SANDBOX_CONTROL_REQUEST_TOO_LARGE', 'request exceeds the control limit');
   }
   if (request.family === 'task-create') {
-    const expected = ['candidate', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
+    const expected = ['candidate', 'controllerProcess', 'controllerProof', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
     if (Object.keys(request).sort().join(',') !== expected.sort().join(',')) {
       fail('SANDBOX_CONTROL_REQUEST_INVALID', 'request schema or authorization is invalid');
     }
+    if (request.controllerProcess !== null || request.controllerProof !== null) {
+      fail('SANDBOX_CONTROL_REQUEST_INVALID', 'task-create cannot carry controller authority');
+    }
     return { ...request, candidate: validateTaskCreateCandidate(request.candidate) } as SandboxTaskCreateRequest;
   }
-  const expected = ['args', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
+  if (request.family === 'codex-controller') {
+    const expected = ['args', 'command', 'controllerProcess', 'controllerProof', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
+    if (Object.keys(request).sort().join(',') !== expected.sort().join(',')
+      || !Array.isArray(request.args) || request.args.length !== 0
+      || !['open', 'close'].includes(request.command as string)
+      || !validControllerProcess(request.controllerProcess)
+      || (request.command === 'open' && request.controllerProof !== null)
+      || (request.command === 'close' && !validControllerProof(request.controllerProof))) {
+      fail('SANDBOX_CONTROL_REQUEST_INVALID', 'controller request schema is invalid');
+    }
+    if (manifest.mode !== 'task-bound' || !manifest.taskId) {
+      fail('SANDBOX_CONTROL_BRANCH_ONLY', 'branch-only sandboxes cannot register a Codex controller');
+    }
+    return request as SandboxCodexControllerRequest;
+  }
+  const expected = ['args', 'controllerProcess', 'controllerProof', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
   if (Object.keys(request).sort().join(',') !== expected.sort().join(',')
     || !Array.isArray(request.args) || !request.args.every((arg) => typeof arg === 'string')) {
     fail('SANDBOX_CONTROL_REQUEST_INVALID', 'request schema or authorization is invalid');
@@ -141,13 +167,40 @@ export function validateSandboxControlRequest(
     && request.args.some((arg) => arg === '--git-worktree-root' || arg.startsWith('--git-worktree-root='))) {
     fail('SANDBOX_CONTROL_REQUEST_INVALID', 'worktree binding is reserved for the control broker');
   }
+  if (request.controllerProcess !== null
+    || (request.controllerProof !== null && !validControllerProof(request.controllerProof))) {
+    fail('SANDBOX_CONTROL_REQUEST_INVALID', 'controller authority is invalid');
+  }
+  if (request.family !== 'task-orchestration' && request.controllerProof !== null) {
+    fail('SANDBOX_CONTROL_REQUEST_INVALID', 'controller proof is not allowed for this family');
+  }
   return request as SandboxTaskCommandRequest;
 }
 
 export function bindSandboxControlTask(request: SandboxControlRequest, taskId: string): string[] {
-  if (request.family === 'task-create') fail('SANDBOX_CONTROL_REQUEST_INVALID', 'task-create requests do not bind a current task');
+  if (request.family === 'task-create' || request.family === 'codex-controller') {
+    fail('SANDBOX_CONTROL_REQUEST_INVALID', `${request.family} requests do not bind a current task`);
+  }
   if (request.args.length === 0) fail('SANDBOX_CONTROL_REQUEST_INVALID', 'command arguments are required');
   return [taskId, ...request.args.slice(1)];
+}
+
+function validControllerProcess(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const processValue = value as Record<string, unknown>;
+  return Object.keys(processValue).sort().join(',') === 'pid,startTime'
+    && Number.isSafeInteger(processValue.pid) && (processValue.pid as number) > 0
+    && Number.isSafeInteger(processValue.startTime) && (processValue.startTime as number) >= 0;
+}
+
+function validControllerProof(value: unknown): value is CodexControllerLeaseProofV1 {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proof = value as Record<string, unknown>;
+  return Object.keys(proof).sort().join(',') === 'controllerProcess,leaseId,leaseSecret,version'
+    && proof.version === 1
+    && typeof proof.leaseId === 'string' && /^[a-f0-9]{64}$/u.test(proof.leaseId)
+    && typeof proof.leaseSecret === 'string' && /^[a-f0-9]{64}$/u.test(proof.leaseSecret)
+    && validControllerProcess(proof.controllerProcess);
 }
 
 export function controlError(error: unknown): SandboxControlError {

--- a/lib/task/codex-orchestration.ts
+++ b/lib/task/codex-orchestration.ts
@@ -82,6 +82,27 @@ function controllerContext(taskId: string, repoRoot: string) {
     : null;
 }
 
+function brokerControllerBinding(): Readonly<{ instanceDigest: string; controlGeneration: string }> | null {
+  const raw = process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING;
+  if (!raw) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_BINDING_INVALID');
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_BINDING_INVALID');
+  }
+  const binding = value as Record<string, unknown>;
+  if (Object.keys(binding).sort().join(',') !== 'controlGeneration,instanceDigest'
+    || typeof binding.instanceDigest !== 'string' || !/^[a-f0-9]{64}$/u.test(binding.instanceDigest)
+    || typeof binding.controlGeneration !== 'string' || binding.controlGeneration.length === 0) {
+    throw new Error('CODEX_SANDBOX_CONTROLLER_BINDING_INVALID');
+  }
+  return binding as { instanceDigest: string; controlGeneration: string };
+}
+
 async function prepareCodexOrchestrationDelegation(
   taskRef: string,
   input: Readonly<{
@@ -105,14 +126,27 @@ async function prepareCodexOrchestrationDelegation(
       );
     }
     const buildIdentity = options.buildIdentity ?? computeLifecycleBuildIdentity(repoRoot);
-    const controller = controllerContext(resolved.taskId, repoRoot);
+    const localController = controllerContext(resolved.taskId, repoRoot);
+    const brokerController = brokerControllerBinding();
+    if (localController && brokerController
+      && (localController.controllerInstanceDigest !== brokerController.instanceDigest
+        || localController.controlGeneration !== brokerController.controlGeneration)) {
+      return bridgeFailure(
+        'CODEX_SANDBOX_CONTROLLER_BINDING_MISMATCH',
+        'broker and local controller bindings do not match'
+      );
+    }
+    const controller = brokerController ?? (localController ? {
+      instanceDigest: localController.controllerInstanceDigest,
+      controlGeneration: localController.controlGeneration
+    } : null);
     const capabilityStore = options.capabilityStore ?? createCodexCapabilityStore();
     const consumed = capabilityStore.consume(input.capabilityToken, {
       taskId: resolved.taskId,
       hookDefinitionHash: preflight.hookDefinitionHash,
       buildIdentity,
       ...(controller ? { controller: {
-        instanceDigest: controller.controllerInstanceDigest,
+        instanceDigest: controller.instanceDigest,
         controlGeneration: controller.controlGeneration
       } } : {})
     });
@@ -125,7 +159,7 @@ async function prepareCodexOrchestrationDelegation(
         capabilitySessionId: consumed.sessionId!,
         capabilityTurnId: consumed.turnId!,
         capabilityToolUseId: consumed.toolUseId!,
-        controllerInstanceDigest: controller?.controllerInstanceDigest ?? null,
+        controllerInstanceDigest: controller?.instanceDigest ?? null,
         controlGeneration: controller?.controlGeneration ?? null
       }
     }, coreOptions(options));

--- a/lib/task/codex-orchestration.ts
+++ b/lib/task/codex-orchestration.ts
@@ -7,7 +7,11 @@ import {
   resolveCodexThread
 } from '../agent-clients/adapters/codex-lifecycle/app-server.ts';
 import { createCodexLifecycleStore } from '../agent-clients/adapters/codex-lifecycle/store.ts';
-import { createCodexCapabilityStore } from '../agent-clients/adapters/codex-lifecycle/capability-store.ts';
+import {
+  createCodexCapabilityStore,
+  isCodexCapabilityProvenanceDetail
+} from '../agent-clients/adapters/codex-lifecycle/capability-store.ts';
+import type { CodexCapabilityProvenanceDetail } from '../agent-clients/adapters/codex-lifecycle/capability-store.ts';
 import { computeLifecycleBuildIdentity } from '../agent-clients/adapters/codex-lifecycle/build-identity.ts';
 import type { LifecycleBuildIdentity } from '../agent-clients/adapters/codex-lifecycle/build-identity.ts';
 import { verifyCodexSandboxControllerContext } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
@@ -52,10 +56,10 @@ function coreOptions(options: CodexBridgeOptions): OrchestrationOptions {
   return { ...options.orchestrationOptions, repoRoot: options.repoRoot ?? options.orchestrationOptions?.repoRoot };
 }
 
-function bridgeFailure(code: string, message: string): OrchestrationResult {
+function bridgeFailure(code: string, message: string, detail?: CodexCapabilityProvenanceDetail): OrchestrationResult {
   return {
     status: 'failed', changed: false, taskId: null, run: null, next: null,
-    error: { code, message }
+    error: { code, message, ...(detail ? { detail } : {}) }
   };
 }
 
@@ -126,11 +130,20 @@ async function prepareCodexOrchestrationDelegation(
       }
     }, coreOptions(options));
   } catch (error) {
+    const detailValue = error instanceof Error
+      ? (error as Error & { detail?: unknown }).detail
+      : undefined;
+    const detail = error instanceof Error
+      && error.name === 'CODEX_CAPABILITY_PROVENANCE_MISMATCH'
+      && isCodexCapabilityProvenanceDetail(detailValue)
+      ? detailValue
+      : undefined;
     return bridgeFailure(
       error instanceof Error && error.name.startsWith('CODEX_CAPABILITY_')
         ? error.name
         : 'ORCHESTRATION_CLIENT_PREFLIGHT_FAILED',
-      error instanceof Error ? error.message : String(error)
+      error instanceof Error ? error.message : String(error),
+      detail
     );
   }
 }

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -49,6 +49,7 @@ import type { WorkspaceSnapshotContext } from './workspace-snapshot.ts';
 import { assertGitRepositoryBinding } from '../git/worktree-identity.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
 import { hasActiveCodexLifecycleEvidence } from '../agent-clients/adapters/codex-lifecycle/store.ts';
+import type { CodexCapabilityProvenanceDetail } from '../agent-clients/adapters/codex-lifecycle/capability-store.ts';
 import {
   CommitIntentError,
   commitIntentPath,
@@ -203,6 +204,7 @@ type OrchestrationResult = Readonly<{
     client?: AgentClientId;
     missingFields?: readonly string[];
     modelSelectionContext?: ReturnType<typeof getAgentClientModelSelection>;
+    detail?: CodexCapabilityProvenanceDetail;
   }> | null;
 }>;
 type OrchestrationStageIdentity = Readonly<{

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -861,7 +861,7 @@ test('sandbox broker opens and closes a host-only Codex controller registration 
   fs.writeFileSync(docker, '#!/bin/sh\n[ "$1" = exec ] && [ "$3" = cat ] && exec cat "$4"\nexit 1\n', { mode: 0o700 });
   fs.writeFileSync(manifestPath, `${JSON.stringify({
     version: 5,
-    engine: 'docker',
+    engine: 'native',
     repoRoot: root,
     worktreeRoot: root,
     project: 'demo',

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -4,7 +4,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { requestSandboxControl, requestSandboxTaskCreate } from '../../../lib/sandbox/control/client.ts';
+import {
+  requestCodexControllerClose,
+  requestCodexControllerOpen,
+  requestSandboxControl,
+  requestSandboxTaskCreate
+} from '../../../lib/sandbox/control/client.ts';
 import {
   garbageCollectSandboxControlRoot,
   quiesceSandboxControlRoot,
@@ -820,6 +825,95 @@ test('sandbox control client and broker exchange a task-bound response', async (
     });
     assert.equal(response.exitCode, 1);
     assert.match(response.stdout, /LIFECYCLE_PAYLOAD_INVALID/);
+  } finally {
+    child.kill();
+    await new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) resolve();
+      else child.once('exit', () => resolve());
+    });
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('sandbox broker opens and closes a host-only Codex controller registration across processes', onPlatforms('linux'), async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-controller-roundtrip-'));
+  const channelDir = path.join(root, 'channel');
+  const manifestPath = path.join(root, 'manifest.json');
+  const statusDir = path.join(root, 'public');
+  const processingDir = path.join(root, 'processing');
+  const fakeBin = path.join(root, 'bin-fixture');
+  for (const directory of [channelDir, statusDir, processingDir, fakeBin]) fs.mkdirSync(directory, { recursive: true });
+  const branch = initializeRepository(root);
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: '0.9.9-alpha.0' }));
+  for (const relative of [
+    '.codex/hooks.json',
+    '.codex/agents/agent-infra-lifecycle-executor.toml',
+    '.codex/agents/agent-infra-lifecycle-reviewer.toml',
+    '.agents/hooks/lifecycle-delegation.js',
+    '.agents/skills/run-task/SKILL.md',
+    '.agents/rules/lifecycle-orchestration.md'
+  ]) {
+    const target = path.join(root, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.resolve(relative), target);
+  }
+  const docker = path.join(fakeBin, 'docker');
+  fs.writeFileSync(docker, '#!/bin/sh\n[ "$1" = exec ] && [ "$3" = cat ] && exec cat "$4"\nexit 1\n', { mode: 0o700 });
+  fs.writeFileSync(manifestPath, `${JSON.stringify({
+    version: 5,
+    engine: 'docker',
+    repoRoot: root,
+    worktreeRoot: root,
+    project: 'demo',
+    container: 'demo-dev-feature',
+    containerIdentity: { id: 'container-id', labels: {} },
+    branch,
+    mode: 'task-bound',
+    taskId: 'TASK-20260809-010203',
+    token: 'controller-secret',
+    generation: 'controller-generation',
+    channelDir,
+    publicStatusDir: statusDir,
+    processingDir,
+    runtimeDir: path.join(root, 'runtime')
+  })}\n`);
+  const child = spawn(
+    process.execPath,
+    ['--experimental-strip-types', '--no-warnings', path.resolve('bin/internal-cli.ts'), 'sandbox-control', 'serve', '--manifest', manifestPath],
+    { cwd: path.resolve('.'), stdio: 'ignore', env: { ...process.env, PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}` } }
+  );
+  try {
+    waitForFile(path.join(root, 'broker.json'), 5_000);
+    waitForHealthyStatus(statusDir, 5_000);
+    const startTime = getProcessStartTime(process.pid);
+    assert.ok(startTime);
+    const opened = requestCodexControllerOpen({
+      controllerProcess: { pid: process.pid, startTime },
+      channelDir,
+      statusDir,
+      token: 'controller-secret',
+      generation: 'controller-generation',
+      timeoutMs: 5_000
+    });
+    const registration = fs.readFileSync(path.join(root, 'codex-controller.json'), 'utf8');
+    assert.equal(registration.includes(opened.lease.leaseSecret), false);
+    assert.equal(fs.lstatSync(path.join(root, 'codex-controller.json')).mode & 0o777, 0o600);
+    const closed = requestCodexControllerClose({
+      controllerProcess: opened.lease.controllerProcess,
+      controllerProof: {
+        version: 1,
+        leaseId: opened.lease.leaseId,
+        leaseSecret: opened.lease.leaseSecret,
+        controllerProcess: opened.lease.controllerProcess
+      },
+      channelDir,
+      statusDir,
+      token: 'controller-secret',
+      generation: 'controller-generation',
+      timeoutMs: 5_000
+    });
+    assert.equal(closed.changed, true);
+    assert.equal(fs.existsSync(path.join(root, 'codex-controller.json')), false);
   } finally {
     child.kill();
     await new Promise<void>((resolve) => {

--- a/tests/unit/core/codex-build-identity.test.ts
+++ b/tests/unit/core/codex-build-identity.test.ts
@@ -89,6 +89,22 @@ test('lifecycle build identity reads one validated manifest file list', () => {
   assert.ok(manifest.executableFiles.includes(
     'lib/agent-clients/adapters/codex-lifecycle/manifest-files.json'
   ));
+  for (const root of [
+    'lib/internal/sandbox-control.ts',
+    'lib/sandbox/control/protocol.ts',
+    'lib/sandbox/control/client.ts',
+    'lib/sandbox/control/executor.ts',
+    'lib/sandbox/control/controller-registration.ts',
+    'lib/agent-clients/adapters/codex-lifecycle/controller-context.ts',
+    'lib/server/process-state.ts',
+    'lib/sandbox/shell.ts'
+  ]) {
+    assert.ok(manifest.executableFiles.includes(root), root);
+    assert.equal(fs.lstatSync(path.join(process.cwd(), root)).isFile(), true, root);
+  }
+  const closure = resolveLifecycleExecutableFiles(process.cwd(), manifest.executableFiles);
+  assert.ok(closure.includes('lib/sandbox/control/controller-registration.ts'));
+  assert.ok(closure.includes('lib/agent-clients/adapters/codex-lifecycle/controller-context.ts'));
   assert.ok(manifest.contractFiles.includes('.agents/skills/run-task/SKILL.md'));
 });
 

--- a/tests/unit/core/codex-build-identity.test.ts
+++ b/tests/unit/core/codex-build-identity.test.ts
@@ -6,6 +6,8 @@ import test, { after } from 'node:test';
 
 import {
   computeLifecycleBuildIdentity,
+  isCanonicalLifecyclePackageVersion,
+  isLifecycleProtocolVersion,
   readLifecycleManifestFiles,
   resolveLifecycleExecutableFiles,
   verifyLifecycleBuildIdentity
@@ -62,6 +64,16 @@ test('lifecycle build identity separates executable and contract hashes', () => 
   );
 });
 
+test('lifecycle build identity preserves exact package version text', () => {
+  const root = fixture();
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: '1.2.3+build.5' }));
+  const identity = computeLifecycleBuildIdentity(root, {
+    executableFiles: ['lib/protocol.ts'],
+    contractFiles: ['lib/protocol.ts']
+  });
+  assert.equal(identity.packageVersion, '1.2.3+build.5');
+});
+
 test('lifecycle executable identity expands the complete relative import closure', () => {
   const root = fixture();
   fs.writeFileSync(path.join(root, 'lib', 'protocol.ts'), "import { helper } from './helper.ts';\nexport const protocol = helper;\n");
@@ -78,4 +90,17 @@ test('lifecycle build identity reads one validated manifest file list', () => {
     'lib/agent-clients/adapters/codex-lifecycle/manifest-files.json'
   ));
   assert.ok(manifest.contractFiles.includes('.agents/skills/run-task/SKILL.md'));
+});
+
+test('lifecycle package version validator accepts only canonical semver', () => {
+  assert.equal(isLifecycleProtocolVersion(3), true);
+  assert.equal(isLifecycleProtocolVersion(2), false);
+  assert.equal(isLifecycleProtocolVersion('3'), false);
+  assert.equal(isCanonicalLifecyclePackageVersion('1.2.3'), true);
+  assert.equal(isCanonicalLifecyclePackageVersion('0.9.9-alpha.0'), true);
+  assert.equal(isCanonicalLifecyclePackageVersion('v1.2.3'), false);
+  assert.equal(isCanonicalLifecyclePackageVersion('1.2'), false);
+  assert.equal(isCanonicalLifecyclePackageVersion('>=1.2.3'), false);
+  assert.equal(isCanonicalLifecyclePackageVersion(' invalid '), false);
+  assert.equal(isCanonicalLifecyclePackageVersion(null), false);
 });

--- a/tests/unit/core/codex-capability-store.test.ts
+++ b/tests/unit/core/codex-capability-store.test.ts
@@ -97,6 +97,216 @@ test('Codex capability expiry and provenance mismatch fail closed', () => {
   }), /CODEX_CAPABILITY_PROVENANCE_MISMATCH/);
 });
 
+test('Codex capability mismatch exposes fixed safe field detail without consuming', () => {
+  const root = mkdtempSync('codex-capability-detail-');
+  const controller = { instanceDigest: 'i'.repeat(64), controlGeneration: 'generation-1' };
+  const store = createCodexCapabilityStore({ root, token: () => 'detail-token' });
+  const armed = store.arm({
+    taskId: 'TASK-20260101-000001',
+    buildIdentity: build,
+    controller
+  });
+  store.attest({
+    token: armed.token,
+    sessionId: 'session-secret',
+    turnId: 'turn-secret',
+    toolUseId: 'tool-secret',
+    hookDefinitionHash: 'c'.repeat(64),
+    buildIdentity: build,
+    controller
+  });
+
+  assert.throws(() => store.consume(armed.token, {
+    taskId: 'TASK-20260101-000002',
+    hookDefinitionHash: 'd'.repeat(64),
+    buildIdentity: {
+      protocolVersion: 3,
+      packageVersion: '1.2.4',
+      internalExecutableBuildHash: 'f'.repeat(64),
+      lifecycleContractHash: 'e'.repeat(64)
+    },
+    controller: { instanceDigest: 'j'.repeat(64), controlGeneration: 'generation-2' }
+  }), (error: unknown) => {
+    assert.equal(error instanceof Error && error.name, 'CODEX_CAPABILITY_PROVENANCE_MISMATCH');
+    const detail = (error as { detail?: unknown }).detail;
+    assert.deepEqual(detail, {
+      kind: 'codex-capability-provenance-mismatch',
+      version: 1,
+      fields: {
+        taskId: {
+          matches: false,
+          expected: { kind: 'digest-prefix', value: 'sha256:e0669166e5733c3a' },
+          actual: { kind: 'digest-prefix', value: 'sha256:e8dbe4a4d8fdd5f1' }
+        },
+        hookDefinitionHash: {
+          matches: false,
+          expected: { kind: 'digest-prefix', value: 'sha256:0c365521729ffa91' },
+          actual: { kind: 'digest-prefix', value: 'sha256:caf64839e259fbb3' }
+        },
+        buildIdentity: {
+          protocolVersion: {
+            matches: true,
+            expected: { kind: 'protocol-version', value: 3 },
+            actual: { kind: 'protocol-version', value: 3 }
+          },
+          packageVersion: {
+            matches: false,
+            expected: { kind: 'semver', value: '1.2.4' },
+            actual: { kind: 'semver', value: '1.2.3' }
+          },
+          internalExecutableBuildHash: {
+            matches: false,
+            expected: { kind: 'digest-prefix', value: 'sha256:15eb94f73038f786' },
+            actual: { kind: 'digest-prefix', value: 'sha256:9746b6aeb2193daa' }
+          },
+          lifecycleContractHash: {
+            matches: false,
+            expected: { kind: 'digest-prefix', value: 'sha256:5896d13b1a9fe473' },
+            actual: { kind: 'digest-prefix', value: 'sha256:c37350387c5d73db' }
+          }
+        },
+        controller: {
+          instanceDigest: {
+            matches: false,
+            expected: { kind: 'presence', present: true },
+            actual: { kind: 'presence', present: true }
+          },
+          controlGeneration: {
+            matches: false,
+            expected: { kind: 'presence', present: true },
+            actual: { kind: 'presence', present: true }
+          }
+        }
+      }
+    });
+    assert.equal(JSON.stringify(detail).includes('detail-token'), false);
+    assert.equal(JSON.stringify(detail).includes('session-secret'), false);
+    return true;
+  });
+
+  assert.deepEqual(store.inspect(armed.token), {
+    ...store.inspect(armed.token),
+    status: 'attested',
+    revision: 2
+  });
+});
+
+test('Codex capability detail maps malformed persisted identity to absent', () => {
+  const root = mkdtempSync('codex-capability-detail-invalid-');
+  const store = createCodexCapabilityStore({ root, token: () => 'invalid-detail-token' });
+  const armed = store.arm({ taskId: 'TASK-20260101-000001', buildIdentity: build });
+  store.attest({
+    token: armed.token,
+    sessionId: 'session',
+    turnId: 'turn',
+    toolUseId: 'tool',
+    hookDefinitionHash: 'c'.repeat(64),
+    buildIdentity: build
+  });
+  const record = JSON.parse(fs.readFileSync(armed.path, 'utf8'));
+  record.buildIdentity.packageVersion = 'arbitrary raw identity';
+  fs.writeFileSync(armed.path, `${JSON.stringify(record)}\n`);
+
+  assert.throws(() => store.consume(armed.token, {
+    taskId: 'TASK-20260101-000002',
+    hookDefinitionHash: 'c'.repeat(64),
+    buildIdentity: build
+  }), (error: unknown) => {
+    const detail = (error as { detail?: { fields?: { buildIdentity?: { packageVersion?: { actual?: unknown } } } } }).detail;
+    assert.deepEqual(detail?.fields?.buildIdentity?.packageVersion?.actual, { kind: 'absent' });
+    assert.equal(JSON.stringify(detail).includes('arbitrary raw identity'), false);
+    return true;
+  });
+});
+
+test('Codex capability rejects malformed persisted controller without consuming', () => {
+  const root = mkdtempSync('codex-capability-controller-invalid-');
+  const controller = { instanceDigest: 'i'.repeat(64), controlGeneration: 'generation-1' };
+  const store = createCodexCapabilityStore({ root, token: () => 'invalid-controller-token' });
+  const armed = store.arm({
+    taskId: 'TASK-20260101-000001',
+    buildIdentity: build,
+    controller
+  });
+  store.attest({
+    token: armed.token,
+    sessionId: 'session',
+    turnId: 'turn',
+    toolUseId: 'tool',
+    hookDefinitionHash: 'c'.repeat(64),
+    buildIdentity: build,
+    controller
+  });
+  const record = JSON.parse(fs.readFileSync(armed.path, 'utf8'));
+  record.controller = {};
+  fs.writeFileSync(armed.path, `${JSON.stringify(record)}\n`);
+
+  assert.throws(() => store.consume(armed.token, {
+    taskId: 'TASK-20260101-000001',
+    hookDefinitionHash: 'c'.repeat(64),
+    buildIdentity: build
+  }), (error: unknown) => {
+    assert.equal(error instanceof Error && error.name, 'CODEX_CAPABILITY_PROVENANCE_MISMATCH');
+    const detail = (error as { detail?: { fields?: { controller?: { instanceDigest?: { matches?: boolean } } } } }).detail;
+    assert.equal(detail?.fields?.controller?.instanceDigest?.matches, false);
+    return true;
+  });
+  assert.equal(store.inspect(armed.token).status, 'attested');
+  assert.equal(store.inspect(armed.token).revision, 2);
+});
+
+test('Codex capability detail localizes one controller field mismatch', () => {
+  const scenarios = [
+    {
+      name: 'instance digest',
+      expected: { instanceDigest: 'j'.repeat(64), controlGeneration: 'generation-1' },
+      matches: { instanceDigest: false, controlGeneration: true }
+    },
+    {
+      name: 'control generation',
+      expected: { instanceDigest: 'i'.repeat(64), controlGeneration: 'generation-2' },
+      matches: { instanceDigest: true, controlGeneration: false }
+    }
+  ] as const;
+
+  for (const scenario of scenarios) {
+    const root = mkdtempSync(`codex-capability-controller-${scenario.name.replaceAll(' ', '-')}-`);
+    const controller = { instanceDigest: 'i'.repeat(64), controlGeneration: 'generation-1' };
+    const store = createCodexCapabilityStore({ root, token: () => `controller-${scenario.name}` });
+    const armed = store.arm({
+      taskId: 'TASK-20260101-000001',
+      buildIdentity: build,
+      controller
+    });
+    store.attest({
+      token: armed.token,
+      sessionId: 'session',
+      turnId: 'turn',
+      toolUseId: 'tool',
+      hookDefinitionHash: 'c'.repeat(64),
+      buildIdentity: build,
+      controller
+    });
+
+    assert.throws(() => store.consume(armed.token, {
+      taskId: 'TASK-20260101-000001',
+      hookDefinitionHash: 'c'.repeat(64),
+      buildIdentity: build,
+      controller: scenario.expected
+    }), (error: unknown) => {
+      const detail = (error as { detail?: { fields?: { controller?: {
+        instanceDigest?: { matches?: boolean };
+        controlGeneration?: { matches?: boolean };
+      } } } }).detail;
+      assert.equal(detail?.fields?.controller?.instanceDigest?.matches, scenario.matches.instanceDigest);
+      assert.equal(detail?.fields?.controller?.controlGeneration?.matches, scenario.matches.controlGeneration);
+      return true;
+    });
+    assert.equal(store.inspect(armed.token).status, 'attested');
+    assert.equal(store.inspect(armed.token).revision, 2);
+  }
+});
+
 test('Codex capability compare-and-swap preserves a competing attestation', () => {
   const root = mkdtempSync('codex-capability-cas-');
   let armedPath = '';

--- a/tests/unit/core/codex-capability-store.test.ts
+++ b/tests/unit/core/codex-capability-store.test.ts
@@ -385,20 +385,23 @@ test('Codex capability serializes concurrent attestation writers', async () => {
     worker.once('error', reject);
   });
 
-  await Promise.all(workers.map(nextMessage));
-  workers[0]!.postMessage('go');
-  assert.equal(Atomics.wait(state, 0, 0, 1_000), 'ok');
-  workers[1]!.postMessage('go');
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  const secondWriterEntered = Atomics.load(state, 1);
-  Atomics.store(state, 2, 1);
-  Atomics.notify(state, 2, 2);
+  try {
+    await Promise.all(workers.map(nextMessage));
+    workers[0]!.postMessage('go');
+    assert.notEqual(Atomics.wait(state, 0, 0, 1_000), 'timed-out');
+    workers[1]!.postMessage('go');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const secondWriterEntered = Atomics.load(state, 1);
+    Atomics.store(state, 2, 1);
+    Atomics.notify(state, 2, 2);
 
-  const results = await Promise.all(workers.map(nextMessage));
-  assert.equal(secondWriterEntered, 0);
-  assert.deepEqual(results.map(({ status }) => status).sort(), ['error', 'ok']);
-  assert.equal(results.find(({ status }) => status === 'error')?.name, 'CODEX_CAPABILITY_REVISION_CONFLICT');
-  await Promise.all(workers.map((worker) => worker.terminate()));
+    const results = await Promise.all(workers.map(nextMessage));
+    assert.equal(secondWriterEntered, 0);
+    assert.deepEqual(results.map(({ status }) => status).sort(), ['error', 'ok']);
+    assert.equal(results.find(({ status }) => status === 'error')?.name, 'CODEX_CAPABILITY_REVISION_CONFLICT');
+  } finally {
+    await Promise.all(workers.map((worker) => worker.terminate()));
+  }
 });
 
 test('Codex capability consume lazily removes old terminal records', () => {

--- a/tests/unit/core/codex-orchestration.test.ts
+++ b/tests/unit/core/codex-orchestration.test.ts
@@ -90,6 +90,36 @@ test('Codex prepare preflight fails before workspace capture or receipt creation
   assert.equal(readRun(f.taskDir)?.baseline, '');
 });
 
+test('Codex prepare preserves safe provenance detail from capability consume', async () => {
+  const f = fixture();
+  const currentCapability = capability(f.root, 'capability-detail-token');
+  let captures = 0;
+  const result = await prepareCodexOrchestrationDelegation(taskId, {
+    client: 'codex', requestedModel: 'executor-model', requestedReasoningEffort: 'xhigh',
+    capabilityToken: currentCapability.token
+  }, {
+    repoRoot: f.root,
+    capabilityStore: currentCapability.store,
+    buildIdentity: { ...buildIdentity, packageVersion: '0.9.8-alpha.0' },
+    preflight: async () => ({
+      ...(await preflight()),
+      hookDefinitionHash: 'd'.repeat(64)
+    }),
+    orchestrationOptions: { captureWorkspace: () => { captures += 1; return 'before'; } }
+  });
+
+  assert.equal(result.error?.code, 'CODEX_CAPABILITY_PROVENANCE_MISMATCH');
+  assert.equal(result.error?.message, 'CODEX_CAPABILITY_PROVENANCE_MISMATCH: capability consumption identity does not match');
+  assert.equal(JSON.stringify(result.error?.detail).includes('capability-detail-token'), false);
+  assert.equal(result.error?.detail?.kind, 'codex-capability-provenance-mismatch');
+  assert.equal(result.error?.detail?.version, 1);
+  assert.equal(result.error?.detail?.fields.buildIdentity.packageVersion.matches, false);
+  assert.equal(result.error?.detail?.fields.hookDefinitionHash.matches, false);
+  assert.equal(captures, 0);
+  assert.equal(readRun(f.taskDir)?.pendingDelegation, null);
+  assert.equal(readRun(f.taskDir)?.baseline, '');
+});
+
 test('Codex parent reconciliation ignores unrelated completed waits', async () => {
   const f = fixture();
   const store = createCodexLifecycleStore({

--- a/tests/unit/core/codex-orchestration.test.ts
+++ b/tests/unit/core/codex-orchestration.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -6,6 +7,12 @@ import test, { after } from 'node:test';
 
 import { createCodexLifecycleStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/store.ts';
 import { createCodexCapabilityStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/capability-store.ts';
+import { computeLifecycleBuildIdentity } from '../../../lib/agent-clients/adapters/codex-lifecycle/build-identity.ts';
+import {
+  contextFromControllerLease,
+  writeCodexSandboxControllerContext
+} from '../../../lib/agent-clients/adapters/codex-lifecycle/controller-context.ts';
+import { getProcessStartTime } from '../../../lib/server/process-state.ts';
 import {
   activateCodexOrchestrationDelegation,
   activateCodexSpawnDelegation,
@@ -57,22 +64,130 @@ function fixture() {
   return { root, taskDir };
 }
 
-function capability(root: string, token: string) {
+function capability(
+  root: string,
+  token: string,
+  controller?: Readonly<{ instanceDigest: string; controlGeneration: string }>
+) {
   const store = createCodexCapabilityStore({
     root: path.join(root, '.agents', 'workspace', '.runtime', 'codex-capabilities'),
     token: () => token
   });
-  const armed = store.arm({ taskId, buildIdentity });
+  const armed = store.arm({ taskId, buildIdentity, ...(controller ? { controller } : {}) });
   store.attest({
     token: armed.token,
     sessionId: 'parent',
     turnId: 'parent-turn',
     toolUseId: 'capability-tool',
     hookDefinitionHash: 'hook-hash',
-    buildIdentity
+    buildIdentity,
+    ...(controller ? { controller } : {})
   });
   return { store, token: armed.token };
 }
+
+test('Codex prepare consumes a controller-bound capability from the trusted broker binding', async () => {
+  const f = fixture();
+  const controller = { instanceDigest: 'e'.repeat(64), controlGeneration: 'generation-1' };
+  const currentCapability = capability(f.root, 'broker-controller-token', controller);
+  const previous = process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING;
+  process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING = JSON.stringify(controller);
+  try {
+    const result = await prepareCodexOrchestrationDelegation(taskId, {
+      client: 'codex',
+      requestedModel: 'executor-model',
+      requestedReasoningEffort: 'xhigh',
+      capabilityToken: currentCapability.token
+    }, {
+      repoRoot: f.root,
+      capabilityStore: currentCapability.store,
+      buildIdentity,
+      preflight,
+      orchestrationOptions: { captureWorkspace: () => 'before', id: () => 'receipt-controller' }
+    });
+    assert.equal(result.status, 'running');
+    assert.equal(result.run?.pendingDelegation?.lifecycleProvenance?.controllerInstanceDigest, controller.instanceDigest);
+    assert.equal(result.run?.pendingDelegation?.lifecycleProvenance?.controlGeneration, controller.controlGeneration);
+  } finally {
+    if (previous === undefined) delete process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING;
+    else process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING = previous;
+  }
+});
+
+test('Codex prepare rejects mismatched broker and verified local controller bindings before consume', async () => {
+  const f = fixture();
+  const contractFiles = [
+    '.codex/hooks.json',
+    '.codex/agents/agent-infra-lifecycle-executor.toml',
+    '.codex/agents/agent-infra-lifecycle-reviewer.toml',
+    '.agents/hooks/lifecycle-delegation.js',
+    '.agents/skills/run-task/SKILL.md',
+    '.agents/rules/lifecycle-orchestration.md'
+  ];
+  for (const relative of contractFiles) {
+    const file = path.join(f.root, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `${relative}\n`);
+  }
+  const realBuild = computeLifecycleBuildIdentity(f.root);
+  const processStartTime = getProcessStartTime(process.pid);
+  assert.ok(processStartTime);
+  const profileFiles = contractFiles.slice(1, 3).map((relative) => path.join(f.root, relative)).sort();
+  const profileHash = crypto.createHash('sha256');
+  for (const file of profileFiles) {
+    profileHash.update(path.basename(file));
+    profileHash.update('\0');
+    profileHash.update(fs.readFileSync(file));
+    profileHash.update('\0');
+  }
+  const contextPath = path.join(f.root, 'controller-context.json');
+  writeCodexSandboxControllerContext(contextPath, contextFromControllerLease({
+    version: 1,
+    leaseId: '7'.repeat(64),
+    leaseSecret: '8'.repeat(64),
+    taskId,
+    controlGeneration: 'local-generation',
+    controllerInstanceDigest: 'e'.repeat(64),
+    controllerProcess: { pid: process.pid, startTime: processStartTime },
+    buildIdentity: realBuild,
+    issuedAt: Date.now() - 1_000,
+    expiresAt: Date.now() + 60_000
+  }, {
+    hookDefinitionHash: crypto.createHash('sha256').update(fs.readFileSync(path.join(f.root, '.codex', 'hooks.json'))).digest('hex'),
+    lifecycleProfilesHash: profileHash.digest('hex')
+  }));
+  const currentCapability = capability(f.root, 'dual-controller-token');
+  const previousContext = process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT;
+  const previousBinding = process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING;
+  const previousGeneration = process.env.AGENT_INFRA_CONTROL_GENERATION;
+  process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT = contextPath;
+  process.env.AGENT_INFRA_CONTROL_GENERATION = 'local-generation';
+  process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING = JSON.stringify({
+    instanceDigest: 'f'.repeat(64),
+    controlGeneration: 'broker-generation'
+  });
+  try {
+    const result = await prepareCodexOrchestrationDelegation(taskId, {
+      client: 'codex', capabilityToken: currentCapability.token
+    }, {
+      repoRoot: f.root,
+      capabilityStore: currentCapability.store,
+      buildIdentity,
+      preflight,
+      orchestrationOptions: { captureWorkspace: () => { throw new Error('workspace must not be captured'); } }
+    });
+    assert.equal(result.error?.code, 'CODEX_SANDBOX_CONTROLLER_BINDING_MISMATCH');
+    assert.equal(currentCapability.store.inspect(currentCapability.token).status, 'attested');
+    assert.equal(readRun(f.taskDir)?.pendingDelegation, null);
+  } finally {
+    if (previousContext === undefined) delete process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT;
+    else process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT = previousContext;
+    if (previousBinding === undefined) delete process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING;
+    else process.env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING = previousBinding;
+    if (previousGeneration === undefined) delete process.env.AGENT_INFRA_CONTROL_GENERATION;
+    else process.env.AGENT_INFRA_CONTROL_GENERATION = previousGeneration;
+  }
+});
 
 test('Codex prepare preflight fails before workspace capture or receipt creation', async () => {
   const f = fixture();

--- a/tests/unit/core/codex-sandbox-controller.test.ts
+++ b/tests/unit/core/codex-sandbox-controller.test.ts
@@ -8,6 +8,7 @@ import {
   prepareCodexSandboxController,
   verifyCodexSandboxControllerContext
 } from '../../../lib/agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
+import { computeLifecycleBuildIdentity } from '../../../lib/agent-clients/adapters/codex-lifecycle/build-identity.ts';
 
 const fixtureRoots = new Set<string>();
 after(() => {
@@ -57,8 +58,44 @@ function fixture() {
   return { root, codexHome, runtimeDir };
 }
 
+function controllerBroker(root: string, taskId = 'TASK-20260101-000001', generation = 'generation') {
+  let active = false;
+  const leaseId = 'c'.repeat(64);
+  const leaseSecret = 'd'.repeat(64);
+  return {
+    openController: ((params: { controllerProcess: { pid: number; startTime: number } }) => {
+      if (active) throw new Error('CODEX_SANDBOX_CONTROLLER_BUSY');
+      active = true;
+      return {
+        version: 1 as const,
+        status: 'opened' as const,
+        changed: true as const,
+        lease: {
+          version: 1 as const,
+          leaseId,
+          leaseSecret,
+          taskId,
+          controlGeneration: generation,
+          controllerInstanceDigest: 'e'.repeat(64),
+          controllerProcess: params.controllerProcess,
+          buildIdentity: computeLifecycleBuildIdentity(root),
+          issuedAt: Date.now(),
+          expiresAt: Date.now() + 60_000
+        },
+        error: null
+      };
+    }) as never,
+    closeController: (() => {
+      const changed = active;
+      active = false;
+      return { version: 1 as const, status: 'closed' as const, changed, lease: null, error: null };
+    }) as never
+  };
+}
+
 test('sandbox controller prepares an isolated allowlisted home and fixed launch flags', () => {
   const f = fixture();
+  const broker = controllerBroker(f.root);
   const prepared = prepareCodexSandboxController({
     taskId: 'TASK-20260101-000001',
     taskRef: '01'
@@ -74,6 +111,7 @@ test('sandbox controller prepares an isolated allowlisted home and fixed launch 
       runtimeDir: f.runtimeDir
     },
     verifyTaskBinding: () => {},
+    ...broker,
     codexVersion: () => '0.147.0',
     environment: { ...process.env, UNRELATED_CONTROLLER_SECRET: 'must-not-leak' }
   });
@@ -116,6 +154,7 @@ test('sandbox controller prepares an isolated allowlisted home and fixed launch 
 
 test('sandbox controller rejects symlinked credentials before launch', () => {
   const f = fixture();
+  const broker = controllerBroker(f.root);
   fs.unlinkSync(path.join(f.codexHome, 'auth.json'));
   fs.symlinkSync(path.join(f.root, 'package.json'), path.join(f.codexHome, 'auth.json'));
   assert.throws(() => prepareCodexSandboxController({
@@ -126,6 +165,7 @@ test('sandbox controller rejects symlinked credentials before launch', () => {
     temporaryRoot: trackedTemporaryRoot('codex-controller-runtime-'),
     control: { token: 'token', generation: 'generation', channelDir: '/control', statusDir: '/status', runtimeDir: f.runtimeDir },
     verifyTaskBinding: () => {},
+    ...broker,
     codexVersion: () => '0.147.0'
   }), /INPUT_INVALID/);
 });
@@ -133,17 +173,35 @@ test('sandbox controller rejects symlinked credentials before launch', () => {
 test('sandbox controller enforces a task lease and controller context binding', () => {
   const f = fixture();
   const temporaryRoot = trackedTemporaryRoot('codex-controller-runtime-');
+  const broker = controllerBroker(f.root);
   const options = {
     repoRoot: f.root,
     codexHome: f.codexHome,
     temporaryRoot,
     control: { token: 'token', generation: 'generation', channelDir: '/control', statusDir: '/status', runtimeDir: f.runtimeDir },
     verifyTaskBinding: () => {},
+    ...broker,
     codexVersion: () => '0.147.0'
   } as const;
   const prepared = prepareCodexSandboxController({
     taskId: 'TASK-20260101-000001', taskRef: '01'
   }, options);
+  const contextRaw = fs.readFileSync(prepared.contextPath, 'utf8');
+  const contextValue = JSON.parse(contextRaw) as Record<string, unknown>;
+  assert.equal(contextValue.version, 2);
+  fs.writeFileSync(prepared.contextPath, `${JSON.stringify({ ...contextValue, extra: true })}\n`, { mode: 0o600 });
+  assert.throws(() => verifyCodexSandboxControllerContext(
+    prepared.contextPath,
+    'TASK-20260101-000001',
+    { repoRoot: f.root, generation: 'generation' }
+  ), /CONTEXT_INVALID/);
+  fs.writeFileSync(prepared.contextPath, `${JSON.stringify({ ...contextValue, version: 1 })}\n`, { mode: 0o600 });
+  assert.throws(() => verifyCodexSandboxControllerContext(
+    prepared.contextPath,
+    'TASK-20260101-000001',
+    { repoRoot: f.root, generation: 'generation' }
+  ), /CONTEXT_INVALID/);
+  fs.writeFileSync(prepared.contextPath, contextRaw, { mode: 0o600 });
   assert.throws(() => prepareCodexSandboxController({
     taskId: 'TASK-20260101-000001', taskRef: '01'
   }, options), /CONTROLLER_BUSY/);
@@ -158,4 +216,23 @@ test('sandbox controller enforces a task lease and controller context binding', 
     { repoRoot: f.root, generation: 'other' }
   ), /CONTEXT_INVALID/);
   prepared.cleanup();
+});
+
+test('sandbox controller closes a broker lease when the opened binding is invalid', () => {
+  const f = fixture();
+  const options = {
+    repoRoot: f.root,
+    codexHome: f.codexHome,
+    temporaryRoot: trackedTemporaryRoot('codex-controller-invalid-binding-'),
+    control: { token: 'token', generation: 'generation', channelDir: '/control', statusDir: '/status', runtimeDir: f.runtimeDir },
+    verifyTaskBinding: () => {},
+    ...controllerBroker(f.root, 'TASK-20260101-999999'),
+    codexVersion: () => '0.147.0'
+  } as const;
+  const prepare = () => prepareCodexSandboxController({
+    taskId: 'TASK-20260101-000001', taskRef: '01'
+  }, options);
+
+  assert.throws(prepare, /SANDBOX_CONTROL_RESULT_INVALID/);
+  assert.throws(prepare, /SANDBOX_CONTROL_RESULT_INVALID/);
 });

--- a/tests/unit/sandbox/workspace-control.test.ts
+++ b/tests/unit/sandbox/workspace-control.test.ts
@@ -31,7 +31,15 @@ import {
   readSandboxControlManifest,
   readSandboxControlManifestForTransition
 } from '../../../lib/sandbox/control/lifecycle.ts';
-import { nodeEntryArgs } from '../../../lib/sandbox/control/executor.ts';
+import { executeRequest, nodeEntryArgs } from '../../../lib/sandbox/control/executor.ts';
+import { parseCodexControllerResult, SandboxControlClientError } from '../../../lib/sandbox/control/client.ts';
+import {
+  closeCodexControllerRegistration,
+  CodexControllerRegistrationError,
+  openCodexControllerRegistration,
+  readCodexControllerRegistration,
+  resolveCodexControllerBinding
+} from '../../../lib/sandbox/control/controller-registration.ts';
 
 const manifest: SandboxControlManifest = {
   version: 5,
@@ -52,6 +60,244 @@ const manifest: SandboxControlManifest = {
   runtimeDir: '/runtime'
 };
 
+const controllerBuild = {
+  protocolVersion: 3,
+  packageVersion: '0.9.9-alpha.0',
+  internalExecutableBuildHash: 'a'.repeat(64),
+  lifecycleContractHash: 'b'.repeat(64)
+} as const;
+
+test('controller registration requires a live requested process across create and replacement states', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'controller-registration-'));
+  const manifestPath = path.join(root, 'manifest.json');
+  fs.writeFileSync(manifestPath, '{}\n', { mode: 0o600 });
+  const requested = { pid: 200, startTime: 20 };
+  const credentials = ['c'.repeat(64), 'd'.repeat(64), 'e'.repeat(64)];
+  const opened = openCodexControllerRegistration({
+    manifest,
+    manifestPath,
+    controllerProcess: requested,
+    buildIdentity: controllerBuild
+  }, {
+    now: () => 1_000,
+    probeProcess: () => 'alive',
+    randomHex: () => credentials.shift()!
+  });
+  assert.equal(opened.status, 'opened');
+  assert.equal(readCodexControllerRegistration(manifestPath).controllerProcess.pid, 200);
+  assert.equal(fs.readFileSync(path.join(root, 'codex-controller.json'), 'utf8').includes(opened.lease.leaseSecret), false);
+
+  closeCodexControllerRegistration({ manifest, manifestPath, proof: {
+    version: 1,
+    leaseId: opened.lease.leaseId,
+    leaseSecret: opened.lease.leaseSecret,
+    controllerProcess: requested
+  } });
+  for (const state of ['dead', 'unknown'] as const) {
+    assert.throws(() => openCodexControllerRegistration({
+      manifest,
+      manifestPath,
+      controllerProcess: requested,
+      buildIdentity: controllerBuild
+    }, {
+      now: () => 1_000,
+      probeProcess: () => state,
+      randomHex: () => 'd'.repeat(64)
+    }), state === 'dead' ? /PROCESS_INACTIVE/ : /PROCESS_UNKNOWN/);
+    assert.equal(fs.existsSync(path.join(root, 'codex-controller.json')), false);
+  }
+});
+
+test('controller registration replacement uses byte-equal compare before commit', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'controller-registration-cas-'));
+  const manifestPath = path.join(root, 'manifest.json');
+  fs.writeFileSync(manifestPath, '{}\n', { mode: 0o600 });
+  const first = openCodexControllerRegistration({
+    manifest,
+    manifestPath,
+    controllerProcess: { pid: 100, startTime: 10 },
+    buildIdentity: controllerBuild
+  }, { now: () => 1_000, probeProcess: () => 'alive', randomHex: () => 'e'.repeat(64) });
+  const registrationPath = path.join(root, 'codex-controller.json');
+  const expired = { ...readCodexControllerRegistration(manifestPath), issuedAt: 0, expiresAt: 999 };
+  fs.writeFileSync(registrationPath, `${JSON.stringify(expired)}\n`, { mode: 0o600 });
+  assert.throws(() => openCodexControllerRegistration({
+    manifest,
+    manifestPath,
+    controllerProcess: { pid: 200, startTime: 20 },
+    buildIdentity: controllerBuild
+  }, {
+    now: () => 2_000,
+    probeProcess: () => 'alive',
+    randomHex: () => 'f'.repeat(64),
+    beforeCommit: () => fs.writeFileSync(registrationPath, `${JSON.stringify({ ...expired, leaseId: first.lease.leaseId.slice(0, -1) + '0' })}\n`, { mode: 0o600 })
+  }), /OWNERSHIP_LOST/);
+  assert.equal(readCodexControllerRegistration(manifestPath).controllerProcess.pid, 100);
+});
+
+test('controller registration covers every existing and requested process state without unsafe mutation', () => {
+  const existingStates = ['missing', 'alive', 'expired', 'dead', 'unknown', 'invalid'] as const;
+  const requestedStates = ['alive', 'dead', 'zombie', 'unknown'] as const;
+  for (const existingState of existingStates) {
+    for (const requestedState of requestedStates) {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), `controller-matrix-${existingState}-${requestedState}-`));
+      const manifestPath = path.join(root, 'manifest.json');
+      const file = path.join(root, 'codex-controller.json');
+      fs.writeFileSync(manifestPath, '{}\n', { mode: 0o600 });
+      if (existingState !== 'missing') {
+        const seedValues = ['1'.repeat(64), '2'.repeat(64), '3'.repeat(64)];
+        openCodexControllerRegistration({
+          manifest,
+          manifestPath,
+          controllerProcess: { pid: 100, startTime: 10 },
+          buildIdentity: controllerBuild
+        }, { now: () => 1_000, probeProcess: () => 'alive', randomHex: () => seedValues.shift()! });
+        if (existingState === 'expired') {
+          const value = readCodexControllerRegistration(manifestPath);
+          fs.writeFileSync(file, `${JSON.stringify({ ...value, issuedAt: 0, expiresAt: 999 })}\n`, { mode: 0o600 });
+        } else if (existingState === 'invalid') {
+          fs.writeFileSync(file, `${JSON.stringify({ ...readCodexControllerRegistration(manifestPath), extra: true })}\n`, { mode: 0o600 });
+        }
+      }
+      const before = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null;
+      const values = ['4'.repeat(64), '5'.repeat(64), '6'.repeat(64)];
+      const attempt = () => openCodexControllerRegistration({
+        manifest,
+        manifestPath,
+        controllerProcess: { pid: 200, startTime: 20 },
+        buildIdentity: controllerBuild
+      }, {
+        now: () => 2_000,
+        randomHex: () => values.shift()!,
+        probeProcess: (identity) => identity.pid === 100
+          ? existingState === 'alive' ? 'alive' : existingState === 'unknown' ? 'unknown' : 'dead'
+          : requestedState === 'alive' ? 'alive' : requestedState === 'unknown' ? 'unknown' : 'dead'
+      });
+      const succeeds = requestedState === 'alive'
+        && (existingState === 'missing' || existingState === 'expired' || existingState === 'dead');
+      if (succeeds) {
+        assert.equal(attempt().status, 'opened', `${existingState}/${requestedState}`);
+        assert.equal(readCodexControllerRegistration(manifestPath).controllerProcess.pid, 200);
+      } else {
+        assert.throws(attempt, Error, `${existingState}/${requestedState}`);
+        assert.equal(fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null, before, `${existingState}/${requestedState}`);
+      }
+    }
+  }
+});
+
+test('controller proof failures preserve the host registration', () => {
+  const cases = [
+    ['wrong-secret', 'CODEX_SANDBOX_CONTROLLER_PROOF_INVALID'],
+    ['expired', 'CODEX_SANDBOX_CONTROLLER_LEASE_EXPIRED'],
+    ['cross-task', 'CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID'],
+    ['cross-generation', 'CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID'],
+    ['cross-container', 'CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID'],
+    ['cross-build', 'CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID'],
+    ['cross-process', 'CODEX_SANDBOX_CONTROLLER_PROOF_INVALID'],
+    ['dead-process', 'CODEX_SANDBOX_CONTROLLER_PROCESS_INACTIVE'],
+    ['unknown-process', 'CODEX_SANDBOX_CONTROLLER_PROCESS_UNKNOWN']
+  ] as const;
+  for (const [scenario, expectedCode] of cases) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `controller-proof-${scenario}-`));
+    const manifestPath = path.join(root, 'manifest.json');
+    fs.writeFileSync(manifestPath, '{}\n', { mode: 0o600 });
+    const values = ['7'.repeat(64), '8'.repeat(64), '9'.repeat(64)];
+    const opened = openCodexControllerRegistration({
+      manifest,
+      manifestPath,
+      controllerProcess: { pid: 100, startTime: 10 },
+      buildIdentity: controllerBuild
+    }, { now: () => 1_000, probeProcess: () => 'alive', randomHex: () => values.shift()! });
+    const file = path.join(root, 'codex-controller.json');
+    const before = fs.readFileSync(file, 'utf8');
+    const proof = {
+      version: 1 as const,
+      leaseId: opened.lease.leaseId,
+      leaseSecret: scenario === 'wrong-secret' ? '0'.repeat(64) : opened.lease.leaseSecret,
+      controllerProcess: scenario === 'cross-process'
+        ? { pid: 101, startTime: 10 }
+        : opened.lease.controllerProcess
+    };
+    const candidateManifest = scenario === 'cross-task'
+      ? { ...manifest, taskId: 'TASK-20260809-999999' }
+      : scenario === 'cross-generation'
+        ? { ...manifest, generation: 'other-generation' }
+        : scenario === 'cross-container'
+          ? { ...manifest, containerIdentity: { ...manifest.containerIdentity, id: 'other-container' } }
+          : manifest;
+    assert.throws(() => resolveCodexControllerBinding({
+      manifest: candidateManifest,
+      manifestPath,
+      proof,
+      buildIdentity: scenario === 'cross-build'
+        ? { ...controllerBuild, lifecycleContractHash: '0'.repeat(64) }
+        : controllerBuild,
+      now: scenario === 'expired' ? 14_402_000 : 2_000,
+      probeProcess: () => scenario === 'dead-process' ? 'dead' : scenario === 'unknown-process' ? 'unknown' : 'alive'
+    }), new RegExp(expectedCode));
+    assert.equal(fs.readFileSync(file, 'utf8'), before, scenario);
+  }
+});
+
+test('controller proof rejection occurs before the domain child and workspace mutation', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'controller-proof-executor-'));
+  const sentinel = path.join(root, 'workspace-sentinel');
+  fs.writeFileSync(sentinel, 'unchanged\n');
+  const proof = {
+    version: 1 as const,
+    leaseId: '7'.repeat(64),
+    leaseSecret: '8'.repeat(64),
+    controllerProcess: { pid: 100, startTime: 10 }
+  };
+  for (const code of [
+    'CODEX_SANDBOX_CONTROLLER_PROOF_INVALID',
+    'CODEX_SANDBOX_CONTROLLER_LEASE_EXPIRED',
+    'CODEX_SANDBOX_CONTROLLER_REGISTRATION_INVALID',
+    'CODEX_SANDBOX_CONTROLLER_PROCESS_INACTIVE',
+    'CODEX_SANDBOX_CONTROLLER_PROCESS_UNKNOWN'
+  ]) {
+    let spawns = 0;
+    const request = {
+      version: 3 as const,
+      id: '12345678-1234-1234-1234-123456789abc',
+      token: manifest.token,
+      generation: manifest.generation,
+      issuedAt: 1_000,
+      expiresAt: 3_000,
+      family: 'task-orchestration' as const,
+      args: [manifest.taskId!, 'prepare', '--client', 'codex'],
+      controllerProcess: null,
+      controllerProof: proof
+    };
+    const result = executeRequest(manifest, path.join(root, 'manifest.json'), request, {
+      buildIdentity: () => controllerBuild,
+      resolveControllerBinding: (() => { throw new CodexControllerRegistrationError(code, 'rejected'); }) as never,
+      spawnDomain: (() => { spawns += 1; throw new Error('domain child must not spawn'); }) as never
+    });
+    assert.equal(result.exitCode, 1, code);
+    assert.match(result.stdout, new RegExp(code), code);
+    assert.equal(spawns, 0, code);
+    assert.equal(fs.readFileSync(sentinel, 'utf8'), 'unchanged\n', code);
+  }
+  let missingProofSpawns = 0;
+  const missingProof = executeRequest(manifest, path.join(root, 'manifest.json'), {
+    version: 3,
+    id: '12345678-1234-1234-1234-123456789abd',
+    token: manifest.token,
+    generation: manifest.generation,
+    issuedAt: 1_000,
+    expiresAt: 3_000,
+    family: 'task-orchestration',
+    args: [manifest.taskId!, 'prepare', '--client', 'codex'],
+    controllerProcess: null,
+    controllerProof: null
+  }, { spawnDomain: (() => { missingProofSpawns += 1; }) as never });
+  assert.match(missingProof.stdout, /CODEX_SANDBOX_CONTROLLER_PROOF_REQUIRED/);
+  assert.equal(missingProofSpawns, 0);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'unchanged\n');
+});
+
 test('TypeScript control entries retain explicit strip-types startup', () => {
   assert.deepEqual(nodeEntryArgs('/repo/bin/internal-cli.ts', ['sandbox-control', 'serve']), [
     '--experimental-strip-types', '--no-warnings', '/repo/bin/internal-cli.ts', 'sandbox-control', 'serve'
@@ -63,14 +309,16 @@ test('TypeScript control entries retain explicit strip-types startup', () => {
 
 test('control requests are restricted to allowed families and rebound to the manifest task', () => {
   const request = validateSandboxControlRequest({
-    version: 2,
+    version: 3,
     id: '12345678-1234-1234-1234-123456789abc',
     token: 'secret',
     generation: 'generation-1',
     issuedAt: 1_000,
     expiresAt: 3_000,
     family: 'task-lifecycle',
-    args: ['08', 'complete', '--agent', 'codex']
+    args: ['08', 'complete', '--agent', 'codex'],
+    controllerProcess: null,
+    controllerProof: null
   }, manifest, { now: 2_000 });
   assert.deepEqual(bindSandboxControlTask(request, manifest.taskId!), [
     'TASK-20260809-010203',
@@ -84,16 +332,67 @@ test('control requests are restricted to allowed families and rebound to the man
   );
 });
 
+test('control protocol rejects request v2 and controller result parser enforces exact wire phases', () => {
+  const request = {
+    version: 3,
+    id: '12345678-1234-1234-1234-123456789abc',
+    token: 'secret',
+    generation: 'generation-1',
+    issuedAt: 1_000,
+    expiresAt: 3_000,
+    family: 'task-lifecycle',
+    args: ['08', 'status'],
+    controllerProcess: null,
+    controllerProof: null
+  };
+  assert.throws(() => validateSandboxControlRequest({ ...request, version: 2 }, manifest, { now: 2_000 }), /REQUEST_INVALID/);
+  const opened = {
+    version: 1,
+    status: 'opened',
+    changed: true,
+    lease: {
+      version: 1,
+      leaseId: 'c'.repeat(64),
+      leaseSecret: 'd'.repeat(64),
+      taskId: manifest.taskId!,
+      controlGeneration: manifest.generation,
+      controllerInstanceDigest: 'e'.repeat(64),
+      controllerProcess: { pid: 200, startTime: 20 },
+      buildIdentity: controllerBuild,
+      issuedAt: 1_000,
+      expiresAt: 2_000
+    },
+    error: null
+  };
+  const response = {
+    version: 2 as const,
+    id: request.id,
+    phase: 'completed' as const,
+    exitCode: 0,
+    stdout: `${JSON.stringify(opened)}\n`,
+    stderr: '',
+    error: null
+  };
+  assert.equal(parseCodexControllerResult(response).status, 'opened');
+  assert.throws(
+    () => parseCodexControllerResult({ ...response, stdout: `${JSON.stringify({ ...opened, extra: true })}\n` }),
+    (error: unknown) => error instanceof SandboxControlClientError && error.detail.code === 'SANDBOX_CONTROL_RESULT_INVALID'
+  );
+  assert.throws(() => parseCodexControllerResult({ ...response, exitCode: 1 }), /controller success result is invalid/);
+});
+
 test('branch-only sandboxes and incorrect tokens fail closed', () => {
   const request = {
-    version: 2,
+    version: 3,
     id: '12345678-1234-1234-1234-123456789abc',
     token: 'secret',
     generation: 'generation-1',
     issuedAt: 1_000,
     expiresAt: 3_000,
     family: 'task-orchestration',
-    args: ['08', 'status']
+    args: ['08', 'status'],
+    controllerProcess: null,
+    controllerProof: null
   };
   assert.throws(
     () => validateSandboxControlRequest(request, { ...manifest, mode: 'branch-only', taskId: null }, { now: 2_000 }),
@@ -103,18 +402,55 @@ test('branch-only sandboxes and incorrect tokens fail closed', () => {
     () => validateSandboxControlRequest({ ...request, token: 'wrong' }, manifest, { now: 2_000 }),
     /REQUEST_INVALID/
   );
+  const branchManifest = { ...manifest, mode: 'branch-only' as const, taskId: null };
+  assert.throws(() => validateSandboxControlRequest({
+    ...request,
+    family: 'codex-controller',
+    command: 'open',
+    args: [],
+    controllerProcess: { pid: 100, startTime: 10 },
+    controllerProof: null
+  }, branchManifest, { now: 2_000 }), /SANDBOX_CONTROL_BRANCH_ONLY/);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'branch-controller-denied-'));
+  const manifestPath = path.join(root, 'manifest.json');
+  fs.writeFileSync(manifestPath, '{}\n', { mode: 0o600 });
+  assert.throws(() => openCodexControllerRegistration({
+    manifest: branchManifest,
+    manifestPath,
+    controllerProcess: { pid: 100, startTime: 10 },
+    buildIdentity: controllerBuild
+  }, { probeProcess: () => 'alive' }), /SANDBOX_CONTROL_BRANCH_ONLY/);
+  const proof = {
+    version: 1 as const,
+    leaseId: '7'.repeat(64),
+    leaseSecret: '8'.repeat(64),
+    controllerProcess: { pid: 100, startTime: 10 }
+  };
+  assert.throws(() => closeCodexControllerRegistration({
+    manifest: branchManifest, manifestPath, proof
+  }), /SANDBOX_CONTROL_BRANCH_ONLY/);
+  assert.throws(() => resolveCodexControllerBinding({
+    manifest: branchManifest,
+    manifestPath,
+    proof,
+    buildIdentity: controllerBuild,
+    probeProcess: () => 'alive'
+  }), /SANDBOX_CONTROL_BRANCH_ONLY/);
+  assert.equal(fs.existsSync(path.join(root, 'codex-controller.json')), false);
 });
 
 test('task-orchestration requests cannot override the manifest worktree binding', () => {
   assert.throws(() => validateSandboxControlRequest({
-    version: 2,
+    version: 3,
     id: '12345678-1234-1234-1234-123456789abc',
     token: 'secret',
     generation: 'generation-1',
     issuedAt: 1_000,
     expiresAt: 3_000,
     family: 'task-orchestration',
-    args: ['08', 'commit-status', '--git-worktree-root', '/other']
+    args: ['08', 'commit-status', '--git-worktree-root', '/other'],
+    controllerProcess: null,
+    controllerProof: null
   }, manifest, { now: 2_000 }), /REQUEST_INVALID/);
 });
 
@@ -147,14 +483,16 @@ test('task-create is authorized in both sandbox modes without task rebinding', (
   };
   for (const mode of ['task-bound', 'branch-only'] as const) {
     const request = validateSandboxControlRequest({
-      version: 2,
+      version: 3,
       id: '12345678-1234-1234-1234-123456789abc',
       token: 'secret',
       generation: 'generation-1',
       issuedAt: 1_000,
       expiresAt: 3_000,
       family: 'task-create',
-      candidate
+      candidate,
+      controllerProcess: null,
+      controllerProof: null
     }, { ...manifest, mode, taskId: mode === 'task-bound' ? manifest.taskId : null }, { now: 2_000 });
     assert.equal(request.family, 'task-create');
     assert.equal(request.candidate.title, candidate.title);
@@ -358,14 +696,16 @@ test('cutover snapshot detects replaced generation evidence before materializati
 
 test('control request deadline and generation fail closed', () => {
   const request = {
-    version: 2,
+    version: 3,
     id: '12345678-1234-1234-1234-123456789abc',
     token: 'secret',
     generation: 'generation-1',
     issuedAt: 1_000,
     expiresAt: 3_000,
     family: 'task-lifecycle',
-    args: ['08', 'status']
+    args: ['08', 'status'],
+    controllerProcess: null,
+    controllerProof: null
   };
   assert.throws(
     () => validateSandboxControlRequest(request, manifest, { now: 3_001 }),


### PR DESCRIPTION
## 摘要

- 为 Codex capability consume failure 增加去敏的 expected/actual 字段级 provenance detail。
- 保持 canonical controller shape 的 fail-closed 校验、整体授权比较、CAS/replay 状态机和一次性消费语义不变。
- 增加 digest-only 与 generation-only controller mismatch 回归，并覆盖 bridge detail 透传。

## 验证

- 定向测试：19/19 通过。
- 清洁 runtime `npm run typecheck`：通过。
- 清洁 runtime `npm run test:core`：2193 passed，3 skipped，0 failed。
- `npm test`：2510 passed，4 skipped，0 failed。
- `git diff --check`、审查快照树校验和提交前检查通过。

## 审查

- `review-code-r3.md`：Approved；0 阻塞项、0 主要问题、0 次要问题。
- 保留 1 项人工校验：在真实 task-bound Codex 环境对 Run `af3c17a9-ee0e-4c61-9427-4d922965cbe8` 执行诊断取证。

## 关联 Issue

Closes #895

Generated with AI assistance
