### PR TITLE
fix(sandbox): 修复损坏 worktree 导致沙箱无法删除


### DIFF
--- a/lib/sandbox/commands/rm.ts
+++ b/lib/sandbox/commands/rm.ts
@@ -10,6 +10,8 @@ import {
   containerNameCandidates,
   sandboxBranchLabel,
   sandboxLabel,
+  sandboxTaskIdLabel,
+  sandboxWorkspaceModeLabel,
   shareBranchDir,
   shellConfigDirCandidates,
   worktreeDirCandidates
@@ -18,7 +20,12 @@ import { ENGINES, detectEngine, engineDisplayName, isManagedEngine, stopManagedV
 import { pruneSandboxDanglingImages } from '../image-prune.ts';
 import { assertManagedPath, removeManagedDir, removeWorktreeDir } from '../managed-fs.ts';
 import { runEngine, runOk, runOkEngine, runSafe, runSafeEngine } from '../shell.ts';
-import { resolveSandboxTarget, type SandboxWorkspaceIdentity } from '../workspace-identity.ts';
+import {
+  parseSandboxWorkspaceIdentity,
+  resolveSandboxTarget,
+  sameSandboxWorkspaceIdentity,
+  type SandboxWorkspaceIdentity
+} from '../workspace-identity.ts';
 import { sandboxControlPaths, sandboxWorkspaceViewPaths } from '../workspace-view.ts';
 import { removeSandboxControlRoot, readSandboxControlManifest } from '../control/lifecycle.ts';
 import { inspectSandboxControlContainer } from '../control/container-identity.ts';
@@ -31,10 +38,15 @@ import {
   createCleanPermit,
   createDiscardPermit,
   formatWorktreeSnapshot,
+  inspectRecoveredWorktree,
   inspectWorktrees,
   verifyWorktreePermit
 } from '../worktree-safety.ts';
-import type { WorktreeInspection, WorktreeRemovalPermit } from '../worktree-safety.ts';
+import type {
+  WorktreeInspection,
+  WorktreeRecoveryContext,
+  WorktreeRemovalPermit
+} from '../worktree-safety.ts';
 
 const USAGE = `Usage:
   ai sandbox rm <branch>                    Remove one sandbox (branch | TASK-id | short id)
@@ -60,6 +72,7 @@ type RmTarget = {
 
 type RmOneOptions = {
   assumeYes?: boolean;
+  interactive?: boolean;
   quiet?: boolean;
   target?: RmTarget;
   permits?: ReadonlyMap<string, WorktreeRemovalPermit>;
@@ -72,34 +85,51 @@ type PromptDependencies = {
   isCancel?: typeof p.isCancel;
 };
 
+function recoveryContexts(
+  config: SandboxConfig,
+  target: RmTarget,
+  worktrees: readonly string[]
+): Map<string, WorktreeRecoveryContext> {
+  const candidates = worktreeDirCandidates(config, target.effectiveBranch).map((candidate) => path.resolve(candidate));
+  const existingCandidates = candidates.filter((candidate) => fs.existsSync(candidate));
+  if (existingCandidates.length !== 1) return new Map();
+
+  const resolvedWorkspace = resolveSandboxTarget(target.effectiveBranch, config.repoRoot).workspace;
+  const sameWorkspace = resolvedWorkspace.mode === target.workspace.mode
+    && (resolvedWorkspace.mode !== 'task-bound'
+      || (target.workspace.mode === 'task-bound' && resolvedWorkspace.taskId === target.workspace.taskId));
+  if (!sameWorkspace) return new Map();
+
+  const contexts = new Map<string, WorktreeRecoveryContext>();
+  for (const worktree of worktrees) {
+    const resolvedWorktree = path.resolve(worktree);
+    if (resolvedWorktree !== existingCandidates[0]) continue;
+    for (const root of target.controlRoots.filter((candidate) => fs.existsSync(candidate))) {
+      assertLegacyCandidateEvidence(root, config.controlBase, config, target.effectiveBranch, target.matchedContainers);
+      assertControlRootMatchesTarget(root, target.effectiveBranch, target.workspace);
+    }
+    contexts.set(resolvedWorktree, {
+      repoRoot: config.repoRoot,
+      worktreeBase: config.worktreeBase,
+      branch: target.effectiveBranch,
+      identitySource: target.workspace.mode,
+      taskId: target.workspace.mode === 'task-bound' ? target.workspace.taskId : null
+    });
+  }
+  return contexts;
+}
+
 function resolveRmTarget(config: SandboxConfig, tools: SandboxTool[], branch: string): RmTarget {
   assertValidBranchName(branch);
   const engine = detectEngine(config);
-  let effectiveBranch = branch;
-  let worktreeCandidates = worktreeDirCandidates(config, branch);
-  let toolCandidates = tools.map((tool) => ({
+  const effectiveBranch = branch;
+  const worktreeCandidates = worktreeDirCandidates(config, branch);
+  const toolCandidates = tools.map((tool) => ({
     tool,
     candidates: toolConfigDirCandidates(tool, config.project, branch)
   }));
   const existing = runEngine(engine, 'docker', ['ps', '-a', '--format', '{{.Names}}']).split('\n').filter(Boolean);
   const matchedContainers = containerNameCandidates(config, branch).filter((name) => existing.includes(name));
-
-  if (matchedContainers.length > 0) {
-    const resolvedBranch = runEngine(engine, 'docker', [
-      'inspect',
-      '-f',
-      `{{ index .Config.Labels "${sandboxBranchLabel(config)}" }}`,
-      matchedContainers[0] ?? ''
-    ]);
-    if (resolvedBranch) {
-      effectiveBranch = resolvedBranch;
-      worktreeCandidates = worktreeDirCandidates(config, effectiveBranch);
-      toolCandidates = tools.map((tool) => ({
-        tool,
-        candidates: toolConfigDirCandidates(tool, config.project, effectiveBranch)
-      }));
-    }
-  }
 
   const workspace = resolveSandboxTarget(effectiveBranch, config.repoRoot).workspace;
   const identities: SandboxWorkspaceIdentity[] = workspace.mode === 'task-bound'
@@ -124,6 +154,51 @@ function resolveRmTarget(config: SandboxConfig, tools: SandboxTool[], branch: st
     controlRoots: [...new Set(controlRoots)],
     workspaceViewRoots: [...new Set(workspaceViewRoots)]
   };
+}
+
+function assertMatchedContainerIdentities(config: SandboxConfig, target: RmTarget): void {
+  for (const container of target.matchedContainers) {
+    const rawLabels = runSafeEngine(target.engine, 'docker', [
+      'inspect', '--format', '{{json .Config.Labels}}', container
+    ]).trim();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawLabels);
+    } catch {
+      throw new Error(`SANDBOX_WORKSPACE_IDENTITY_UNKNOWN: container '${container}' labels are invalid`);
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`SANDBOX_WORKSPACE_IDENTITY_UNKNOWN: container '${container}' labels are incomplete`);
+    }
+    const labels = parsed as Record<string, unknown>;
+    if (Object.values(labels).some((value) => typeof value !== 'string')) {
+      throw new Error(`SANDBOX_WORKSPACE_IDENTITY_UNKNOWN: container '${container}' labels are incomplete`);
+    }
+    const stringLabels = labels as Record<string, string>;
+    const branch = stringLabels[sandboxBranchLabel(config)];
+    if (branch !== target.branch) {
+      throw new Error(
+        `SANDBOX_WORKSPACE_IDENTITY_CONFLICT: container '${container}' branch is ${JSON.stringify(branch ?? null)}, `
+        + `but this request is ${JSON.stringify(target.branch)}`
+      );
+    }
+    const identity = parseSandboxWorkspaceIdentity(stringLabels, {
+      mode: sandboxWorkspaceModeLabel(config),
+      taskId: sandboxTaskIdLabel(config)
+    });
+    if (identity.mode === 'legacy-invalid' || !sameSandboxWorkspaceIdentity(identity, target.workspace)) {
+      const existingDescription = identity.mode === 'task-bound'
+        ? `task-bound:${identity.taskId}`
+        : identity.mode;
+      const requestedDescription = target.workspace.mode === 'task-bound'
+        ? `task-bound:${target.workspace.taskId}`
+        : target.workspace.mode;
+      throw new Error(
+        `SANDBOX_WORKSPACE_IDENTITY_CONFLICT: container '${container}' is ${existingDescription}, `
+        + `but this request is ${requestedDescription}`
+      );
+    }
+  }
 }
 
 function assertControlRootMatchesTarget(root: string, effectiveBranch: string, workspace: SandboxWorkspaceIdentity): void {
@@ -254,10 +329,17 @@ async function authorizeWorktrees(
   {
     interactive = Boolean(process.stdin.isTTY),
     confirm = p.confirm,
-    isCancel = p.isCancel
-  }: PromptDependencies & { interactive?: boolean } = {}
+    isCancel = p.isCancel,
+    recovery = new Map<string, WorktreeRecoveryContext>()
+  }: PromptDependencies & { interactive?: boolean; recovery?: ReadonlyMap<string, WorktreeRecoveryContext> } = {}
 ): Promise<Map<string, WorktreeRemovalPermit>> {
-  const inspections = inspectWorktrees(worktrees);
+  const inspections = worktrees.map((worktree) => {
+    const inspection = inspectWorktrees([worktree])[0]!;
+    const context = recovery.get(path.resolve(worktree));
+    return inspection.status === 'failed' && context
+      ? inspectRecoveredWorktree(worktree, context)
+      : inspection;
+  });
   const failures = inspections.filter((inspection) => inspection.status === 'failed');
   if (failures.length > 0) throw new Error(`Unable to inspect worktree(s):\n${blockerMessage(failures)}`);
   const permits = cleanPermits(inspections);
@@ -286,6 +368,7 @@ async function rmOne(
   const target = options.target ?? resolveRmTarget(config, tools, branch);
   const { effectiveBranch, engine, matchedContainers, existingWorktrees, toolCandidates } = target;
   const { workspace, controlRoots, workspaceViewRoots } = target;
+  assertMatchedContainerIdentities(config, target);
   const confirm = options.prompt?.confirm ?? p.confirm;
   const isCancel = options.prompt?.isCancel ?? p.isCancel;
 
@@ -293,12 +376,19 @@ async function rmOne(
     p.intro(pc.cyan(`Removing sandbox for ${branch}`));
   }
 
+  const recovery = options.permits
+    ? new Map<string, WorktreeRecoveryContext>()
+    : recoveryContexts(config, target, existingWorktrees);
   const permits = options.permits
     ? new Map(options.permits)
     : await authorizeWorktrees(existingWorktrees, {
         allowDirtyDiscard: options.allowDirtyDiscard ?? true,
         assumeYes: Boolean(options.assumeYes)
-      }, options.prompt);
+      }, {
+        ...options.prompt,
+        interactive: options.interactive ?? Boolean(process.stdin.isTTY),
+        recovery
+      });
   for (const worktree of existingWorktrees) {
     const permit = permits.get(path.resolve(worktree));
     if (!permit) throw new Error(`Missing worktree removal permit: ${worktree}`);
@@ -328,6 +418,7 @@ async function rmOne(
       inspectContainer: (timeoutMs) => inspectSandboxControlContainer(manifest, { timeoutMs }),
       removeContainer: (timeoutMs) => removeExactSandboxContainer(engine, manifest, timeoutMs)
     });
+    removeEmptyManagedParent(path.join(config.controlBase, config.project), root);
   }
 
   const uncoordinatedContainers = matchedContainers.filter((name) => !coordinatedContainers.has(name));

--- a/lib/sandbox/managed-fs.ts
+++ b/lib/sandbox/managed-fs.ts
@@ -36,6 +36,11 @@ export function removeWorktreeDir(
     throw new Error(`Worktree permit target mismatch: ${dir}`);
   }
   verifyWorktreePermit(permit);
+  if (permit.snapshot.source === 'recovered') {
+    removeManagedDir(worktreeBase, dir);
+    runSafeFn('git', ['-C', repoRoot, 'worktree', 'prune']);
+    return;
+  }
   try {
     runFn('git', ['-C', repoRoot, 'worktree', 'remove', dir, '--force']);
   } catch (error) {

--- a/lib/sandbox/worktree-safety.ts
+++ b/lib/sandbox/worktree-safety.ts
@@ -1,7 +1,9 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { runProbe } from './shell.ts';
+import { resolveSandboxTarget } from './workspace-identity.ts';
 
 type WorktreeChange = {
   indexStatus: string;
@@ -16,6 +18,8 @@ type WorktreeSnapshot = {
   head: string;
   changes: readonly WorktreeChange[];
   identity: string;
+  source?: 'registered' | 'recovered';
+  recovery?: WorktreeRecoveryContext;
 };
 
 type WorktreeInspection =
@@ -27,6 +31,14 @@ type WorktreeRemovalPermit = {
   mode: 'clean' | 'discard';
   snapshot: WorktreeSnapshot;
 };
+
+type WorktreeRecoveryContext = Readonly<{
+  repoRoot: string;
+  worktreeBase: string;
+  branch: string;
+  identitySource: 'branch-only' | 'task-bound';
+  taskId: string | null;
+}>;
 
 type Probe = typeof runProbe;
 
@@ -164,6 +176,196 @@ function captureOnce(worktree: string, probe: Probe): WorktreeSnapshot {
   return { worktree: resolvedWorktree, branch, head, changes, identity: hash.digest('hex') };
 }
 
+function probeTextWithEnv(
+  probe: Probe,
+  repoRoot: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): string {
+  const result = probe('git', args, { cwd: repoRoot, encoding: 'utf8', env });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : result.stderr.toString('utf8').trim();
+    throw new Error(stderr || `git ${args[0] ?? 'command'} failed with exit code ${result.status ?? 'unknown'}`);
+  }
+  return typeof result.stdout === 'string' ? result.stdout : result.stdout.toString('utf8');
+}
+
+function probeMetadataCommand(
+  probe: Probe,
+  repoRoot: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): boolean {
+  const result = probe('git', args, { cwd: repoRoot, encoding: 'utf8', env });
+  if (result.error) throw result.error;
+  return result.status === 0;
+}
+
+function hasValidHeadContent(content: string): boolean {
+  return /^(?:ref:\s+refs\/\S+|[0-9a-f]{40}|[0-9a-f]{64})$/i.test(content.trim());
+}
+
+function assertRecoverableMetadata(worktree: string, repoRoot: string, probe: Probe): void {
+  const dotGit = path.join(worktree, '.git');
+  let dotGitStat: fs.Stats;
+  try {
+    dotGitStat = fs.lstatSync(dotGit);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  if (dotGitStat.isSymbolicLink() || dotGitStat.isDirectory()) {
+    throw new Error('WORKTREE_RECOVERY_METADATA_NOT_ELIGIBLE');
+  }
+  if (!dotGitStat.isFile()) throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+
+  const content = fs.readFileSync(dotGit, 'utf8').trim();
+  const match = /^gitdir:\s*(.+)$/i.exec(content);
+  if (!match) throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+
+  const commonDir = fs.realpathSync.native(path.resolve(repoRoot, probeText(probe, repoRoot, [
+    'rev-parse', '--git-common-dir'
+  ]).trim()));
+  const adminRoot = path.join(commonDir, 'worktrees');
+  const adminPath = path.resolve(path.dirname(dotGit), match[1]!);
+  const relative = path.relative(adminRoot, adminPath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative) || relative.includes(path.sep)) {
+    throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+  }
+
+  if (!fs.existsSync(adminPath)) return;
+  const adminStat = fs.lstatSync(adminPath);
+  if (adminStat.isSymbolicLink()) throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+  if (!adminStat.isDirectory()) return;
+
+  const requiredFiles = ['HEAD', 'gitdir', 'commondir', 'index'];
+  if (requiredFiles.some((name) => !fs.existsSync(path.join(adminPath, name)))) return;
+  for (const name of requiredFiles) {
+    const filePath = path.join(adminPath, name);
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+  }
+
+  const adminGitdir = fs.readFileSync(path.join(adminPath, 'gitdir'), 'utf8').trim();
+  const adminCommonDir = fs.readFileSync(path.join(adminPath, 'commondir'), 'utf8').trim();
+  const adminGitdirPath = adminGitdir ? path.resolve(adminPath, adminGitdir) : '';
+  const adminCommonDirPath = adminCommonDir
+    ? fs.realpathSync.native(path.resolve(adminPath, adminCommonDir))
+    : '';
+  if (!adminGitdir || adminGitdirPath !== path.resolve(dotGit)
+    || !adminCommonDir || adminCommonDirPath !== commonDir) {
+    throw new Error('WORKTREE_RECOVERY_METADATA_INVALID');
+  }
+
+  const headContent = fs.readFileSync(path.join(adminPath, 'HEAD'), 'utf8');
+  const indexContent = fs.readFileSync(path.join(adminPath, 'index'));
+  if (!hasValidHeadContent(headContent) || indexContent.subarray(0, 4).toString('ascii') !== 'DIRC') return;
+
+  const validationEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of ['GIT_DIR', 'GIT_COMMON_DIR', 'GIT_INDEX_FILE', 'GIT_WORK_TREE', 'GIT_PREFIX']) {
+    delete validationEnv[key];
+  }
+  validationEnv.GIT_DIR = adminPath;
+  validationEnv.GIT_WORK_TREE = path.resolve(worktree);
+  if (!probeMetadataCommand(probe, repoRoot, ['rev-parse', '--verify', 'HEAD^{commit}'], validationEnv)) return;
+  if (!probeMetadataCommand(probe, repoRoot, ['ls-files', '--stage', '-z'], validationEnv)) return;
+  throw new Error('WORKTREE_RECOVERY_METADATA_REGISTERED');
+}
+
+function parseRecoveredStatus(raw: string): WorktreeChange[] {
+  const records = raw.split('\0');
+  const changes: WorktreeChange[] = [];
+  for (let index = 0; index < records.length;) {
+    const status = records[index++] ?? '';
+    if (!status) continue;
+    const code = status[0] ?? '';
+    if (code === 'R' || code === 'C') {
+      const originalPath = records[index++];
+      const nextPath = records[index++];
+      if (!originalPath || !nextPath) throw new Error('Unable to parse recovered Git rename record');
+      changes.push({ indexStatus: code, worktreeStatus: ' ', path: nextPath, originalPath });
+      continue;
+    }
+    const filePath = records[index++];
+    if (!filePath) throw new Error('Unable to parse recovered Git status record');
+    changes.push({
+      indexStatus: code === 'D' ? ' ' : code,
+      worktreeStatus: code === 'D' ? 'D' : ' ',
+      path: filePath
+    });
+  }
+  return changes;
+}
+
+function captureRecoveredOnce(
+  worktree: string,
+  recovery: WorktreeRecoveryContext,
+  probe: Probe
+): WorktreeSnapshot {
+  const resolvedWorktree = path.resolve(worktree);
+  const resolvedBase = path.resolve(recovery.worktreeBase);
+  const relative = path.relative(resolvedBase, resolvedWorktree);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`WORKTREE_RECOVERY_PATH_INVALID: ${resolvedWorktree}`);
+  }
+  const stat = fs.lstatSync(resolvedWorktree);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error('WORKTREE_RECOVERY_PATH_INVALID');
+  const canonical = fs.realpathSync.native(resolvedWorktree);
+  if (canonical !== resolvedWorktree) throw new Error('WORKTREE_RECOVERY_PATH_INVALID');
+  const resolvedWorkspace = resolveSandboxTarget(recovery.branch, recovery.repoRoot).workspace;
+  if (recovery.identitySource === 'branch-only' && resolvedWorkspace.mode !== 'branch-only') {
+    throw new Error('WORKTREE_RECOVERY_IDENTITY_CHANGED');
+  }
+  if (recovery.identitySource === 'task-bound'
+    && (resolvedWorkspace.mode !== 'task-bound' || resolvedWorkspace.taskId !== recovery.taskId)) {
+    throw new Error('WORKTREE_RECOVERY_IDENTITY_CHANGED');
+  }
+  assertRecoverableMetadata(resolvedWorktree, recovery.repoRoot, probe);
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-recovered-index-'));
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of ['GIT_DIR', 'GIT_COMMON_DIR', 'GIT_PREFIX']) delete env[key];
+  env.GIT_INDEX_FILE = path.join(tempDir, 'index');
+  env.GIT_WORK_TREE = resolvedWorktree;
+  try {
+    const baseline = probeTextWithEnv(probe, recovery.repoRoot, [
+      'rev-parse', '--verify', `refs/heads/${recovery.branch}^{commit}`
+    ], env).trim();
+    if (!baseline) throw new Error(`WORKTREE_RECOVERY_BRANCH_INVALID: ${recovery.branch}`);
+    probeTextWithEnv(probe, recovery.repoRoot, ['read-tree', baseline], env);
+    probeTextWithEnv(probe, recovery.repoRoot, ['add', '-A', '--', '.'], env);
+    const status = probeTextWithEnv(probe, recovery.repoRoot, [
+      'diff', '--cached', '--name-status', '--find-renames', '-z', '--', '.'
+    ], env);
+    const changes = parseRecoveredStatus(status);
+    const hash = createHash('sha256');
+    updatePart(hash, 'source', 'recovered');
+    updatePart(hash, 'worktree', resolvedWorktree);
+    updatePart(hash, 'repo-root', path.resolve(recovery.repoRoot));
+    updatePart(hash, 'branch', recovery.branch);
+    updatePart(hash, 'baseline', baseline);
+    updatePart(hash, 'identity-source', recovery.identitySource);
+    updatePart(hash, 'task-id', recovery.taskId ?? '');
+    updatePart(hash, 'status', status);
+    for (const change of changes) {
+      hashPath(hash, resolvedWorktree, change.path, probe);
+      if (change.originalPath) hashPath(hash, resolvedWorktree, change.originalPath, probe);
+    }
+    return {
+      worktree: resolvedWorktree,
+      branch: recovery.branch,
+      head: baseline,
+      changes,
+      identity: hash.digest('hex'),
+      source: 'recovered',
+      recovery: { ...recovery }
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 function inspectWorktree(worktree: string, { probe = runProbe }: { probe?: Probe } = {}): WorktreeInspection {
   const resolvedWorktree = path.resolve(worktree);
   try {
@@ -171,6 +373,28 @@ function inspectWorktree(worktree: string, { probe = runProbe }: { probe?: Probe
     const second = captureOnce(resolvedWorktree, probe);
     if (first.identity !== second.identity) {
       return { status: 'failed', worktree: resolvedWorktree, message: 'Snapshot changed while inspecting worktree' };
+    }
+    return { status: second.changes.length === 0 ? 'clean' : 'dirty', snapshot: second };
+  } catch (error) {
+    return {
+      status: 'failed',
+      worktree: resolvedWorktree,
+      message: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+function inspectRecoveredWorktree(
+  worktree: string,
+  recovery: WorktreeRecoveryContext,
+  { probe = runProbe }: { probe?: Probe } = {}
+): WorktreeInspection {
+  const resolvedWorktree = path.resolve(worktree);
+  try {
+    const first = captureRecoveredOnce(resolvedWorktree, recovery, probe);
+    const second = captureRecoveredOnce(resolvedWorktree, recovery, probe);
+    if (first.identity !== second.identity) {
+      return { status: 'failed', worktree: resolvedWorktree, message: 'Snapshot changed while recovering worktree' };
     }
     return { status: second.changes.length === 0 ? 'clean' : 'dirty', snapshot: second };
   } catch (error) {
@@ -201,7 +425,9 @@ function verifyWorktreePermit(
   permit: WorktreeRemovalPermit,
   options: { probe?: Probe } = {}
 ): WorktreeSnapshot {
-  const current = inspectWorktree(permit.snapshot.worktree, options);
+  const current = permit.snapshot.source === 'recovered' && permit.snapshot.recovery
+    ? inspectRecoveredWorktree(permit.snapshot.worktree, permit.snapshot.recovery, options)
+    : inspectWorktree(permit.snapshot.worktree, options);
   if (current.status === 'failed') throw new Error(`Unable to verify worktree permit: ${current.message}`);
   if (current.snapshot.identity !== permit.snapshot.identity || (permit.mode === 'clean' && current.status !== 'clean')) {
     throw new Error(`Worktree changed after authorization: ${permit.snapshot.worktree}`);
@@ -227,8 +453,9 @@ export {
   createCleanPermit,
   createDiscardPermit,
   formatWorktreeSnapshot,
+  inspectRecoveredWorktree,
   inspectWorktree,
   inspectWorktrees,
   verifyWorktreePermit
 };
-export type { WorktreeChange, WorktreeInspection, WorktreeRemovalPermit, WorktreeSnapshot };
+export type { WorktreeChange, WorktreeInspection, WorktreeRecoveryContext, WorktreeRemovalPermit, WorktreeSnapshot };

--- a/tests/integration/cli/codex-lifecycle.test.ts
+++ b/tests/integration/cli/codex-lifecycle.test.ts
@@ -9,6 +9,7 @@ import test, { after } from 'node:test';
 import {
   envWithPrependedPath,
   INTERNAL_CLI_PATH,
+  sandboxControlSafeEnv,
   writeNodeCommandShim
 } from '../../helpers.ts';
 const fixtureRoots = new Set<string>();
@@ -58,7 +59,13 @@ function fixture() {
   fs.writeFileSync(path.join(root, '.codex', 'hooks.json'), hooks);
   return {
     root,
-    env: envWithPrependedPath(process.env, bin),
+    env: envWithPrependedPath(sandboxControlSafeEnv({
+      ...process.env,
+      AGENT_INFRA_RUNTIME_DIR: undefined,
+      AGENT_INFRA_TASK_ID: undefined,
+      AGENT_INFRA_EXECUTOR_MANIFEST: undefined,
+      AGENT_INFRA_CODEX_CONTROLLER_CONTEXT: undefined
+    }), bin),
     hookDefinitionHash: crypto.createHash('sha256').update(hooks).digest('hex')
   };
 }

--- a/tests/integration/cli/sandbox-worktree-safety.test.ts
+++ b/tests/integration/cli/sandbox-worktree-safety.test.ts
@@ -77,6 +77,51 @@ function addFixtureWorktree(
   return worktree;
 }
 
+function removeWorktreeMetadata(worktree: string): void {
+  const dotGit = fs.readFileSync(path.join(worktree, ".git"), "utf8").trim();
+  const match = /^gitdir:\s*(.+)$/i.exec(dotGit);
+  assert.ok(match?.[1]);
+  fs.rmSync(path.resolve(path.dirname(path.join(worktree, ".git")), match[1]), { recursive: true, force: true });
+}
+
+function addActiveTask(
+  repoDir: string,
+  taskId: string,
+  branch: string,
+  shortId = "7"
+): void {
+  const activeRoot = path.join(repoDir, ".agents", "workspace", "active");
+  fs.mkdirSync(path.join(activeRoot, taskId), { recursive: true });
+  fs.writeFileSync(
+    path.join(activeRoot, taskId, "task.md"),
+    `---\nid: ${taskId}\nbranch: ${branch}\n---\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(activeRoot, ".short-ids.json"),
+    `${JSON.stringify({ version: 1, ids: { [shortId]: taskId } })}\n`,
+    "utf8"
+  );
+}
+
+async function withFixtureDocker<T>(
+  fixture: ReturnType<typeof writeSandboxEngineFixture>,
+  callback: () => Promise<T>
+): Promise<T> {
+  const originalPath = process.env.PATH;
+  const originalDockerLogPath = process.env.DOCKER_LOG_PATH;
+  process.env.PATH = envWithPrependedPath(process.env, fixture.binDir).PATH;
+  process.env.DOCKER_LOG_PATH = fixture.logPath;
+  try {
+    return await callback();
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalDockerLogPath === undefined) delete process.env.DOCKER_LOG_PATH;
+    else process.env.DOCKER_LOG_PATH = originalDockerLogPath;
+  }
+}
+
 function spawnSandboxCli(
   fixture: ReturnType<typeof writeSandboxEngineFixture>,
   tmpDir: string,
@@ -237,6 +282,73 @@ test("sandbox rm retries control and workspace cleanup after the container is al
   }
 });
 
