### PR TITLE
fix(cli): 修复沙箱完成任务时终态校验读取陈旧挂载


### DIFF
--- a/.agents/rules/task-management.md
+++ b/.agents/rules/task-management.md
@@ -28,7 +28,7 @@
 - 历史 `gemini` / `gemini-cli` 仅保留 `ai task log` 渲染兼容，不接受写入
 - 人工步骤例外：无论使用哪个 Agent，只要是人做的决定，统一声明 `human`
 
-六个内部命令（`task-event` / `task-lifecycle` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`）对 `--agent` 做白名单硬校验：接受短名、长名或 `human`，非标准值返回对应 `*_PAYLOAD_INVALID` 错误；长名在落库/透传前归一化为短名。渲染端 `ai task log` 对无法识别的 token 保留 `human` 归类并附加 `(unknown)` 标记。
+七个内部命令（`task-event` / `task-lifecycle` / `task-finalization` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`）对 `--agent` 做白名单硬校验：接受短名、长名或 `human`，非标准值返回对应 `*_PAYLOAD_INVALID` 错误；长名在落库/透传前归一化为短名。渲染端 `ai task log` 对无法识别的 token 保留 `human` 归类并附加 `(unknown)` 标记。
 
 ## 状态快照与完成验证入口
 

--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -38,7 +38,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ## 步骤开始：本地生命周期边界
 
-正常完成路径在 active 阶段完成业务更新、平台同步和预完成门禁后，才由步骤 6 的单次 lifecycle intent 原子完成基础终态字段、started/done 日志、目录转移和短号释放；不得提前手工写入这些机械状态。已归档任务只允许进入 `finalization-retry` 场景，不回迁目录或重新执行 lifecycle。
+正常完成路径在 active 阶段完成业务更新、平台同步和预完成门禁后，才由步骤 6 的单次 finalization intent 按固定顺序原子推进生命周期、终态 task 评论和完成校验；不得提前手工写入这些机械状态。已归档任务只允许进入 `finalization-retry` 场景，不回迁目录或重新执行 lifecycle。
 
 ## 执行步骤
 ### 1. 验证任务存在
@@ -167,40 +167,34 @@ agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 
 `--force` 不解除本硬门禁：未关闭分歧必须先在账本闭合，未复审提交必须重新审查、具备有效豁免，或由平台适配器为绑定的变更请求（PR/MR）提供权威合并快照与远端 refs，并在隔离临时仓库中证明单父 squash merge 等价，或在无有效变更请求时由本地 Git 对象证明唯一受保护提交是内容等价的单父重写且之后无受保护提交；平台 preflight 必须通过。适配器不支持所需能力，平台事实、Git 对象、拓扑、内容证据缺失，或当前 Git 凭据不能读取远端证据 refs 时 fail closed。全部 checks 由平台适配器提供规范化状态，并在合并前通过 `review-code` / `watch-pr` 路由承担；其中 required checks 仍受分支保护 / ruleset 强制。
 
