### PR TITLE
fix(cli): 规范化生命周期入口 shebang 哈希


### DIFF
--- a/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
@@ -61,12 +61,21 @@ function normalizeRelativePath(value: string): string {
   return value.replaceAll('\\', '/');
 }
 
+function isSafeLifecyclePath(value: unknown): value is string {
+  return exactText(value)
+    && value === normalizeRelativePath(value)
+    && !path.isAbsolute(value)
+    && !/^[A-Za-z]:[\\/]/u.test(value)
+    && !value.split('/').includes('..');
+}
+
 function isLifecycleLauncherLine(value: unknown): value is string {
   return typeof value === 'string'
     && value.length > 1
     && value.slice(0, -1).trim() === value.slice(0, -1)
     && value.startsWith('#!')
     && value.endsWith('\n')
+    && value.indexOf('\n') === value.length - 1
     && !value.includes('\r');
 }
 
@@ -78,8 +87,8 @@ function readLifecycleLauncherShebang(
     throw new Error('Lifecycle manifest launcher shebang policy is invalid');
   }
   const policy = value as Record<string, unknown>;
-  if (!exactText(policy.sourceFile)
-    || !exactText(policy.compiledFile)
+  if (!isSafeLifecyclePath(policy.sourceFile)
+    || !isSafeLifecyclePath(policy.compiledFile)
     || !isLifecycleLauncherLine(policy.canonicalLine)
     || !Array.isArray(policy.acceptedLines)
     || !policy.acceptedLines.every(isLifecycleLauncherLine)
@@ -118,8 +127,8 @@ function readLifecycleManifestFiles(packageRoot: string): LifecycleManifestFiles
   };
   if (!Array.isArray(value.executableFiles)
     || !Array.isArray(value.contractFiles)
-    || !value.executableFiles.every(exactText)
-    || !value.contractFiles.every(exactText)
+    || !value.executableFiles.every(isSafeLifecyclePath)
+    || !value.contractFiles.every(isSafeLifecyclePath)
     || new Set(value.executableFiles).size !== value.executableFiles.length
     || new Set(value.contractFiles).size !== value.contractFiles.length) {
     throw new Error('Lifecycle manifest file list is invalid');

--- a/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/build-identity.ts
@@ -22,6 +22,14 @@ type LifecycleBuildIdentityOptions = Readonly<{
 type LifecycleManifestFiles = Readonly<{
   executableFiles: readonly string[];
   contractFiles: readonly string[];
+  launcherShebang: LifecycleLauncherShebang;
+}>;
+
+type LifecycleLauncherShebang = Readonly<{
+  sourceFile: string;
+  compiledFile: string;
+  canonicalLine: string;
+  acceptedLines: readonly string[];
 }>;
 
 type IdentityVerification = Readonly<{
@@ -53,6 +61,47 @@ function normalizeRelativePath(value: string): string {
   return value.replaceAll('\\', '/');
 }
 
+function isLifecycleLauncherLine(value: unknown): value is string {
+  return typeof value === 'string'
+    && value.length > 1
+    && value.slice(0, -1).trim() === value.slice(0, -1)
+    && value.startsWith('#!')
+    && value.endsWith('\n')
+    && !value.includes('\r');
+}
+
+function readLifecycleLauncherShebang(
+  value: unknown,
+  executableFiles: readonly string[]
+): LifecycleLauncherShebang {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Lifecycle manifest launcher shebang policy is invalid');
+  }
+  const policy = value as Record<string, unknown>;
+  if (!exactText(policy.sourceFile)
+    || !exactText(policy.compiledFile)
+    || !isLifecycleLauncherLine(policy.canonicalLine)
+    || !Array.isArray(policy.acceptedLines)
+    || !policy.acceptedLines.every(isLifecycleLauncherLine)
+    || new Set(policy.acceptedLines).size !== policy.acceptedLines.length
+    || !policy.acceptedLines.includes(policy.canonicalLine)
+    || !executableFiles.includes(policy.sourceFile)
+    || policy.compiledFile !== normalizeRelativePath(path.join(
+      'dist',
+      policy.sourceFile.endsWith('.ts')
+        ? policy.sourceFile.replace(/\.ts$/u, '.js')
+        : policy.sourceFile
+    ))) {
+    throw new Error('Lifecycle manifest launcher shebang policy is invalid');
+  }
+  return Object.freeze({
+    sourceFile: policy.sourceFile,
+    compiledFile: policy.compiledFile,
+    canonicalLine: policy.canonicalLine,
+    acceptedLines: Object.freeze([...policy.acceptedLines])
+  });
+}
+
 function readLifecycleManifestFiles(packageRoot: string): LifecycleManifestFiles {
   const file = path.join(
     packageRoot,
@@ -65,6 +114,7 @@ function readLifecycleManifestFiles(packageRoot: string): LifecycleManifestFiles
   const value = JSON.parse(fs.readFileSync(file, 'utf8')) as {
     executableFiles?: unknown;
     contractFiles?: unknown;
+    launcherShebang?: unknown;
   };
   if (!Array.isArray(value.executableFiles)
     || !Array.isArray(value.contractFiles)
@@ -74,9 +124,11 @@ function readLifecycleManifestFiles(packageRoot: string): LifecycleManifestFiles
     || new Set(value.contractFiles).size !== value.contractFiles.length) {
     throw new Error('Lifecycle manifest file list is invalid');
   }
+  const executableFiles = Object.freeze([...value.executableFiles] as string[]);
   return Object.freeze({
-    executableFiles: Object.freeze([...value.executableFiles] as string[]),
-    contractFiles: Object.freeze([...value.contractFiles] as string[])
+    executableFiles,
+    contractFiles: Object.freeze([...value.contractFiles] as string[]),
+    launcherShebang: readLifecycleLauncherShebang(value.launcherShebang, executableFiles)
   });
 }
 
@@ -94,7 +146,28 @@ function executablePackageRoot(): string {
   }
 }
 
-function hashFiles(root: string, files: readonly string[]): string {
+function normalizeLifecycleLauncherBytes(
+  relative: string,
+  content: Buffer,
+  policy: LifecycleLauncherShebang
+): Buffer {
+  const normalized = normalizeRelativePath(relative);
+  if (normalized !== policy.sourceFile && normalized !== policy.compiledFile) return content;
+  const lineEnd = content.indexOf(0x0a);
+  if (lineEnd < 0) return content;
+  const firstLine = content.subarray(0, lineEnd + 1);
+  if (!policy.acceptedLines.some((line) => Buffer.from(line).equals(firstLine))) return content;
+  return Buffer.concat([
+    Buffer.from(policy.canonicalLine),
+    content.subarray(lineEnd + 1)
+  ]);
+}
+
+function hashFiles(
+  root: string,
+  files: readonly string[],
+  launcherShebang?: LifecycleLauncherShebang
+): string {
   const hash = crypto.createHash('sha256');
   for (const relative of [...new Set(files.map(normalizeRelativePath))].sort()) {
     if (path.isAbsolute(relative) || relative.split(/[\\/]/u).includes('..')) {
@@ -107,7 +180,10 @@ function hashFiles(root: string, files: readonly string[]): string {
     }
     hash.update(relative);
     hash.update('\0');
-    hash.update(fs.readFileSync(file));
+    const content = fs.readFileSync(file);
+    hash.update(launcherShebang
+      ? normalizeLifecycleLauncherBytes(relative, content, launcherShebang)
+      : content);
     hash.update('\0');
   }
   return hash.digest('hex');
@@ -157,7 +233,7 @@ function computeLifecycleBuildIdentity(
   if (!exactText(packageJson.version)) throw new Error('Lifecycle package version is invalid');
   let internalExecutableBuildHash: string;
   if (options.executableFiles) {
-    internalExecutableBuildHash = hashFiles(repoRoot, options.executableFiles);
+    internalExecutableBuildHash = hashFiles(repoRoot, options.executableFiles, defaults.launcherShebang);
   } else {
     const manifestFile = path.join(executableRoot, 'dist', 'lifecycle-build-manifest.json');
     if (fs.existsSync(manifestFile)) {
@@ -177,16 +253,25 @@ function computeLifecycleBuildIdentity(
         const compiledFiles = defaults.executableFiles.map((file) =>
           file.endsWith('.ts') ? path.join('dist', file.replace(/\.ts$/u, '.js')) : file
         );
-        if (hashFiles(executableRoot, resolveLifecycleExecutableFiles(executableRoot, compiledFiles)) !== manifest.internalExecutableBuildHash) {
+        if (hashFiles(
+          executableRoot,
+          resolveLifecycleExecutableFiles(executableRoot, compiledFiles),
+          defaults.launcherShebang
+        ) !== manifest.internalExecutableBuildHash) {
           throw new Error('Lifecycle compiled executable build does not match its manifest');
         }
-      } else if (hashFiles(executableRoot, resolveLifecycleExecutableFiles(executableRoot, defaults.executableFiles)) !== manifest.sourceInputHash) {
+      } else if (hashFiles(
+        executableRoot,
+        resolveLifecycleExecutableFiles(executableRoot, defaults.executableFiles),
+        defaults.launcherShebang
+      ) !== manifest.sourceInputHash) {
         throw new Error('Lifecycle executable build manifest is stale or invalid');
       }
       internalExecutableBuildHash = manifest.internalExecutableBuildHash;
     } else internalExecutableBuildHash = hashFiles(
       executableRoot,
-      resolveLifecycleExecutableFiles(executableRoot, defaults.executableFiles)
+      resolveLifecycleExecutableFiles(executableRoot, defaults.executableFiles),
+      defaults.launcherShebang
     );
   }
   return Object.freeze({
@@ -249,6 +334,7 @@ export type {
   IdentityVerification,
   LifecycleIdentityWarning,
   LifecycleBuildIdentity,
+  LifecycleLauncherShebang,
   LifecycleManifestFiles,
   LifecycleBuildIdentityOptions
 };

--- a/lib/agent-clients/adapters/codex-lifecycle/manifest-files.json
+++ b/lib/agent-clients/adapters/codex-lifecycle/manifest-files.json
@@ -30,5 +30,16 @@
     ".agents/hooks/lifecycle-delegation.js",
     ".agents/skills/run-task/SKILL.md",
     ".agents/rules/lifecycle-orchestration.md"
-  ]
+  ],
+  "launcherShebang": {
+    "sourceFile": "bin/internal-cli.ts",
+    "compiledFile": "dist/bin/internal-cli.js",
+    "canonicalLine": "#!/usr/bin/env node\n",
+    "acceptedLines": [
+      "#!/usr/bin/env node\n",
+      "#!/opt/homebrew/opt/node/bin/node\n",
+      "#!/usr/local/opt/node/bin/node\n",
+      "#!/home/linuxbrew/.linuxbrew/opt/node/bin/node\n"
+    ]
+  }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,12 +11,23 @@ function normalizeRelativePath(value) {
   return value.replaceAll("\\", "/");
 }
 
+function isSafeLifecyclePath(value) {
+  return typeof value === "string"
+    && value.trim() === value
+    && value.length > 0
+    && value === normalizeRelativePath(value)
+    && !path.isAbsolute(value)
+    && !/^[A-Za-z]:[\\/]/u.test(value)
+    && !value.split("/").includes("..");
+}
+
 function isLifecycleLauncherLine(value) {
   return typeof value === "string"
     && value.length > 1
     && value.slice(0, -1).trim() === value.slice(0, -1)
     && value.startsWith("#!")
     && value.endsWith("\n")
+    && value.indexOf("\n") === value.length - 1
     && !value.includes("\r");
 }
 
@@ -24,12 +35,8 @@ function readLifecycleLauncherShebang(value, executableFiles) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Lifecycle manifest launcher shebang policy is invalid");
   }
-  if (typeof value.sourceFile !== "string"
-    || value.sourceFile.trim() !== value.sourceFile
-    || value.sourceFile.length === 0
-    || typeof value.compiledFile !== "string"
-    || value.compiledFile.trim() !== value.compiledFile
-    || value.compiledFile.length === 0
+  if (!isSafeLifecyclePath(value.sourceFile)
+    || !isSafeLifecyclePath(value.compiledFile)
     || !isLifecycleLauncherLine(value.canonicalLine)
     || !Array.isArray(value.acceptedLines)
     || !value.acceptedLines.every(isLifecycleLauncherLine)
@@ -103,6 +110,14 @@ const lifecycleFiles = JSON.parse(fs.readFileSync(
   path.join(rootDir, "lib", "agent-clients", "adapters", "codex-lifecycle", "manifest-files.json"),
   "utf8"
 ));
+if (!Array.isArray(lifecycleFiles.executableFiles)
+  || !Array.isArray(lifecycleFiles.contractFiles)
+  || !lifecycleFiles.executableFiles.every(isSafeLifecyclePath)
+  || !lifecycleFiles.contractFiles.every(isSafeLifecyclePath)
+  || new Set(lifecycleFiles.executableFiles).size !== lifecycleFiles.executableFiles.length
+  || new Set(lifecycleFiles.contractFiles).size !== lifecycleFiles.contractFiles.length) {
+  throw new Error("Lifecycle manifest file list is invalid");
+}
 const launcherShebang = readLifecycleLauncherShebang(
   lifecycleFiles.launcherShebang,
   lifecycleFiles.executableFiles

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,12 +11,64 @@ function normalizeRelativePath(value) {
   return value.replaceAll("\\", "/");
 }
 
-function hashFiles(files) {
+function isLifecycleLauncherLine(value) {
+  return typeof value === "string"
+    && value.length > 1
+    && value.slice(0, -1).trim() === value.slice(0, -1)
+    && value.startsWith("#!")
+    && value.endsWith("\n")
+    && !value.includes("\r");
+}
+
+function readLifecycleLauncherShebang(value, executableFiles) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Lifecycle manifest launcher shebang policy is invalid");
+  }
+  if (typeof value.sourceFile !== "string"
+    || value.sourceFile.trim() !== value.sourceFile
+    || value.sourceFile.length === 0
+    || typeof value.compiledFile !== "string"
+    || value.compiledFile.trim() !== value.compiledFile
+    || value.compiledFile.length === 0
+    || !isLifecycleLauncherLine(value.canonicalLine)
+    || !Array.isArray(value.acceptedLines)
+    || !value.acceptedLines.every(isLifecycleLauncherLine)
+    || new Set(value.acceptedLines).size !== value.acceptedLines.length
+    || !value.acceptedLines.includes(value.canonicalLine)
+    || !executableFiles.includes(value.sourceFile)
+    || value.compiledFile !== normalizeRelativePath(path.join(
+      "dist",
+      value.sourceFile.endsWith(".ts")
+        ? value.sourceFile.replace(/\.ts$/u, ".js")
+        : value.sourceFile
+    ))) {
+    throw new Error("Lifecycle manifest launcher shebang policy is invalid");
+  }
+  return value;
+}
+
+function normalizeLifecycleLauncherBytes(relative, content, policy) {
+  const normalized = normalizeRelativePath(relative);
+  if (normalized !== policy.sourceFile && normalized !== policy.compiledFile) return content;
+  const lineEnd = content.indexOf(0x0a);
+  if (lineEnd < 0) return content;
+  const firstLine = content.subarray(0, lineEnd + 1);
+  if (!policy.acceptedLines.some((line) => Buffer.from(line).equals(firstLine))) return content;
+  return Buffer.concat([
+    Buffer.from(policy.canonicalLine),
+    content.subarray(lineEnd + 1)
+  ]);
+}
+
+function hashFiles(files, launcherShebang) {
   const hash = crypto.createHash("sha256");
   for (const relative of [...new Set(files.map(normalizeRelativePath))].sort()) {
     hash.update(relative);
     hash.update("\0");
-    hash.update(fs.readFileSync(path.join(rootDir, relative)));
+    const content = fs.readFileSync(path.join(rootDir, relative));
+    hash.update(launcherShebang
+      ? normalizeLifecycleLauncherBytes(relative, content, launcherShebang)
+      : content);
     hash.update("\0");
   }
   return hash.digest("hex");
@@ -51,6 +103,10 @@ const lifecycleFiles = JSON.parse(fs.readFileSync(
   path.join(rootDir, "lib", "agent-clients", "adapters", "codex-lifecycle", "manifest-files.json"),
   "utf8"
 ));
+const launcherShebang = readLifecycleLauncherShebang(
+  lifecycleFiles.launcherShebang,
+  lifecycleFiles.executableFiles
+);
 const packageVersion = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8")).version;
 const compiledExecutableFiles = lifecycleFiles.executableFiles.map((file) =>
   file.endsWith(".ts") ? path.join("dist", file.replace(/\.ts$/u, ".js")) : file
@@ -58,8 +114,8 @@ const compiledExecutableFiles = lifecycleFiles.executableFiles.map((file) =>
 fs.writeFileSync(path.join(rootDir, "dist", "lifecycle-build-manifest.json"), `${JSON.stringify({
   protocolVersion: 3,
   packageVersion,
-  sourceInputHash: hashFiles(resolveExecutableFiles(lifecycleFiles.executableFiles)),
-  internalExecutableBuildHash: hashFiles(resolveExecutableFiles(compiledExecutableFiles))
+  sourceInputHash: hashFiles(resolveExecutableFiles(lifecycleFiles.executableFiles), launcherShebang),
+  internalExecutableBuildHash: hashFiles(resolveExecutableFiles(compiledExecutableFiles), launcherShebang)
 }, null, 2)}\n`);
 process.stdout.write("Generated dist/lifecycle-build-manifest.json\n");
 

--- a/tests/integration/cli/codex-lifecycle.test.ts
+++ b/tests/integration/cli/codex-lifecycle.test.ts
@@ -92,18 +92,64 @@ function fixture() {
   };
 }
 
-function run(root: string, env: NodeJS.ProcessEnv, args: string[], input = '') {
-  return spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'codex-lifecycle', ...args], {
+function writeCapabilityTask(root: string, taskId: string) {
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\nstatus: active\ncurrent_step: requirement-analysis\nagent_infra_version: v0.9.12-alpha.0\n---\n\n# Task\n`);
+}
+
+function copyCompiledPackage(root: string) {
+  fs.copyFileSync(path.join(process.cwd(), 'package.json'), path.join(root, 'package.json'));
+  fs.cpSync(path.join(process.cwd(), 'dist'), path.join(root, 'dist'), { recursive: true });
+  fs.cpSync(path.join(process.cwd(), 'lib'), path.join(root, 'lib'), { recursive: true });
+  fs.symlinkSync(path.join(process.cwd(), 'node_modules'), path.join(root, 'node_modules'), 'dir');
+}
+
+function rewriteCompiledLauncher(root: string) {
+  const file = path.join(root, 'dist', 'bin', 'internal-cli.js');
+  const content = fs.readFileSync(file);
+  const lineEnd = content.indexOf(0x0a);
+  fs.writeFileSync(file, Buffer.concat([
+    Buffer.from('#!/opt/homebrew/opt/node/bin/node\n'),
+    content.subarray(lineEnd + 1)
+  ]));
+}
+
+function run(root: string, env: NodeJS.ProcessEnv, args: string[], input = '', cliPath = INTERNAL_CLI_PATH) {
+  return spawnSync(process.execPath, [cliPath, 'codex-lifecycle', ...args], {
     cwd: root, env, input, encoding: 'utf8'
   });
+}
+
+function runBuildFixture(launcherShebang: Record<string, unknown>, executableFiles: readonly string[] = ['bin/internal-cli.ts']) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-lifecycle-build-'));
+  fixtureRoots.add(root);
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.copyFileSync(path.join(process.cwd(), 'scripts', 'build.js'), path.join(root, 'scripts', 'build.js'));
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+    type: 'module',
+    version: '0.9.12-alpha.0'
+  }));
+  const manifest = path.join(root, 'lib', 'agent-clients', 'adapters', 'codex-lifecycle', 'manifest-files.json');
+  fs.mkdirSync(path.dirname(manifest), { recursive: true });
+  fs.writeFileSync(manifest, JSON.stringify({ executableFiles, contractFiles: [], launcherShebang }));
+  fs.mkdirSync(path.join(root, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'bin', 'internal-cli.ts'), '#!/usr/bin/env node\n');
+  fs.mkdirSync(path.join(root, 'dist', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'dist', 'bin', 'internal-cli.js'), '#!/usr/bin/env node\n');
+  fs.writeFileSync(path.join(root, 'lib', 'defaults.json'), '{}\n');
+  fs.mkdirSync(path.join(root, 'lib', 'sandbox', 'runtimes'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'lib', 'agent-clients', 'adapters', 'runtimes'), { recursive: true });
+  const result = spawnSync(process.execPath, [path.join(root, 'scripts', 'build.js')], {
+    cwd: root, encoding: 'utf8'
+  });
+  return { root, result };
 }
 
 test('compiled codex-lifecycle CLI rechecks its generated executable identity', () => {
   const { root, env } = fixture();
   const taskId = 'TASK-20260101-000001';
-  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
-  fs.mkdirSync(taskDir, { recursive: true });
-  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\nstatus: active\ncurrent_step: requirement-analysis\nagent_infra_version: v0.9.12-alpha.0\n---\n\n# Task\n`);
+  writeCapabilityTask(root, taskId);
 
   const result = run(root, env, ['capability-arm', '--task-id', taskId]);
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
@@ -112,6 +158,48 @@ test('compiled codex-lifecycle CLI rechecks its generated executable identity', 
   assert.equal(payload.error, null);
   assert.equal(payload.buildIdentity.protocolVersion, 3);
   assert.match(payload.buildIdentity.internalExecutableBuildHash, /^[0-9a-f]{64}$/u);
+});
+
+test('compiled codex-lifecycle CLI accepts a Homebrew-rewritten launcher in an isolated package', () => {
+  const { root, env } = fixture();
+  const taskId = 'TASK-20260101-000001';
+  writeCapabilityTask(root, taskId);
+  copyCompiledPackage(root);
+  rewriteCompiledLauncher(root);
+
+  const result = run(
+    root,
+    env,
+    ['capability-arm', '--task-id', taskId],
+    '',
+    path.join(root, 'dist', 'bin', 'internal-cli.js')
+  );
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.status, 'armed');
+  assert.equal(payload.error, null);
+  assert.equal(payload.buildIdentity.protocolVersion, 3);
+});
+
+test('build rejects malformed launcher policies before creating a lifecycle manifest', () => {
+  for (const [launcherShebang, executableFiles] of [
+    [{
+      sourceFile: 'bin/internal-cli.ts',
+      compiledFile: 'dist/bin/internal-cli.js',
+      canonicalLine: '#!/usr/bin/env node\npayload\n',
+      acceptedLines: ['#!/usr/bin/env node\npayload\n']
+    }, ['bin/internal-cli.ts']],
+    [{
+      sourceFile: '../outside.ts',
+      compiledFile: 'outside.js',
+      canonicalLine: '#!/usr/bin/env node\n',
+      acceptedLines: ['#!/usr/bin/env node\n']
+    }, ['../outside.ts']]
+  ] as const) {
+    const { root, result } = runBuildFixture(launcherShebang, executableFiles);
+    assert.notEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.equal(fs.existsSync(path.join(root, 'dist', 'lifecycle-build-manifest.json')), false);
+  }
 });
 
 test('codex-lifecycle CLI records normalized hook identity across invocations', () => {

--- a/tests/integration/cli/codex-lifecycle.test.ts
+++ b/tests/integration/cli/codex-lifecycle.test.ts
@@ -68,6 +68,17 @@ function fixture() {
   const hooks = '{"hooks":{}}\n';
   fs.mkdirSync(path.join(root, '.codex'), { recursive: true });
   fs.writeFileSync(path.join(root, '.codex', 'hooks.json'), hooks);
+  for (const file of [
+    '.codex/agents/agent-infra-lifecycle-executor.toml',
+    '.codex/agents/agent-infra-lifecycle-reviewer.toml',
+    '.agents/hooks/lifecycle-delegation.js',
+    '.agents/skills/run-task/SKILL.md',
+    '.agents/rules/lifecycle-orchestration.md'
+  ]) {
+    const target = path.join(root, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, 'managed lifecycle contract\n');
+  }
   return {
     root,
     env: envWithPrependedPath(sandboxControlSafeEnv({
@@ -86,6 +97,22 @@ function run(root: string, env: NodeJS.ProcessEnv, args: string[], input = '') {
     cwd: root, env, input, encoding: 'utf8'
   });
 }
+
+test('compiled codex-lifecycle CLI rechecks its generated executable identity', () => {
+  const { root, env } = fixture();
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${taskId}\nstatus: active\ncurrent_step: requirement-analysis\nagent_infra_version: v0.9.12-alpha.0\n---\n\n# Task\n`);
+
+  const result = run(root, env, ['capability-arm', '--task-id', taskId]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.status, 'armed');
+  assert.equal(payload.error, null);
+  assert.equal(payload.buildIdentity.protocolVersion, 3);
+  assert.match(payload.buildIdentity.internalExecutableBuildHash, /^[0-9a-f]{64}$/u);
+});
 
 test('codex-lifecycle CLI records normalized hook identity across invocations', () => {
   const { root, env } = fixture();

--- a/tests/unit/core/codex-build-identity.test.ts
+++ b/tests/unit/core/codex-build-identity.test.ts
@@ -45,6 +45,16 @@ function launcherIdentity(relativePath: string, firstLine: string, body = 'expor
   });
 }
 
+function writeLifecycleManifest(root: string, launcherShebang: Record<string, unknown>) {
+  const file = path.join(root, 'lib', 'agent-clients', 'adapters', 'codex-lifecycle', 'manifest-files.json');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({
+    executableFiles: [launcherShebang.sourceFile],
+    contractFiles: [],
+    launcherShebang
+  }));
+}
+
 test('lifecycle build identity separates executable and contract hashes', () => {
   const root = fixture();
   const options = {
@@ -134,6 +144,27 @@ test('lifecycle manifest declares the exact protected launcher shebang policy', 
       '#!/home/linuxbrew/.linuxbrew/opt/node/bin/node\n'
     ]
   });
+});
+
+test('lifecycle manifest rejects malformed launcher shebang policies', () => {
+  for (const launcherShebang of [
+    {
+      sourceFile: 'bin/internal-cli.ts',
+      compiledFile: 'dist/bin/internal-cli.js',
+      canonicalLine: '#!/usr/bin/env node\npayload\n',
+      acceptedLines: ['#!/usr/bin/env node\npayload\n']
+    },
+    {
+      sourceFile: '../outside.ts',
+      compiledFile: 'outside.js',
+      canonicalLine: '#!/usr/bin/env node\n',
+      acceptedLines: ['#!/usr/bin/env node\n']
+    }
+  ]) {
+    const root = fixture();
+    writeLifecycleManifest(root, launcherShebang);
+    assert.throws(() => readLifecycleManifestFiles(root));
+  }
 });
 
 test('lifecycle identity normalizes only the exact source and compiled launcher lines', () => {

--- a/tests/unit/core/codex-build-identity.test.ts
+++ b/tests/unit/core/codex-build-identity.test.ts
@@ -34,6 +34,17 @@ function fixture() {
   return root;
 }
 
+function launcherIdentity(relativePath: string, firstLine: string, body = 'export const launcher = true;\n') {
+  const root = fixture();
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, Buffer.concat([Buffer.from(firstLine), Buffer.from(body)]));
+  return computeLifecycleBuildIdentity(root, {
+    executableFiles: [relativePath],
+    contractFiles: []
+  });
+}
+
 test('lifecycle build identity separates executable and contract hashes', () => {
   const root = fixture();
   const options = {
@@ -106,6 +117,64 @@ test('lifecycle build identity reads one validated manifest file list', () => {
   assert.ok(closure.includes('lib/sandbox/control/controller-registration.ts'));
   assert.ok(closure.includes('lib/agent-clients/adapters/codex-lifecycle/controller-context.ts'));
   assert.ok(manifest.contractFiles.includes('.agents/skills/run-task/SKILL.md'));
+});
+
+test('lifecycle manifest declares the exact protected launcher shebang policy', () => {
+  const manifest = readLifecycleManifestFiles(process.cwd()) as ReturnType<typeof readLifecycleManifestFiles> & {
+    launcherShebang?: unknown
+  };
+  assert.deepEqual(manifest.launcherShebang, {
+    sourceFile: 'bin/internal-cli.ts',
+    compiledFile: 'dist/bin/internal-cli.js',
+    canonicalLine: '#!/usr/bin/env node\n',
+    acceptedLines: [
+      '#!/usr/bin/env node\n',
+      '#!/opt/homebrew/opt/node/bin/node\n',
+      '#!/usr/local/opt/node/bin/node\n',
+      '#!/home/linuxbrew/.linuxbrew/opt/node/bin/node\n'
+    ]
+  });
+});
+
+test('lifecycle identity normalizes only the exact source and compiled launcher lines', () => {
+  const acceptedLines = [
+    '#!/usr/bin/env node\n',
+    '#!/opt/homebrew/opt/node/bin/node\n',
+    '#!/usr/local/opt/node/bin/node\n',
+    '#!/home/linuxbrew/.linuxbrew/opt/node/bin/node\n'
+  ];
+  const sourceCanonical = launcherIdentity('bin/internal-cli.ts', acceptedLines[0]!);
+  const compiledCanonical = launcherIdentity('dist/bin/internal-cli.js', acceptedLines[0]!);
+  for (const line of acceptedLines) {
+    assert.equal(launcherIdentity('bin/internal-cli.ts', line).internalExecutableBuildHash, sourceCanonical.internalExecutableBuildHash);
+    assert.equal(launcherIdentity('dist/bin/internal-cli.js', line).internalExecutableBuildHash, compiledCanonical.internalExecutableBuildHash);
+  }
+
+  for (const line of [
+    '#!/usr/bin/env node --no-warnings\n',
+    '#!/opt/homebrew/opt/node/bin/node --inspect\n',
+    '#!/custom/homebrew/opt/node/bin/node\n',
+    '#!/usr/bin/env deno\n',
+    '#!/opt/homebrew/opt/node/bin/node\r\n',
+    '#!/opt/homebrew/opt/node/bin/node \n',
+    '#! /usr/bin/env node\n',
+    '#!/opt/homebrew/opt/node/bin/node'
+  ]) {
+    assert.notEqual(
+      launcherIdentity('dist/bin/internal-cli.js', line).internalExecutableBuildHash,
+      compiledCanonical.internalExecutableBuildHash,
+      line
+    );
+  }
+
+  assert.notEqual(
+    launcherIdentity('dist/bin/internal-cli.js', acceptedLines[1]!, 'export const launcher = false;\n').internalExecutableBuildHash,
+    compiledCanonical.internalExecutableBuildHash
+  );
+  assert.notEqual(
+    launcherIdentity('lib/not-the-launcher.js', acceptedLines[1]!).internalExecutableBuildHash,
+    launcherIdentity('lib/not-the-launcher.js', acceptedLines[0]!).internalExecutableBuildHash
+  );
 });
 
 test('lifecycle package version validator accepts only canonical semver', () => {


### PR DESCRIPTION
## Summary

- normalize only the declared lifecycle launcher shebang variants while preserving the rest of the executable closure and contract hashes
- fail closed on malformed launcher policy lines, unsafe package paths, and invalid manifest file lists in both build-time and runtime validators
- cover the installer-rewritten compiled launcher path with an isolated `capability-arm` integration fixture

## Validation

- `npm run typecheck` — passed.
- `npm run test:smoke` — 1,402 passed, 5 skipped, 0 failed.
- `npm run test:core` — 2,392 passed, 10 skipped, 0 failed.
- `npm test` — 2,719 passed, 13 skipped, 0 failed.
- Focused lifecycle integration tests — 8 passed, 0 failed.
- `git diff --check` — passed.

## Review

- `review-code-r2.md` — Approved; 0 blockers, 0 major findings, 0 minor findings, and 1 manual-validation item.
- The reviewed implementation is committed at `ebc2abde`.
- Intel macOS Homebrew, Linuxbrew, and Windows npm/`.cmd` real-install validation remains for maintainers to perform.

## Compatibility and migration

This change follows the approved current-only contract. The compatibility boundary is limited to the four explicit Node launcher shebangs in the lifecycle manifest; malformed policy data fails closed, and no legacy schema fallback, duplicate state, or integrity-check bypass is introduced.

Closes #948

Generated with AI assistance