+test("sandbox rm removes an empty control container parent after control cleanup", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-empty-control-parent-"));
+  const branch = "feature/empty-control-parent";
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+    const config = rmOneConfig(fixture, tmpDir);
+    const container = "demo-dev-feature..empty-control-parent";
+    const controlRoot = path.join(config.controlBase, config.project, container, "branch-only");
+    const channelDir = path.join(controlRoot, "channel");
+    const processingDir = path.join(controlRoot, "processing");
+    fs.mkdirSync(channelDir, { recursive: true });
+    fs.mkdirSync(path.join(controlRoot, "public"), { recursive: true });
+    fs.mkdirSync(processingDir, { recursive: true });
+    fs.writeFileSync(path.join(controlRoot, "manifest.json"), `${JSON.stringify({
+      version: 5, engine: "docker-desktop", repoRoot: fixture.repoDir, worktreeRoot: fixture.repoDir,
+      project: "demo", container, containerIdentity: { id: "empty-parent-container", labels: {} }, branch,
+      mode: "branch-only", taskId: null, token: "empty-parent-secret", generation: "empty-parent-generation",
+      channelDir, publicStatusDir: path.join(controlRoot, "public"), processingDir,
+      runtimeDir: path.join(controlRoot, "runtime")
+    })}\n`);
+    fs.writeFileSync(path.join(controlRoot, "public", "status.json"), `${JSON.stringify({
+      version: 2,
+      generation: "empty-parent-generation",
+      broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
+      state: "healthy",
+      reasonCode: null,
+      activeRequestId: null,
+      updatedAt: Date.now()
+    })}\n`);
+    const previousPath = process.env.PATH;
+    const previousDockerLog = process.env.DOCKER_LOG_PATH;
+    const previousNotFound = process.env.DOCKER_INSPECT_NOT_FOUND;
+    process.env.PATH = envWithPrependedPath(process.env, fixture.binDir).PATH;
+    process.env.DOCKER_LOG_PATH = fixture.logPath;
+    process.env.DOCKER_INSPECT_NOT_FOUND = "1";
+    try {
+      const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+      await rm.rmOne(config, [], branch, {
+        assumeYes: true,
+        target: {
+          branch,
+          effectiveBranch: branch,
+          engine: "docker-desktop",
+          matchedContainers: [],
+          existingWorktrees: [],
+          toolCandidates: [],
+          workspace: { mode: "branch-only" },
+          controlRoots: [controlRoot],
+          workspaceViewRoots: []
+        }
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousDockerLog === undefined) delete process.env.DOCKER_LOG_PATH;
+      else process.env.DOCKER_LOG_PATH = previousDockerLog;
+      if (previousNotFound === undefined) delete process.env.DOCKER_INSPECT_NOT_FOUND;
+      else process.env.DOCKER_INSPECT_NOT_FOUND = previousNotFound;
+    }
+
+    assert.equal(fs.existsSync(controlRoot), false);
+    assert.equal(fs.existsSync(path.dirname(controlRoot)), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("worktree safety snapshot binds staged, unstaged, and unusual untracked content", onPlatforms("linux", "darwin", "win32"), async () => {
   const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
   const fixture = createLinkedWorktree();
@@ -270,6 +382,160 @@ test("worktree safety snapshot binds staged, unstaged, and unusual untracked con
     assert.equal(untracked.snapshot.changes.some((change) => change.path === "ignored.txt"), false);
   } finally {
     fixture.cleanup();
+  }
+});
+
+test("recovered worktree safety uses an isolated branch snapshot after metadata loss", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const fixture = createLinkedWorktree();
+  try {
+    removeWorktreeMetadata(fixture.worktree);
+    const recovery = {
+      repoRoot: fixture.repo,
+      worktreeBase: fixture.base,
+      branch: "feature/safe-delete",
+      identitySource: "branch-only" as const,
+      taskId: null
+    };
+
+    assert.equal(safety.inspectWorktree(fixture.worktree).status, "failed");
+    const clean = safety.inspectRecoveredWorktree(fixture.worktree, recovery);
+    assert.equal(clean.status, "clean");
+    assert.equal(clean.snapshot.source, "recovered");
+
+    fs.writeFileSync(path.join(fixture.worktree, "tracked.txt"), "recovered dirty\n", "utf8");
+    const dirty = safety.inspectRecoveredWorktree(fixture.worktree, recovery);
+    assert.equal(dirty.status, "dirty");
+    assert.ok(dirty.snapshot.changes.some((change) => change.path === "tracked.txt"));
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("recovered worktree safety accepts clearly partial admin metadata", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const fixture = createLinkedWorktree();
+  try {
+    const dotGit = fs.readFileSync(path.join(fixture.worktree, ".git"), "utf8").trim();
+    const match = /^gitdir:\s*(.+)$/i.exec(dotGit);
+    assert.ok(match?.[1]);
+    const adminPath = path.resolve(path.dirname(path.join(fixture.worktree, ".git")), match[1]);
+    fs.rmSync(path.join(adminPath, "commondir"), { force: true });
+
+    const recovered = safety.inspectRecoveredWorktree(fixture.worktree, {
+      repoRoot: fixture.repo,
+      worktreeBase: fixture.base,
+      branch: "feature/safe-delete",
+      identitySource: "branch-only",
+      taskId: null
+    });
+
+    assert.equal(recovered.status, "clean", JSON.stringify(recovered));
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("recovered worktree safety resolves the common Git directory from a linked repo root", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-worktree-linked-root-"));
+  const mainRepo = path.join(root, "main");
+  const repoRoot = path.join(root, "management");
+  const worktreeBase = path.join(root, "sandboxes");
+  const worktree = path.join(worktreeBase, "feature..safe-delete");
+  try {
+    fs.mkdirSync(mainRepo, { recursive: true });
+    fs.mkdirSync(worktreeBase, { recursive: true });
+    git(mainRepo, "init", "-q", "-b", "main");
+    fs.writeFileSync(path.join(mainRepo, "tracked.txt"), "initial\n", "utf8");
+    git(mainRepo, "add", "tracked.txt");
+    git(mainRepo, "-c", "user.name=Sandbox Test", "-c", "user.email=sandbox@example.com", "commit", "-q", "-m", "initial");
+    git(mainRepo, "worktree", "add", "-q", "-b", "management", repoRoot, "HEAD");
+    git(mainRepo, "worktree", "add", "-q", "-b", "feature/safe-delete", worktree, "HEAD");
+    removeWorktreeMetadata(worktree);
+
+    const recovered = safety.inspectRecoveredWorktree(worktree, {
+      repoRoot,
+      worktreeBase,
+      branch: "feature/safe-delete",
+      identitySource: "branch-only",
+      taskId: null
+    });
+
+    assert.equal(recovered.status, "clean", JSON.stringify(recovered));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recovered worktree safety accepts clearly damaged HEAD or index metadata", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  for (const damagedFile of ["HEAD", "index"]) {
+    const fixture = createLinkedWorktree();
+    try {
+      const dotGit = fs.readFileSync(path.join(fixture.worktree, ".git"), "utf8").trim();
+      const match = /^gitdir:\s*(.+)$/i.exec(dotGit);
+      assert.ok(match?.[1]);
+      const adminPath = path.resolve(path.dirname(path.join(fixture.worktree, ".git")), match[1]);
+      fs.writeFileSync(
+        path.join(adminPath, damagedFile),
+        damagedFile === "HEAD"
+          ? "not a valid HEAD\n"
+          : Buffer.from([0x44, 0x49, 0x52, 0x43, 0, 0, 0, 2, 0, 0, 0, 0])
+      );
+
+      const recovered = safety.inspectRecoveredWorktree(fixture.worktree, {
+        repoRoot: fixture.repo,
+        worktreeBase: fixture.base,
+        branch: "feature/safe-delete",
+        identitySource: "branch-only",
+        taskId: null
+      });
+
+      assert.equal(recovered.status, "clean", `${damagedFile}: ${JSON.stringify(recovered)}`);
+    } finally {
+      fixture.cleanup();
+    }
+  }
+});
+
+test("recovered worktree safety rejects damaged content with inconsistent admin pointers", onPlatforms("linux", "darwin", "win32"), async () => {
+  const safety = await loadFreshEsm<SafetyModule>("lib/sandbox/worktree-safety.js");
+  const cases = [
+    { damagedFile: "HEAD", pointerFile: "gitdir" },
+    { damagedFile: "index", pointerFile: "commondir" }
+  ] as const;
+
+  for (const { damagedFile, pointerFile } of cases) {
+    const fixture = createLinkedWorktree();
+    try {
+      const dotGit = fs.readFileSync(path.join(fixture.worktree, ".git"), "utf8").trim();
+      const match = /^gitdir:\s*(.+)$/i.exec(dotGit);
+      assert.ok(match?.[1]);
+      const adminPath = path.resolve(path.dirname(path.join(fixture.worktree, ".git")), match[1]);
+      fs.writeFileSync(
+        path.join(adminPath, damagedFile),
+        damagedFile === "HEAD"
+          ? "not a valid HEAD\n"
+          : Buffer.from([0x44, 0x49, 0x52, 0x43, 0, 0, 0, 2, 0, 0, 0, 0])
+      );
+      const wrongPointer = path.join(path.dirname(adminPath), `wrong-${pointerFile}`);
+      fs.mkdirSync(wrongPointer, { recursive: true });
+      fs.writeFileSync(path.join(adminPath, pointerFile), `${wrongPointer}\n`, "utf8");
+
+      const recovered = safety.inspectRecoveredWorktree(fixture.worktree, {
+        repoRoot: fixture.repo,
+        worktreeBase: fixture.base,
+        branch: "feature/safe-delete",
+        identitySource: "branch-only",
+        taskId: null
+      });
+
+      assert.equal(recovered.status, "failed", `${damagedFile}/${pointerFile}: ${JSON.stringify(recovered)}`);
+      assert.match(recovered.message ?? "", /WORKTREE_RECOVERY_METADATA_INVALID/);
+    } finally {
+      fixture.cleanup();
+    }
   }
 });
 
@@ -448,6 +714,154 @@ test("sandbox rm clean path uses injectable default-yes confirmations and remove
     assert.equal(fs.existsSync(worktree), false);
     assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
     assert.equal(fs.existsSync(share), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm recovers and removes a clean worktree with missing metadata", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const fixture = writeSandboxEngineFixture(fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-recovered-clean-")), { project: "demo" });
+  const tmpDir = path.dirname(fixture.repoDir);
+  const branch = "feature/recovered-clean";
+  try {
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    removeWorktreeMetadata(worktree);
+    const prompts: string[] = [];
+    await withFixtureDocker(fixture, () => rm.rmOne(rmOneConfig(fixture, tmpDir), [], branch, {
+      interactive: true,
+      prompt: {
+        confirm: async (options) => {
+          prompts.push(options.message);
+          return true;
+        },
+        isCancel: (value): value is symbol => false
+      }
+    }));
+
+    assert.equal(fs.existsSync(worktree), false);
+    assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
+    assert.equal(prompts.filter((message) => message.startsWith("Remove worktree")).length, 1);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm refuses a container with conflicting workspace identity before destructive calls", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-container-conflict-"));
+  const branch = "feature/container-conflict";
+  const container = `demo-dev-${branch.replaceAll("/", "..")}`;
+  const row = `${container}\tUp 1 minute\tdemo.sandbox.branch=${branch},demo.sandbox.workspace-mode=task-bound,demo.sandbox.task-id=TASK-20260824-999999`;
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: row });
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    removeWorktreeMetadata(worktree);
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", branch]);
+
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(`${result.stdout}\n${result.stderr}`, /SANDBOX_WORKSPACE_IDENTITY_CONFLICT/);
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "branch", "--list", branch), new RegExp(branch));
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm refuses a container whose branch label conflicts with the requested branch", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-container-branch-conflict-"));
+  const requestedBranch = "feature/container-requested";
+  const labelledBranch = "feature/container-labelled";
+  const container = `demo-dev-${requestedBranch.replaceAll("/", "..")}`;
+  const row = `${container}\tUp 1 minute\tdemo.sandbox.branch=${labelledBranch},demo.sandbox=true`;
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: row });
+    const labelledWorktree = addFixtureWorktree(fixture, tmpDir, labelledBranch);
+    removeWorktreeMetadata(labelledWorktree);
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", requestedBranch]);
+
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(`${result.stdout}\n${result.stderr}`, /SANDBOX_WORKSPACE_IDENTITY_CONFLICT/);
+    assert.equal(fs.existsSync(labelledWorktree), true);
+    assert.match(git(fixture.repoDir, "branch", "--list", labelledBranch), new RegExp(labelledBranch));
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm allows explicit discard of a stable recovered dirty snapshot", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-recovered-dirty-"));
+  const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+  const branch = "feature/recovered-dirty";
+  try {
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    removeWorktreeMetadata(worktree);
+    fs.writeFileSync(path.join(worktree, "tracked.txt"), "discard recovered change\n", "utf8");
+    const prompts: Array<{ message: string; initialValue: boolean }> = [];
+    await withFixtureDocker(fixture, () => rm.rmOne(rmOneConfig(fixture, tmpDir), [], branch, {
+      interactive: true,
+      prompt: {
+        confirm: async (options) => {
+          prompts.push({ message: options.message, initialValue: Boolean(options.initialValue) });
+          return true;
+        },
+        isCancel: (value): value is symbol => false
+      }
+    }));
+
+    assert.equal(fs.existsSync(worktree), false);
+    assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
+    assert.equal(prompts.some(({ message, initialValue }) => (
+      message === "Discard these exact uncommitted changes?" && initialValue === false
+    )), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm accepts a task-bound resolver identity when container and control roots are gone", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-recovered-task-bound-"));
+  const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+  const branch = "agent-infra-feature-recovered-task";
+  try {
+    addActiveTask(fixture.repoDir, "TASK-20260824-000001", branch);
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    removeWorktreeMetadata(worktree);
+    await withFixtureDocker(fixture, () => rm.rmOne(rmOneConfig(fixture, tmpDir), [], branch, {
+      interactive: true,
+      prompt: { confirm: async () => true, isCancel: (value): value is symbol => false }
+    }));
+
+    assert.equal(fs.existsSync(worktree), false);
+    assert.equal(git(fixture.repoDir, "branch", "--list", branch), "");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm keeps malformed recovery metadata fail-closed", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-recovered-invalid-"));
+  const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+  const branch = "feature/recovered-invalid";
+  try {
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    fs.writeFileSync(path.join(worktree, ".git"), "gitdir: /outside/recovery\n", "utf8");
+
+    await assert.rejects(
+      () => withFixtureDocker(fixture, () => rm.rmOne(rmOneConfig(fixture, tmpDir), [], branch, {
+        interactive: true,
+        prompt: { confirm: async () => true, isCancel: (value): value is symbol => false }
+      })),
+      /WORKTREE_RECOVERY_METADATA_INVALID/
+    );
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "branch", "--list", branch), new RegExp(branch));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -645,6 +1059,64 @@ test("sandbox rm --unbound preflights all worktrees before deleting any sandbox"
     assert.equal(fs.existsSync(cleanWorktree), true);
     assert.equal(fs.existsSync(path.join(dirtyWorktree, "untracked.txt")), true);
     assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm --unbound does not use recovered worktree deletion", onPlatforms("linux", "darwin", "win32"), () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-unbound-recovered-"));