-### 6. 执行本地生命周期意图并验证转移
+### 6. 执行宿主 finalization 入口并验证终态
 
 ```bash
-agent-infra-internal task-lifecycle {task-id} complete --agent {standard-agent-token}
+agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-仅 `status=applied|no-op` 视为本地完成。`status=failed` 时展示 `error` 与 completed/pending steps，以同一 intent 重试；不得宣称完成或手工补写局部状态。
+finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。只有结构化结果 `status=completed` 才视为完成；`failed` 或 `blocked` 时展示 `error` 与 completed/pending steps，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。
 
 ```bash
 ls .agents/workspace/completed/{task-id}/task.md
 ```
 
-确认任务目录已成功移动。
+仅在 finalization 返回 `status=completed` 后确认任务目录已成功移动。
 
-### 7. 同步终态 task 评论并完成校验
+### 7. 处理 finalization 重试与结果
 
-场景 A 与场景 B `finalization-retry` 都从 completed 目录执行本步骤。若存在有效的 `issue_number`，先调用：
+场景 A 与场景 B `finalization-retry` 都从宿主执行同一个 `task-finalization` 入口。receipt 只是重入提示，不是 canonical truth：每次重入都要重新验证终态 task 评论和完成校验；只有任务已处于 `completed` 且短号 registry 已释放时，才可跳过不可逆的 lifecycle。不得拆开调用旧的 lifecycle、评论同步或完成校验命令。若 task 评论或校验因网络问题返回 `blocked`，保留 receipt 和已完成状态，修复网络后重跑 complete-task；若生命周期仍未完成，任务保持 active 并从 receipt 的待处理步骤继续。
 
-```bash
-agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}
-```
-
-该调用失败时任务已归档，不能调用只接受 active 任务的 `task-warning`；保留 completed 状态并停止。修复网络或平台问题后重跑 complete-task，会由步骤 1 进入 `finalization-retry`，只重复本步骤。
-
-运行完成校验，确认任务产物和同步状态符合规范：
+完成结果必须包含本次 finalization 的结构化输出，确认任务产物和同步状态符合规范：
 
 ```bash
 agent-infra-internal task-verify {task-id} complete-task.completed --format text
 ```
 
 处理结果：
-- 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- 退出码 1（校验失败）-> 根据输出修复问题后重新运行校验
-- 退出码 2（网络中断或状态标签清理尚未收敛）-> 保留 completed 状态并停止；稍后重跑 complete-task 进入 `finalization-retry`
+- `status=completed` / 退出码 0（全部通过）-> 继续到「告知用户」步骤
+- `status=failed` / 退出码 1 -> 根据输出修复问题后重新运行 finalization
+- `status=blocked` / 退出码 2 -> 保留 receipt 与已完成的步骤并停止；稍后重跑 complete-task 进入 `finalization-retry`
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -12,7 +12,7 @@ const command = process.argv[2] || '';
 
 if (
   process.env.AGENT_INFRA_CONTROL_TOKEN
-  && (command === 'task-lifecycle' || command === 'task-orchestration')
+  && (command === 'task-lifecycle' || command === 'task-orchestration' || command === 'task-finalization')
 ) {
   const { sandboxControl } = await import('../lib/internal/sandbox-control.ts');
   await sandboxControl(['client', command, ...process.argv.slice(3)]);
@@ -137,6 +137,11 @@ if (
   case 'task-lifecycle': {
     const { taskLifecycle } = await import('../lib/internal/task-lifecycle.ts');
     taskLifecycle(process.argv.slice(3));
+    break;
+  }
+  case 'task-finalization': {
+    const { taskFinalization } = await import('../lib/internal/task-finalization.ts');
+    taskFinalization(process.argv.slice(3));
     break;
   }
   case 'task-override': {

--- a/lib/internal/sandbox-control.ts
+++ b/lib/internal/sandbox-control.ts
@@ -1,8 +1,10 @@
 import {
   requestSandboxControl,
+  requestSandboxTaskFinalization,
   requestSandboxTaskControl,
   SandboxControlClientError
 } from '../sandbox/control/client.ts';
+import { normalizeAgentToken, AGENT_USAGE_HINT } from '../agent-clients/tokens.ts';
 import { serveSandboxControl } from '../sandbox/control/server.ts';
 import { runSandboxControlExecutor } from '../sandbox/control/executor.ts';
 import {
@@ -18,6 +20,64 @@ function isCanonicalCodexPrepare(args: readonly string[]): boolean {
     else if (args[index]?.startsWith('--client=')) clients.push(args[index]!.slice('--client='.length));
   }
   return clients.length === 1 && clients[0] === 'codex';
+}
+
+type FinalizationStatus = 'completed' | 'failed' | 'blocked' | 'unknown';
+
+function writeFinalizationEnvelope(
+  status: FinalizationStatus,
+  accepted: boolean,
+  error: { code: string; message: string; retryable: boolean },
+  changed = false,
+  result: unknown = null
+): void {
+  process.stdout.write(`${JSON.stringify({ version: 1, status, changed, accepted, result, error })}\n`);
+}
+
+function finalizationErrorStatus(error: { retryable: boolean; code: string }): FinalizationStatus {
+  if (error.code === 'SANDBOX_CONTROL_RESULT_UNKNOWN') return 'unknown';
+  return error.retryable ? 'blocked' : 'failed';
+}
+
+function sandboxFinalizationClient(args: string[]): void {
+  if (args.length !== 4 || !args[0] || args[1] !== 'complete' || args[2] !== '--agent' || !args[3]) {
+    const error = { code: 'TASK_FINALIZATION_PAYLOAD_INVALID', message: 'task ref, complete intent, and --agent are required', retryable: false };
+    writeFinalizationEnvelope('failed', false, error);
+    process.stderr.write('Usage: agent-infra-internal task-finalization <N | TASK-id> complete --agent <agent>\n');
+    process.exitCode = 1;
+    return;
+  }
+  const agent = normalizeAgentToken(args[3]);
+  if (!agent) {
+    const error = { code: 'TASK_FINALIZATION_PAYLOAD_INVALID', message: `invalid --agent: ${AGENT_USAGE_HINT}`, retryable: false };
+    writeFinalizationEnvelope('failed', false, error);
+    process.exitCode = 1;
+    return;
+  }
+  let response;
+  try {
+    response = requestSandboxTaskFinalization({ agent });
+  } catch (error) {
+    if (!(error instanceof SandboxControlClientError)) throw error;
+    writeFinalizationEnvelope(finalizationErrorStatus(error.detail), error.accepted, error.detail);
+    process.stderr.write(`${error.detail.message}\n`);
+    process.exitCode = error.detail.code === 'SANDBOX_CONTROL_RESULT_UNKNOWN' ? 1 : error.detail.retryable ? 2 : 1;
+    return;
+  }
+  if (response.phase === 'rejected') {
+    const error = response.error ?? {
+      code: 'SANDBOX_CONTROL_REJECTED',
+      message: 'sandbox control rejected the finalization request',
+      retryable: false
+    };
+    writeFinalizationEnvelope(finalizationErrorStatus(error), error.code === 'SANDBOX_CONTROL_RESULT_UNKNOWN', error);
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = error.code === 'SANDBOX_CONTROL_RESULT_UNKNOWN' ? 1 : error.retryable ? 2 : 1;
+    return;
+  }
+  process.stdout.write(response.stdout);
+  process.stderr.write(response.stderr);
+  process.exitCode = response.exitCode ?? 1;
 }
 
 async function sandboxControl(args: string[]): Promise<void> {
@@ -49,6 +109,10 @@ async function sandboxControl(args: string[]): Promise<void> {
   }
   if (operation === 'client') {
     const [family = '', ...commandArgs] = rest;
+    if (family === 'task-finalization') {
+      sandboxFinalizationClient(commandArgs);
+      return;
+    }
     let response;
     try {
       if (family === 'task-orchestration' && isCanonicalCodexPrepare(commandArgs)) {

--- a/lib/internal/task-finalization.ts
+++ b/lib/internal/task-finalization.ts
@@ -1,0 +1,65 @@
+import { normalizeAgentToken, AGENT_USAGE_HINT } from '../agent-clients/tokens.ts';
+import { applyTaskFinalization } from '../task/finalization.ts';
+import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
+
+const USAGE = 'Usage: agent-infra-internal task-finalization <N | TASK-id> complete --agent <agent>\n';
+
+type FinalizationError = Readonly<{ code: string; message: string; retryable: boolean }>;
+
+function envelope(
+  status: 'completed' | 'failed' | 'blocked' | 'unknown',
+  changed: boolean,
+  accepted: boolean,
+  result: ReturnType<typeof applyTaskFinalization> | null,
+  error: FinalizationError | null
+): string {
+  return `${JSON.stringify({ version: 1, status, changed, accepted, result, error })}\n`;
+}
+
+function exitCode(status: 'completed' | 'failed' | 'blocked' | 'unknown'): number {
+  return status === 'completed' ? 0 : status === 'blocked' ? 2 : 1;
+}
+
+function fail(message: string): void {
+  const error = { code: 'TASK_FINALIZATION_PAYLOAD_INVALID', message, retryable: false };
+  process.stdout.write(envelope('failed', false, false, null, error));
+  process.stderr.write(USAGE);
+  process.exitCode = 1;
+}
+
+function taskFinalization(args: string[] = []): void {
+  if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
+  if (args.length !== 4 || !args[0] || args[1] !== 'complete' || args[2] !== '--agent' || !args[3]) {
+    fail('task ref, complete intent, and --agent are required');
+    return;
+  }
+  const agent = normalizeAgentToken(args[3]);
+  if (!agent) {
+    fail(`invalid --agent: ${AGENT_USAGE_HINT}`);
+    return;
+  }
+  let repoRoot: string;
+  try {
+    repoRoot = detectRepoRoot();
+  } catch (error) {
+    const detail = { code: 'REPO_ROOT_NOT_FOUND', message: error instanceof Error ? error.message : String(error), retryable: false };
+    process.stdout.write(envelope('failed', false, true, null, detail));
+    process.exitCode = 1;
+    return;
+  }
+  const resolved = resolveTaskRef(args[0], { repoRoot });
+  if (!resolved.ok) {
+    const detail = { code: resolved.code, message: resolved.message, retryable: false };
+    process.stdout.write(envelope('failed', false, true, null, detail));
+    process.exitCode = 1;
+    return;
+  }
+  const result = applyTaskFinalization(
+    { taskRef: resolved.taskId, intent: 'complete', agent },
+    { repoRoot }
+  );
+  process.stdout.write(envelope(result.status, result.changed, true, result, result.error));
+  process.exitCode = exitCode(result.status);
+}
+
+export { taskFinalization };

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -11,6 +11,7 @@ import {
   type SandboxControlResponse,
   type SandboxTaskCreateRequest,
   type SandboxTaskCommandRequest,
+  type SandboxTaskFinalizationRequest,
   type SandboxCodexControllerRequest
 } from './protocol.ts';
 import type {
@@ -18,6 +19,7 @@ import type {
   CodexControllerOpened
 } from './controller-registration.ts';
 import type { ProcessIdentity } from '../../server/process-state.ts';
+import { normalizeAgentToken } from '../../agent-clients/tokens.ts';
 import { readSandboxControlStatus } from './state.ts';
 import type { TaskCreateCandidateV1 } from '../../task/create.ts';
 
@@ -184,7 +186,7 @@ export function requestSandboxControl(params: Readonly<{
   token?: string; generation?: string; timeoutMs?: number;
 }>): SandboxControlResponse {
   if (!isSandboxControlFamily(params.family)) clientError('SANDBOX_CONTROL_COMMAND_DENIED', `'${params.family}' is not allowed`, false);
-  if (params.family === 'task-create' || params.family === 'codex-controller') {
+  if (params.family === 'task-create' || params.family === 'codex-controller' || params.family === 'task-finalization') {
     clientError('SANDBOX_CONTROL_COMMAND_DENIED', `'${params.family}' requires a typed request`, false);
   }
   const auth = authority(params);
@@ -221,6 +223,34 @@ export function requestSandboxTaskControl(params: Readonly<{
     args: params.args,
     controllerProcess: null,
     controllerProof: params.controllerProof
+  };
+  return exchangeSandboxControl(request, params);
+}
+
+export function requestSandboxTaskFinalization(params: Readonly<{
+  agent: string;
+  channelDir?: string;
+  statusDir?: string;
+  token?: string;
+  generation?: string;
+  timeoutMs?: number;
+}>): SandboxControlResponse {
+  const agent = normalizeAgentToken(params.agent);
+  if (!agent) clientError('SANDBOX_CONTROL_REQUEST_INVALID', 'task-finalization agent is invalid', false);
+  const auth = authority(params);
+  const issuedAt = Date.now();
+  const request: SandboxTaskFinalizationRequest = {
+    version: 3,
+    id: randomUUID(),
+    ...auth,
+    issuedAt,
+    expiresAt: issuedAt + SANDBOX_CONTROL_ADMISSION_WINDOW_MS,
+    family: 'task-finalization',
+    operation: 'complete',
+    agent,
+    args: [],
+    controllerProcess: null,
+    controllerProof: null
   };
   return exchangeSandboxControl(request, params);
 }

--- a/lib/sandbox/control/executor.ts
+++ b/lib/sandbox/control/executor.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { getProcessStartTime } from '../../server/process-state.ts';
 import { createTask } from '../../task/create-service.ts';
+import { applyTaskFinalization } from '../../task/finalization.ts';
 import { bindSandboxControlTask, type SandboxControlExecution, type SandboxControlManifest, type SandboxControlRequest } from './protocol.ts';
 import { atomicWriteJson, executionPath, terminateSandboxControlExecution } from './state.ts';
 import { computeLifecycleBuildIdentity } from '../../agent-clients/adapters/codex-lifecycle/build-identity.ts';
@@ -165,6 +166,22 @@ function orchestrationFailure(code: string, message: string): SandboxControlExec
   };
 }
 
+function finalizationResult(result: ReturnType<typeof applyTaskFinalization>): SandboxControlExecutionResult {
+  const payload = {
+    version: 1,
+    status: result.status,
+    changed: result.changed,
+    accepted: true,
+    result,
+    error: result.error
+  };
+  return {
+    exitCode: result.status === 'completed' ? 0 : result.status === 'blocked' ? 2 : 1,
+    stdout: `${JSON.stringify(payload)}\n`,
+    stderr: ''
+  };
+}
+
 function isCodexPrepare(args: readonly string[]): boolean {
   if (args[1] !== 'prepare') return false;
   const values: string[] = [];
@@ -213,6 +230,12 @@ export function executeRequest(
     } catch (error) {
       return controllerFailure(error);
     }
+  }
+  if (request.family === 'task-finalization') {
+    return finalizationResult(applyTaskFinalization(
+      { taskRef: manifest.taskId!, intent: 'complete', agent: request.agent },
+      { repoRoot: manifest.repoRoot }
+    ));
   }
   const boundArgs = bindSandboxControlTask(request, manifest.taskId!);
   let controllerBinding: Readonly<{ instanceDigest: string; controlGeneration: string }> | null = null;

--- a/lib/sandbox/control/protocol.ts
+++ b/lib/sandbox/control/protocol.ts
@@ -1,4 +1,5 @@
 import { validateTaskCreateCandidate, type TaskCreateCandidateV1 } from '../../task/create.ts';
+import { normalizeAgentToken } from '../../agent-clients/tokens.ts';
 import type { ProcessIdentity } from '../../server/process-state.ts';
 import type { CodexControllerLeaseProofV1 } from './controller-registration.ts';
 
@@ -7,7 +8,7 @@ export const SANDBOX_CONTROL_ADMISSION_WINDOW_MS = 2_000;
 export const SANDBOX_CONTROL_STATUS_INTERVAL_MS = 250;
 export const SANDBOX_CONTROL_STATUS_STALE_MS = 1_500;
 export const SANDBOX_CONTROL_FUTURE_SKEW_MS = 1_000;
-export const SANDBOX_CONTROL_FAMILIES = ['task-lifecycle', 'task-orchestration', 'task-create', 'codex-controller'] as const;
+export const SANDBOX_CONTROL_FAMILIES = ['task-lifecycle', 'task-orchestration', 'task-finalization', 'task-create', 'codex-controller'] as const;
 export type SandboxControlTimingPolicy = Readonly<{
   controlTickMs: number;
   parkedBindingInitialMs: number;
@@ -51,6 +52,9 @@ type RequestBase = Readonly<{
 export type SandboxTaskCommandRequest = RequestBase & Readonly<{
   family: 'task-lifecycle' | 'task-orchestration'; args: string[];
 }>;
+export type SandboxTaskFinalizationRequest = RequestBase & Readonly<{
+  family: 'task-finalization'; operation: 'complete'; agent: string; args: [];
+}>;
 export type SandboxTaskCreateRequest = RequestBase & Readonly<{
   family: 'task-create'; candidate: TaskCreateCandidateV1;
 }>;
@@ -59,7 +63,7 @@ export type SandboxCodexControllerRequest = RequestBase & Readonly<{
   command: 'open' | 'close';
   args: [];
 }>;
-export type SandboxControlRequest = SandboxTaskCommandRequest | SandboxTaskCreateRequest | SandboxCodexControllerRequest;
+export type SandboxControlRequest = SandboxTaskCommandRequest | SandboxTaskFinalizationRequest | SandboxTaskCreateRequest | SandboxCodexControllerRequest;
 export type SandboxControlError = Readonly<{ code: string; message: string; retryable: boolean }>;
 export type SandboxControlResponse = Readonly<{
   version: 2; id: string; phase: 'accepted' | 'completed' | 'rejected'; exitCode: number | null;
@@ -152,6 +156,20 @@ export function validateSandboxControlRequest(
     }
     return request as SandboxCodexControllerRequest;
   }
+  if (request.family === 'task-finalization') {
+    const expected = ['agent', 'args', 'controllerProcess', 'controllerProof', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'operation', 'token', 'version'];
+    if (Object.keys(request).sort().join(',') !== expected.sort().join(',')
+      || request.operation !== 'complete'
+      || !Array.isArray(request.args) || request.args.length !== 0
+      || typeof request.agent !== 'string' || normalizeAgentToken(request.agent) !== request.agent
+      || request.controllerProcess !== null || request.controllerProof !== null) {
+      fail('SANDBOX_CONTROL_REQUEST_INVALID', 'task-finalization request schema or authorization is invalid');
+    }
+    if (manifest.mode !== 'task-bound' || !manifest.taskId) {
+      fail('SANDBOX_CONTROL_BRANCH_ONLY', 'branch-only sandboxes cannot finalize tasks');
+    }
+    return request as SandboxTaskFinalizationRequest;
+  }
   const expected = ['args', 'controllerProcess', 'controllerProof', 'expiresAt', 'family', 'generation', 'id', 'issuedAt', 'token', 'version'];
   if (Object.keys(request).sort().join(',') !== expected.sort().join(',')
     || !Array.isArray(request.args) || !request.args.every((arg) => typeof arg === 'string')) {
@@ -178,7 +196,7 @@ export function validateSandboxControlRequest(
 }
 
 export function bindSandboxControlTask(request: SandboxControlRequest, taskId: string): string[] {
-  if (request.family === 'task-create' || request.family === 'codex-controller') {
+  if (request.family === 'task-create' || request.family === 'codex-controller' || request.family === 'task-finalization') {
     fail('SANDBOX_CONTROL_REQUEST_INVALID', `${request.family} requests do not bind a current task`);
   }
   if (request.args.length === 0) fail('SANDBOX_CONTROL_REQUEST_INVALID', 'command arguments are required');

--- a/lib/task/finalization.ts
+++ b/lib/task/finalization.ts
@@ -1,0 +1,374 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { syncPlatformComment } from '../platform/issue-comments.ts';
+import type { PlatformResult } from '../platform/types.ts';
+import {
+  applyTaskLifecycle,
+  type TaskLifecycleOptions,
+  type TaskLifecycleRequest,
+  type TaskLifecycleResult
+} from './lifecycle.ts';
+import { resolveTaskRef } from './resolve-ref.ts';
+import { inspectShortIdRegistry } from './short-id.ts';
+import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
+import { verifyTaskEvent } from './verification.ts';
+import type { TaskVerificationResult } from './verification.ts';
+
+const RECEIPT_VERSION = 1 as const;
+const FINALIZATION_STEPS = ['lifecycle', 'task-comment', 'verification'] as const;
+type FinalizationStep = typeof FINALIZATION_STEPS[number];
+type FinalizationStepState = 'pending' | 'done' | 'skipped';
+type FinalizationError = { code: string; message: string; retryable: boolean };
+
+type TaskFinalizationRequest = Readonly<{
+  taskRef: string;
+  intent: 'complete';
+  agent: string;
+}>;
+
+type TaskFinalizationOptions = Readonly<{
+  repoRoot: string;
+  metadataProvider?: TaskLifecycleOptions['metadataProvider'];
+  lifecycle?: typeof applyTaskLifecycle;
+  commentSync?: typeof syncPlatformComment;
+  verify?: typeof verifyTaskEvent;
+}>;
+
+type TaskFinalizationReceipt = Readonly<{
+  version: typeof RECEIPT_VERSION;
+  taskId: string;
+  intent: 'complete';
+  lifecycle: FinalizationStepState;
+  taskComment: FinalizationStepState;
+  verification: FinalizationStepState;
+  updatedAt: string;
+  lastError: FinalizationError | null;
+}>;
+
+type TaskFinalizationStep = Readonly<{
+  status: string;
+  changed: boolean;
+  error: FinalizationError | null;
+  completedSteps?: readonly string[];
+  pendingSteps?: readonly string[];
+}>;
+
+type TaskFinalizationResult = Readonly<{
+  status: 'completed' | 'failed' | 'blocked';
+  changed: boolean;
+  taskId: string | null;
+  lifecycle: TaskFinalizationStep | null;
+  taskComment: TaskFinalizationStep | null;
+  verification: TaskFinalizationStep | null;
+  completedSteps: readonly FinalizationStep[];
+  pendingSteps: readonly FinalizationStep[];
+  error: FinalizationError | null;
+}>;
+
+function finalizationRoot(repoRoot: string): string {
+  return path.join(repoRoot, '.agents', 'workspace', '.task-finalization');
+}
+
+function receiptPath(repoRoot: string, taskId: string): string {
+  return path.join(finalizationRoot(repoRoot), `${taskId}.json`);
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function errorOf(error: unknown, fallbackCode: string, retryable = false): FinalizationError {
+  const value = error as { code?: unknown; message?: unknown; retryable?: unknown } | null;
+  const code = typeof value?.code === 'string' && value.code ? value.code : fallbackCode;
+  const message = typeof value?.message === 'string' && value.message ? value.message : String(error);
+  return { code, message, retryable: value?.retryable === true || retryable };
+}
+
+function failed(
+  taskId: string | null,
+  error: FinalizationError,
+  overrides: Partial<TaskFinalizationResult> = {}
+): TaskFinalizationResult {
+  return {
+    status: error.retryable ? 'blocked' : 'failed',
+    changed: false,
+    taskId,
+    lifecycle: null,
+    taskComment: null,
+    verification: null,
+    completedSteps: [],
+    pendingSteps: [...FINALIZATION_STEPS],
+    error,
+    ...overrides
+  };
+}
+
+function emptyReceipt(taskId: string): TaskFinalizationReceipt {
+  return {
+    version: RECEIPT_VERSION,
+    taskId,
+    intent: 'complete',
+    lifecycle: 'pending',
+    taskComment: 'pending',
+    verification: 'pending',
+    updatedAt: now(),
+    lastError: null
+  };
+}
+
+function validateReceipt(value: unknown, taskId: string): TaskFinalizationReceipt {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('receipt must be an object');
+  const receipt = value as Record<string, unknown>;
+  const states = ['pending', 'done', 'skipped'];
+  if (
+    receipt.version !== RECEIPT_VERSION || receipt.taskId !== taskId || receipt.intent !== 'complete'
+    || !states.includes(String(receipt.lifecycle))
+    || !states.includes(String(receipt.taskComment))
+    || !states.includes(String(receipt.verification))
+    || typeof receipt.updatedAt !== 'string'
+    || (receipt.lastError !== null && (typeof receipt.lastError !== 'object' || Array.isArray(receipt.lastError)))
+  ) throw new Error('receipt schema is invalid');
+  return receipt as TaskFinalizationReceipt;
+}
+
+function readReceipt(repoRoot: string, taskId: string): TaskFinalizationReceipt | null {
+  const file = receiptPath(repoRoot, taskId);
+  if (!fs.existsSync(file)) return null;
+  return validateReceipt(JSON.parse(fs.readFileSync(file, 'utf8')) as unknown, taskId);
+}
+
+function writeReceipt(repoRoot: string, receipt: TaskFinalizationReceipt): void {
+  const directory = finalizationRoot(repoRoot);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const target = receiptPath(repoRoot, receipt.taskId);
+  const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(receipt)}\n`, { mode: 0o600, flag: 'wx' });
+    fs.renameSync(temporary, target);
+  } catch (error) {
+    try { fs.unlinkSync(temporary); } catch { /* preserve the primary error */ }
+    throw error;
+  }
+}
+
+function updateReceipt(
+  repoRoot: string,
+  receipt: TaskFinalizationReceipt,
+  patch: Partial<Pick<TaskFinalizationReceipt, 'lifecycle' | 'taskComment' | 'verification' | 'lastError'>>
+): TaskFinalizationReceipt {
+  const next = { ...receipt, ...patch, updatedAt: now() };
+  writeReceipt(repoRoot, next);
+  return next;
+}
+
+function completedSteps(receipt: TaskFinalizationReceipt): FinalizationStep[] {
+  return FINALIZATION_STEPS.filter((step) => receipt[step === 'task-comment' ? 'taskComment' : step] !== 'pending');
+}
+
+function pendingSteps(receipt: TaskFinalizationReceipt): FinalizationStep[] {
+  return FINALIZATION_STEPS.filter((step) => receipt[step === 'task-comment' ? 'taskComment' : step] === 'pending');
+}
+
+function lifecycleStep(result: TaskLifecycleResult): TaskFinalizationStep {
+  return {
+    status: result.status,
+    changed: result.changed,
+    error: result.error ? errorOf(result.error, 'LIFECYCLE_FAILED') : null,
+    completedSteps: result.completedSteps ?? [],
+    pendingSteps: result.pendingSteps ?? []
+  };
+}
+
+function commentStep(result: PlatformResult): TaskFinalizationStep {
+  return {
+    status: result.status,
+    changed: result.changed,
+    error: result.error ? errorOf(result.error, 'COMMENT_SYNC_FAILED') : null
+  };
+}
+
+function verificationStep(result: TaskVerificationResult): TaskFinalizationStep {
+  return {
+    status: result.status,
+    changed: false,
+    error: result.status === 'pass' ? null : verificationFailure(result)
+  };
+}
+
+function verificationFailure(result: TaskVerificationResult): FinalizationError {
+  if (result.error) return errorOf(result.error, 'VERIFY_FAILED', result.status === 'blocked');
+  const invocation = [...result.invocations].reverse().find((item) => item.status !== 'pass');
+  const payload = invocation?.payload;
+  const details = [payload?.message, payload?.summary, payload?.action]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+  const code = result.status === 'blocked' || invocation?.status === 'blocked'
+    ? 'CHECK_BLOCKED'
+    : result.status === 'fail' ? 'CHECK_FAILED' : 'VERIFY_FAILED';
+  return {
+    code,
+    message: details.length > 0 ? details.join(' - ') : `verification ${result.status}`,
+    retryable: code === 'CHECK_BLOCKED'
+  };
+}
+
+function terminalResult(
+  taskId: string,
+  receipt: TaskFinalizationReceipt,
+  steps: Pick<TaskFinalizationResult, 'lifecycle' | 'taskComment' | 'verification'>,
+  changed: boolean,
+  error: FinalizationError | null = null
+): TaskFinalizationResult {
+  const pending = pendingSteps(receipt);
+  const blocked = [steps.lifecycle, steps.taskComment, steps.verification].some((step) => step?.status === 'blocked');
+  return {
+    status: pending.length === 0 ? 'completed' : blocked ? 'blocked' : 'failed',
+    changed,
+    taskId,
+    ...steps,
+    completedSteps: completedSteps(receipt),
+    pendingSteps: pending,
+    error
+  };
+}
+
+function applyUnderLock(
+  request: TaskFinalizationRequest,
+  taskId: string,
+  options: TaskFinalizationOptions
+): TaskFinalizationResult {
+  const repoRoot = path.resolve(options.repoRoot);
+  const lifecycle = options.lifecycle ?? applyTaskLifecycle;
+  const commentSync = options.commentSync ?? syncPlatformComment;
+  const verify = options.verify ?? verifyTaskEvent;
+  let receipt: TaskFinalizationReceipt;
+  try {
+    receipt = readReceipt(repoRoot, taskId) ?? emptyReceipt(taskId);
+    if (!fs.existsSync(receiptPath(repoRoot, taskId))) writeReceipt(repoRoot, receipt);
+  } catch (error) {
+    return failed(taskId, errorOf(error, 'TASK_FINALIZATION_RECEIPT_INVALID'));
+  }
+
+  let lifecycleResult: TaskFinalizationStep | null = null;
+  let changed = false;
+  try {
+    const resolved = resolveTaskRef(taskId, { repoRoot });
+    const registry = resolved.ok && resolved.state === 'completed' ? inspectShortIdRegistry(repoRoot) : null;
+    if (registry && registry.status !== 'valid') {
+      const detail: FinalizationError = {
+        code: 'TASK_FINALIZATION_SHORT_ID_REGISTRY_UNAVAILABLE',
+        message: `cannot verify canonical short-id registry: ${registry.error.code}: ${registry.error.message}`,
+        retryable: false
+      };
+      receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'pending', lastError: detail });
+      return terminalResult(taskId, receipt, {
+        lifecycle: { status: 'failed', changed: false, error: detail },
+        taskComment: null,
+        verification: null
+      }, changed, detail);
+    }
+    const shortIds = registry?.status === 'valid' ? registry.shortIds : null;
+    if (shortIds?.has(taskId)) {
+      const detail: FinalizationError = {
+        code: 'TASK_FINALIZATION_CANONICAL_STATE_INVALID',
+        message: 'completed task still has an active short-id registry entry',
+        retryable: false
+      };
+      receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'pending', lastError: detail });
+      return terminalResult(taskId, receipt, {
+        lifecycle: { status: 'failed', changed: false, error: detail },
+        taskComment: null,
+        verification: null
+      }, changed, detail);
+    }
+    const lifecycleDone = receipt.lifecycle === 'done' && resolved.ok && resolved.state === 'completed' && shortIds !== null;
+    if (lifecycleDone) {
+      lifecycleResult = { status: 'no-op', changed: false, error: null };
+      receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'done', lastError: null });
+    } else {
+      const result = lifecycle(
+        { taskRef: taskId, intent: 'complete', agent: request.agent },
+        { repoRoot, ...(options.metadataProvider ? { metadataProvider: options.metadataProvider } : {}) }
+      );
+      lifecycleResult = lifecycleStep(result);
+      if (result.status !== 'applied' && result.status !== 'no-op') {
+        receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'pending', lastError: lifecycleResult.error });
+        return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment: null, verification: null }, result.changed, lifecycleResult.error);
+      }
+      changed = result.changed;
+      receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'done', lastError: null });
+    }
+  } catch (error) {
+    const detail = errorOf(error, 'TASK_FINALIZATION_LIFECYCLE_FAILED');
+    try { receipt = updateReceipt(repoRoot, receipt, { lifecycle: 'pending', lastError: detail }); } catch { /* preserve the primary error */ }
+    return failed(taskId, detail, { lifecycle: lifecycleResult });
+  }
+
+  let taskComment: TaskFinalizationStep | null = null;
+  try {
+    const result = commentSync(taskId, { kind: 'task', agent: request.agent, cwd: repoRoot });
+    taskComment = commentStep(result);
+    if (result.status === 'applied' || result.status === 'no-op') {
+      const skipped = result.error?.code === 'ISSUE_NOT_LINKED';
+      receipt = updateReceipt(repoRoot, receipt, { taskComment: skipped ? 'skipped' : 'done', lastError: null });
+      taskComment = skipped ? { ...taskComment, status: 'skipped' } : taskComment;
+      changed = changed || result.changed;
+    } else {
+      receipt = updateReceipt(repoRoot, receipt, { taskComment: 'pending', lastError: taskComment.error });
+      return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment, verification: null }, changed, taskComment.error);
+    }
+  } catch (error) {
+    const detail = errorOf(error, 'COMMENT_SYNC_FAILED', true);
+    try { receipt = updateReceipt(repoRoot, receipt, { taskComment: 'pending', lastError: detail }); } catch { /* preserve the primary error */ }
+    return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment: { status: 'blocked', changed: false, error: detail }, verification: null }, changed, detail);
+  }
+
+  let verification: TaskFinalizationStep | null = null;
+  try {
+    const result = verify(
+      { taskRef: taskId, event: 'complete-task.completed' },
+      { repoRoot }
+    );
+    verification = verificationStep(result);
+    if (result.status === 'pass') {
+      receipt = updateReceipt(repoRoot, receipt, { verification: 'done', lastError: null });
+    } else {
+      receipt = updateReceipt(repoRoot, receipt, { verification: 'pending', lastError: verification.error });
+      return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment, verification }, changed, verification.error);
+    }
+  } catch (error) {
+    const detail = errorOf(error, 'VERIFY_FAILED', true);
+    try { receipt = updateReceipt(repoRoot, receipt, { verification: 'pending', lastError: detail }); } catch { /* preserve the primary error */ }
+    return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment, verification: { status: 'blocked', changed: false, error: detail } }, changed, detail);
+  }
+  return terminalResult(taskId, receipt, { lifecycle: lifecycleResult, taskComment, verification }, changed);
+}
+
+function applyTaskFinalization(request: TaskFinalizationRequest, options: TaskFinalizationOptions): TaskFinalizationResult {
+  if (request.intent !== 'complete' || !request.taskRef || !request.agent) {
+    return failed(null, { code: 'TASK_FINALIZATION_PAYLOAD_INVALID', message: 'complete finalization requires taskRef and agent', retryable: false });
+  }
+  const repoRoot = path.resolve(options.repoRoot);
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot });
+  if (!resolved.ok) return failed(resolved.taskId, { code: resolved.code, message: resolved.message, retryable: false });
+  try {
+    return withTaskExecutionLock(repoRoot, resolved.taskId, 'task-finalization.complete', () => applyUnderLock(request, resolved.taskId, options));
+  } catch (error) {
+    const detail = error instanceof TaskExecutionLockError
+      ? { code: error.code, message: error.message, retryable: error.code === 'ORCHESTRATION_LOCK_BUSY' }
+      : errorOf(error, 'TASK_FINALIZATION_FAILED');
+    return failed(resolved.taskId, detail);
+  }
+}
+
+export { applyTaskFinalization };
+export type {
+  FinalizationError,
+  FinalizationStep,
+  TaskFinalizationOptions,
+  TaskFinalizationReceipt,
+  TaskFinalizationRequest,
+  TaskFinalizationResult,
+  TaskFinalizationStep
+};

--- a/lib/task/short-id.ts
+++ b/lib/task/short-id.ts
@@ -201,6 +201,10 @@ type RegistrySchema = {
   ids: Record<string, string>;
 };
 
+type ShortIdRegistryInspection =
+  | { status: 'valid'; shortIds: Map<string, string> }
+  | { status: 'missing' | 'invalid'; error: { code: string; message: string } };
+
 type ShortIdMutationEffect = 'alloc' | 'release' | 'none';
 type ShortIdMutationResult = {
   effect: 'allocated' | 'released' | 'unchanged';
@@ -446,6 +450,64 @@ function loadShortIdByTaskId(repoRoot: string): Map<string, string> {
   return map;
 }
 
+function inspectShortIdRegistry(repoRoot: string): ShortIdRegistryInspection {
+  const registryPath = path.join(repoRoot, '.agents', 'workspace', 'active', REGISTRY_NAME);
+  if (!fs.existsSync(registryPath)) {
+    return {
+      status: 'missing',
+      error: {
+        code: 'SHORT_ID_REGISTRY_NOT_FOUND',
+        message: 'canonical short-id registry is missing'
+      }
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(registryPath, 'utf8');
+  } catch {
+    return {
+      status: 'invalid',
+      error: {
+        code: 'SHORT_ID_REGISTRY_READ_FAILED',
+        message: 'canonical short-id registry is unreadable'
+      }
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      status: 'invalid',
+      error: {
+        code: 'SHORT_ID_REGISTRY_INVALID_JSON',
+        message: 'canonical short-id registry contains invalid JSON'
+      }
+    };
+  }
+
+  try {
+    const registry = validateRegistry(parsed, registryPath, configuredShortIdLength(repoRoot));
+    const shortIds = new Map<string, string>();
+    for (const [key, taskId] of Object.entries(registry.ids)) shortIds.set(taskId, key);
+    return { status: 'valid', shortIds };
+  } catch (error) {
+    return {
+      status: 'invalid',
+      error: {
+        code: typeof (error as { code?: unknown }).code === 'string'
+          ? (error as { code: string }).code
+          : 'SHORT_ID_REGISTRY_INVALID_SCHEMA',
+        message: (error as { code?: unknown }).code === 'SHORT_ID_REGISTRY_DUPLICATE_TASK'
+          ? 'canonical short-id registry contains duplicate task entries'
+          : 'canonical short-id registry has invalid schema'
+      }
+    };
+  }
+}
+
 /**
  * Resolve a branch to its active-task short id (`NN`), or `null` when no
  * active task is bound to that branch.
@@ -485,6 +547,7 @@ export {
   resolveShortIdReadOnly,
   lookupShortIdByBranch,
   loadShortIdByTaskId,
+  inspectShortIdRegistry,
   configuredShortIdLength,
   mutateShortIdRegistry,
   executeShortIdCommand
@@ -497,5 +560,6 @@ export type {
   ShortIdMutationEffect,
   ShortIdMutationResult,
   ShortIdCommandRequest,
-  ShortIdCommandResult
+  ShortIdCommandResult,
+  ShortIdRegistryInspection
 };

--- a/templates/.agents/rules/task-management.en.md
+++ b/templates/.agents/rules/task-management.en.md
@@ -28,7 +28,7 @@ Map user intent to the corresponding workflow command:
 - Historical `gemini` / `gemini-cli` remain read-only for `ai task log` rendering and are not writable
 - Manual-step exception: no matter which agent is used, a human-made decision is always declared as `human`
 
-The six internal commands (`task-event` / `task-lifecycle` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`) hard-validate `--agent` against a whitelist: they accept a short token, a long name, or `human`, and reject non-standard values with the matching `*_PAYLOAD_INVALID` error; long names are normalized to the short token before being persisted or forwarded. The `ai task log` renderer keeps unknown tokens grouped as `human` but appends a visible `(unknown)` marker.
+The seven internal commands (`task-event` / `task-lifecycle` / `task-finalization` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`) hard-validate `--agent` against a whitelist: they accept a short token, a long name, or `human`, and reject non-standard values with the matching `*_PAYLOAD_INVALID` error; long names are normalized to the short token before being persisted or forwarded. The `ai task log` renderer keeps unknown tokens grouped as `human` but appends a visible `(unknown)` marker.
 
 ## State Snapshot and Completion Verification Entrypoints
 

--- a/templates/.agents/rules/task-management.zh-CN.md
+++ b/templates/.agents/rules/task-management.zh-CN.md
@@ -28,7 +28,7 @@
 - 历史 `gemini` / `gemini-cli` 仅保留 `ai task log` 渲染兼容，不接受写入
 - 人工步骤例外：无论使用哪个 Agent，只要是人做的决定，统一声明 `human`
 
-六个内部命令（`task-event` / `task-lifecycle` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`）对 `--agent` 做白名单硬校验：接受短名、长名或 `human`，非标准值返回对应 `*_PAYLOAD_INVALID` 错误；长名在落库/透传前归一化为短名。渲染端 `ai task log` 对无法识别的 token 保留 `human` 归类并附加 `(unknown)` 标记。
+七个内部命令（`task-event` / `task-lifecycle` / `task-finalization` / `platform-issue` / `platform-comment` / `platform-pr` / `task-orchestration`）对 `--agent` 做白名单硬校验：接受短名、长名或 `human`，非标准值返回对应 `*_PAYLOAD_INVALID` 错误；长名在落库/透传前归一化为短名。渲染端 `ai task log` 对无法识别的 token 保留 `human` 归类并附加 `(unknown)` 标记。
 
 ## 状态快照与完成验证入口
 

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -38,7 +38,7 @@ Before the state check is complete, do not make external-state assertions such a
 
 ## Step Start: Local Lifecycle Boundary
 
-On the normal path, complete business updates, platform sync, and the pre-completion gate while the task is active. Only then may the lifecycle intent in Step 6 atomically commit base terminal fields, the started/done pair, the directory move, and short-id release. Do not write those mechanical fields first. An archived task may only enter `finalization-retry`; do not move it back or rerun lifecycle.
+On the normal path, complete business updates, platform sync, and the pre-completion gate while the task is active. Only then may the single finalization intent in Step 6 advance lifecycle, the terminal task comment, and the completion gate in a fixed order. Do not write those mechanical fields first. An archived task may only enter `finalization-retry`; do not move it back or rerun lifecycle.
 
 ## Steps
 
@@ -168,40 +168,34 @@ When preflight's `post-review-commit` check passes through a human-decided exemp
 
 `--force` does not lift this hard gate: close ledger disagreements; re-review or exempt post-review commits, use the platform adapter's authoritative snapshot and remote refs for the bound change request (PR/MR) to prove a content-equivalent single-parent squash merge in an isolated temporary repository, or, without a valid change request, prove from local Git objects that the only protected commit is a content-equivalent single-parent rewrite with no later protected commits; then pass platform preflight. An unsupported adapter capability, missing required platform facts, Git objects, topology, or content evidence, or current Git credentials that cannot read the remote evidence refs fails closed. The platform adapter supplies normalized state for all checks, enforced before merge by the `review-code` / `watch-pr` routes; required checks remain additionally enforced by branch protection / rulesets.
 
-### 6. Apply the Local Lifecycle Intent and Verify the Move
+### 6. Run the Host Finalization Entry Point and Verify the Terminal State
 
 ```bash
-agent-infra-internal task-lifecycle {task-id} complete --agent {standard-agent-token}
+agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-Only `status=applied|no-op` means local completion succeeded. On `status=failed`, show the structured error and recovery steps and retry the same intent; do not claim completion or hand-repair partial state.
+Finalization runs lifecycle -> the terminal task comment -> the `complete-task.completed` gate in a fixed order and records each step in the host receipt. Only structured `status=completed` means completion succeeded. On `failed` or `blocked`, show the error and completed/pending steps, fix the cause, and retry through the same entry point; do not claim completion or hand-repair partial state.
 
 ```bash
 ls .agents/workspace/completed/{task-id}/task.md
 ```
 
-Confirm the task directory was successfully moved.
+Check the task directory only after finalization returns `status=completed`.
 
-### 7. Sync the Terminal Task Comment and Run the Gate
+### 7. Handle Finalization Retries and Results
 
-Both Scenario A and Scenario B `finalization-retry` execute this step from the completed directory. If a valid `issue_number` exists, first run:
+Both Scenario A and Scenario B `finalization-retry` run the same `task-finalization` entry point from the host. The receipt is only a re-entry hint, not canonical truth: every re-entry revalidates the terminal task comment and completion gate; only an already `completed` task with its short-id registry entry released may skip the irreversible lifecycle. Do not split the operation into the former lifecycle, comment-sync, or completion-gate commands. If the task comment or gate is blocked by the network, preserve the receipt and completed steps, fix the network, and rerun complete-task. If lifecycle has not completed, keep the task active and resume the pending steps from the receipt.
 
-```bash
-agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}
-```
-
-If this call fails, the task is already archived and `task-warning` cannot accept it. Keep the task completed and stop. After fixing the network or platform issue, rerun complete-task; Step 1 will enter `finalization-retry` and repeat only this step.
-
-Run the verification gate to confirm the task artifact and sync state are valid:
+The result must include the structured output from this finalization run, confirming that the task artifact and sync state are valid:
 
 ```bash
 agent-infra-internal task-verify {task-id} complete-task.completed --format text
 ```
 
 Handle the result as follows:
-- exit code 0 (all checks passed) -> continue to the "Inform User" step
-- exit code 1 (validation failed) -> fix the reported issues and run the gate again
-- exit code 2 (network blocked or status-label cleanup is still pending) -> keep the task completed and stop; rerun complete-task later to enter `finalization-retry`
+- `status=completed` / exit code 0 (all checks passed) -> continue to the "Inform User" step
+- `status=failed` / exit code 1 -> fix the reported issues and run finalization again
+- `status=blocked` / exit code 2 -> preserve the receipt and completed steps and stop; rerun complete-task later to enter `finalization-retry`
 
 Keep the gate output in your reply as fresh evidence. Do not claim completion without output from this run.
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -38,7 +38,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 ## 步骤开始：本地生命周期边界
 
-正常完成路径在 active 阶段完成业务更新、平台同步和预完成门禁后，才由步骤 6 的单次 lifecycle intent 原子完成基础终态字段、started/done 日志、目录转移和短号释放；不得提前手工写入这些机械状态。已归档任务只允许进入 `finalization-retry` 场景，不回迁目录或重新执行 lifecycle。
+正常完成路径在 active 阶段完成业务更新、平台同步和预完成门禁后，才由步骤 6 的单次 finalization intent 按固定顺序原子推进生命周期、终态 task 评论和完成校验；不得提前手工写入这些机械状态。已归档任务只允许进入 `finalization-retry` 场景，不回迁目录或重新执行 lifecycle。
 
 ## 执行步骤
 ### 1. 验证任务存在
@@ -167,40 +167,34 @@ agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 
 `--force` 不解除本硬门禁：未关闭分歧必须先在账本闭合，未复审提交必须重新审查、具备有效豁免，或由平台适配器为绑定的变更请求（PR/MR）提供权威合并快照与远端 refs，并在隔离临时仓库中证明单父 squash merge 等价，或在无有效变更请求时由本地 Git 对象证明唯一受保护提交是内容等价的单父重写且之后无受保护提交；平台 preflight 必须通过。适配器不支持所需能力，平台事实、Git 对象、拓扑、内容证据缺失，或当前 Git 凭据不能读取远端证据 refs 时 fail closed。全部 checks 由平台适配器提供规范化状态，并在合并前通过 `review-code` / `watch-pr` 路由承担；其中 required checks 仍受分支保护 / ruleset 强制。
 
-### 6. 执行本地生命周期意图并验证转移
+### 6. 执行宿主 finalization 入口并验证终态
 
 ```bash
-agent-infra-internal task-lifecycle {task-id} complete --agent {standard-agent-token}
+agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-仅 `status=applied|no-op` 视为本地完成。`status=failed` 时展示 `error` 与 completed/pending steps，以同一 intent 重试；不得宣称完成或手工补写局部状态。
+finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。只有结构化结果 `status=completed` 才视为完成；`failed` 或 `blocked` 时展示 `error` 与 completed/pending steps，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。
 
 ```bash
 ls .agents/workspace/completed/{task-id}/task.md
 ```
 
-确认任务目录已成功移动。
+仅在 finalization 返回 `status=completed` 后确认任务目录已成功移动。
 
-### 7. 同步终态 task 评论并完成校验
+### 7. 处理 finalization 重试与结果
 
-场景 A 与场景 B `finalization-retry` 都从 completed 目录执行本步骤。若存在有效的 `issue_number`，先调用：
+场景 A 与场景 B `finalization-retry` 都从宿主执行同一个 `task-finalization` 入口。receipt 只是重入提示，不是 canonical truth：每次重入都要重新验证终态 task 评论和完成校验；只有任务已处于 `completed` 且短号 registry 已释放时，才可跳过不可逆的 lifecycle。不得拆开调用旧的 lifecycle、评论同步或完成校验命令。若 task 评论或校验因网络问题返回 `blocked`，保留 receipt 和已完成状态，修复网络后重跑 complete-task；若生命周期仍未完成，任务保持 active 并从 receipt 的待处理步骤继续。
 
-```bash
-agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}
-```
-
-该调用失败时任务已归档，不能调用只接受 active 任务的 `task-warning`；保留 completed 状态并停止。修复网络或平台问题后重跑 complete-task，会由步骤 1 进入 `finalization-retry`，只重复本步骤。
-
-运行完成校验，确认任务产物和同步状态符合规范：
+完成结果必须包含本次 finalization 的结构化输出，确认任务产物和同步状态符合规范：
 
 ```bash
 agent-infra-internal task-verify {task-id} complete-task.completed --format text
 ```
 
 处理结果：
-- 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- 退出码 1（校验失败）-> 根据输出修复问题后重新运行校验
-- 退出码 2（网络中断或状态标签清理尚未收敛）-> 保留 completed 状态并停止；稍后重跑 complete-task 进入 `finalization-retry`
+- `status=completed` / 退出码 0（全部通过）-> 继续到「告知用户」步骤
+- `status=failed` / 退出码 1 -> 根据输出修复问题后重新运行 finalization
+- `status=blocked` / 退出码 2 -> 保留 receipt 与已完成的步骤并停止；稍后重跑 complete-task 进入 `finalization-retry`
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 

--- a/tests/integration/cli/complete-task-preflight.test.ts
+++ b/tests/integration/cli/complete-task-preflight.test.ts
@@ -137,6 +137,28 @@ test('preflight success permits one archive and releases the short id', () => {
   }
 });
 
+test('host finalization CLI completes the terminal sequence and makes replay idempotent', () => {
+  const f = fixture();
+  try {
+    const first = run(f.root, ['task-finalization', TASK_ID, 'complete', '--agent', 'codex']);
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+    const firstPayload = JSON.parse(first.stdout);
+    assert.equal(firstPayload.status, 'completed');
+    assert.equal(firstPayload.accepted, true);
+    assert.equal(firstPayload.result.status, 'completed');
+    assert.equal(fs.existsSync(path.join(f.root, '.agents', 'workspace', 'completed', TASK_ID, 'task.md')), true);
+
+    const second = run(f.root, ['task-finalization', TASK_ID, 'complete', '--agent', 'codex']);
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    const secondPayload = JSON.parse(second.stdout);
+    assert.equal(secondPayload.status, 'completed');
+    assert.equal(secondPayload.changed, false);
+    assert.equal((fs.readFileSync(path.join(f.root, '.agents', 'workspace', 'completed', TASK_ID, 'task.md'), 'utf8').match(/Complete Task/g) ?? []).length, 2);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
 test('completed verification resolves the archived task without moving it back to active', () => {
   const f = fixture();
   try {

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -17,6 +17,7 @@ import {
   removeSandboxControlRoot
 } from '../../../lib/sandbox/control/lifecycle.ts';
 import { DEFAULT_SANDBOX_CONTROL_TIMING } from '../../../lib/sandbox/control/protocol.ts';
+import { prepareSandboxControlExecution } from '../../../lib/sandbox/control/executor.ts';
 import { serveSandboxControl } from '../../../lib/sandbox/control/server.ts';
 import { startSandboxControlBroker } from '../../../lib/sandbox/recovery.ts';
 import { getProcessStartTime, isProcessAlive } from '../../../lib/server/process-state.ts';
@@ -57,6 +58,71 @@ async function waitForStatusStateAsync(statusDir: string, state: string, timeout
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`Timed out waiting for ${state} status in ${statusDir}`);
+}
+
+async function waitForRequestAsync(requestsDir: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const request = fs.readdirSync(requestsDir).find((name) => name.endsWith('.json'));
+    if (request) return request;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for a request in ${requestsDir}`);
+}
+
+function runTaskFinalizationClient(params: {
+  channelDir: string;
+  statusDir: string;
+  token: string;
+  generation: string;
+  timeoutMs: number;
+}): Promise<{ exitCode: number; payload: Record<string, unknown>; stderr: string }> {
+  const script = [
+    "import { requestSandboxTaskFinalization } from './lib/sandbox/control/client.ts';",
+    'try {',
+    '  const response = requestSandboxTaskFinalization({',
+    "    agent: 'codex',",
+    '    channelDir: process.env.TEST_CHANNEL_DIR,',
+    '    statusDir: process.env.TEST_STATUS_DIR,',
+    '    token: process.env.TEST_TOKEN,',
+    '    generation: process.env.TEST_GENERATION,',
+    '    timeoutMs: Number(process.env.TEST_TIMEOUT_MS)',
+    '  });',
+    "  process.stdout.write(JSON.stringify({ phase: response.phase, exitCode: response.exitCode, stdout: response.stdout, stderr: response.stderr, error: response.error }) + '\\n');",
+    '} catch (error) {',
+    '  const value = error;',
+    "  process.stdout.write(JSON.stringify({ error: value.detail ?? { code: 'CLIENT_FAILED', message: String(value), retryable: false }, accepted: value.accepted ?? false }) + '\\n');",
+    '  process.exitCode = 1;',
+    '}'
+  ].join('\n');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--experimental-strip-types', '--no-warnings', '--input-type=module', '--eval', script], {
+      cwd: path.resolve('.'),
+      env: {
+        ...process.env,
+        TEST_CHANNEL_DIR: params.channelDir,
+        TEST_STATUS_DIR: params.statusDir,
+        TEST_TOKEN: params.token,
+        TEST_GENERATION: params.generation,
+        TEST_TIMEOUT_MS: String(params.timeoutMs)
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      try {
+        resolve({ exitCode: code ?? 1, payload: JSON.parse(stdout) as Record<string, unknown>, stderr });
+      } catch (error) {
+        reject(new Error(`client output was invalid: ${String(error)}\n${stdout}${stderr}`));
+      }
+    });
+  });
 }
 
 function monotonicNowMs(): number {
@@ -792,6 +858,205 @@ test('sandbox control client tolerates a transient torn response but rejects sta
     const stable = await collect(stableClient);
     assert.equal(stable.exitCode, 1);
     assert.equal(JSON.parse(stable.stdout).code, 'SANDBOX_CONTROL_RESPONSE_INVALID');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-finalization client exposes accepted result loss as a structured unknown result', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-finalization-unknown-'));
+  const channelDir = path.join(root, 'channel');
+  const requestsDir = path.join(channelDir, 'requests');
+  const responsesDir = path.join(channelDir, 'responses');
+  const statusDir = path.join(root, 'public');
+  fs.mkdirSync(requestsDir, { recursive: true });
+  fs.mkdirSync(responsesDir);
+  fs.mkdirSync(statusDir);
+  const startTime = getProcessStartTime(process.pid);
+  assert.ok(startTime);
+  const generation = 'finalization-generation';
+  fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
+    version: 2,
+    generation,
+    broker: { pid: process.pid, startTime, brokerId: 'finalization-broker' },
+    state: 'healthy',
+    reasonCode: null,
+    activeRequestId: null,
+    updatedAt: Date.now()
+  })}\n`);
+  const child = spawn(process.execPath, [
+    '--experimental-strip-types', '--no-warnings', path.resolve('bin/internal-cli.ts'),
+    'sandbox-control', 'client', 'task-finalization', '08', 'complete', '--agent', 'codex'
+  ], {
+    cwd: path.resolve('.'),
+    env: {
+      ...process.env,
+      AGENT_INFRA_CONTROL_TOKEN: 'finalization-secret',
+      AGENT_INFRA_CONTROL_GENERATION: generation,
+      AGENT_INFRA_CONTROL_DIR: channelDir,
+      AGENT_INFRA_CONTROL_STATUS_DIR: statusDir
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+  child.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+  try {
+    const deadline = Date.now() + 2_000;
+    let requestName: string | undefined;
+    while (!(requestName = fs.readdirSync(requestsDir).find((name) => name.endsWith('.json'))) && Date.now() < deadline) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+    assert.ok(requestName);
+    const request = JSON.parse(fs.readFileSync(path.join(requestsDir, requestName), 'utf8')) as Record<string, unknown>;
+    assert.equal(request.family, 'task-finalization');
+    assert.equal(request.operation, 'complete');
+    assert.equal(request.agent, 'codex');
+    assert.deepEqual(request.args, []);
+    assert.equal('taskRef' in request, false);
+    assert.equal('repoRoot' in request, false);
+    fs.writeFileSync(path.join(responsesDir, requestName), `${JSON.stringify({
+      version: 2,
+      id: requestName.slice(0, -5),
+      phase: 'rejected',
+      exitCode: null,
+      stdout: '',
+      stderr: 'SANDBOX_CONTROL_RESULT_UNKNOWN\n',
+      error: { code: 'SANDBOX_CONTROL_RESULT_UNKNOWN', message: 'result unknown', retryable: false }
+    })}\n`);
+    const exitCode = await new Promise<number>((resolve) => child.once('close', (code) => resolve(code ?? 1)));
+    assert.equal(exitCode, 1, stderr);
+    assert.deepEqual(JSON.parse(stdout), {
+      version: 1,
+      status: 'unknown',
+      changed: false,
+      accepted: true,
+      result: null,
+      error: { code: 'SANDBOX_CONTROL_RESULT_UNKNOWN', message: 'result unknown', retryable: false }
+    });
+    assert.match(stderr, /result unknown/);
+  } finally {
+    if (child.exitCode === null) child.kill('SIGTERM');
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-bound finalization compensates an accepted response loss through the same host executor entry', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-finalization-compensation-'));
+  const taskId = 'TASK-20260809-010203';
+  const token = 'lifecycle-secret';
+  const generation = 'finalization-compensation-generation';
+  try {
+    const branch = initializeRepository(root);
+    const manifestPath = writeControlManifest(root, branch, generation);
+    const activeTaskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+    fs.mkdirSync(path.join(root, '.agents', 'skills', 'complete-task', 'config'), { recursive: true });
+    fs.mkdirSync(activeTaskDir, { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ task: { shortIdLength: 2 } }));
+    fs.writeFileSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json'), `${JSON.stringify({ version: 1, ids: { '08': taskId } })}\n`);
+    fs.writeFileSync(path.join(root, '.agents', 'skills', 'complete-task', 'config', 'verify.json'), JSON.stringify({ skill: 'complete-task', checks: {} }));
+    fs.writeFileSync(path.join(activeTaskDir, 'task.md'), [
+      '---', `id: ${taskId}`, 'type: bugfix', 'workflow: bug-fix', 'status: active',
+      'created_at: 2026-08-09 01:02:03+00:00', 'updated_at: 2026-08-09 01:02:03+00:00',
+      'agent_infra_version: v0.9.9', 'current_step: code-review', 'assigned_to: codex',
+      'target_date:', '---', '', '# Task', '', '## Activity Log', ''
+    ].join('\n'));
+
+    const statusDir = path.join(root, 'public');
+    const channelDir = path.join(root, 'channel');
+    const requestsDir = path.join(channelDir, 'requests');
+    const responsesDir = path.join(channelDir, 'responses');
+    fs.mkdirSync(requestsDir, { recursive: true });
+    fs.mkdirSync(responsesDir, { recursive: true });
+    const startTime = getProcessStartTime(process.pid);
+    assert.ok(startTime);
+    fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
+      version: 2,
+      generation,
+      broker: { pid: process.pid, startTime, brokerId: 'finalization-compensation-broker' },
+      state: 'healthy',
+      reasonCode: null,
+      activeRequestId: null,
+      updatedAt: Date.now()
+    })}\n`);
+
+    const serveOne = async (dropCompletedResponse: boolean) => {
+      const requestName = await waitForRequestAsync(requestsDir, 2_000);
+      const requestPath = path.join(requestsDir, requestName);
+      const request = JSON.parse(fs.readFileSync(requestPath, 'utf8')) as { id: string; family: string; operation: string; agent: string };
+      assert.equal(request.id, requestName.slice(0, -5));
+      assert.equal(request.family, 'task-finalization');
+      assert.equal(request.operation, 'complete');
+      assert.equal(request.agent, 'codex');
+      const prepared = await prepareSandboxControlExecution({
+        manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+        manifestPath,
+        request: JSON.parse(fs.readFileSync(requestPath, 'utf8')),
+        requestPath,
+        internalCliPath: path.resolve('bin/internal-cli.ts')
+      });
+      fs.writeFileSync(path.join(responsesDir, requestName), `${JSON.stringify({
+        version: 2, id: request.id, phase: 'accepted', exitCode: null, stdout: '', stderr: '', error: null
+      })}\n`);
+      prepared.start();
+      const executionResult = await prepared.completion;
+      if (!dropCompletedResponse) {
+        fs.writeFileSync(path.join(responsesDir, requestName), `${JSON.stringify({
+          version: 2, id: request.id, phase: 'completed', exitCode: executionResult.exitCode,
+          stdout: executionResult.stdout, stderr: executionResult.stderr, error: null
+        })}\n`);
+      }
+      fs.rmSync(path.join(root, 'processing', request.id), { recursive: true, force: true });
+      fs.rmSync(requestPath, { force: true });
+      return executionResult;
+    };
+
+    const firstBroker = serveOne(true);
+    const firstClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: 500 });
+    const firstExecution = await firstBroker;
+    assert.equal(firstClient.exitCode, 1);
+    assert.equal((firstClient.payload.error as { code?: string }).code, 'SANDBOX_CONTROL_RESULT_UNKNOWN');
+    assert.equal(firstClient.payload.accepted, true);
+    assert.equal(JSON.parse(firstExecution.stdout).status, 'completed');
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'completed', taskId, 'task.md')), true);
+
+    const registryPath = path.join(root, '.agents', 'workspace', 'active', '.short-ids.json');
+    fs.writeFileSync(registryPath, '{not-json\n');
+    const failedBroker = serveOne(false);
+    const failedClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: 2_000 });
+    const failedExecution = await failedBroker;
+    assert.equal(failedExecution.exitCode, 1);
+    assert.equal(failedClient.exitCode, 0);
+    assert.equal(failedClient.payload.phase, 'completed');
+    const failedOutput = String(failedClient.payload.stdout);
+    assert.equal(failedOutput.includes(root), false);
+    assert.equal(failedExecution.stdout.includes(root), false);
+    assert.equal(fs.readFileSync(path.join(root, '.agents', 'workspace', '.task-finalization', `${taskId}.json`), 'utf8').includes(root), false);
+    assert.equal((JSON.parse(failedOutput) as { error: { code: string } }).error.code, 'TASK_FINALIZATION_SHORT_ID_REGISTRY_UNAVAILABLE');
+
+    fs.writeFileSync(registryPath, `${JSON.stringify({ version: 1, ids: {} })}\n`);
+    const secondBroker = serveOne(false);
+    const secondClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: 2_000 });
+    const secondExecution = await secondBroker;
+    assert.equal(secondClient.exitCode, 0, secondClient.stderr);
+    assert.equal(secondClient.payload.phase, 'completed');
+    const compensated = JSON.parse(String(secondClient.payload.stdout)) as {
+      status: string;
+      changed: boolean;
+      result: { status: string; changed: boolean; lifecycle: { status: string }; taskComment: { status: string }; verification: { status: string } };
+    };
+    assert.equal(compensated.status, 'completed');
+    assert.equal(compensated.changed, false);
+    assert.equal(compensated.result.status, 'completed');
+    assert.equal(compensated.result.changed, false);
+    assert.equal(compensated.result.lifecycle.status, 'no-op');
+    assert.equal(compensated.result.taskComment.status, 'skipped');
+    assert.equal(compensated.result.verification.status, 'pass');
+    assert.equal(JSON.parse(secondExecution.stdout).status, 'completed');
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json'), 'utf8')).ids, {});
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../lib/sandbox/control/lifecycle.ts';
 import { DEFAULT_SANDBOX_CONTROL_TIMING } from '../../../lib/sandbox/control/protocol.ts';
 import { prepareSandboxControlExecution } from '../../../lib/sandbox/control/executor.ts';
+import { atomicWriteJson } from '../../../lib/sandbox/control/state.ts';
 import { serveSandboxControl } from '../../../lib/sandbox/control/server.ts';
 import { startSandboxControlBroker } from '../../../lib/sandbox/recovery.ts';
 import { getProcessStartTime, isProcessAlive } from '../../../lib/server/process-state.ts';
@@ -951,6 +952,7 @@ test('task-bound finalization compensates an accepted response loss through the 
   const taskId = 'TASK-20260809-010203';
   const token = 'lifecycle-secret';
   const generation = 'finalization-compensation-generation';
+  let heartbeat: NodeJS.Timeout | undefined;
   try {
     const branch = initializeRepository(root);
     const manifestPath = writeControlManifest(root, branch, generation);
@@ -984,6 +986,15 @@ test('task-bound finalization compensates an accepted response loss through the 
       activeRequestId: null,
       updatedAt: Date.now()
     })}\n`);
+    const statusPath = path.join(statusDir, 'status.json');
+    heartbeat = setInterval(() => {
+      try {
+        const status = JSON.parse(fs.readFileSync(statusPath, 'utf8')) as Record<string, unknown>;
+        atomicWriteJson(statusPath, { ...status, updatedAt: Date.now() });
+      } catch {
+        // The fixture is being removed.
+      }
+    }, 250);
 
     const serveOne = async (dropCompletedResponse: boolean) => {
       const requestName = await waitForRequestAsync(requestsDir, SANDBOX_CONTROL_TEST_TIMEOUT_MS);
@@ -1060,6 +1071,7 @@ test('task-bound finalization compensates an accepted response loss through the 
     assert.equal(JSON.parse(secondExecution.stdout).status, 'completed');
     assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json'), 'utf8')).ids, {});
   } finally {
+    if (heartbeat) clearInterval(heartbeat);
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -70,6 +70,8 @@ async function waitForRequestAsync(requestsDir: string, timeoutMs: number): Prom
   throw new Error(`Timed out waiting for a request in ${requestsDir}`);
 }
 
+const SANDBOX_CONTROL_TEST_TIMEOUT_MS = 5_000;
+
 function runTaskFinalizationClient(params: {
   channelDir: string;
   statusDir: string;
@@ -984,7 +986,7 @@ test('task-bound finalization compensates an accepted response loss through the 
     })}\n`);
 
     const serveOne = async (dropCompletedResponse: boolean) => {
-      const requestName = await waitForRequestAsync(requestsDir, 2_000);
+      const requestName = await waitForRequestAsync(requestsDir, SANDBOX_CONTROL_TEST_TIMEOUT_MS);
       const requestPath = path.join(requestsDir, requestName);
       const request = JSON.parse(fs.readFileSync(requestPath, 'utf8')) as { id: string; family: string; operation: string; agent: string };
       assert.equal(request.id, requestName.slice(0, -5));
@@ -1026,7 +1028,7 @@ test('task-bound finalization compensates an accepted response loss through the 
     const registryPath = path.join(root, '.agents', 'workspace', 'active', '.short-ids.json');
     fs.writeFileSync(registryPath, '{not-json\n');
     const failedBroker = serveOne(false);
-    const failedClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: 2_000 });
+    const failedClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: SANDBOX_CONTROL_TEST_TIMEOUT_MS });
     const failedExecution = await failedBroker;
     assert.equal(failedExecution.exitCode, 1);
     assert.equal(failedClient.exitCode, 0);
@@ -1039,7 +1041,7 @@ test('task-bound finalization compensates an accepted response loss through the 
 
     fs.writeFileSync(registryPath, `${JSON.stringify({ version: 1, ids: {} })}\n`);
     const secondBroker = serveOne(false);
-    const secondClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: 2_000 });
+    const secondClient = await runTaskFinalizationClient({ channelDir, statusDir, token, generation, timeoutMs: SANDBOX_CONTROL_TEST_TIMEOUT_MS });
     const secondExecution = await secondBroker;
     assert.equal(secondClient.exitCode, 0, secondClient.stderr);
     assert.equal(secondClient.payload.phase, 'completed');

--- a/tests/unit/sandbox/workspace-control.test.ts
+++ b/tests/unit/sandbox/workspace-control.test.ts
@@ -332,6 +332,80 @@ test('control requests are restricted to allowed families and rebound to the man
   );
 });
 
+test('task finalization uses a typed task-bound request with manifest authority', () => {
+  const request = validateSandboxControlRequest({
+    version: 3,
+    id: '12345678-1234-1234-1234-123456789abc',
+    token: manifest.token,
+    generation: manifest.generation,
+    issuedAt: 1_000,
+    expiresAt: 3_000,
+    family: 'task-finalization',
+    operation: 'complete',
+    agent: 'codex',
+    args: [],
+    controllerProcess: null,
+    controllerProof: null
+  }, manifest, { now: 2_000 });
+  assert.equal(request.family, 'task-finalization');
+  assert.equal(request.operation, 'complete');
+  assert.equal(request.agent, 'codex');
+  assert.deepEqual(request.args, []);
+  assert.throws(() => bindSandboxControlTask(request, manifest.taskId!), /REQUEST_INVALID/);
+  assert.throws(() => validateSandboxControlRequest({ ...request, args: ['TASK-20260809-999999'] }, manifest, { now: 2_000 }), /REQUEST_INVALID/);
+  assert.throws(() => validateSandboxControlRequest({ ...request, operation: 'status' }, manifest, { now: 2_000 }), /REQUEST_INVALID/);
+  assert.throws(() => validateSandboxControlRequest({ ...request, repoRoot: '/untrusted' }, manifest, { now: 2_000 }), /REQUEST_INVALID/);
+  assert.throws(() => validateSandboxControlRequest(request, { ...manifest, mode: 'branch-only', taskId: null }, { now: 2_000 }), /SANDBOX_CONTROL_BRANCH_ONLY/);
+});
+
+test('sandbox executor finalizes only the manifest task and returns no control authority', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'finalization-executor-'));
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  try {
+    fs.mkdirSync(path.join(taskDir), { recursive: true });
+    fs.mkdirSync(path.join(root, '.agents', 'skills', 'complete-task', 'config'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({ task: { shortIdLength: 2 } }));
+    fs.writeFileSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json'), `${JSON.stringify({ version: 1, ids: { '01': taskId } })}\n`);
+    fs.writeFileSync(path.join(root, '.agents', 'skills', 'complete-task', 'config', 'verify.json'), JSON.stringify({
+      skill: 'complete-task', checks: { 'review-ledger': null, 'manual-validation': {}, 'post-review-commit': null, 'platform-sync-preflight': null }
+    }));
+    fs.writeFileSync(path.join(taskDir, 'task.md'), [
+      '---', `id: ${taskId}`, 'status: active', 'current_step: code-review', 'updated_at: old', 'agent_infra_version: old', 'target_date:', '---',
+      '', '# Task', '', '## Activity Log', ''
+    ].join('\n'));
+    const result = executeRequest({
+      ...manifest,
+      repoRoot: root,
+      worktreeRoot: root,
+      taskId,
+      runtimeDir: path.join(root, 'runtime')
+    }, path.join(root, 'manifest.json'), {
+      version: 3,
+      id: '12345678-1234-1234-1234-123456789abc',
+      token: manifest.token,
+      generation: manifest.generation,
+      issuedAt: 1_000,
+      expiresAt: 3_000,
+      family: 'task-finalization',
+      operation: 'complete',
+      agent: 'codex',
+      args: [],
+      controllerProcess: null,
+      controllerProof: null
+    });
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.status, 'completed');
+    assert.equal(payload.accepted, true);
+    assert.equal(result.stdout.includes(manifest.token), false);
+    assert.equal(result.stdout.includes(root), false);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'completed', taskId, 'task.md')), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('control protocol rejects request v2 and controller result parser enforces exact wire phases', () => {
   const request = {
     version: 3,

--- a/tests/unit/scripts/task-short-id.test.ts
+++ b/tests/unit/scripts/task-short-id.test.ts
@@ -22,7 +22,7 @@ test("all direct alloc-class SKILLs invoke task-short-id.js alloc inside executi
   }
 });
 
-test("migrated lifecycle SKILL templates invoke the typed lifecycle command", () => {
+test("migrated lifecycle SKILL templates invoke their typed completion command", () => {
   const intents = {
     "complete-task": "complete",
     "cancel-task": "cancel",
@@ -35,19 +35,21 @@ test("migrated lifecycle SKILL templates invoke the typed lifecycle command", ()
     for (const lang of ["en", "zh-CN"]) {
       const file = path.join(TEMPLATES_SKILLS, skill, `SKILL.${lang}.md`);
       const content = fs.readFileSync(file, "utf8");
-      assert.match(content, new RegExp(`agent-infra-internal task-lifecycle \\{task-id\\} ${intent}`));
+      const command = skill === "complete-task" ? "task-finalization" : "task-lifecycle";
+      assert.match(content, new RegExp(`agent-infra-internal ${command} \\{task-id\\} ${intent}`));
     }
   }
 });
 
-test("migrated runtime SKILLs invoke the same lifecycle intents as templates", () => {
+test("migrated runtime SKILLs invoke the same typed completion intents as templates", () => {
   const intents = {
     "complete-task": "complete", "cancel-task": "cancel", "block-task": "block",
     "close-codescan": "close-codescan", "close-dependabot": "close-dependabot", "restore-task": "restore"
   } as const;
   for (const [skill, intent] of Object.entries(intents)) {
     const content = fs.readFileSync(path.resolve(process.cwd(), ".agents", "skills", skill, "SKILL.md"), "utf8");
-    assert.match(content, new RegExp(`agent-infra-internal task-lifecycle \\{task-id\\} ${intent}`));
+    const command = skill === "complete-task" ? "task-finalization" : "task-lifecycle";
+    assert.match(content, new RegExp(`agent-infra-internal ${command} \\{task-id\\} ${intent}`));
   }
 });
 

--- a/tests/unit/task/finalization.test.ts
+++ b/tests/unit/task/finalization.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { platformResult } from '../../../lib/platform/types.ts';
+import {
+  applyTaskFinalization,
+  type TaskFinalizationOptions,
+  type TaskFinalizationRequest
+} from '../../../lib/task/finalization.ts';
+import type { TaskVerificationResult } from '../../../lib/task/verification.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+const METADATA = { timestamp: '2026-08-24 12:00:00+00:00', agentInfraVersion: 'v0.9.9' };
+
+function fixture(): { repoRoot: string; taskDir: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-finalization-'));
+  const taskDir = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, '.agents', '.airc.json'), JSON.stringify({ task: { shortIdLength: 2 } }));
+  fs.writeFileSync(path.join(repoRoot, '.agents', 'workspace', 'active', '.short-ids.json'), `${JSON.stringify({ version: 1, ids: { '01': TASK_ID } })}\n`);
+  fs.writeFileSync(path.join(taskDir, 'task.md'), [
+    '---', `id: ${TASK_ID}`, 'issue_number: 42', 'status: active', 'current_step: code-review',
+    'assigned_to: codex', 'updated_at: old', 'agent_infra_version: old', 'target_date:', '---',
+    '', '# Task', '', '## Activity Log', ''
+  ].join('\n'));
+  return { repoRoot, taskDir };
+}
+
+function verification(status: 'pass' | 'fail' | 'blocked'): TaskVerificationResult {
+  const payload = status === 'pass'
+    ? { gate: 'pass', summary: '1 passed, 0 failed', action: 'All declared checks passed' }
+    : { gate: status, summary: status === 'blocked' ? '0 passed, 0 failed, 1 blocked' : '0 passed, 1 failed', action: status === 'blocked' ? 'Resolve blocked complete-task check and re-run gate' : 'Fix complete-task issues and re-run gate' };
+  return {
+    status,
+    changed: false,
+    event: 'complete-task.completed',
+    requestRef: TASK_ID,
+    taskId: TASK_ID,
+    taskDir: `/completed/${TASK_ID}`,
+    taskState: 'completed',
+    skill: 'complete-task',
+    mode: 'gate',
+    artifact: null,
+    invocations: status === 'pass' ? [] : [{ status, exitCode: status === 'blocked' ? 2 : 1, payload }],
+    error: null
+  };
+}
+
+function options(
+  repoRoot: string,
+  commentSync: NonNullable<TaskFinalizationOptions['commentSync']>,
+  verify: NonNullable<TaskFinalizationOptions['verify']>
+): TaskFinalizationOptions {
+  return {
+    repoRoot,
+    metadataProvider: () => METADATA,
+    commentSync,
+    verify
+  };
+}
+
+const request: TaskFinalizationRequest = { taskRef: TASK_ID, intent: 'complete', agent: 'codex' };
+
+test('host finalization uses the canonical root and makes a successful replay a no-op', () => {
+  const f = fixture();
+  let commentCalls = 0;
+  let verifyCalls = 0;
+  const commentSync: NonNullable<TaskFinalizationOptions['commentSync']> = (_taskRef, received) => {
+    commentCalls += 1;
+    assert.equal(received.cwd, f.repoRoot);
+    return platformResult(commentCalls === 1 ? 'applied' : 'no-op');
+  };
+  const verify: NonNullable<TaskFinalizationOptions['verify']> = (received, receivedOptions) => {
+    verifyCalls += 1;
+    assert.deepEqual(received, { taskRef: TASK_ID, event: 'complete-task.completed' });
+    assert.equal(receivedOptions?.repoRoot, f.repoRoot);
+    return verification('pass');
+  };
+  try {
+    const first = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    const second = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    assert.equal(first.status, 'completed');
+    assert.equal(second.status, 'completed');
+    assert.equal(commentCalls, 2);
+    assert.equal(verifyCalls, 2);
+    assert.equal(second.taskComment?.status, 'no-op');
+    assert.equal(fs.existsSync(path.join(f.repoRoot, '.agents', 'workspace', 'completed', TASK_ID, 'task.md')), true);
+    assert.equal((fs.readFileSync(path.join(f.repoRoot, '.agents', 'workspace', 'completed', TASK_ID, 'task.md'), 'utf8').match(/Complete Task/g) ?? []).length, 2);
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('host finalization revalidates canonical steps when the receipt is absent', () => {
+  const f = fixture();
+  let commentCalls = 0;
+  let verifyCalls = 0;
+  const commentSync: NonNullable<TaskFinalizationOptions['commentSync']> = () => {
+    commentCalls += 1;
+    return platformResult(commentCalls === 1 ? 'applied' : 'no-op');
+  };
+  const verify: NonNullable<TaskFinalizationOptions['verify']> = () => {
+    verifyCalls += 1;
+    return verification('pass');
+  };
+  try {
+    const first = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    fs.rmSync(path.join(f.repoRoot, '.agents', 'workspace', '.task-finalization', `${TASK_ID}.json`));
+    const second = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    assert.equal(first.status, 'completed');
+    assert.equal(second.status, 'completed');
+    assert.equal(second.lifecycle?.status, 'no-op');
+    assert.equal(commentCalls, 2);
+    assert.equal(verifyCalls, 2);
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('host finalization returns actionable verification gate failures and retries them', () => {
+  const f = fixture();
+  let verifyCalls = 0;
+  const commentSync: NonNullable<TaskFinalizationOptions['commentSync']> = () => platformResult('no-op');
+  const verify: NonNullable<TaskFinalizationOptions['verify']> = () => {
+    verifyCalls += 1;
+    return verification(verifyCalls === 2 ? 'fail' : 'pass');
+  };
+  try {
+    const first = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    const failed = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    const recovered = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    assert.equal(first.status, 'completed');
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.error?.code, 'CHECK_FAILED');
+    assert.match(failed.error?.message ?? '', /Fix complete-task issues/);
+    assert.deepEqual(failed.pendingSteps, ['verification']);
+    assert.equal(recovered.status, 'completed');
+    assert.equal(verifyCalls, 3);
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('host finalization retries only the pending terminal steps after a comment failure', () => {
+  const f = fixture();
+  let commentCalls = 0;
+  let verifyCalls = 0;
+  const commentSync: NonNullable<TaskFinalizationOptions['commentSync']> = () => {
+    commentCalls += 1;
+    return commentCalls === 1
+      ? platformResult('blocked', { error: { code: 'NETWORK_RETRY', message: 'temporary', retryable: true } })
+      : platformResult('no-op');
+  };
+  const verify: NonNullable<TaskFinalizationOptions['verify']> = () => {
+    verifyCalls += 1;
+    return verification('pass');
+  };
+  try {
+    const first = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    const second = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+    assert.equal(first.status, 'blocked');
+    assert.equal(first.lifecycle?.status, 'applied');
+    assert.equal(first.pendingSteps.includes('task-comment'), true);
+    assert.equal(second.status, 'completed');
+    assert.equal(commentCalls, 2);
+    assert.equal(verifyCalls, 1);
+    assert.equal(fs.existsSync(path.join(f.repoRoot, '.agents', 'workspace', 'completed', TASK_ID)), true);
+  } finally {
+    fs.rmSync(f.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('host finalization fails closed when the canonical short-id registry is unavailable', () => {
+  const mutations: Array<[string, (registryPath: string) => void]> = [
+    ['missing', (registryPath) => fs.unlinkSync(registryPath)],
+    ['malformed JSON', (registryPath) => fs.writeFileSync(registryPath, '{not-json\n')],
+    ['invalid schema', (registryPath) => fs.writeFileSync(registryPath, JSON.stringify({ version: 1, ids: [] }))]
+  ];
+
+  for (const [label, mutate] of mutations) {
+    const f = fixture();
+    const commentSync: NonNullable<TaskFinalizationOptions['commentSync']> = () => platformResult('no-op');
+    const verify: NonNullable<TaskFinalizationOptions['verify']> = () => verification('pass');
+    const registryPath = path.join(f.repoRoot, '.agents', 'workspace', 'active', '.short-ids.json');
+    try {
+      const first = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+      mutate(registryPath);
+      const replay = applyTaskFinalization(request, options(f.repoRoot, commentSync, verify));
+      assert.equal(first.status, 'completed', label);
+      assert.equal(replay.status, 'failed', label);
+      assert.equal(replay.error?.code, 'TASK_FINALIZATION_SHORT_ID_REGISTRY_UNAVAILABLE', label);
+      assert.equal(replay.lifecycle?.status, 'failed', label);
+      assert.equal(replay.pendingSteps.includes('lifecycle'), true, label);
+      const receipt = fs.readFileSync(path.join(f.repoRoot, '.agents', 'workspace', '.task-finalization', `${TASK_ID}.json`), 'utf8');
+      assert.equal(JSON.stringify(replay).includes(f.repoRoot), false, label);
+      assert.equal(receipt.includes(f.repoRoot), false, label);
+    } finally {
+      fs.rmSync(f.repoRoot, { recursive: true, force: true });
+    }
+  }
+});

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1558,21 +1558,17 @@ test("complete-task splits active preflight checks from completed-state checks",
   });
 });
 
-test("complete-task docs keep remote preflight before lifecycle and terminal sync after it", () => {
+test("complete-task docs keep remote preflight before host finalization", () => {
   skillDocPaths("complete-task").forEach((relativePath) => {
     const content = read(relativePath);
     const externalResolve = content.indexOf("platform-pr resolve-external {task-id}");
     const artifactSync = content.indexOf("platform-comment backfill {task-id}");
     const preflight = content.indexOf("task-verify {task-id} complete-task.preflight");
-    const lifecycle = content.indexOf("task-lifecycle {task-id} complete");
-    const taskSync = content.indexOf("platform-comment sync {task-id} --kind task");
-    const completedGate = content.indexOf("task-verify {task-id} complete-task.completed");
+    const finalization = content.indexOf("task-finalization {task-id} complete");
 
     assert.ok(externalResolve >= 0 && externalResolve < artifactSync, `${relativePath} should resolve external delivery before platform backfill`);
     assert.ok(artifactSync >= 0 && artifactSync < preflight, `${relativePath} should backfill completion artifacts before preflight`);
-    assert.ok(preflight < lifecycle, `${relativePath} should run preflight before lifecycle completion`);
-    assert.ok(lifecycle < taskSync, `${relativePath} should sync the terminal task comment after lifecycle completion`);
-    assert.ok(taskSync < completedGate, `${relativePath} should run the completed gate after terminal task sync`);
+    assert.ok(preflight >= 0 && preflight < finalization, `${relativePath} should run preflight before host finalization`);
     assert.ok(content.includes("finalization-retry"), `${relativePath} should define the retry branch identifier`);
   });
 });


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

Closes #861

**Issue 链接 / Issue Link:** #861

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix

## 📝 变更目的 / Purpose of the Change

Task-bound sandboxes can retain a stale `active/<task-id>` bind mount after the host has completed the task. This change makes host finalization authoritative from lifecycle completion onward, so host and sandbox callers share the same idempotent completion behavior and terminal verification no longer depends on the stale sandbox view.

当宿主机完成任务后，task-bound 沙箱可能仍保留陈旧的 `active/<task-id>` bind mount。本变更从 lifecycle completion 开始收敛到宿主权威 finalization 入口，使宿主机和沙箱调用共享同一套可幂等完成语义，终态校验不再依赖沙箱中的陈旧视图。

## 📋 主要变更 / Brief Changelog

- Add a typed `task-finalization` sandbox-control family and route both direct and task-bound completion through the host finalization service.
- Persist receipt-backed lifecycle, terminal comment, and verification progress for safe response-loss compensation and retry.
- Fail closed when the canonical short-id registry is unavailable, while keeping registry errors path-free across domain results, receipts, and sandbox output.

## 🧪 验证变更 / Verifying this Change

### Test Steps

```text
npm run typecheck
npm run test:smoke
npm run test:core
npm test
```

### Test Coverage

- [x] 我已经添加了单元测试 / I have added unit tests
- [x] 所有现有测试都通过 / All existing tests pass
- [ ] 我已经进行了手动测试 / I have performed manual testing

Results: smoke 1318/1318 passed; core 2230 passed, 3 skipped; full 2547 passed, 4 skipped.

## ✅ 贡献者检查清单 / Contributor Checklist

- [x] 确保有 GitHub Issue 对应这个变更 / A GitHub Issue exists for this change
- [x] PR 只解决一个 Issue / This PR addresses one issue
- [x] PR 中的 commit 有意义 / The commit has a meaningful subject and body
- [x] 代码遵循项目规范 / Code follows project conventions
- [x] 已完成自我代码审查 / Self-review completed
- [x] 已编写必要的行为测试 / Necessary behavior tests were added
- [x] 已考虑向后兼容性 / Backward compatibility considered

## 审查者注意事项 / Reviewer Notes

`review-code-r4.md` is approved with 0 blockers, 0 major findings, 0 minor findings, and 0 manual-validation items. Please review the host-authoritative finalization boundary, accepted-response-loss compensation, strict short-id registry handling, and the no-host-path leakage assertions.

Generated with AI assistance