+  const branch = "feature/recovered-batch";
+  const row = `demo-dev-${branch.replaceAll("/", "..")}	Up 1 minute	demo.sandbox.branch=${branch},demo.sandbox=true`;
+  try {
+    const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo", dockerStdoutForPs: row });
+    const worktree = addFixtureWorktree(fixture, tmpDir, branch);
+    removeWorktreeMetadata(worktree);
+
+    const result = spawnSandboxCli(fixture, tmpDir, ["rm", "--unbound", "--yes"]);
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}\n${result.stderr}`, /worktree preflight found blocker/);
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "branch", "--list", branch), new RegExp(branch));
+    assert.equal(fixture.readDockerCalls().some((call) => call[0] === "stop" || call[0] === "rm"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox rm refuses a recovered worktree whose path does not match the requested branch", onPlatforms("linux", "darwin", "win32"), async () => {
+  const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-rm-recovered-path-conflict-"));
+  const fixture = writeSandboxEngineFixture(tmpDir, { project: "demo" });
+  const actualBranch = "feature/recovered-actual";
+  const requestedBranch = "feature/recovered-requested";
+  try {
+    const worktree = addFixtureWorktree(fixture, tmpDir, actualBranch);
+    removeWorktreeMetadata(worktree);
+    await assert.rejects(
+      () => withFixtureDocker(fixture, () => rm.rmOne(rmOneConfig(fixture, tmpDir), [], requestedBranch, {
+        target: {
+          branch: requestedBranch,
+          effectiveBranch: requestedBranch,
+          engine: "docker-desktop",
+          matchedContainers: [],
+          existingWorktrees: [worktree],
+          toolCandidates: [],
+          workspace: { mode: "branch-only" },
+          controlRoots: [],
+          workspaceViewRoots: []
+        },
+        interactive: true,
+        prompt: {
+          confirm: async () => true,
+          isCancel: (value): value is symbol => false
+        }
+      })),
+      /Unable to inspect worktree/
+    );
+    assert.equal(fs.existsSync(worktree), true);
+    assert.match(git(fixture.repoDir, "branch", "--list", actualBranch), new RegExp(actualBranch));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 摘要 / Summary

- 修复受管 worktree 的 `.git` 指针或主仓库 worktree metadata 损坏/缺失时，单个 `ai sandbox rm` 被永久阻塞的问题。
- 通过目标身份、受管路径和隔离快照建立可审计的安全删除路径；无法证明安全、非交互、`--yes` 和批量删除仍 fail closed。
- 保留 known-dirty 的单目标交互确认丢弃语义，并清理删除后不再需要的空控制父目录。
- 隔离 direct-host Codex lifecycle 测试与 task-bound runtime 环境，避免测试夹具之间发生证据重放冲突。

This fixes single-sandbox deletion when a managed worktree's `.git` pointer or the main repository's worktree metadata is damaged or missing. The recovery path remains identity-bound and fail-closed for unverifiable, non-interactive, `--yes`, and batch deletion paths, while stable known-dirty snapshots remain available for explicit single-target discard confirmation.

## 主要变更 / Changes

- Extend worktree safety inspection with isolated, repeatable snapshots for damaged worktree metadata.
- Connect the safe recovery path to sandbox removal while retaining identity checks, permission revalidation, and batch preflight protection.
- Clean empty control-parent directories after successful single-sandbox removal.
- Add regression coverage for damaged pointers, missing metadata, clean/dirty worktrees, batch protection, and control-directory cleanup.
- Remove task-bound runtime variables from the direct-host lifecycle fixture environment.

## 验证 / Verification

- `node scripts/run-tests.js --skip-build tests/integration/cli/codex-lifecycle.test.ts`: 4 passed, 0 failed.
- `npm run typecheck`: passed.
- `npm run test:core`: 2200 passed, 3 skipped, 0 failed.
- `npm test`: 2517 passed, 4 skipped, 0 failed.
- `git diff --check` and the pre-commit hook: passed.

## 审查 / Review

- `review-code-r5.md`: Approved；0 blocker、0 major、0 minor、无需人工验证。

## 关联 Issue / Related Issue

Closes #896

Generated with AI assistance
