### PR TITLE
fix(platform): 修复 in 标签同步断层并回填历史数据


### DIFF
--- a/.agents/rules/issue-pr-commands.md
+++ b/.agents/rules/issue-pr-commands.md
@@ -39,7 +39,7 @@ agent-infra-internal platform-pr sync {task-id} \
   --agent {standard-agent-token} --metadata --closing-issue
 ```
 
-core 从关联 Issue 复制 type / `in:` labels、assignee、具体 milestone，并确保 closing association。权限不足返回逐项 `skipped` 和顶层 `degraded`；不得反向修改 Issue。
+core 根据 task-bound diff/PR files 与仓库映射计算唯一 `in:` target；唯一 closing Issue 按 Issue→PR 顺序收敛，其他 metadata 从关联 Issue 复制。零或多个 closing Issue 只更新 PR 并返回 `degraded`；不得从 Issue 反向复制 `in:`，也不清除非 `in:` labels。权限不足逐项返回 `skipped`，部分副作用返回 `blocked` 与 `IN_LABEL_SYNC_PARTIAL`。
 
 ## 状态语义
 

--- a/.agents/rules/issue-sync.md
+++ b/.agents/rules/issue-sync.md
@@ -71,6 +71,8 @@ agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token
 
 status labels 始终至多一个；关闭后不保留 status label。`in:` labels 只从项目允许映射与仓库实际 labels 交集产生。需求复选框以 task.md 原文为身份，歧义时 fail closed。
 
+PR event 的 `in:` 同步使用 `agent-infra-internal platform-pr sync-in-labels --pr <N> [--cwd <path>]`。PR files 是事件证据；唯一 closing Issue 按 Issue→PR 顺序写入并复读，零或多个 closing Issue 只写 PR 并返回 `degraded`。写入后副作用不明或复读未收敛必须返回 `blocked` 与 `IN_LABEL_SYNC_PARTIAL`，不得吞为 warning 或新增 `partial` 状态。
+
 ## 补发
 
 complete-task 按 artifact catalog 时间线遍历本地已有产物：task 使用 `--kind task`，其余使用 `--kind artifact --artifact <file> --backfill`；最后用 `--kind summary --body-file <path>` 原地同步交付摘要。artifact backfill 在远端缺少 marker 时创建带“历史产物补发”提示的评论；已存在合法 marker 集合时保持原评论和分片不变并返回 `no-op`；marker 冲突仍失败。该判定由 core 完成，不由 Skill 扫描评论或拼标题。

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -144,6 +144,8 @@ echo "$result"
 
 测试通过后，通过 `agent-infra-internal git-workflow commit --input {checkpoint-input}` 调用共享 commit core，输入 `delivery: { "mode": "local" }`、明确 paths、expected HEAD/tree、task ref、agent 和 code round。该调用只创建本地 checkpoint，不访问远端；core 会在 commit 前写入 durable intent，并在 task writer 成功后清理 intent。checkpoint 失败或 task 状态未闭合时，不得发送 `code.completed`。
 
+checkpoint 成功后，若任务存在 `issue_number`，调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {delivery-base-ref}`，由 task-bound `delivery_base_ref` 产生 Issue 的 `in:` target；该同步失败时记录 warning 并停止本轮，不发送 `code.completed`。
+
 排查测试失败或行为不符合预期时，先读取 `.agents/rules/debugging-guide.md`，按其四阶段流程定位根因，禁止盲目改代码重试。
 
 ### 9. 编写实现报告
@@ -162,7 +164,7 @@ echo "$result"
   - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
   - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
 
-如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则记录 warning 并继续；Issue 元数据边界仍见 `.agents/rules/issue-sync.md`）：
+如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（状态/评论失败按规则记录 warning；Issue `in:` evidence 同步失败不得发送 `code.completed`；边界见 `.agents/rules/issue-sync.md`）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`

--- a/.agents/skills/code-task/config/verify.json
+++ b/.agents/skills/code-task/config/verify.json
@@ -46,6 +46,7 @@
       "verify_task_comment_content": true,
       "verify_issue_type": true,
       "verify_issue_fields": false,
+      "verify_in_labels_computed": true,
       "verify_milestone": true,
       "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",

--- a/.agents/skills/commit/reference/issue-metadata-sync.md
+++ b/.agents/skills/commit/reference/issue-metadata-sync.md
@@ -14,6 +14,8 @@
 agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {base-branch} --requirements
 ```
 
+`--base`（如保留）必须与 task.md 的 `delivery_base_ref` 完全一致；core 以 task-bound base 作为唯一 diff evidence，不回退到 `main` 或仓库默认分支。`in:` target 只来自 `labels.in` 映射与仓库实际 labels 的交集，并保留其他 labels。
+
 ## 错误处理
 
 同步失败只记为警告，不阻塞已完成的 `git commit`。

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -74,7 +74,7 @@ description: >
 
 ### 6. 同步 PR 元数据
 
-记录 `platform-pr create` 结构化结果中的 `result`（`pr_created`、`pr_reused` 或 `no_op`），并调用 `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`。core 从 Issue 复制 type / `in:` labels、assignee 和具体 milestone，并维护 Development 关联；逐项权限不足返回 degraded，不反向更新 Issue。PR 已成功绑定后，metadata/summary 同步失败只产生与 primary result 对应的 `pr_created_with_warnings`、`pr_reused_with_warnings` 或 `no_op_with_warnings`，保留主动作事实，重试只执行未完成的同步步骤。
+记录 `platform-pr create` 结构化结果中的 `result`（`pr_created`、`pr_reused` 或 `no_op`），并调用 `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`。`in:` target 由 shared core 根据 task-bound diff/PR evidence 和仓库映射计算，唯一 closing Issue 按 Issue→PR 顺序收敛，其他 metadata 仍从 Issue 同步；不从 Issue 反向复制 `in:`，也不清除非 `in:` labels。权限不足逐项返回 degraded，部分副作用返回 blocked/`IN_LABEL_SYNC_PARTIAL`。
 
 ### 7. 生成 PR 代码增减报告
 

--- a/.agents/skills/create-pr/config/verify.json
+++ b/.agents/skills/create-pr/config/verify.json
@@ -21,6 +21,7 @@
       "when": "issue_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_match_pr": true,
+      "verify_in_labels_computed": true,
       "verify_pr_type_label": true,
       "verify_pr_assignee": true,
       "verify_issue_fields": true,

--- a/.agents/skills/create-pr/reference/pr-body-template.md
+++ b/.agents/skills/create-pr/reference/pr-body-template.md
@@ -42,7 +42,7 @@ git diff <target-branch>...HEAD
 
 元数据同步顺序：
 1. 通过 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询 Issue labels 和 milestone
-2. 从映射出的 type label、非 `type:` / 非 `status:` 的 Issue labels，以及当前 Issue `in:` labels 构建 `{label-args}`（commit 已经计算过，不在此重算，也不写回 Issue）
+2. 从映射出的 type label 和非 `type:` / 非 `status:` 的 Issue labels 构建 `{label-args}`；`in:` labels 由 shared platform core 根据 task-bound diff/PR evidence 统一计算，不在正文生成步骤重算，也不从 Issue 反向复制
 3. 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 复用 Issue milestone 构建 `{milestone-arg}`
 4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入
 5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价关闭关键字

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -20,36 +20,22 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v7
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.9.0
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build platform sync core
+        run: npm run build
+
       - name: Sync in-labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          changed_files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
-            --paginate --jq '.[].filename' | jq -Rn '[inputs]')
-
-          should_labels=$(jq -rn \
-            --argjson files "$changed_files" \
-            --argjson mapping "$(jq '.labels.in // {}' .agents/.airc.json)" \
-            '$mapping
-            | to_entries
-            | map(select(.value | any(. as $prefix | $files | any(startswith($prefix)))))
-            | map("in: " + .key)
-            | .[]?')
-
-          set -- \
-            --repo "$GITHUB_REPOSITORY" \
-            --pr "$PR_NUMBER" \
-            --prefix "in: "
-
-          while IFS= read -r label; do
-            [ -z "$label" ] && continue
-            set -- "$@" --target "$label"
-          done <<EOF
-          $should_labels
-          EOF
-
-          .github/scripts/sync-labels-to-set.sh "$@"
+        run: node dist/bin/internal-cli.js platform-pr sync-in-labels --pr "$PR_NUMBER" --cwd "$GITHUB_WORKSPACE"
 
       - name: Assign PR creator if unassigned
         env:

--- a/lib/internal/platform-pr.ts
+++ b/lib/internal/platform-pr.ts
@@ -8,7 +8,8 @@ import {
   inspectPlatformPullRequest,
   resolveExternalPullRequest,
   skipPlatformPullRequestFact,
-  syncPlatformPullRequest
+  syncPlatformPullRequest,
+  syncPlatformPullRequestInLabels
 } from '../platform/pull-requests.ts';
 import type { PullRequestResult } from '../platform/pull-requests.ts';
 import { summaryContext, syncPullRequestSummary } from '../platform/pr-summary.ts';
@@ -20,6 +21,7 @@ const USAGE = `Usage: agent-infra-internal platform-pr inspect <task-ref> [--cwd
        agent-infra-internal platform-pr bind <task-ref> --pr <N> --agent <agent> [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr skip <task-ref> --agent <agent> [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr sync <task-ref> --agent <agent> [--metadata] [--closing-issue] --result <pr_created|pr_reused|no_op> [--dry-run] [--cwd <path>]
+       agent-infra-internal platform-pr sync-in-labels --pr <N> [--dry-run] [--cwd <path>]
        agent-infra-internal platform-pr summary-context <task-ref> [--cwd <path>]
        agent-infra-internal platform-pr summary-sync <task-ref> --agent <agent> --body-file <path|-> --result <pr_created|pr_reused|no_op> [--dry-run] [--cwd <path>]
 `;
@@ -66,7 +68,19 @@ function readFile(value: string, cwd: string): string {
 function platformPr(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'summary-context', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || !['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'sync-in-labels', 'summary-context', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (operation === 'sync-in-labels') {
+    const parsed = parse(args, 1);
+    if (parsed.error) { fail(parsed.error); return; }
+    const values = parsed.values;
+    const unexpected = Object.keys(values).find((name) => !['cwd', 'pr', 'dryRun'].includes(name));
+    if (unexpected) { fail(`sync-in-labels does not accept --${unexpected}`); return; }
+    const pr = Number(values.pr);
+    if (!Number.isInteger(pr) || pr <= 0) { fail('sync-in-labels requires a positive --pr'); return; }
+    const cwd = path.resolve(typeof values.cwd === 'string' ? values.cwd : process.cwd());
+    finish(syncPlatformPullRequestInLabels(pr, { cwd, dryRun: values.dryRun === true }));
+    return;
+  }
   const taskRef = args[1];
   if (!taskRef || taskRef.startsWith('--')) { fail(`${operation} requires a task ref`); return; }
   const parsed = parse(args, 2);
@@ -80,6 +94,7 @@ function platformPr(args: string[] = []): void {
     bind: ['cwd', 'agent', 'pr', 'dryRun'],
     skip: ['cwd', 'agent', 'dryRun'],
     sync: ['cwd', 'agent', 'metadata', 'closingIssue', 'result', 'dryRun'],
+    'sync-in-labels': ['cwd', 'pr', 'dryRun'],
     'summary-context': ['cwd'],
     'summary-sync': ['cwd', 'agent', 'bodyFile', 'result', 'dryRun']
   };

--- a/lib/platform/github-client.ts
+++ b/lib/platform/github-client.ts
@@ -8,7 +8,7 @@ import type { PlatformError } from './types.ts';
 type RunResult = { status: number | null; stdout: string; stderr: string; error?: Error };
 type RunOptions = { cwd?: string; input?: string };
 type Runner = (args: string[], options: RunOptions) => RunResult;
-type RequestOptions = RunOptions & { method?: 'GET' | 'PATCH' | 'POST' | 'DELETE' };
+type RequestOptions = RunOptions & { method?: 'GET' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' };
 type ClientResult<T> = { ok: true; value: T } | { ok: false; error: PlatformError };
 type ResponseMetadata = {
   status: number;
@@ -158,7 +158,7 @@ function createGitHubClient(options: ClientOptions = {}): GitHubClient {
 
   function run(args: string[], request: RequestOptions = {}): ClientResult<string> {
     const method = request.method || 'GET';
-    const retryableMethod = method === 'GET' || method === 'PATCH';
+    const retryableMethod = method === 'GET' || method === 'PATCH' || method === 'PUT';
     let attempt = 0;
     while (true) {
       const result = runner(args, request);

--- a/lib/platform/in-label-sync.ts
+++ b/lib/platform/in-label-sync.ts
@@ -1,0 +1,75 @@
+import { computeInLabels } from './metadata-labels.ts';
+
+type InLabelPlan = {
+  current: string[];
+  target: string[];
+  labels: string[];
+  changed: boolean;
+};
+
+type InLabelResource = {
+  kind: 'issue' | 'pull-request';
+  number: number;
+  labels: string[];
+};
+
+function inLabels(labels: readonly string[]): string[] {
+  return [...new Set(labels.filter((label) => label.startsWith('in:')))].sort();
+}
+
+function mergeInLabels(labels: readonly string[], target: readonly string[]): string[] {
+  return [...new Set([
+    ...labels.filter((label) => !label.startsWith('in:')),
+    ...target
+  ])].sort();
+}
+
+function planInLabelUpdate(input: {
+  changedFiles: readonly string[];
+  currentLabels: readonly string[];
+  mapping: Record<string, unknown>;
+  repositoryLabels: Set<string>;
+}): InLabelPlan {
+  const current = inLabels(input.currentLabels);
+  const target = computeInLabels([...input.changedFiles], input.mapping, input.repositoryLabels);
+  const labels = mergeInLabels(input.currentLabels, target);
+  return { current, target, labels, changed: labels.join('\0') !== [...input.currentLabels].sort().join('\0') };
+}
+
+function flattenPages(value: unknown): unknown[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((page) => Array.isArray(page) ? page : [page]);
+}
+
+function extractRepositoryLabelNames(value: unknown): string[] {
+  return flattenPages(value).flatMap((entry) => {
+    if (typeof entry === 'string') return [entry];
+    if (entry && typeof entry === 'object' && typeof (entry as { name?: unknown }).name === 'string') {
+      return [(entry as { name: string }).name];
+    }
+    return [];
+  }).filter(Boolean).sort();
+}
+
+function extractPullRequestFileNames(value: unknown): string[] | null {
+  const entries = flattenPages(value);
+  if (!Array.isArray(value) || entries.some((entry) => !entry || typeof entry !== 'object')) return null;
+  const names = entries.map((entry) => (entry as { filename?: unknown }).filename);
+  if (names.some((name) => typeof name !== 'string' || !name.trim())) return null;
+  return [...new Set(names as string[])].sort();
+}
+
+function resourceSnapshot(kind: InLabelResource['kind'], number: number, labels: readonly string[]): InLabelResource {
+  return { kind, number, labels: [...labels].sort() };
+}
+
+export {
+  extractPullRequestFileNames,
+  extractRepositoryLabelNames,
+  flattenPages,
+  inLabels,
+  mergeInLabels,
+  planInLabelUpdate,
+  resourceSnapshot
+};
+export type { InLabelPlan, InLabelResource };

--- a/lib/platform/in-label-sync.ts
+++ b/lib/platform/in-label-sync.ts
@@ -1,16 +1,38 @@
 import { computeInLabels } from './metadata-labels.ts';
+import type { GitHubClient } from './github-client.ts';
+import type { PlatformError } from './types.ts';
 
 type InLabelPlan = {
   current: string[];
   target: string[];
   labels: string[];
   changed: boolean;
+  error: InLabelValidationError | null;
 };
 
 type InLabelResource = {
   kind: 'issue' | 'pull-request';
   number: number;
   labels: string[];
+};
+
+type InLabelValidationError = {
+  code: string;
+  message: string;
+  retryable: boolean;
+};
+
+type LabelPrefix = string | readonly string[];
+
+type LabelDelta = {
+  add: string[];
+  remove: string[];
+};
+
+type LabelDeltaResult = {
+  status: 'applied' | 'no-op' | 'failed' | 'blocked';
+  changed: boolean;
+  error: PlatformError | null;
 };
 
 function inLabels(labels: readonly string[]): string[] {
@@ -24,6 +46,55 @@ function mergeInLabels(labels: readonly string[], target: readonly string[]): st
   ])].sort();
 }
 
+function invalidInLabelInput(code: string, message: string): { ok: false; error: InLabelValidationError } {
+  return { ok: false, error: { code, message, retryable: false } };
+}
+
+function validateInLabelMapping(value: unknown): { ok: true; value: Record<string, string[]> } | { ok: false; error: InLabelValidationError } {
+  if (value === undefined) return { ok: true, value: {} };
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return invalidInLabelInput('IN_LABEL_SYNC_MAPPING_INVALID', 'labels.in must be an object of non-empty string arrays');
+  }
+  const normalized: Record<string, string[]> = {};
+  for (const [name, rawPrefixes] of Object.entries(value)) {
+    if (!name.trim() || !Array.isArray(rawPrefixes) || rawPrefixes.length === 0 || rawPrefixes.some((prefix) => typeof prefix !== 'string' || !prefix.trim())) {
+      return invalidInLabelInput('IN_LABEL_SYNC_MAPPING_INVALID', `labels.in entry '${name}' must be a non-empty string array`);
+    }
+    normalized[name] = rawPrefixes.map((prefix) => prefix.trim());
+  }
+  return { ok: true, value: normalized };
+}
+
+function repositoryLabelPages(value: unknown): unknown[][] | null {
+  if (!Array.isArray(value)) return null;
+  if (value.length === 0) return [];
+  if (value.every((page) => Array.isArray(page))) return value as unknown[][];
+  if (value.every((entry) => entry && typeof entry === 'object' && !Array.isArray(entry))) return [value];
+  return null;
+}
+
+function validateRepositoryLabelPayload(value: unknown): { ok: true; value: string[] } | { ok: false; error: InLabelValidationError } {
+  const pages = repositoryLabelPages(value);
+  if (!pages) return invalidInLabelInput('IN_LABEL_SYNC_LABELS_INVALID', 'Repository labels response must be an array of pages');
+  const names: string[] = [];
+  for (const page of pages) {
+    for (const entry of page) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry) || typeof (entry as { name?: unknown }).name !== 'string' || !(entry as { name: string }).name.trim()) {
+        return invalidInLabelInput('IN_LABEL_SYNC_LABELS_INVALID', 'Repository labels response contains an entry without a valid name');
+      }
+      names.push((entry as { name: string }).name);
+    }
+  }
+  return { ok: true, value: [...new Set(names)].sort() };
+}
+
+function validateRepositoryLabelSet(value: unknown): { ok: true; value: Set<string> } | { ok: false; error: InLabelValidationError } {
+  if (!(value instanceof Set) || [...value].some((label) => typeof label !== 'string' || !label.trim())) {
+    return invalidInLabelInput('IN_LABEL_SYNC_LABELS_INVALID', 'Repository labels must be a set of non-empty names');
+  }
+  return { ok: true, value: new Set([...value] as string[]) };
+}
+
 function planInLabelUpdate(input: {
   changedFiles: readonly string[];
   currentLabels: readonly string[];
@@ -31,9 +102,64 @@ function planInLabelUpdate(input: {
   repositoryLabels: Set<string>;
 }): InLabelPlan {
   const current = inLabels(input.currentLabels);
-  const target = computeInLabels([...input.changedFiles], input.mapping, input.repositoryLabels);
+  const mapping = validateInLabelMapping(input.mapping);
+  const repositoryLabels = validateRepositoryLabelSet(input.repositoryLabels);
+  if (!mapping.ok) return { current, target: [...current], labels: [...input.currentLabels].sort(), changed: false, error: mapping.error };
+  if (!repositoryLabels.ok) return { current, target: [...current], labels: [...input.currentLabels].sort(), changed: false, error: repositoryLabels.error };
+  const target = computeInLabels([...input.changedFiles], mapping.value, repositoryLabels.value);
   const labels = mergeInLabels(input.currentLabels, target);
-  return { current, target, labels, changed: labels.join('\0') !== [...input.currentLabels].sort().join('\0') };
+  return { current, target, labels, changed: labels.join('\0') !== [...input.currentLabels].sort().join('\0'), error: null };
+}
+
+function startsWithPrefix(label: string, prefix: LabelPrefix): boolean {
+  return (Array.isArray(prefix) ? prefix : [prefix]).some((value) => label.startsWith(value));
+}
+
+function labelDelta(current: readonly string[], target: readonly string[], prefix: LabelPrefix = 'in:'): LabelDelta {
+  const currentLabels = [...new Set(current)].sort();
+  const targetLabels = [...new Set(target.filter((label) => startsWithPrefix(label, prefix)))].sort();
+  return {
+    add: targetLabels.filter((label) => !currentLabels.includes(label)),
+    remove: currentLabels.filter((label) => startsWithPrefix(label, prefix) && !targetLabels.includes(label))
+  };
+}
+
+function syncLabelDelta(
+  client: GitHubClient,
+  repository: string,
+  number: number,
+  cwd: string,
+  current: readonly string[],
+  target: readonly string[],
+  prefix: LabelPrefix = 'in:'
+): LabelDeltaResult {
+  const delta = labelDelta(current, target, prefix);
+  let changed = false;
+  const failure = (error: PlatformError): LabelDeltaResult => {
+    if (changed || error.retryable) {
+      return {
+        status: 'blocked',
+        changed,
+        error: { ...error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${error.message}` }
+      };
+    }
+    return { status: 'failed', changed: false, error };
+  };
+  for (const label of delta.remove) {
+    const removed = client.json<unknown>([
+      'api', `repos/${repository}/issues/${number}/labels/${encodeURIComponent(label)}`, '-X', 'DELETE'
+    ], { cwd, method: 'DELETE' });
+    if (!removed.ok) return failure(removed.error);
+    changed = true;
+  }
+  for (const label of delta.add) {
+    const added = client.json<unknown>([
+      'api', `repos/${repository}/issues/${number}/labels`, '-X', 'POST', '--input', '-'
+    ], { cwd, method: 'POST', input: JSON.stringify({ labels: [label] }) });
+    if (!added.ok) return failure(added.error);
+    changed = true;
+  }
+  return { status: changed ? 'applied' : 'no-op', changed, error: null };
 }
 
 function flattenPages(value: unknown): unknown[] {
@@ -68,8 +194,12 @@ export {
   extractRepositoryLabelNames,
   flattenPages,
   inLabels,
+  labelDelta,
   mergeInLabels,
   planInLabelUpdate,
-  resourceSnapshot
+  resourceSnapshot,
+  syncLabelDelta,
+  validateInLabelMapping,
+  validateRepositoryLabelPayload
 };
-export type { InLabelPlan, InLabelResource };
+export type { InLabelPlan, InLabelResource, InLabelValidationError, LabelDelta, LabelDeltaResult, LabelPrefix };

--- a/lib/platform/issues.ts
+++ b/lib/platform/issues.ts
@@ -695,9 +695,15 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
   for (const operation of restPlanned.filter((item) => item.name === 'labels:status' || item.name === 'labels:in')) {
     const prefix = operation.name === 'labels:status' ? 'status:' : 'in:';
     const synced = syncLabelDelta(base.client, repository, base.issueNumber, base.resolved.repoRoot, currentLabels, operation.value as string[], prefix);
-    if (synced.status === 'failed' || synced.status === 'blocked') return result(synced.status, base.resolved.taskId, base.issueNumber, {
-      changed: labelsChanged || synced.changed, issue: snapshot, operations: plan.operations, error: synced.error
-    });
+    if (synced.status === 'failed' || synced.status === 'blocked') {
+      const partial = labelsChanged || synced.status === 'blocked';
+      const error = partial && synced.error
+        ? { ...synced.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${synced.error.message}` }
+        : synced.error;
+      return result(partial ? 'blocked' : synced.status, base.resolved.taskId, base.issueNumber, {
+        changed: labelsChanged || synced.changed, issue: snapshot, operations: plan.operations, error
+      });
+    }
     currentLabels = applyLabelDeltaToSnapshot(currentLabels, operation.value as string[], prefix);
     labelsChanged ||= synced.changed;
   }
@@ -717,7 +723,7 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
   if (inLabelWrite) {
     const reread = inspectGitHubIssue(base.client, repository, base.issueNumber, base.resolved.repoRoot);
     if (!reread.ok) return result('blocked', base.resolved.taskId, base.issueNumber, {
-      issue: snapshot, operations: plan.operations,
+      changed: labelsChanged, issue: snapshot, operations: plan.operations,
       error: { ...reread.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${reread.error.message}` }
     });
     const expected = (inLabelWrite.value as string[]).filter((label) => label.startsWith('in:')).sort();

--- a/lib/platform/issues.ts
+++ b/lib/platform/issues.ts
@@ -14,7 +14,6 @@ import type { GitHubClient } from './github-client.ts';
 import {
   DEFAULT_REQUIREMENT_SECTION_ANCHORS,
   chooseMilestone,
-  computeInLabels,
   desiredIssueType,
   normalizeOption,
   planIssueMetadata
@@ -22,6 +21,7 @@ import {
 import type { IssueDesiredState, PlannedOperation, Requirement, RequirementSectionAnchor } from './issue-metadata.ts';
 import { platformResult } from './types.ts';
 import type { PlatformResult } from './types.ts';
+import { planInLabelUpdate } from './in-label-sync.ts';
 
 type IssueSnapshot = {
   repository: string;
@@ -634,16 +634,33 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
         : { name: 'labels:in', status: 'skipped', reasonCode: 'TRIAGE_REQUIRED' });
   }
   if (options.inLabels === 'from-diff') {
-    try {
-      const changed = execFileSync('git', ['diff', `${options.base}...HEAD`, '--name-only'], { cwd: base.resolved.repoRoot, encoding: 'utf8' }).trim().split('\n').filter(Boolean);
-      const config = JSON.parse(fs.readFileSync(`${base.resolved.repoRoot}/.agents/.airc.json`, 'utf8'));
-      const targets = computeInLabels(changed, config?.labels?.in || {}, new Set(repositoryLabels));
-      const labels = [...snapshot.labels.filter((label) => !label.startsWith('in:')), ...targets].sort();
-      plan.operations.push(labels.join('\0') === snapshot.labels.join('\0')
-        ? { name: 'labels:in', status: 'no-op', reasonCode: null }
-        : { name: 'labels:in', status: 'planned', reasonCode: null, value: labels });
-    } catch {
-      plan.operations.push({ name: 'labels:in', status: 'skipped', reasonCode: 'DIFF_UNAVAILABLE' });
+    const taskBase = typeof base.frontmatter.delivery_base_ref === 'string'
+      ? base.frontmatter.delivery_base_ref.trim()
+      : '';
+    if (!taskBase) {
+      plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: 'IN_LABEL_SYNC_BASE_MISSING' });
+    } else if (options.base && options.base !== taskBase) {
+      plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: 'IN_LABEL_SYNC_BASE_MISMATCH' });
+    } else {
+      try {
+        const changed = execFileSync('git', ['diff', `${taskBase}...HEAD`, '--name-only'], {
+          cwd: base.resolved.repoRoot, encoding: 'utf8'
+        }).trim().split(/\r?\n/).filter(Boolean);
+        const config = JSON.parse(fs.readFileSync(`${base.resolved.repoRoot}/.agents/.airc.json`, 'utf8')) as {
+          labels?: { in?: Record<string, unknown> };
+        };
+        const planned = planInLabelUpdate({
+          changedFiles: changed,
+          currentLabels: snapshot.labels,
+          mapping: config.labels?.in || {},
+          repositoryLabels: new Set(repositoryLabels)
+        });
+        plan.operations.push(planned.changed
+          ? { name: 'labels:in', status: 'planned', reasonCode: null, value: planned.labels }
+          : { name: 'labels:in', status: 'no-op', reasonCode: null });
+      } catch {
+        plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: 'IN_LABEL_SYNC_EVIDENCE_UNAVAILABLE' });
+      }
     }
   }
   const graph = planGraphMetadata(
@@ -666,7 +683,29 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
     const patched = base.client.json<unknown>(['api', `repos/${repository}/issues/${base.issueNumber}`, '-X', 'PATCH', '--input', '-'], {
       cwd: base.resolved.repoRoot, method: 'PATCH', input: JSON.stringify(payload)
     });
-    if (!patched.ok) return result(patched.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error: patched.error });
+    if (!patched.ok) {
+      const inLabelWrite = restPlanned.some((operation) => operation.name === 'labels:in');
+      const error = inLabelWrite && patched.error.retryable
+        ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
+        : patched.error;
+      return result(error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error });
+    }
+  }
+  let finalSnapshot = snapshot;
+  const inLabelWrite = restPlanned.find((operation) => operation.name === 'labels:in' && operation.status === 'planned');
+  if (inLabelWrite) {
+    const reread = inspectGitHubIssue(base.client, repository, base.issueNumber, base.resolved.repoRoot);
+    if (!reread.ok) return result('blocked', base.resolved.taskId, base.issueNumber, {
+      issue: snapshot, operations: plan.operations,
+      error: { ...reread.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${reread.error.message}` }
+    });
+    const expected = (inLabelWrite.value as string[]).filter((label) => label.startsWith('in:')).sort();
+    const actual = reread.value.labels.filter((label) => label.startsWith('in:')).sort();
+    if (expected.join('\0') !== actual.join('\0')) return result('blocked', base.resolved.taskId, base.issueNumber, {
+      issue: reread.value, operations: plan.operations,
+      error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Issue in: labels did not converge after update', retryable: true }
+    });
+    finalSnapshot = reread.value;
   }
   for (const operation of graphPlanned) {
     if (!graph.issueId) return result('failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error: { code: 'ISSUE_GRAPH_IDENTITY_INVALID', message: 'Issue GraphQL identity is unavailable', retryable: false } });
@@ -675,7 +714,7 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
   }
   return result(skipped ? 'degraded' : 'applied', base.resolved.taskId, base.issueNumber, {
     changed: true, platform: base.context.platform, capabilities: base.context.capabilities,
-    resource: { kind: 'issue', number: base.issueNumber }, issue: snapshot,
+    resource: { kind: 'issue', number: base.issueNumber }, issue: finalSnapshot,
     operations: plan.operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' } : operation), error: null
   });
 }

--- a/lib/platform/issues.ts
+++ b/lib/platform/issues.ts
@@ -21,7 +21,13 @@ import {
 import type { IssueDesiredState, PlannedOperation, Requirement, RequirementSectionAnchor } from './issue-metadata.ts';
 import { platformResult } from './types.ts';
 import type { PlatformResult } from './types.ts';
-import { planInLabelUpdate } from './in-label-sync.ts';
+import {
+  labelDelta,
+  planInLabelUpdate,
+  syncLabelDelta,
+  validateInLabelMapping,
+  validateRepositoryLabelPayload
+} from './in-label-sync.ts';
 
 type IssueSnapshot = {
   repository: string;
@@ -462,31 +468,23 @@ function milestoneBasis(repoRoot: string, current: string | null): string | null
 
 function applyRestOperations(snapshot: IssueSnapshot, operations: PlannedOperation[]) {
   const payload: Record<string, unknown> = {};
-  let labels = [...snapshot.labels];
-  let labelsChanged = false;
   for (const operation of operations) {
     if (operation.status !== 'planned') continue;
-    if (operation.name === 'labels:status') {
-      labels = [
-        ...labels.filter((label) => !label.startsWith('status:')),
-        ...(operation.value as string[]).filter((label) => label.startsWith('status:'))
-      ];
-      labelsChanged = true;
-    }
-    if (operation.name === 'labels:in') {
-      labels = [
-        ...labels.filter((label) => !label.startsWith('in:')),
-        ...(operation.value as string[]).filter((label) => label.startsWith('in:'))
-      ];
-      labelsChanged = true;
-    }
     if (operation.name === 'assignees') payload.assignees = operation.value;
     if (operation.name === 'requirements') payload.body = operation.value;
     if (operation.name === 'state') payload.state = operation.value;
     if (operation.name === 'milestone') payload.milestone = operation.value;
   }
-  if (labelsChanged) payload.labels = [...new Set(labels)].sort();
   return payload;
+}
+
+function applyLabelDeltaToSnapshot(current: string[], target: readonly string[], prefix: string): string[] {
+  const delta = labelDelta(current, target, prefix);
+  const targetLabels = [...new Set(target.filter((label) => label.startsWith(prefix)))];
+  return [...new Set([
+    ...current.filter((label) => !delta.remove.includes(label)),
+    ...targetLabels
+  ])].sort();
 }
 
 type DesiredFieldValue = {
@@ -600,7 +598,9 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
   if (options.status !== undefined || options.inLabels !== undefined) {
     const labels = base.client.json<unknown>(['api', '--paginate', '--slurp', `repos/${repository}/labels?per_page=100`], { cwd: base.resolved.repoRoot });
     if (!labels.ok) return result(labels.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, error: labels.error });
-    repositoryLabels = listNames(labels.value).flatMap((name) => name);
+    const validated = validateRepositoryLabelPayload(labels.value);
+    if (!validated.ok) return result('failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, error: validated.error });
+    repositoryLabels = validated.value;
   }
   let milestones: Array<{ title: string; number: number }> = [];
   if (options.milestone !== undefined) {
@@ -649,17 +649,28 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
         const config = JSON.parse(fs.readFileSync(`${base.resolved.repoRoot}/.agents/.airc.json`, 'utf8')) as {
           labels?: { in?: Record<string, unknown> };
         };
-        const planned = planInLabelUpdate({
-          changedFiles: changed,
-          currentLabels: snapshot.labels,
-          mapping: config.labels?.in || {},
-          repositoryLabels: new Set(repositoryLabels)
-        });
-        plan.operations.push(planned.changed
-          ? { name: 'labels:in', status: 'planned', reasonCode: null, value: planned.labels }
-          : { name: 'labels:in', status: 'no-op', reasonCode: null });
+        const mapping = validateInLabelMapping(config.labels?.in);
+        if (!mapping.ok) {
+          plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: mapping.error.code });
+        } else {
+          const planned = planInLabelUpdate({
+            changedFiles: changed,
+            currentLabels: snapshot.labels,
+            mapping: mapping.value,
+            repositoryLabels: new Set(repositoryLabels)
+          });
+          if (planned.error) {
+            plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: planned.error.code });
+          } else {
+            plan.operations.push(planned.changed
+              ? { name: 'labels:in', status: 'planned', reasonCode: null, value: planned.labels }
+              : { name: 'labels:in', status: 'no-op', reasonCode: null });
+          }
+        }
       } catch {
-        plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: 'IN_LABEL_SYNC_EVIDENCE_UNAVAILABLE' });
+        if (!plan.operations.some((operation) => operation.name === 'labels:in' && operation.status === 'failed')) {
+          plan.operations.push({ name: 'labels:in', status: 'failed', reasonCode: 'IN_LABEL_SYNC_EVIDENCE_UNAVAILABLE' });
+        }
       }
     }
   }
@@ -679,16 +690,26 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
   const payload = applyRestOperations(snapshot, restPlanned);
   if (typeof payload.milestone === 'string') payload.milestone = milestones.find((item) => item.title === payload.milestone)?.number ?? payload.milestone;
   if (options.closeReason) payload.state_reason = options.closeReason;
+  let currentLabels = [...snapshot.labels];
+  let labelsChanged = false;
+  for (const operation of restPlanned.filter((item) => item.name === 'labels:status' || item.name === 'labels:in')) {
+    const prefix = operation.name === 'labels:status' ? 'status:' : 'in:';
+    const synced = syncLabelDelta(base.client, repository, base.issueNumber, base.resolved.repoRoot, currentLabels, operation.value as string[], prefix);
+    if (synced.status === 'failed' || synced.status === 'blocked') return result(synced.status, base.resolved.taskId, base.issueNumber, {
+      changed: labelsChanged || synced.changed, issue: snapshot, operations: plan.operations, error: synced.error
+    });
+    currentLabels = applyLabelDeltaToSnapshot(currentLabels, operation.value as string[], prefix);
+    labelsChanged ||= synced.changed;
+  }
   if (Object.keys(payload).length > 0) {
     const patched = base.client.json<unknown>(['api', `repos/${repository}/issues/${base.issueNumber}`, '-X', 'PATCH', '--input', '-'], {
       cwd: base.resolved.repoRoot, method: 'PATCH', input: JSON.stringify(payload)
     });
     if (!patched.ok) {
-      const inLabelWrite = restPlanned.some((operation) => operation.name === 'labels:in');
-      const error = inLabelWrite && patched.error.retryable
+      const error = labelsChanged || patched.error.retryable
         ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
         : patched.error;
-      return result(error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error });
+      return result(labelsChanged || error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { changed: labelsChanged, issue: snapshot, operations: plan.operations, error });
     }
   }
   let finalSnapshot = snapshot;
@@ -706,14 +727,26 @@ function syncPlatformIssue(taskRef: string, options: SyncOptions): IssueResult {
       error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Issue in: labels did not converge after update', retryable: true }
     });
     finalSnapshot = reread.value;
+  } else if (labelsChanged) {
+    const reread = inspectGitHubIssue(base.client, repository, base.issueNumber, base.resolved.repoRoot);
+    if (!reread.ok) return result('blocked', base.resolved.taskId, base.issueNumber, {
+      changed: labelsChanged, issue: snapshot, operations: plan.operations,
+      error: { ...reread.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `Label synchronization is partial or unknown: ${reread.error.message}` }
+    });
+    finalSnapshot = reread.value;
   }
   for (const operation of graphPlanned) {
     if (!graph.issueId) return result('failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error: { code: 'ISSUE_GRAPH_IDENTITY_INVALID', message: 'Issue GraphQL identity is unavailable', retryable: false } });
     const written = executeGraphOperation(base.client, base.resolved.repoRoot, graph.issueId, operation);
-    if (!written.ok) return result(written.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { issue: snapshot, operations: plan.operations, error: written.error });
+    if (!written.ok) {
+      const error = labelsChanged || written.error.retryable
+        ? { ...written.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${written.error.message}` }
+        : written.error;
+      return result(labelsChanged || error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, { changed: labelsChanged, issue: finalSnapshot, operations: plan.operations, error });
+    }
   }
   return result(skipped ? 'degraded' : 'applied', base.resolved.taskId, base.issueNumber, {
-    changed: true, platform: base.context.platform, capabilities: base.context.capabilities,
+    changed: labelsChanged || Object.keys(payload).length > 0 || graphPlanned.length > 0, platform: base.context.platform, capabilities: base.context.capabilities,
     resource: { kind: 'issue', number: base.issueNumber }, issue: finalSnapshot,
     operations: plan.operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' } : operation), error: null
   });

--- a/lib/platform/metadata-labels.ts
+++ b/lib/platform/metadata-labels.ts
@@ -23,8 +23,11 @@ function computeInLabels(
 ): string[] {
   return Object.entries(mapping).flatMap(([name, rawPrefixes]) => {
     if (!Array.isArray(rawPrefixes)) return [];
-    const matches = rawPrefixes.some((prefix) => typeof prefix === 'string' && prefix.length > 0
-      && changedFiles.some((file) => file === prefix.replace(/\/$/, '') || file.startsWith(prefix)));
+    const matches = rawPrefixes.some((prefix) => {
+      if (typeof prefix !== 'string' || prefix.trim().length === 0) return false;
+      const normalized = prefix.trim().replace(/\/+$/, '');
+      return changedFiles.some((file) => file === normalized || file.startsWith(`${normalized}/`));
+    });
     const label = `in: ${name}`;
     return matches && repositoryLabels.has(label) ? [label] : [];
   }).sort();

--- a/lib/platform/pull-request-metadata.ts
+++ b/lib/platform/pull-request-metadata.ts
@@ -36,13 +36,14 @@ function planPullRequestMetadata(input: {
   taskType: string;
   issueNumber: number;
   capabilities: PlatformCapabilities;
+  inLabels?: string[];
 }): { operations: PullRequestMetadataOperation[] } {
   const typeLabel = taskTypeLabel(input.taskType);
-  const copiedLabels = input.issue.labels.filter((label) => label.startsWith('in:'));
+  const targetInLabels = input.inLabels || input.pullRequest.labels.filter((label) => label.startsWith('in:'));
   const desiredLabels = [...new Set([
     ...input.pullRequest.labels.filter((label) => !label.startsWith('type:') && !label.startsWith('in:')),
     ...(typeLabel ? [typeLabel] : []),
-    ...copiedLabels
+    ...targetInLabels.filter((label) => label.startsWith('in:'))
   ])].sort();
   const body = ensureClosingReference(input.pullRequest.body, input.issueNumber);
   return { operations: [

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -20,8 +20,10 @@ import type { IssueSnapshot } from './issues.ts';
 import { planPullRequestMetadata } from './pull-request-metadata.ts';
 import {
   extractPullRequestFileNames,
-  extractRepositoryLabelNames,
-  planInLabelUpdate
+  planInLabelUpdate,
+  syncLabelDelta,
+  validateInLabelMapping,
+  validateRepositoryLabelPayload
 } from './in-label-sync.ts';
 import { platformResult } from './types.ts';
 import type { PlatformOperation, PlatformResult } from './types.ts';
@@ -785,8 +787,8 @@ function readInLabelMapping(repoRoot: string): { ok: true; value: Record<string,
     const config = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8')) as {
       labels?: { in?: unknown };
     };
-    const mapping = config.labels?.in;
-    return { ok: true, value: mapping && typeof mapping === 'object' && !Array.isArray(mapping) ? mapping as Record<string, unknown> : {} };
+    const mapping = validateInLabelMapping(config.labels?.in);
+    return mapping.ok ? { ok: true, value: mapping.value } : mapping;
   } catch (error) {
     return {
       ok: false,
@@ -837,7 +839,8 @@ function inspectClosingIssueNumbers(client: GitHubClient, repository: string, pu
 function inspectRepositoryLabels(client: GitHubClient, repository: string, cwd: string) {
   const response = client.json<unknown>(['api', '--paginate', '--slurp', `repos/${repository}/labels?per_page=100`], { cwd });
   if (!response.ok) return response;
-  return { ok: true as const, value: new Set(extractRepositoryLabelNames(response.value)) };
+  const labels = validateRepositoryLabelPayload(response.value);
+  return labels.ok ? { ok: true as const, value: new Set(labels.value) } : labels;
 }
 
 function inspectPullRequestFiles(client: GitHubClient, repository: string, pullRequest: number, cwd: string) {
@@ -880,6 +883,7 @@ function inspectTaskInLabelTarget(
   const planned = planInLabelUpdate({
     changedFiles, currentLabels: pullRequest.labels, mapping: mapping.value, repositoryLabels: labels.value
   });
+  if (planned.error) return { ok: false as const, error: planned.error };
   return { ok: true as const, value: { changedFiles, target: planned.target } };
 }
 
@@ -926,10 +930,15 @@ function syncPlatformPullRequestInLabels(prNumber: number, options: SharedOption
     platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
     resource: { kind: 'pull-request', number: prNumber }, error: repositoryLabels.error
   });
-  const target = planInLabelUpdate({
+  const plannedTarget = planInLabelUpdate({
     changedFiles: files.value, currentLabels: fetched.value.labels,
     mapping: mapping.value, repositoryLabels: repositoryLabels.value
-  }).target;
+  });
+  if (plannedTarget.error) return result('failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: prNumber }, error: plannedTarget.error
+  });
+  const target = plannedTarget.target;
   const association = inspectClosingIssueNumbers(client, repository, prNumber, cwd);
   if (!association.ok) return result(association.error.retryable ? 'blocked' : 'failed', null, null, prNumber, {
     platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
@@ -990,21 +999,18 @@ function syncPlatformPullRequestInLabels(prNumber: number, options: SharedOption
   let successfulWrites = 0;
   for (const item of plans) {
     if (!item.plan.changed) continue;
-    const patched = client.json<unknown>(['api', `repos/${repository}/issues/${item.number}/labels`, '-X', 'PUT', '--input', '-'], {
-      cwd, method: 'PUT', input: JSON.stringify({ labels: item.plan.labels })
-    });
-    if (!patched.ok) {
-      const partial = successfulWrites > 0 || patched.error.retryable;
-      const error = partial
-        ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
-        : patched.error;
-      return result(partial || patched.error.retryable ? 'blocked' : 'failed', null, issueNumber, prNumber, {
-        changed: successfulWrites > 0, platform: context.platform, capabilities: context.capabilities,
+    const synced = syncLabelDelta(client, repository, item.number, cwd, item.snapshot.labels, item.plan.target);
+    if (synced.status === 'failed' || synced.status === 'blocked') {
+      const state = resourcesState.find((resource) => resource.kind === item.kind && resource.number === item.number)!;
+      state.effect = synced.status === 'blocked' ? 'unknown' : 'no-op';
+      state.after = synced.status === 'blocked' ? null : item.snapshot.labels;
+      return result(synced.status, null, issueNumber, prNumber, {
+        changed: successfulWrites > 0 || synced.changed, platform: context.platform, capabilities: context.capabilities,
         pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
-        evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error
+        evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error: synced.error
       });
     }
-    successfulWrites += 1;
+    successfulWrites += synced.changed ? 1 : 0;
     const reread = item.kind === 'issue'
       ? inspectGitHubIssue(client, repository, item.number, cwd)
       : inspectGitHubPullRequest(client, repository, item.number, cwd);
@@ -1572,33 +1578,12 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
       platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, error: target.error
     }));
     inLabels = target.value.target;
-    // The target was computed against repository labels above; merge only the current Issue labels with that target here.
-    const issueLabels = [...new Set([...issue.issue.labels.filter((label) => !label.startsWith('in:')), ...inLabels])].sort();
+    const issueInLabels = issue.issue.labels.filter((label) => label.startsWith('in:')).sort();
     inLabelIssueOperation = !base.context.capabilities.triage
       ? { name: 'labels:in:issue', status: 'skipped', reasonCode: 'TRIAGE_REQUIRED' }
-      : issueLabels.join('\0') === issue.issue.labels.join('\0')
+      : issueInLabels.join('\0') === inLabels.join('\0')
         ? { name: 'labels:in:issue', status: 'no-op', reasonCode: null }
         : { name: 'labels:in:issue', status: 'planned', reasonCode: null };
-    if (inLabelIssueOperation.status === 'planned' && !options.dryRun) {
-      const patchedIssue = base.client.json<unknown>(['api', `repos/${base.context.platform.repository}/issues/${base.issueNumber}/labels`, '-X', 'PUT', '--input', '-'], {
-        cwd: base.resolved.repoRoot, method: 'PUT', input: JSON.stringify({ labels: issueLabels })
-      });
-      if (!patchedIssue.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
-        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
-        operations: [inLabelIssueOperation], error: { ...patchedIssue.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patchedIssue.error.message}` }
-      }));
-      const rereadIssue = inspectGitHubIssue(base.client, base.context.platform.repository!, base.issueNumber, base.resolved.repoRoot);
-      if (!rereadIssue.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
-        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
-        operations: [inLabelIssueOperation], error: { ...rereadIssue.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${rereadIssue.error.message}` }
-      }));
-      const expectedIssueInLabels = issueLabels.filter((label) => label.startsWith('in:')).sort();
-      const actualIssueInLabels = rereadIssue.value.labels.filter((label) => label.startsWith('in:')).sort();
-      if (actualIssueInLabels.join('\0') !== expectedIssueInLabels.join('\0')) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
-        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
-        operations: [inLabelIssueOperation], error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Issue in: labels did not converge after update', retryable: true }
-      }));
-    }
   }
   const planned = planPullRequestMetadata({
     pullRequest: fetched.value,
@@ -1613,24 +1598,51 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
     ...(inLabelIssueOperation ? [inLabelIssueOperation] : []),
     ...planned.map(({ name, status, reasonCode }) => ({ name, status, reasonCode }))
   ];
-  if (options.dryRun) return softenFailure(result(planned.some((operation) => operation.status === 'planned') || inLabelIssueOperation?.status === 'planned' ? 'planned' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
-    platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, operations, error: null
-  }));
+  const prLabelOperation = planned.find((operation) => operation.name === 'labels' && operation.status === 'planned');
+  const prLabelWrite = Boolean(prLabelOperation);
+  const authorityPlanned = inLabelIssueOperation?.status === 'planned' || prLabelWrite;
   const payload: Record<string, unknown> = {};
   for (const operation of planned) {
     if (operation.status !== 'planned') continue;
-    if (operation.name === 'labels') payload.labels = operation.value;
     if (operation.name === 'assignees') payload.assignees = operation.value;
     if (operation.name === 'closing-issue') payload.body = operation.value;
     if (operation.name === 'milestone') {
       const milestones = base.client.json<unknown[]>(['api', '--paginate', '--slurp', `repos/${base.context.platform.repository}/milestones?state=open&per_page=100`], { cwd: base.resolved.repoRoot });
-      if (!milestones.ok) return softenFailure(result(milestones.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, { pullRequest: fetched.value, operations, error: milestones.error }));
+      if (!milestones.ok) {
+        const output = result(milestones.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+          platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, operations, error: milestones.error
+        });
+        return authorityPlanned ? output : softenFailure(output);
+      }
       const flat = milestones.value.flatMap((entry) => Array.isArray(entry) ? entry : [entry]) as Array<{ title?: string; number?: number }>;
       payload.milestone = flat.find((entry) => entry.title === operation.value)?.number ?? null;
     }
   }
-  const issueInLabelChanged = inLabelIssueOperation?.status === 'planned';
-  if (Object.keys(payload).length === 0) {
+  if (options.dryRun) return softenFailure(result(planned.some((operation) => operation.status === 'planned') || inLabelIssueOperation?.status === 'planned' ? 'planned' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, operations, error: null
+  }));
+  let issueInLabelChanged = false;
+  if (inLabelIssueOperation?.status === 'planned') {
+    const syncedIssue = syncLabelDelta(base.client, base.context.platform.repository!, base.issueNumber, base.resolved.repoRoot, issue.issue.labels, inLabels);
+    if (syncedIssue.status === 'failed' || syncedIssue.status === 'blocked') return result(syncedIssue.status, base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
+      operations, error: syncedIssue.error
+    });
+    const rereadIssue = inspectGitHubIssue(base.client, base.context.platform.repository!, base.issueNumber, base.resolved.repoRoot);
+    if (!rereadIssue.ok) return result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: syncedIssue.changed, platform: base.context.platform, capabilities: base.context.capabilities,
+      pullRequest: fetched.value, operations,
+      error: { ...rereadIssue.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${rereadIssue.error.message}` }
+    });
+    const actualIssueInLabels = rereadIssue.value.labels.filter((label) => label.startsWith('in:')).sort();
+    if (actualIssueInLabels.join('\0') !== inLabels.join('\0')) return result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: syncedIssue.changed, platform: base.context.platform, capabilities: base.context.capabilities,
+      pullRequest: fetched.value, operations,
+      error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Issue in: labels did not converge after update', retryable: true }
+    });
+    issueInLabelChanged = syncedIssue.changed;
+  }
+  if (Object.keys(payload).length === 0 && !prLabelWrite) {
     const degraded = planned.some((operation) => operation.status === 'skipped');
     return softenFailure(result(issueInLabelChanged ? degraded ? 'degraded' : 'applied' : degraded ? 'degraded' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
       changed: issueInLabelChanged, platform: base.context.platform, capabilities: base.context.capabilities,
@@ -1641,25 +1653,37 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
   const patched = base.client.json<RemotePullRequest>(['api', `repos/${base.context.platform.repository}/issues/${base.prNumber}`, '-X', 'PATCH', '--input', '-'], {
     cwd: base.resolved.repoRoot, method: 'PATCH', input: JSON.stringify(payload)
   });
-  const prLabelWrite = planned.some((operation) => operation.name === 'labels' && operation.status === 'planned');
   if (!patched.ok) {
-    const partial = prLabelWrite && patched.error.retryable;
+    const partial = issueInLabelChanged || patched.error.retryable;
     const error = partial
       ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
       : patched.error;
-    return softenFailure(result(partial || patched.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+    const output = result(partial || patched.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
       changed: issueInLabelChanged, pullRequest: fetched.value, operations, error
-    }));
+    });
+    return authorityPlanned ? output : softenFailure(output);
   }
+  const prMetadataChanged = Object.keys(payload).length > 0;
   let finalPullRequest = fetched.value;
   if (prLabelWrite) {
+    const desiredLabels = prLabelOperation?.value as string[];
+    const syncedPullRequest = syncLabelDelta(base.client, base.context.platform.repository!, base.prNumber, base.resolved.repoRoot, fetched.value.labels, desiredLabels, ['in:', 'type:']);
+    if (syncedPullRequest.status === 'failed' || syncedPullRequest.status === 'blocked') {
+      const partial = issueInLabelChanged || prMetadataChanged || syncedPullRequest.status === 'blocked';
+      const error = partial && syncedPullRequest.error
+        ? { ...syncedPullRequest.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${syncedPullRequest.error.message}` }
+        : syncedPullRequest.error;
+      return result(partial ? 'blocked' : syncedPullRequest.status, base.resolved.taskId, base.issueNumber, base.prNumber, {
+        changed: issueInLabelChanged || prMetadataChanged || syncedPullRequest.changed, platform: base.context.platform, capabilities: base.context.capabilities,
+        pullRequest: fetched.value, operations, error
+      });
+    }
     const rereadPullRequest = inspectGitHubPullRequest(base.client, base.context.platform.repository!, base.prNumber, base.resolved.repoRoot);
     if (!rereadPullRequest.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
       changed: true, pullRequest: fetched.value, operations,
       error: { ...rereadPullRequest.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${rereadPullRequest.error.message}` }
     }));
-    const expectedPrInLabels = (planned.find((operation) => operation.name === 'labels')?.value as string[])
-      .filter((label) => label.startsWith('in:')).sort();
+    const expectedPrInLabels = inLabels;
     const actualPrInLabels = rereadPullRequest.value.labels.filter((label) => label.startsWith('in:')).sort();
     if (expectedPrInLabels.join('\0') !== actualPrInLabels.join('\0')) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
       changed: true, pullRequest: rereadPullRequest.value, operations,
@@ -1668,7 +1692,7 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
     finalPullRequest = rereadPullRequest.value;
   }
   return softenFailure(result(planned.some((operation) => operation.status === 'skipped') ? 'degraded' : 'applied', base.resolved.taskId, base.issueNumber, base.prNumber, {
-    changed: true, platform: base.context.platform, capabilities: base.context.capabilities,
+    changed: issueInLabelChanged || prMetadataChanged || prLabelWrite, platform: base.context.platform, capabilities: base.context.capabilities,
     resource: { kind: 'pull-request', number: base.prNumber }, pullRequest: finalPullRequest,
     operations: operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' } : operation), error: null
   }));

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -15,8 +15,14 @@ import type { PlatformChangeRequestSnapshot } from './adapters.ts';
 import { parseGitHubRemote, resolvePlatformContext } from './context.ts';
 import { createGitHubClient } from './github-client.ts';
 import type { GitHubClient } from './github-client.ts';
-import { inspectPlatformIssue } from './issues.ts';
+import { inspectGitHubIssue, inspectPlatformIssue } from './issues.ts';
+import type { IssueSnapshot } from './issues.ts';
 import { planPullRequestMetadata } from './pull-request-metadata.ts';
+import {
+  extractPullRequestFileNames,
+  extractRepositoryLabelNames,
+  planInLabelUpdate
+} from './in-label-sync.ts';
 import { platformResult } from './types.ts';
 import type { PlatformOperation, PlatformResult } from './types.ts';
 import { inspectCompletionArtifacts } from '../task/finalization-artifacts.ts';
@@ -39,6 +45,15 @@ type PullRequestResult = PlatformResult & {
   result: 'pr_created' | 'pr_reused' | 'no_op' | 'pr_created_with_warnings' | 'pr_reused_with_warnings' | 'no_op_with_warnings' | 'failed' | 'blocked' | null;
   creation: CreationOutcome | null;
   warnings: readonly OperationWarning[];
+  evidence?: { kind: string; pullRequestFiles?: string[]; closingIssues?: number[] };
+  resources?: Array<{
+    kind: 'issue' | 'pull-request';
+    number: number;
+    before: string[];
+    expected: string[];
+    after: string[] | null;
+    effect: 'no-op' | 'applied' | 'unknown';
+  }>;
 };
 type InspectionOptions = { cwd?: string; client?: unknown };
 type SharedOptions = { cwd?: string; client?: GitHubClient };
@@ -763,6 +778,262 @@ function inspectPlatformPullRequestByNumber(prNumber: number, options: Inspectio
   });
 }
 
+const CLOSING_ISSUES_QUERY = 'query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){closingIssuesReferences(first:100,after:$cursor){nodes{number} pageInfo{hasNextPage endCursor}}}}}';
+
+function readInLabelMapping(repoRoot: string): { ok: true; value: Record<string, unknown> } | { ok: false; error: { code: string; message: string; retryable: boolean } } {
+  try {
+    const config = JSON.parse(fs.readFileSync(path.join(repoRoot, '.agents', '.airc.json'), 'utf8')) as {
+      labels?: { in?: unknown };
+    };
+    const mapping = config.labels?.in;
+    return { ok: true, value: mapping && typeof mapping === 'object' && !Array.isArray(mapping) ? mapping as Record<string, unknown> : {} };
+  } catch (error) {
+    return {
+      ok: false,
+      error: { code: 'IN_LABEL_SYNC_CONFIG_INVALID', message: error instanceof Error ? error.message : String(error), retryable: false }
+    };
+  }
+}
+
+function inspectClosingIssueNumbers(client: GitHubClient, repository: string, pullRequest: number, cwd: string) {
+  const [owner, name] = repository.split('/');
+  if (!owner || !name) return {
+    ok: false as const,
+    error: { code: 'IN_LABEL_SYNC_REPOSITORY_INVALID', message: 'Repository identity is invalid', retryable: false }
+  };
+  let cursor: string | null = null;
+  const numbers: number[] = [];
+  for (;;) {
+    const args = ['api', 'graphql', '-f', `query=${CLOSING_ISSUES_QUERY}`, '-F', `owner=${owner}`, '-F', `name=${name}`, '-F', `number=${pullRequest}`];
+    if (cursor) args.push('-F', `cursor=${cursor}`);
+    const response = client.json<unknown>(args, { cwd });
+    if (!response.ok) return response;
+    const connection = (response.value as {
+      data?: { repository?: { pullRequest?: { closingIssuesReferences?: {
+        nodes?: unknown[]; pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+      } } } };
+    })?.data?.repository?.pullRequest?.closingIssuesReferences;
+    if (!connection || !Array.isArray(connection.nodes) || !connection.pageInfo) return {
+      ok: false as const,
+      error: { code: 'IN_LABEL_SYNC_ASSOCIATION_INVALID', message: 'Closing Issue response is incomplete', retryable: false }
+    };
+    for (const node of connection.nodes) {
+      const issue = Number((node as { number?: unknown })?.number);
+      if (!Number.isSafeInteger(issue) || issue <= 0) return {
+        ok: false as const,
+        error: { code: 'IN_LABEL_SYNC_ASSOCIATION_INVALID', message: 'Closing Issue identity is invalid', retryable: false }
+      };
+      numbers.push(issue);
+    }
+    if (!connection.pageInfo.hasNextPage) return { ok: true as const, value: [...new Set(numbers)] };
+    if (!connection.pageInfo.endCursor || connection.pageInfo.endCursor === cursor) return {
+      ok: false as const,
+      error: { code: 'IN_LABEL_SYNC_ASSOCIATION_INVALID', message: 'Closing Issue pagination cursor is invalid', retryable: false }
+    };
+    cursor = connection.pageInfo.endCursor;
+  }
+}
+
+function inspectRepositoryLabels(client: GitHubClient, repository: string, cwd: string) {
+  const response = client.json<unknown>(['api', '--paginate', '--slurp', `repos/${repository}/labels?per_page=100`], { cwd });
+  if (!response.ok) return response;
+  return { ok: true as const, value: new Set(extractRepositoryLabelNames(response.value)) };
+}
+
+function inspectPullRequestFiles(client: GitHubClient, repository: string, pullRequest: number, cwd: string) {
+  const response = client.json<unknown>(['api', '--paginate', '--slurp', `repos/${repository}/pulls/${pullRequest}/files?per_page=100`], { cwd });
+  if (!response.ok) return response;
+  const files = extractPullRequestFileNames(response.value);
+  return files ? { ok: true as const, value: files } : {
+    ok: false as const,
+    error: { code: 'IN_LABEL_SYNC_FILES_INVALID', message: 'Pull request files response is incomplete', retryable: false }
+  };
+}
+
+function inspectTaskInLabelTarget(
+  repoRoot: string,
+  frontmatter: Record<string, unknown>,
+  pullRequest: PullRequestSnapshot,
+  repository: string,
+  client: GitHubClient
+) {
+  const baseRef = typeof frontmatter.delivery_base_ref === 'string' ? frontmatter.delivery_base_ref.trim() : '';
+  if (!baseRef) return {
+    ok: false as const,
+    error: { code: 'IN_LABEL_SYNC_BASE_MISSING', message: 'Task has no delivery_base_ref for in-label evidence', retryable: false }
+  };
+  let changedFiles: string[];
+  try {
+    changedFiles = execFileSync('git', ['diff', `${baseRef}...HEAD`, '--name-only'], {
+      cwd: repoRoot, encoding: 'utf8'
+    }).trim().split(/\r?\n/).filter(Boolean);
+  } catch (error) {
+    return {
+      ok: false as const,
+      error: { code: 'IN_LABEL_SYNC_EVIDENCE_UNAVAILABLE', message: error instanceof Error ? error.message : String(error), retryable: false }
+    };
+  }
+  const mapping = readInLabelMapping(repoRoot);
+  if (!mapping.ok) return mapping;
+  const labels = inspectRepositoryLabels(client, repository, repoRoot);
+  if (!labels.ok) return labels;
+  const planned = planInLabelUpdate({
+    changedFiles, currentLabels: pullRequest.labels, mapping: mapping.value, repositoryLabels: labels.value
+  });
+  return { ok: true as const, value: { changedFiles, target: planned.target } };
+}
+
+function inLabelResource(
+  kind: 'issue' | 'pull-request',
+  number: number,
+  before: string[],
+  expected: string[],
+  after: string[] | null,
+  effect: 'no-op' | 'applied' | 'unknown'
+) {
+  return { kind, number, before: [...before].sort(), expected: [...expected].sort(), after: after ? [...after].sort() : null, effect };
+}
+
+function syncPlatformPullRequestInLabels(prNumber: number, options: SharedOptions & { dryRun?: boolean } = {}): PullRequestResult {
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const client = options.client || createGitHubClient();
+  const context = resolvePlatformContext({ cwd, client });
+  const usable = (context.status === 'no-op' || context.status === 'degraded') && context.platform.repository;
+  if (!usable) return result(context.status, null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, operations: context.operations, error: context.error
+  });
+  if (!Number.isSafeInteger(prNumber) || prNumber <= 0) return result('failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities,
+    error: { code: 'PR_NUMBER_INVALID', message: 'PR number must be positive', retryable: false }
+  });
+  const repository = context.platform.repository!;
+  const fetched = inspectGitHubPullRequest(client, repository, prNumber, cwd);
+  if (!fetched.ok) return result(fetched.error.retryable ? 'blocked' : 'failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, resource: { kind: 'pull-request', number: prNumber }, error: fetched.error
+  });
+  const files = inspectPullRequestFiles(client, repository, prNumber, cwd);
+  if (!files.ok) return result(files.error.retryable ? 'blocked' : 'failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: prNumber }, error: files.error
+  });
+  const mapping = readInLabelMapping(cwd);
+  if (!mapping.ok) return result('failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: prNumber }, error: mapping.error
+  });
+  const repositoryLabels = inspectRepositoryLabels(client, repository, cwd);
+  if (!repositoryLabels.ok) return result(repositoryLabels.error.retryable ? 'blocked' : 'failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: prNumber }, error: repositoryLabels.error
+  });
+  const target = planInLabelUpdate({
+    changedFiles: files.value, currentLabels: fetched.value.labels,
+    mapping: mapping.value, repositoryLabels: repositoryLabels.value
+  }).target;
+  const association = inspectClosingIssueNumbers(client, repository, prNumber, cwd);
+  if (!association.ok) return result(association.error.retryable ? 'blocked' : 'failed', null, null, prNumber, {
+    platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: prNumber }, evidence: { kind: 'pull-request-files', pullRequestFiles: files.value }, error: association.error
+  });
+
+  const issueNumber = association.value.length === 1 ? association.value[0]! : null;
+  let issue: IssueSnapshot | null = null;
+  if (issueNumber) {
+    const fetchedIssue = inspectGitHubIssue(client, repository, issueNumber, cwd);
+    if (!fetchedIssue.ok) return result(fetchedIssue.error.retryable ? 'blocked' : 'failed', null, issueNumber, prNumber, {
+      platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+      resource: { kind: 'issue', number: issueNumber }, evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error: fetchedIssue.error
+    });
+    issue = fetchedIssue.value;
+  }
+
+  const resources = issue
+    ? [
+      { kind: 'issue' as const, number: issue.number, snapshot: issue },
+      { kind: 'pull-request' as const, number: prNumber, snapshot: fetched.value }
+    ]
+    : [{ kind: 'pull-request' as const, number: prNumber, snapshot: fetched.value }];
+  const plans = resources.map((resource) => ({
+    ...resource,
+    plan: planInLabelUpdate({
+      changedFiles: files.value, currentLabels: resource.snapshot.labels,
+      mapping: mapping.value, repositoryLabels: repositoryLabels.value
+    })
+  }));
+  const operations: PlatformOperation[] = [
+    { name: 'closing-issues', status: 'no-op', reasonCode: association.value.length === 1 ? null : association.value.length === 0 ? 'ISSUE_ASSOCIATION_NONE' : 'ISSUE_ASSOCIATION_AMBIGUOUS' },
+    ...plans.map((item) => ({
+      name: `labels:in:${item.kind}`,
+      status: !context.capabilities.triage ? 'skipped' as const : item.plan.changed ? 'planned' as const : 'no-op' as const,
+      reasonCode: !context.capabilities.triage ? 'TRIAGE_REQUIRED' : null
+    }))
+  ];
+  const willWrite = context.capabilities.triage && !options.dryRun;
+  const resourcesState = plans.map((item) => inLabelResource(
+    item.kind,
+    item.number,
+    item.snapshot.labels,
+    target,
+    item.plan.changed && willWrite ? null : item.snapshot.labels,
+    item.plan.changed && willWrite ? 'unknown' : 'no-op'
+  ));
+  if (options.dryRun || !context.capabilities.triage) return result(
+    !context.capabilities.triage || association.value.length !== 1 ? 'degraded' : plans.some((item) => item.plan.changed) ? 'planned' : 'no-op',
+    null, issueNumber, prNumber, {
+      platform: context.platform, capabilities: context.capabilities, pullRequest: fetched.value,
+      resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
+      evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error: null
+    }
+  );
+
+  let currentPullRequest = fetched.value;
+  let successfulWrites = 0;
+  for (const item of plans) {
+    if (!item.plan.changed) continue;
+    const patched = client.json<unknown>(['api', `repos/${repository}/issues/${item.number}/labels`, '-X', 'PUT', '--input', '-'], {
+      cwd, method: 'PUT', input: JSON.stringify({ labels: item.plan.labels })
+    });
+    if (!patched.ok) {
+      const partial = successfulWrites > 0 || patched.error.retryable;
+      const error = partial
+        ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
+        : patched.error;
+      return result(partial || patched.error.retryable ? 'blocked' : 'failed', null, issueNumber, prNumber, {
+        changed: successfulWrites > 0, platform: context.platform, capabilities: context.capabilities,
+        pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
+        evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error
+      });
+    }
+    successfulWrites += 1;
+    const reread = item.kind === 'issue'
+      ? inspectGitHubIssue(client, repository, item.number, cwd)
+      : inspectGitHubPullRequest(client, repository, item.number, cwd);
+    if (!reread.ok) return result('blocked', null, issueNumber, prNumber, {
+      changed: true, platform: context.platform, capabilities: context.capabilities,
+      pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
+      evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value },
+      error: { ...reread.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${reread.error.message}` }
+    });
+    const after = reread.value.labels;
+    const state = resourcesState.find((resource) => resource.kind === item.kind && resource.number === item.number)!;
+    state.after = after;
+    state.effect = after.filter((label) => label.startsWith('in:')).sort().join('\0') === target.join('\0') ? 'applied' : 'unknown';
+    if (state.effect === 'unknown') return result('blocked', null, issueNumber, prNumber, {
+      changed: true, platform: context.platform, capabilities: context.capabilities,
+      pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
+      evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value },
+      error: { code: 'IN_LABEL_SYNC_PARTIAL', message: `${item.kind} #${item.number} did not converge to the expected in: labels`, retryable: true }
+    });
+    if (item.kind === 'pull-request') currentPullRequest = reread.value as PullRequestSnapshot;
+  }
+  return result(association.value.length !== 1 ? 'degraded' : successfulWrites > 0 ? 'applied' : 'no-op', null, issueNumber, prNumber, {
+    changed: successfulWrites > 0, platform: context.platform, capabilities: context.capabilities,
+    pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber },
+    operations: operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' as const } : operation),
+    resources: resourcesState, evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error: null
+  });
+}
+
 function appendActivity(content: string, line: string): string {
   const body = extractSection(content, ['活动日志', 'Activity Log']);
   return `${body.replace(/\s+$/, '')}${body.trim() ? '\n' : ''}${line}`;
@@ -1256,7 +1527,9 @@ function createPlatformPullRequest(taskRef: string, options: CreateOptions): Pul
 function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullRequestResult {
   const warningResult = warningResultForPrimary(options.primaryResult);
   const softenFailure = (output: PullRequestResult): PullRequestResult => {
+    const authorityError = output.error?.code.startsWith('IN_LABEL_SYNC') || output.error?.code.startsWith('PR_IDENTITY');
     const warning = output.error && output.task.prNumber !== null
+      && !authorityError
       && !['PR_NOT_LINKED', 'PR_BIND_CONFLICT'].includes(output.error.code)
       ? {
         code: output.error.code,
@@ -1291,16 +1564,56 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
   if (!issue.issue) return softenFailure(result(issue.status, base.resolved.taskId, base.issueNumber, base.prNumber, {
     platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, error: issue.error
   }));
+  let inLabels = fetched.value.labels.filter((label) => label.startsWith('in:')).sort();
+  let inLabelIssueOperation: PlatformOperation | null = null;
+  if (options.metadata) {
+    const target = inspectTaskInLabelTarget(base.resolved.repoRoot, base.frontmatter, fetched.value, base.context.platform.repository!, base.client);
+    if (!target.ok) return softenFailure(result(target.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, error: target.error
+    }));
+    inLabels = target.value.target;
+    // The target was computed against repository labels above; merge only the current Issue labels with that target here.
+    const issueLabels = [...new Set([...issue.issue.labels.filter((label) => !label.startsWith('in:')), ...inLabels])].sort();
+    inLabelIssueOperation = !base.context.capabilities.triage
+      ? { name: 'labels:in:issue', status: 'skipped', reasonCode: 'TRIAGE_REQUIRED' }
+      : issueLabels.join('\0') === issue.issue.labels.join('\0')
+        ? { name: 'labels:in:issue', status: 'no-op', reasonCode: null }
+        : { name: 'labels:in:issue', status: 'planned', reasonCode: null };
+    if (inLabelIssueOperation.status === 'planned' && !options.dryRun) {
+      const patchedIssue = base.client.json<unknown>(['api', `repos/${base.context.platform.repository}/issues/${base.issueNumber}/labels`, '-X', 'PUT', '--input', '-'], {
+        cwd: base.resolved.repoRoot, method: 'PUT', input: JSON.stringify({ labels: issueLabels })
+      });
+      if (!patchedIssue.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
+        operations: [inLabelIssueOperation], error: { ...patchedIssue.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patchedIssue.error.message}` }
+      }));
+      const rereadIssue = inspectGitHubIssue(base.client, base.context.platform.repository!, base.issueNumber, base.resolved.repoRoot);
+      if (!rereadIssue.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
+        operations: [inLabelIssueOperation], error: { ...rereadIssue.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${rereadIssue.error.message}` }
+      }));
+      const expectedIssueInLabels = issueLabels.filter((label) => label.startsWith('in:')).sort();
+      const actualIssueInLabels = rereadIssue.value.labels.filter((label) => label.startsWith('in:')).sort();
+      if (actualIssueInLabels.join('\0') !== expectedIssueInLabels.join('\0')) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+        platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value,
+        operations: [inLabelIssueOperation], error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Issue in: labels did not converge after update', retryable: true }
+      }));
+    }
+  }
   const planned = planPullRequestMetadata({
     pullRequest: fetched.value,
     issue: issue.issue,
     taskType: String(base.frontmatter.type || 'task'),
     issueNumber: base.issueNumber,
-    capabilities: base.context.capabilities
+    capabilities: base.context.capabilities,
+    inLabels
   }).operations.filter((operation) => options.metadata || operation.name === 'closing-issue')
     .filter((operation) => options.closingIssue || operation.name !== 'closing-issue');
-  const operations: PlatformOperation[] = planned.map(({ name, status, reasonCode }) => ({ name, status, reasonCode }));
-  if (options.dryRun) return softenFailure(result(planned.some((operation) => operation.status === 'planned') ? 'planned' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+  const operations: PlatformOperation[] = [
+    ...(inLabelIssueOperation ? [inLabelIssueOperation] : []),
+    ...planned.map(({ name, status, reasonCode }) => ({ name, status, reasonCode }))
+  ];
+  if (options.dryRun) return softenFailure(result(planned.some((operation) => operation.status === 'planned') || inLabelIssueOperation?.status === 'planned' ? 'planned' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
     platform: base.context.platform, capabilities: base.context.capabilities, pullRequest: fetched.value, operations, error: null
   }));
   const payload: Record<string, unknown> = {};
@@ -1316,19 +1629,47 @@ function syncPlatformPullRequest(taskRef: string, options: SyncOptions): PullReq
       payload.milestone = flat.find((entry) => entry.title === operation.value)?.number ?? null;
     }
   }
+  const issueInLabelChanged = inLabelIssueOperation?.status === 'planned';
   if (Object.keys(payload).length === 0) {
     const degraded = planned.some((operation) => operation.status === 'skipped');
-    return softenFailure(result(degraded ? 'degraded' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
-      platform: base.context.platform, capabilities: base.context.capabilities, resource: { kind: 'pull-request', number: base.prNumber }, pullRequest: fetched.value, operations, error: null
+    return softenFailure(result(issueInLabelChanged ? degraded ? 'degraded' : 'applied' : degraded ? 'degraded' : 'no-op', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: issueInLabelChanged, platform: base.context.platform, capabilities: base.context.capabilities,
+      resource: { kind: 'pull-request', number: base.prNumber }, pullRequest: fetched.value,
+      operations: operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' } : operation), error: null
     }));
   }
   const patched = base.client.json<RemotePullRequest>(['api', `repos/${base.context.platform.repository}/issues/${base.prNumber}`, '-X', 'PATCH', '--input', '-'], {
     cwd: base.resolved.repoRoot, method: 'PATCH', input: JSON.stringify(payload)
   });
-  if (!patched.ok) return softenFailure(result(patched.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, { pullRequest: fetched.value, operations, error: patched.error }));
+  const prLabelWrite = planned.some((operation) => operation.name === 'labels' && operation.status === 'planned');
+  if (!patched.ok) {
+    const partial = prLabelWrite && patched.error.retryable;
+    const error = partial
+      ? { ...patched.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${patched.error.message}` }
+      : patched.error;
+    return softenFailure(result(partial || patched.error.retryable ? 'blocked' : 'failed', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: issueInLabelChanged, pullRequest: fetched.value, operations, error
+    }));
+  }
+  let finalPullRequest = fetched.value;
+  if (prLabelWrite) {
+    const rereadPullRequest = inspectGitHubPullRequest(base.client, base.context.platform.repository!, base.prNumber, base.resolved.repoRoot);
+    if (!rereadPullRequest.ok) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: true, pullRequest: fetched.value, operations,
+      error: { ...rereadPullRequest.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${rereadPullRequest.error.message}` }
+    }));
+    const expectedPrInLabels = (planned.find((operation) => operation.name === 'labels')?.value as string[])
+      .filter((label) => label.startsWith('in:')).sort();
+    const actualPrInLabels = rereadPullRequest.value.labels.filter((label) => label.startsWith('in:')).sort();
+    if (expectedPrInLabels.join('\0') !== actualPrInLabels.join('\0')) return softenFailure(result('blocked', base.resolved.taskId, base.issueNumber, base.prNumber, {
+      changed: true, pullRequest: rereadPullRequest.value, operations,
+      error: { code: 'IN_LABEL_SYNC_PARTIAL', message: 'Pull request in: labels did not converge after update', retryable: true }
+    }));
+    finalPullRequest = rereadPullRequest.value;
+  }
   return softenFailure(result(planned.some((operation) => operation.status === 'skipped') ? 'degraded' : 'applied', base.resolved.taskId, base.issueNumber, base.prNumber, {
     changed: true, platform: base.context.platform, capabilities: base.context.capabilities,
-    resource: { kind: 'pull-request', number: base.prNumber }, pullRequest: fetched.value,
+    resource: { kind: 'pull-request', number: base.prNumber }, pullRequest: finalPullRequest,
     operations: operations.map((operation) => operation.status === 'planned' ? { ...operation, status: 'applied' } : operation), error: null
   }));
 }
@@ -1438,7 +1779,8 @@ export {
   skipPlatformPullRequestFact,
   selectExternalPullRequest,
   selectPullRequest,
-  syncPlatformPullRequest
+  syncPlatformPullRequest,
+  syncPlatformPullRequestInLabels
 };
 export type { BindOptions, CreateOptions, ExternalPullRequestResult, ExternalPullRequestSelection, PullRequestPrimaryResult, PullRequestResult, PullRequestSnapshot, ResolveExternalOptions, SkipFactOptions, SyncOptions };
 export { warningResultForPrimary };

--- a/lib/platform/pull-requests.ts
+++ b/lib/platform/pull-requests.ts
@@ -1004,10 +1004,14 @@ function syncPlatformPullRequestInLabels(prNumber: number, options: SharedOption
       const state = resourcesState.find((resource) => resource.kind === item.kind && resource.number === item.number)!;
       state.effect = synced.status === 'blocked' ? 'unknown' : 'no-op';
       state.after = synced.status === 'blocked' ? null : item.snapshot.labels;
-      return result(synced.status, null, issueNumber, prNumber, {
+      const partial = successfulWrites > 0 || synced.status === 'blocked';
+      const error = partial && synced.error
+        ? { ...synced.error, code: 'IN_LABEL_SYNC_PARTIAL', message: `In-label synchronization is partial or unknown: ${synced.error.message}` }
+        : synced.error;
+      return result(partial ? 'blocked' : synced.status, null, issueNumber, prNumber, {
         changed: successfulWrites > 0 || synced.changed, platform: context.platform, capabilities: context.capabilities,
         pullRequest: currentPullRequest, resource: { kind: 'pull-request', number: prNumber }, operations, resources: resourcesState,
-        evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error: synced.error
+        evidence: { kind: 'pull-request-files', pullRequestFiles: files.value, closingIssues: association.value }, error
       });
     }
     successfulWrites += synced.changed ? 1 : 0;

--- a/lib/platform/verification-sync.ts
+++ b/lib/platform/verification-sync.ts
@@ -9,7 +9,7 @@ import { hasCheckedRequirement, resolveRequirementSection } from "./issue-metada
 import { inspectGitHubIssueMetadata, requirementSectionAnchors } from "./issues.ts";
 import { listRemoteComments } from "./issue-comments.ts";
 import { taskTypeLabel } from "./metadata-labels.ts";
-import { extractRepositoryLabelNames, planInLabelUpdate } from "./in-label-sync.ts";
+import { planInLabelUpdate, validateInLabelMapping, validateRepositoryLabelPayload } from "./in-label-sync.ts";
 import { inspectGitHubPullRequest } from "./pull-requests.ts";
 import { readPrDeliveryFact } from "../task/pr-delivery-fact.ts";
 
@@ -1163,12 +1163,19 @@ function computeExpectedInLabels(taskDir: any, repository: any): any {
     return repoLabelsResult;
   }
 
+  const repositoryLabels = validateRepositoryLabelPayload(repoLabelsResult.value);
+  if (!repositoryLabels.ok) {
+    return { ok: false, type: "check_failed", message: repositoryLabels.error.message };
+  }
   const planned = planInLabelUpdate({
     changedFiles,
     currentLabels: [],
     mapping: mapping.value ?? {},
-    repositoryLabels: new Set(extractRepositoryLabelNames(repoLabelsResult.value))
+    repositoryLabels: new Set(repositoryLabels.value)
   });
+  if (planned.error) {
+    return { ok: false, type: "check_failed", message: planned.error.message };
+  }
   return { ok: true, labels: planned.target, mode: "mapped" };
 }
 
@@ -1180,26 +1187,10 @@ function loadInLabelMapping(): any {
 
   try {
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    const mapping = config?.labels?.in;
-    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
-      return { ok: true, value: {} };
-    }
-
-    const normalized: Record<string, string[]> = {};
-    for (const [label, prefixes] of Object.entries(mapping)) {
-      if (!Array.isArray(prefixes)) {
-        continue;
-      }
-
-      const cleaned = prefixes
-        .map((value) => String(value || "").trim())
-        .filter(Boolean);
-      if (cleaned.length > 0) {
-        normalized[label] = cleaned;
-      }
-    }
-
-    return { ok: true, value: normalized };
+    const mapping = validateInLabelMapping(config?.labels?.in);
+    return mapping.ok
+      ? { ok: true, value: mapping.value }
+      : { ok: false, type: "check_failed", message: mapping.error.message };
   } catch (error: any) {
     return { ok: false, type: "check_failed", message: `Unable to parse .agents/.airc.json: ${error.message}` };
   }

--- a/lib/platform/verification-sync.ts
+++ b/lib/platform/verification-sync.ts
@@ -9,6 +9,7 @@ import { hasCheckedRequirement, resolveRequirementSection } from "./issue-metada
 import { inspectGitHubIssueMetadata, requirementSectionAnchors } from "./issues.ts";
 import { listRemoteComments } from "./issue-comments.ts";
 import { taskTypeLabel } from "./metadata-labels.ts";
+import { extractRepositoryLabelNames, planInLabelUpdate } from "./in-label-sync.ts";
 import { inspectGitHubPullRequest } from "./pull-requests.ts";
 import { readPrDeliveryFact } from "../task/pr-delivery-fact.ts";
 
@@ -715,7 +716,7 @@ function checkInLabelsComputed(context: any, remoteData: any): any {
     return null;
   }
 
-  const expectedInLabels = computeExpectedInLabels(context.taskDir);
+  const expectedInLabels = computeExpectedInLabels(context.taskDir, context.upstreamRepo);
   if (!expectedInLabels.ok) {
     return expectedInLabels.type === "check_failed"
       ? failResult(CHECK_TYPE, expectedInLabels.message, expectedInLabels.type)
@@ -1127,10 +1128,18 @@ function formatLabelList(labels: any): any {
   return labels.length > 0 ? labels.join(", ") : "none";
 }
 
-function computeExpectedInLabels(taskDir: any): any {
-  const changedFilesResult = gitText(["diff", "main...HEAD", "--name-only"], taskDir);
+function computeExpectedInLabels(taskDir: any, repository: any): any {
+  const task = loadTask(taskDir);
+  if (!task.ok) {
+    return task;
+  }
+  const baseRef = String(task.metadata?.delivery_base_ref || "").trim();
+  if (!baseRef) {
+    return { ok: false, type: "check_failed", message: "Task has no delivery_base_ref for in-label evidence" };
+  }
+  const changedFilesResult = gitText(["diff", `${baseRef}...HEAD`, "--name-only"], taskDir);
   if (!changedFilesResult.ok) {
-    return changedFilesResult;
+    return { ...changedFilesResult, type: "network_error" };
   }
 
   const changedFiles = String(changedFilesResult.value || "")
@@ -1143,55 +1152,24 @@ function computeExpectedInLabels(taskDir: any): any {
     return mapping;
   }
 
-  if (Object.keys(mapping.value ?? {}).length > 0) {
-    const labels = new Set();
-
-    for (const file of changedFiles) {
-      for (const [label, prefixes] of Object.entries(mapping.value ?? {}) as Array<[string, string[]]>) {
-        if (prefixes.some((prefix: any) => file.startsWith(prefix))) {
-          labels.add(`in: ${label}`);
-        }
-      }
-    }
-
-    return { ok: true, labels: Array.from(labels).sort(), mode: "mapped" };
+  if (Object.keys(mapping.value ?? {}).length === 0) {
+    return { ok: true, labels: [], mode: "mapped" };
   }
 
-  const repoLabelsResult = withRetry(() => ghJson([
-    "label",
-    "list",
-    "--limit",
-    "200",
-    "--json",
-    "name"
+  const repoLabelsResult = withRetry(() => ghPaginatedJson([
+    "api", "--paginate", "--slurp", `repos/${repository}/labels?per_page=100`
   ], taskDir));
   if (!repoLabelsResult.ok) {
     return repoLabelsResult;
   }
 
-  const repoInLabels = new Set(
-    extractLabelNames(repoLabelsResult.value)
-      .filter((label: any) => label.startsWith("in:"))
-  );
-
-  if (repoInLabels.size === 0) {
-    return { ok: true, labels: [], mode: "fallback" };
-  }
-
-  const labels = new Set();
-  for (const file of changedFiles) {
-    const topLevel = file.split("/")[0];
-    if (!topLevel) {
-      continue;
-    }
-
-    const candidate = `in: ${topLevel}`;
-    if (repoInLabels.has(candidate)) {
-      labels.add(candidate);
-    }
-  }
-
-  return { ok: true, labels: Array.from(labels).sort(), mode: "fallback" };
+  const planned = planInLabelUpdate({
+    changedFiles,
+    currentLabels: [],
+    mapping: mapping.value ?? {},
+    repositoryLabels: new Set(extractRepositoryLabelNames(repoLabelsResult.value))
+  });
+  return { ok: true, labels: planned.target, mode: "mapped" };
 }
 
 function loadInLabelMapping(): any {

--- a/templates/.agents/rules/issue-pr-commands.en.md
+++ b/templates/.agents/rules/issue-pr-commands.en.md
@@ -29,6 +29,6 @@ agent-infra-internal platform-pr sync {task-id} \
   --agent {standard-agent-token} --metadata --closing-issue
 ```
 
-Conflicting bindings do not change `task.md`. Metadata comes from the linked Issue, permission-bound items degrade independently, and an already-created PR is never rolled back.
+Conflicting bindings do not change `task.md`. The shared core computes one `in:` target from task-bound diff/PR files and the repository mapping. A unique closing Issue is converged before the PR; other metadata comes from the linked Issue. Zero or multiple closing Issues update only the PR and return `degraded`; `in:` labels are never copied back from the Issue or removed from unrelated resources. Permission-bound items degrade independently, partial side effects return `blocked` with `IN_LABEL_SYNC_PARTIAL`, and an already-created PR is never rolled back.
 
 Statuses `planned|applied|no-op|degraded` exit 0, `failed` exits 1, and `blocked` exits 2.

--- a/templates/.agents/rules/issue-pr-commands.zh-CN.md
+++ b/templates/.agents/rules/issue-pr-commands.zh-CN.md
@@ -39,7 +39,7 @@ agent-infra-internal platform-pr sync {task-id} \
   --agent {standard-agent-token} --metadata --closing-issue
 ```
 
-core 从关联 Issue 复制 type / `in:` labels、assignee、具体 milestone，并确保 closing association。权限不足返回逐项 `skipped` 和顶层 `degraded`；不得反向修改 Issue。
+core 根据 task-bound diff/PR files 与仓库映射计算唯一 `in:` target；唯一 closing Issue 按 Issue→PR 顺序收敛，其他 metadata 从关联 Issue 复制。零或多个 closing Issue 只更新 PR 并返回 `degraded`；不得从 Issue 反向复制 `in:`，也不清除非 `in:` labels。权限不足逐项返回 `skipped`，部分副作用返回 `blocked` 与 `IN_LABEL_SYNC_PARTIAL`。
 
 ## 状态语义
 

--- a/templates/.agents/rules/issue-sync.en.md
+++ b/templates/.agents/rules/issue-sync.en.md
@@ -25,6 +25,8 @@ agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token
 
 The core owns status/in labels, assignees, milestones, Issue Type, pinned fields, requirements, state, capabilities, dry-run, retries, errors, and idempotency. Omitted flags preserve values; `none` explicitly clears them. Status labels converge to at most one, and ambiguous requirement identity fails closed.
 
+PR event `in:` synchronization uses `agent-infra-internal platform-pr sync-in-labels --pr <N> [--cwd <path>]`. PR files are the event evidence; a unique closing Issue is written and re-read before the PR. Zero or multiple closing Issues update only the PR and return `degraded`; unknown side effects or failed convergence return `blocked` with `IN_LABEL_SYNC_PARTIAL`.
+
 `planned|applied|no-op|degraded` exit 0; `failed` exits 1; `blocked` exits 2.
 
 Map material degraded/failed/blocked results to workflow warnings through the structured intent; callers must not edit warning rows directly:

--- a/templates/.agents/rules/issue-sync.zh-CN.md
+++ b/templates/.agents/rules/issue-sync.zh-CN.md
@@ -71,6 +71,8 @@ agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token
 
 status labels 始终至多一个；关闭后不保留 status label。`in:` labels 只从项目允许映射与仓库实际 labels 交集产生。需求复选框以 task.md 原文为身份，歧义时 fail closed。
 
+PR event 的 `in:` 同步使用 `agent-infra-internal platform-pr sync-in-labels --pr <N> [--cwd <path>]`。PR files 是事件证据；唯一 closing Issue 按 Issue→PR 顺序写入并复读，零或多个 closing Issue 只写 PR 并返回 `degraded`。写入后副作用不明或复读未收敛必须返回 `blocked` 与 `IN_LABEL_SYNC_PARTIAL`。
+
 ## 补发
 
 complete-task 按 artifact catalog 时间线遍历本地已有产物：task 使用 `--kind task`，其余使用 `--kind artifact --artifact <file> --backfill`；最后用 `--kind summary --body-file <path>` 原地同步交付摘要。artifact backfill 在远端缺少 marker 时创建带“历史产物补发”提示的评论；已存在合法 marker 集合时保持原评论和分片不变并返回 `no-op`；marker 冲突仍失败。该判定由 core 完成，不由 Skill 扫描评论或拼标题。

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -106,6 +106,8 @@ When triaging a test failure or unexpected behavior, first read `.agents/rules/d
 
 After tests pass, call the shared commit core with `agent-infra-internal git-workflow commit --input {checkpoint-input}`. Pass `delivery: { "mode": "local" }`, explicit paths, expected HEAD/tree, task ref, agent, and the code round. This creates only a local checkpoint and does not contact a remote. The core writes a durable intent before committing and removes it after task-writer synchronization; do not emit `code.completed` if either checkpoint or task synchronization fails.
 
+After the checkpoint succeeds, when task.md has an `issue_number`, run `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {delivery-base-ref}`. The task-bound `delivery_base_ref` is the only source for Issue `in:` evidence; record a warning and stop this round without emitting `code.completed` if this sync fails.
+
 ### 9. Write the Code Report
 
 Create `.agents/workspace/active/{task-id}/{code-artifact}`.
@@ -116,7 +118,7 @@ Create `.agents/workspace/active/{task-id}/{code-artifact}`.
 
 After requirement checkboxes are updated, run the initial event `agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --files-modified {n} --tests-passed {n} {execution-flag}`; in fix mode use `--fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}` instead; in decision mode add `--implementation-input {input-id}` to the initial counts. The core atomically records the artifact link, stage, metadata, done log, and decision-input consumption.
 
-If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, then:
+If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, then (status/comment failures follow the warning rules; an Issue `in:` evidence failure must not emit `code.completed`):
 - Run `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - Run `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - Run `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -144,6 +144,8 @@ echo "$result"
 
 测试通过后，通过 `agent-infra-internal git-workflow commit --input {checkpoint-input}` 调用共享 commit core，输入 `delivery: { "mode": "local" }`、明确 paths、expected HEAD/tree、task ref、agent 和 code round。该调用只创建本地 checkpoint，不访问远端；core 会在 commit 前写入 durable intent，并在 task writer 成功后清理 intent。checkpoint 失败或 task 状态未闭合时，不得发送 `code.completed`。
 
+checkpoint 成功后，若任务存在 `issue_number`，调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {delivery-base-ref}`，由 task-bound `delivery_base_ref` 产生 Issue 的 `in:` target；该同步失败时记录 warning 并停止本轮，不发送 `code.completed`。
+
 排查测试失败或行为不符合预期时，先读取 `.agents/rules/debugging-guide.md`，按其四阶段流程定位根因，禁止盲目改代码重试。
 
 ### 9. 编写实现报告
@@ -162,7 +164,7 @@ echo "$result"
   - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
   - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
 
-如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则记录 warning 并继续；Issue 元数据边界仍见 `.agents/rules/issue-sync.md`）：
+如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（状态/评论失败按规则记录 warning；Issue `in:` evidence 同步失败不得发送 `code.completed`；边界见 `.agents/rules/issue-sync.md`）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`

--- a/templates/.agents/skills/code-task/config/verify.en.json
+++ b/templates/.agents/skills/code-task/config/verify.en.json
@@ -46,6 +46,7 @@
       "verify_task_comment_content": true,
       "verify_issue_type": true,
       "verify_issue_fields": false,
+      "verify_in_labels_computed": true,
       "verify_milestone": true,
       "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",

--- a/templates/.agents/skills/code-task/config/verify.zh-CN.json
+++ b/templates/.agents/skills/code-task/config/verify.zh-CN.json
@@ -46,6 +46,7 @@
       "verify_task_comment_content": true,
       "verify_issue_type": true,
       "verify_issue_fields": false,
+      "verify_in_labels_computed": true,
       "verify_milestone": true,
       "verify_milestone_specific": true,
       "expected_status_label_key": "inProgress",

--- a/templates/.agents/skills/commit/reference/issue-metadata-sync.en.md
+++ b/templates/.agents/skills/commit/reference/issue-metadata-sync.en.md
@@ -14,6 +14,8 @@ Call one declarative intent. The internal core owns diff computation, repository
 agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {base-branch} --requirements
 ```
 
+If `--base` is supplied, it must exactly match task.md's `delivery_base_ref`; the core uses that task-bound ref as the only diff evidence and never falls back to `main` or a repository default. The `in:` target is the intersection of the `labels.in` mapping and repository labels, and unrelated labels are preserved.
+
 ## Error Handling
 
 Treat sync failures as warnings only. Do not block an already completed `git commit`.

--- a/templates/.agents/skills/commit/reference/issue-metadata-sync.zh-CN.md
+++ b/templates/.agents/skills/commit/reference/issue-metadata-sync.zh-CN.md
@@ -14,6 +14,8 @@
 agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --in-labels from-diff --base {base-branch} --requirements
 ```
 
+`--base`（如保留）必须与 task.md 的 `delivery_base_ref` 完全一致；core 以 task-bound base 作为唯一 diff evidence，不回退到 `main` 或仓库默认分支。`in:` target 只来自 `labels.in` 映射与仓库实际 labels 的交集，并保留其他 labels。
+
 ## 错误处理
 
 同步失败只记为警告，不阻塞已完成的 `git commit`。

--- a/templates/.agents/skills/create-pr/SKILL.en.md
+++ b/templates/.agents/skills/create-pr/SKILL.en.md
@@ -74,7 +74,7 @@ If `{task-id}` is available and the related task provides `issue_number`, keep `
 
 ### 6. Sync PR Metadata
 
-Capture the `result` field from `platform-pr create` (`pr_created`, `pr_reused`, or `no_op`), then run `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`. The core copies type / `in:` labels, assignee, and a specific milestone from the Issue and maintains the closing association. Permission-bound items degrade independently, and the Issue is never updated in reverse. After the PR identity is bound, metadata or summary sync failures produce `pr_created_with_warnings`, `pr_reused_with_warnings`, or `no_op_with_warnings` from that primary result, preserve the primary-action fact, and retry only unfinished sync steps.
+Capture the `result` field from `platform-pr create` (`pr_created`, `pr_reused`, or `no_op`), then run `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`. The shared core computes one `in:` target from task-bound diff/PR evidence and the repository mapping, converges a unique closing Issue before the PR, and syncs other metadata from the Issue. It never copies `in:` labels back from the Issue or removes unrelated labels. Permission failures degrade independently; partial side effects return blocked/`IN_LABEL_SYNC_PARTIAL`.
 
 ### 7. Generate the PR Code Change Report
 

--- a/templates/.agents/skills/create-pr/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-pr/SKILL.zh-CN.md
@@ -74,7 +74,7 @@ description: >
 
 ### 6. 同步 PR 元数据
 
-记录 `platform-pr create` 结构化结果中的 `result`（`pr_created`、`pr_reused` 或 `no_op`），并调用 `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`。core 从 Issue 复制 type / `in:` labels、assignee 和具体 milestone，并维护 Development 关联；逐项权限不足返回 degraded，不反向更新 Issue。PR 已成功绑定后，metadata/summary 同步失败只产生与 primary result 对应的 `pr_created_with_warnings`、`pr_reused_with_warnings` 或 `no_op_with_warnings`，保留主动作事实，重试只执行未完成的同步步骤。
+记录 `platform-pr create` 结构化结果中的 `result`（`pr_created`、`pr_reused` 或 `no_op`），并调用 `agent-infra-internal platform-pr sync {task-id} --agent {standard-agent-token} --metadata --closing-issue --result {primary-result}`。`in:` target 由 shared core 根据 task-bound diff/PR evidence 和仓库映射计算，唯一 closing Issue 按 Issue→PR 顺序收敛，其他 metadata 仍从 Issue 同步；不从 Issue 反向复制 `in:`，也不清除非 `in:` labels。权限不足逐项返回 degraded，部分副作用返回 blocked/`IN_LABEL_SYNC_PARTIAL`。
 
 ### 7. 生成 PR 代码增减报告
 

--- a/templates/.agents/skills/create-pr/config/verify.json
+++ b/templates/.agents/skills/create-pr/config/verify.json
@@ -21,6 +21,7 @@
       "when": "issue_number_exists",
       "expected_pr_comment_marker": "<!-- sync-pr:{task-id}:summary -->",
       "verify_in_labels_match_pr": true,
+      "verify_in_labels_computed": true,
       "verify_pr_type_label": true,
       "verify_pr_assignee": true,
       "verify_issue_fields": true,

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.en.md
@@ -42,7 +42,7 @@ Type label mapping:
 
 Metadata sync order:
 1. query Issue labels and milestone via the Issue read command in `.agents/rules/issue-pr-commands.md`
-2. build `{label-args}` from the mapped type label, non-`type:` / non-`status:` Issue labels, and the current Issue `in:` labels (commit already computed them, so do not recompute them here and do not write back to the Issue)
+2. build `{label-args}` from the mapped type label and non-`type:` / non-`status:` Issue labels; `in:` labels are computed once by the shared platform core from task-bound diff/PR evidence, so do not recompute them here or copy them back from the Issue
 3. build `{milestone-arg}` by following "Phase 3: `create-pr`" in `.agents/rules/milestone-inference.md` and reusing the Issue milestone directly
 4. pass `{label-args}` and `{milestone-arg}` atomically by using the create-PR command template and permission-degradation rules in `.agents/rules/issue-pr-commands.md`
 5. ensure the PR body contains `Closes #{issue-number}` or an equivalent closing keyword

--- a/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
+++ b/templates/.agents/skills/create-pr/reference/pr-body-template.zh-CN.md
@@ -42,7 +42,7 @@ git diff <target-branch>...HEAD
 
 元数据同步顺序：
 1. 通过 `.agents/rules/issue-pr-commands.md` 的 Issue 读取命令查询 Issue labels 和 milestone
-2. 从映射出的 type label、非 `type:` / 非 `status:` 的 Issue labels，以及当前 Issue `in:` labels 构建 `{label-args}`（commit 已经计算过，不在此重算，也不写回 Issue）
+2. 从映射出的 type label 和非 `type:` / 非 `status:` 的 Issue labels 构建 `{label-args}`；`in:` labels 由 shared platform core 根据 task-bound diff/PR evidence 统一计算，不在正文生成步骤重算，也不从 Issue 反向复制
 3. 按 `.agents/rules/milestone-inference.md` 的 "阶段 3：`create-pr`" 复用 Issue milestone 构建 `{milestone-arg}`
 4. 按 `.agents/rules/issue-pr-commands.md` 的创建 PR 命令模板与权限降级规则，将 `{label-args}` 和 `{milestone-arg}` 原子化传入
 5. 确保 PR 正文包含 `Closes #{issue-number}` 或等价关闭关键字

--- a/templates/.github/workflows/pr-label.yml
+++ b/templates/.github/workflows/pr-label.yml
@@ -20,36 +20,17 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v7
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.9.0
+
       - name: Sync in-labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          changed_files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
-            --paginate --jq '.[].filename' | jq -Rn '[inputs]')
-
-          should_labels=$(jq -rn \
-            --argjson files "$changed_files" \
-            --argjson mapping "$(jq '.labels.in // {}' .agents/.airc.json)" \
-            '$mapping
-            | to_entries
-            | map(select(.value | any(. as $prefix | $files | any(startswith($prefix)))))
-            | map("in: " + .key)
-            | .[]?')
-
-          set -- \
-            --repo "$GITHUB_REPOSITORY" \
-            --pr "$PR_NUMBER" \
-            --prefix "in: "
-
-          while IFS= read -r label; do
-            [ -z "$label" ] && continue
-            set -- "$@" --target "$label"
-          done <<EOF
-          $should_labels
-          EOF
-
-          .github/scripts/sync-labels-to-set.sh "$@"
+          AGENT_INFRA_VERSION: 0.9.13-alpha.0
+        run: npm exec --yes --package="@fitlab-ai/agent-infra@$AGENT_INFRA_VERSION" -- agent-infra-internal platform-pr sync-in-labels --pr "$PR_NUMBER" --cwd "$GITHUB_WORKSPACE"
 
       - name: Assign PR creator if unassigned
         env:

--- a/tests/e2e/core/validate-artifact-helpers.ts
+++ b/tests/e2e/core/validate-artifact-helpers.ts
@@ -154,6 +154,7 @@ function buildTaskFrontmatter(overrides: FrontmatterOverrides = {}) {
     updated_at: formatTimestamp(now),
     agent_infra_version: "v0.9.11-alpha.0",
     pr_delivery_fact: factValue(buildUnboundFact()),
+    delivery_base_ref: "main",
     issue_number: "N/A",
     current_step: "code",
     assigned_to: "codex",
@@ -602,7 +603,7 @@ async function withProjectTempRoot<T>(prefix: string, fn: (tempRoot: string) => 
 }
 
 function setupPlatformSyncEnv(tempRoot: string): PlatformSyncEnv {
-  const taskDir = path.join(tempRoot, "TASK-20260328-000001");
+  const taskDir = path.join(tempRoot, ".agents", "workspace", "active", "TASK-20260328-000001");
   const binDir = path.join(tempRoot, "bin");
   const ghPath = writeFakeGh(path.join(binDir, "gh"));
   const issuePath = path.join(tempRoot, "issue.json");
@@ -613,6 +614,17 @@ function setupPlatformSyncEnv(tempRoot: string): PlatformSyncEnv {
   const labelsPath = path.join(tempRoot, "labels.json");
 
   initIsolatedGitRepo(tempRoot, { remote: "git@github.com:fitlab-ai/agent-infra.git" });
+  const configName = spawnSync("git", ["config", "user.name", "Test"], { cwd: tempRoot, encoding: "utf8", env: gitSafeEnv() });
+  const configEmail = spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: tempRoot, encoding: "utf8", env: gitSafeEnv() });
+  assert.equal(configName.status, 0, configName.stderr);
+  assert.equal(configEmail.status, 0, configEmail.stderr);
+  write(path.join(tempRoot, ".platform-sync-base"), "base\n");
+  const addBase = spawnSync("git", ["add", ".platform-sync-base"], { cwd: tempRoot, encoding: "utf8", env: gitSafeEnv() });
+  const commitBase = spawnSync("git", ["commit", "-qm", "platform sync base"], { cwd: tempRoot, encoding: "utf8", env: gitSafeEnv() });
+  assert.equal(addBase.status, 0, addBase.stderr);
+  assert.equal(commitBase.status, 0, commitBase.stderr);
+  const checkoutFixtureBranch = spawnSync("git", ["checkout", "-qb", "fixture-head"], { cwd: tempRoot, encoding: "utf8", env: gitSafeEnv() });
+  assert.equal(checkoutFixtureBranch.status, 0, checkoutFixtureBranch.stderr);
 
   return {
     taskDir,

--- a/tests/e2e/core/validate-artifact-platform-sync.test.ts
+++ b/tests/e2e/core/validate-artifact-platform-sync.test.ts
@@ -702,6 +702,7 @@ const createPrCases = [
   },
   {
     name: "validate-artifact platform-sync fails when PR and Issue in: labels diverge",
+    changedPath: "tests/unit/core/fixture.txt",
     issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
     prPayload: buildPrPayload({ labels: [{ name: "type: enhancement" }, { name: "in: cli" }, { name: "in: core" }] }),
     expectedStatus: 1,
@@ -709,6 +710,7 @@ const createPrCases = [
   },
   {
     name: "validate-artifact platform-sync fails when create-pr is missing the expected type label",
+    changedPath: "tests/unit/core/fixture.txt",
     taskOverrides: { type: "feature" },
     issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
     prPayload: buildPrPayload({ labels: [{ name: "in: core" }] }),
@@ -717,6 +719,7 @@ const createPrCases = [
   },
   {
     name: "validate-artifact platform-sync passes when create-pr includes the expected type label",
+    changedPath: "tests/unit/core/fixture.txt",
     taskOverrides: { type: "feature" },
     issuePayload: buildIssuePayload({ labels: [{ name: "in: core" }], body: "# Issue\n" }),
     prPayload: buildPrPayload({ labels: [{ name: "type: feature" }, { name: "in: core" }] }),
@@ -759,6 +762,22 @@ const createPrCases = [
 for (const c of createPrCases) {
   test(c.name, () => withTempRoot("agent-infra-platform-sync-pr-", (tempRoot) => {
     const ctx = setupPlatformSyncEnv(tempRoot);
+    const changedPath = "changedPath" in c ? c.changedPath : undefined;
+    if (changedPath) {
+      write(path.join(tempRoot, changedPath), "fixture\n");
+      const addResult = spawnSync("git", ["add", changedPath], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: gitSafeEnv()
+      });
+      assert.equal(addResult.status, 0, addResult.stderr);
+      const commitResult = spawnSync("git", ["commit", "-qm", "fixture change"], {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: gitSafeEnv()
+      });
+      assert.equal(commitResult.status, 0, commitResult.stderr);
+    }
     write(path.join(ctx.taskDir, "task.md"), buildTaskContent({
       issue_number: "65",
       pr_delivery_fact: boundFactValue(77),

--- a/tests/fixtures/validate-artifact/fake-gh.js
+++ b/tests/fixtures/validate-artifact/fake-gh.js
@@ -79,6 +79,16 @@ if (args[0] === "pr" && args[1] === "checks") {
   process.exit(0);
 }
 
+if (args[0] === "api" && args.includes("--paginate") && args.includes("--slurp") && args.some((arg) => /repos\/[^/]+\/[^/]+\/labels\?per_page=100$/.test(arg))) {
+  process.stdout.write(JSON.stringify([[
+    { name: "in: cli" },
+    { name: "in: templates" },
+    { name: "in: core" },
+    { name: "in: meta" }
+  ]]));
+  process.exit(0);
+}
+
 if (args[0] === "label" && args[1] === "list") {
   process.stdout.write(JSON.stringify(readJson("GH_FAKE_LABELS_PATH") || []));
   process.exit(0);

--- a/tests/integration/cli/platform-pr.test.ts
+++ b/tests/integration/cli/platform-pr.test.ts
@@ -36,9 +36,15 @@ function run(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } 
 test('platform-pr CLI advertises all PR and summary intents', () => {
   const output = run(['--help']);
   assert.equal(output.status, 0);
-  for (const operation of ['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'summary-context', 'summary-sync']) {
+  for (const operation of ['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'sync-in-labels', 'summary-context', 'summary-sync']) {
     assert.match(output.stdout, new RegExp(`platform-pr ${operation}`));
   }
+});
+
+test('platform-pr sync-in-labels validates the PR number before platform access', () => {
+  const output = run(['sync-in-labels', '--pr', '0']);
+  assert.equal(output.status, 1);
+  assert.equal(JSON.parse(output.stdout).error.code, 'PR_PAYLOAD_INVALID');
 });
 
 test('platform-pr summary-sync accepts the commit path no-op result before task resolution', () => {

--- a/tests/unit/core/pr-label-workflow.test.ts
+++ b/tests/unit/core/pr-label-workflow.test.ts
@@ -8,10 +8,15 @@ const workflowTargets = [
   "templates/.github/workflows/pr-label.yml"
 ];
 
-test("pr-label workflow template stays in sync with the root workflow", () => {
-  const [rootPath = "", templatePath = ""] = workflowTargets;
-
-  assert.equal(read(rootPath), read(templatePath));
+test("pr-label workflow uses the checked-in core and the template package core", () => {
+  const root = read(workflowTargets[0]!);
+  const template = read(workflowTargets[1]!);
+  assert.match(root, /actions\/setup-node@v7/);
+  assert.match(root, /npm ci --ignore-scripts/);
+  assert.match(root, /npm run build/);
+  assert.match(root, /node dist\/bin\/internal-cli\.js platform-pr sync-in-labels --pr "\$PR_NUMBER"/);
+  assert.match(template, /npm exec --yes --package="@fitlab-ai\/agent-infra@\$AGENT_INFRA_VERSION" -- agent-infra-internal platform-pr sync-in-labels/);
+  assert.match(template, /AGENT_INFRA_VERSION: 0\.9\.13-alpha\.0/);
 });
 
 test("pr-label workflow reacts to PR open and synchronize events", () => {
@@ -23,16 +28,12 @@ test("pr-label workflow reacts to PR open and synchronize events", () => {
   });
 });
 
-test("pr-label workflow syncs in: labels from .airc.json mappings and backfills assignees", () => {
+test("pr-label workflow delegates in-label authority and backfills assignees", () => {
   workflowTargets.forEach((relativePath) => {
     const content = read(relativePath);
 
-    assert.match(content, /jq '\.labels\.in \/\/ \{\}' \.agents\/\.airc\.json/, `${relativePath} should read labels.in from .agents/.airc.json`);
-    assert.match(content, /startswith\(\$prefix\)/, `${relativePath} should match changed files by configured path prefixes`);
     assert.match(content, /--pr "\$PR_NUMBER"/, `${relativePath} should sync labels against the PR target`);
-    assert.match(content, /--prefix "in: "/, `${relativePath} should scope label syncs to the in: prefix`);
-    assert.match(content, /set -- "\$@" --target "\$label"/, `${relativePath} should expand mapped labels into repeated target arguments`);
-    assert.match(content, /\.github\/scripts\/sync-labels-to-set\.sh "\$@"/, `${relativePath} should delegate the final diff to the shared script`);
+    assert.match(content, /platform-pr sync-in-labels/, `${relativePath} should use the typed in-label intent`);
     assert.match(content, /issues: write/, `${relativePath} should request issue write permission for PR labels`);
     assert.match(content, /pull-requests: write/, `${relativePath} should request pull request write permission for assignee updates`);
     assert.match(content, /ASSIGNEES_JSON: \$\{\{ toJSON\(github\.event\.pull_request\.assignees\) \}\}/, `${relativePath} should inspect current assignees from the event payload`);

--- a/tests/unit/platform/in-label-sync.test.ts
+++ b/tests/unit/platform/in-label-sync.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  extractPullRequestFileNames,
+  extractRepositoryLabelNames,
+  mergeInLabels,
+  planInLabelUpdate
+} from '../../../lib/platform/in-label-sync.ts';
+
+test('in-label planner computes a deterministic target and preserves unrelated labels', () => {
+  assert.deepEqual(planInLabelUpdate({
+    changedFiles: ['lib/core.ts', 'templates/.agents/rules/issue-sync.en.md'],
+    currentLabels: ['in: stale', 'type: bug', 'priority: high'],
+    mapping: { core: ['lib/'], templates: ['templates/'] },
+    repositoryLabels: new Set(['in: core', 'in: templates'])
+  }), {
+    current: ['in: stale'],
+    target: ['in: core', 'in: templates'],
+    labels: ['in: core', 'in: templates', 'priority: high', 'type: bug'],
+    changed: true
+  });
+});
+
+test('paginated GitHub values are normalized without accepting malformed file payloads', () => {
+  assert.deepEqual(extractRepositoryLabelNames([[{ name: 'in: core' }], [{ name: 'type: bug' }]]), ['in: core', 'type: bug']);
+  assert.deepEqual(extractPullRequestFileNames([[{ filename: 'a.ts' }], [{ filename: 'b.ts' }]]), ['a.ts', 'b.ts']);
+  assert.equal(extractPullRequestFileNames([{ filename: 'a.ts' }, { status: 'renamed' }]), null);
+});
+
+test('merging in labels is idempotent and removes stale in labels only', () => {
+  assert.deepEqual(mergeInLabels(['in: old', 'keep', 'keep'], ['in: new', 'in: new']), ['in: new', 'keep']);
+});

--- a/tests/unit/platform/in-label-sync.test.ts
+++ b/tests/unit/platform/in-label-sync.test.ts
@@ -4,8 +4,11 @@ import assert from 'node:assert/strict';
 import {
   extractPullRequestFileNames,
   extractRepositoryLabelNames,
+  labelDelta,
   mergeInLabels,
-  planInLabelUpdate
+  planInLabelUpdate,
+  validateInLabelMapping,
+  validateRepositoryLabelPayload
 } from '../../../lib/platform/in-label-sync.ts';
 
 test('in-label planner computes a deterministic target and preserves unrelated labels', () => {
@@ -18,7 +21,8 @@ test('in-label planner computes a deterministic target and preserves unrelated l
     current: ['in: stale'],
     target: ['in: core', 'in: templates'],
     labels: ['in: core', 'in: templates', 'priority: high', 'type: bug'],
-    changed: true
+    changed: true,
+    error: null
   });
 });
 
@@ -30,4 +34,19 @@ test('paginated GitHub values are normalized without accepting malformed file pa
 
 test('merging in labels is idempotent and removes stale in labels only', () => {
   assert.deepEqual(mergeInLabels(['in: old', 'keep', 'keep'], ['in: new', 'in: new']), ['in: new', 'keep']);
+});
+
+test('in-label authority validation fails closed for malformed mappings and repository payloads', () => {
+  assert.equal(validateInLabelMapping('lib/' as unknown).ok, false);
+  assert.equal(validateInLabelMapping({ core: 'lib/' } as unknown).ok, false);
+  assert.equal(validateInLabelMapping({ core: [''] }).ok, false);
+  assert.equal(validateRepositoryLabelPayload({ name: 'in: core' }).ok, false);
+  assert.equal(validateRepositoryLabelPayload([[{ name: 'in: core' }, { color: 'fff' }]]).ok, false);
+  assert.equal(validateRepositoryLabelPayload([[{ name: 'in: core' }], { name: 'in: cli' }] as unknown).ok, false);
+});
+
+test('label delta changes only selected prefixes', () => {
+  assert.deepEqual(labelDelta(['in: old', 'keep', 'type: bug'], ['in: new', 'keep', 'type: feature'], 'in:'), {
+    add: ['in: new'], remove: ['in: old']
+  });
 });

--- a/tests/unit/platform/issues.test.ts
+++ b/tests/unit/platform/issues.test.ts
@@ -29,10 +29,31 @@ function clientFor(handler: (args: string[], input?: string, method?: string) =>
     version() { return { ok: true, value: '2.72.0' }; },
     json(args, options = {}) {
       const value = handler(args, options.input, options.method);
+      if (value && typeof value === 'object' && (value as { ok?: unknown }).ok === false) return value as never;
       return { ok: true, value } as never;
     },
     text() { return { ok: true, value: '' }; }
   };
+}
+
+function inLabelIssueFixture() {
+  const root = fixture('7');
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
+    platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
+  }));
+  fs.writeFileSync(path.join(root, 'base.txt'), 'base\n');
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+  fs.mkdirSync(path.join(root, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'lib', 'core.ts'), 'change\n');
+  const taskPath = path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'task.md');
+  const task = fs.readFileSync(taskPath, 'utf8').replace('issue_number: 7\n---', 'issue_number: 7\ndelivery_base_ref: HEAD~1\n---');
+  fs.writeFileSync(taskPath, task);
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'change'], { cwd: root });
+  return root;
 }
 
 function contextResponse(args: string[]) {
@@ -182,6 +203,73 @@ test('issue in-label sync requires the task-bound base and uses it for diff evid
     assert.equal(result.status, 'applied');
     assert.equal((payload as Record<string, unknown> | null)?.labels, undefined);
     assert.deepEqual(currentLabels, ['keep', 'in: core']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('issue sync upgrades a deterministic in-label failure after status success to partial', () => {
+  const root = inLabelIssueFixture();
+  let labels = ['status: blocked', 'keep'];
+  try {
+    const client = clientFor((args, input) => {
+      const context = contextResponse(args);
+      if (context) return context;
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (endpoint.endsWith('/labels?per_page=100')) return [
+        { name: 'status: blocked' }, { name: 'status: in-progress' }, { name: 'in: core' }
+      ];
+      if (args.includes('DELETE') && endpoint.includes('/labels/')) {
+        labels = labels.filter((label) => label !== decodeURIComponent(endpoint.split('/labels/')[1]!));
+        return {};
+      }
+      if (args.includes('POST') && endpoint.endsWith('/labels')) {
+        const posted = JSON.parse(input || '{}').labels as string[];
+        if (posted.includes('in: core')) return { ok: false, error: { code: 'PLATFORM_REQUEST_INVALID', message: 'label rejected', retryable: false } };
+        labels.push(...posted);
+        return {};
+      }
+      return { number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7', state: 'open', title: 'x', body: '', labels: labels.map((name) => ({ name })), assignees: [], milestone: null };
+    });
+    const result = syncPlatformIssue('TASK-20260101-000001', {
+      cwd: root, agent: 'codex', status: 'in-progress', inLabels: 'from-diff', client
+    });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
+    assert.equal(result.changed, true);
+    assert.deepEqual(labels.sort(), ['keep', 'status: in-progress']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('issue sync reports changed when the post-write in-label reread fails', () => {
+  const root = inLabelIssueFixture();
+  let labels = ['keep'];
+  let issueReads = 0;
+  try {
+    const client = clientFor((args, input) => {
+      const context = contextResponse(args);
+      if (context) return context;
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (endpoint.endsWith('/labels?per_page=100')) return [{ name: 'in: core' }];
+      if (args.includes('POST') && endpoint.endsWith('/labels')) {
+        labels.push(...(JSON.parse(input || '{}').labels as string[]));
+        return {};
+      }
+      if (/issues\/7$/.test(endpoint)) {
+        issueReads += 1;
+        if (issueReads === 2) return { ok: false, error: { code: 'PLATFORM_READ_FAILED', message: 'reread failed', retryable: true } };
+      }
+      return { number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7', state: 'open', title: 'x', body: '', labels: labels.map((name) => ({ name })), assignees: [], milestone: null };
+    });
+    const result = syncPlatformIssue('TASK-20260101-000001', {
+      cwd: root, agent: 'codex', inLabels: 'from-diff', client
+    });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
+    assert.equal(result.changed, true);
+    assert.deepEqual(labels, ['keep', 'in: core']);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/platform/issues.test.ts
+++ b/tests/unit/platform/issues.test.ts
@@ -110,6 +110,67 @@ test('issue sync plans dry-run without writes and applies one converging patch',
   assert.equal(patches, 1);
 });
 
+test('issue in-label sync requires the task-bound base and uses it for diff evidence', () => {
+  const missingBase = fixture('7');
+  try {
+    const client = clientFor((args) => contextResponse(args) || {
+      number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7',
+      state: 'open', title: 'x', body: '', labels: [], assignees: [], milestone: null
+    });
+    const result = syncPlatformIssue('TASK-20260101-000001', {
+      cwd: missingBase, agent: 'codex', client, inLabels: 'from-diff'
+    });
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_BASE_MISSING');
+  } finally {
+    fs.rmSync(missingBase, { recursive: true, force: true });
+  }
+
+  const root = fixture('7');
+  try {
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'base.txt'), 'base\n');
+    execFileSync('git', ['add', '.'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+    execFileSync('git', ['branch', '-M', 'main'], { cwd: root });
+    execFileSync('git', ['checkout', '-qb', 'feature'], { cwd: root });
+    fs.writeFileSync(path.join(root, 'lib.txt'), 'change\n');
+    fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
+      platform: { type: 'github' }, labels: { in: { core: ['lib.txt'] } }
+    }));
+    fs.writeFileSync(path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'task.md'),
+      fs.readFileSync(path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'task.md'), 'utf8')
+        .replace('issue_number: 7', 'issue_number: 7\ndelivery_base_ref: main'));
+    execFileSync('git', ['add', '.'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'change'], { cwd: root });
+    let payload: Record<string, unknown> | null = null;
+    let currentLabels: string[] = [];
+    const client = clientFor((args, input) => {
+      const context = contextResponse(args);
+      if (context) return context;
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (endpoint.endsWith('/labels?per_page=100')) return [{ name: 'in: core' }];
+      if (args.includes('PATCH')) {
+        payload = JSON.parse(input || '{}') as Record<string, unknown>;
+        currentLabels = (payload.labels as string[] | undefined) || currentLabels;
+        return {};
+      }
+      return {
+        number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7',
+        state: 'open', title: 'x', body: '', labels: currentLabels.map((name) => ({ name })), assignees: [], milestone: null
+      };
+    });
+    const result = syncPlatformIssue('TASK-20260101-000001', {
+      cwd: root, agent: 'codex', client, inLabels: 'from-diff'
+    });
+    assert.equal(result.status, 'applied');
+    assert.deepEqual((payload as Record<string, unknown> | null)?.labels, ['in: core']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('requirement anchors follow the deterministically selected Issue Form', () => {
   const root = fixture('7');
   const formDir = path.join(root, '.github', 'ISSUE_TEMPLATE');

--- a/tests/unit/platform/issues.test.ts
+++ b/tests/unit/platform/issues.test.ts
@@ -83,7 +83,7 @@ test('issue create binds exactly once and replay inspects the existing binding',
   assert.equal(posts, 1);
 });
 
-test('issue sync plans dry-run without writes and applies one converging patch', () => {
+test('issue sync plans dry-run without writes and applies incremental label writes', () => {
   const root = fixture('7');
   let patches = 0;
   let labels = ['status: blocked'];
@@ -92,9 +92,16 @@ test('issue sync plans dry-run without writes and applies one converging patch',
     if (context) return context;
     const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
     if (endpoint.endsWith('/labels?per_page=100')) return [{ name: 'status: blocked' }, { name: 'status: in-progress' }];
+    if (args.includes('DELETE') && endpoint.includes('/labels/')) {
+      labels = labels.filter((label) => label !== decodeURIComponent(endpoint.split('/labels/')[1]!));
+      return {};
+    }
+    if (args.includes('POST') && endpoint.endsWith('/labels')) {
+      labels.push(...(JSON.parse(input || '{}').labels as string[]));
+      return {};
+    }
     if (args.includes('PATCH')) {
       patches += 1;
-      labels = JSON.parse(input || '{}').labels;
       return {};
     }
     return { number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7', state: 'open', title: 'x', body: '', labels: labels.map((name) => ({ name })), assignees: [], milestone: null };
@@ -104,19 +111,20 @@ test('issue sync plans dry-run without writes and applies one converging patch',
   assert.equal(patches, 0);
   const applied = syncPlatformIssue('TASK-20260101-000001', { cwd: root, agent: 'codex', status: 'in-progress', client });
   assert.equal(applied.status, 'applied');
-  assert.equal(patches, 1);
+  assert.equal(patches, 0);
+  assert.deepEqual(labels.sort(), ['status: in-progress']);
   const replay = syncPlatformIssue('TASK-20260101-000001', { cwd: root, agent: 'codex', status: 'in-progress', client });
   assert.equal(replay.status, 'no-op');
-  assert.equal(patches, 1);
+  assert.equal(patches, 0);
 });
 
 test('issue in-label sync requires the task-bound base and uses it for diff evidence', () => {
   const missingBase = fixture('7');
   try {
-    const client = clientFor((args) => contextResponse(args) || {
+    const client = clientFor((args) => contextResponse(args) || (args.some((arg) => arg.endsWith('/labels?per_page=100')) ? [{ name: 'in: core' }] : {
       number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/acme/widgets/issues/7',
       state: 'open', title: 'x', body: '', labels: [], assignees: [], milestone: null
-    });
+    }));
     const result = syncPlatformIssue('TASK-20260101-000001', {
       cwd: missingBase, agent: 'codex', client, inLabels: 'from-diff'
     });
@@ -145,15 +153,22 @@ test('issue in-label sync requires the task-bound base and uses it for diff evid
     execFileSync('git', ['add', '.'], { cwd: root });
     execFileSync('git', ['commit', '-qm', 'change'], { cwd: root });
     let payload: Record<string, unknown> | null = null;
-    let currentLabels: string[] = [];
+    let currentLabels: string[] = ['in: stale', 'keep'];
     const client = clientFor((args, input) => {
       const context = contextResponse(args);
       if (context) return context;
       const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
       if (endpoint.endsWith('/labels?per_page=100')) return [{ name: 'in: core' }];
+      if (args.includes('DELETE') && endpoint.includes('/labels/')) {
+        currentLabels = currentLabels.filter((label) => label !== decodeURIComponent(endpoint.split('/labels/')[1]!));
+        return {};
+      }
+      if (args.includes('POST') && endpoint.endsWith('/labels')) {
+        currentLabels.push(...(JSON.parse(input || '{}').labels as string[]));
+        return {};
+      }
       if (args.includes('PATCH')) {
         payload = JSON.parse(input || '{}') as Record<string, unknown>;
-        currentLabels = (payload.labels as string[] | undefined) || currentLabels;
         return {};
       }
       return {
@@ -165,7 +180,8 @@ test('issue in-label sync requires the task-bound base and uses it for diff evid
       cwd: root, agent: 'codex', client, inLabels: 'from-diff'
     });
     assert.equal(result.status, 'applied');
-    assert.deepEqual((payload as Record<string, unknown> | null)?.labels, ['in: core']);
+    assert.equal((payload as Record<string, unknown> | null)?.labels, undefined);
+    assert.deepEqual(currentLabels, ['keep', 'in: core']);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/platform/metadata-labels.test.ts
+++ b/tests/unit/platform/metadata-labels.test.ts
@@ -13,3 +13,11 @@ test('shared metadata labels normalize task types and configured path matches', 
     new Set(['in: cli', 'in: templates'])
   ), ['in: cli', 'in: templates']);
 });
+
+test('configured path matches stop at directory boundaries', () => {
+  assert.deepEqual(computeInLabels(
+    ['library/README.md'],
+    { lib: ['lib/'], library: ['lib'] },
+    new Set(['in: lib', 'in: library'])
+  ), []);
+});

--- a/tests/unit/platform/pull-request-metadata.test.ts
+++ b/tests/unit/platform/pull-request-metadata.test.ts
@@ -11,7 +11,8 @@ test('PR metadata planner converges labels, assignees and milestone deterministi
     issue: { labels: ['type: enhancement', 'in: cli', 'status: in-progress'], assignees: ['codex'], milestone: '0.8.7' },
     taskType: 'refactor',
     issueNumber: 622,
-    capabilities
+    capabilities,
+    inLabels: ['in: cli']
   });
   assert.deepEqual(planned.operations.map(({ name, status, value }) => ({ name, status, value })), [
     { name: 'labels', status: 'planned', value: ['in: cli', 'old', 'type: enhancement'] },
@@ -19,6 +20,19 @@ test('PR metadata planner converges labels, assignees and milestone deterministi
     { name: 'milestone', status: 'planned', value: '0.8.7' },
     { name: 'closing-issue', status: 'planned', value: 'Body\n\nCloses #622' }
   ]);
+});
+
+test('PR metadata planner does not copy Issue in labels when no PR target is supplied', () => {
+  const planned = planPullRequestMetadata({
+    pullRequest: { labels: ['in: pr'], assignees: [], milestone: null, body: '' },
+    issue: { labels: ['in: issue'], assignees: [], milestone: null },
+    taskType: 'task',
+    issueNumber: 9,
+    capabilities
+  });
+  assert.deepEqual(planned.operations[0], {
+    name: 'labels', status: 'planned', reasonCode: null, value: ['in: pr', 'type: task']
+  });
 });
 
 test('PR metadata planner preserves permission-bound state and closing references are idempotent', () => {

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -12,9 +12,10 @@ import {
   resolveGitHubChangeRequestGitEvidence,
   selectExternalPullRequest,
   selectPullRequest,
+  syncPlatformPullRequestInLabels,
   warningResultForPrimary
 } from '../../../lib/platform/pull-requests.ts';
-import type { GitHubClient } from '../../../lib/platform/github-client.ts';
+import type { GitHubClient, RequestOptions } from '../../../lib/platform/github-client.ts';
 
 const remote = (number: number, head = 'feature', base = 'main') => ({
   number,
@@ -115,6 +116,140 @@ test('inspectPlatformPullRequestByNumber reads a bare PR number without a task b
     assert.equal(result.task.prNumber, 42);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('in-label PR sync derives one target from PR files, updates Issue before PR, and re-reads both', () => {
+  const root = prByNumberFixture();
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
+    platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
+  }));
+  let issueLabels = ['in: stale', 'keep'];
+  let prLabels = ['in: stale', 'type: feature'];
+  const calls: string[] = [];
+  const client: GitHubClient = {
+    version() { return { ok: true, value: '2.72.0' }; },
+    json(args: string[], options: RequestOptions = {}) {
+      const joined = args.join(' ');
+      calls.push(joined);
+      if (args[1] === 'graphql' && args.some((arg) => arg.includes('viewer { login }'))) {
+        return { ok: true, value: { data: { viewer: { login: 'codex' } } } };
+      }
+      if (args[0] === 'api' && args[1] === 'repos/o/r') {
+        return { ok: true, value: { full_name: 'o/r', fork: false, permissions: { triage: true, push: true, admin: false } } };
+      }
+      if (/pulls\/42$/.test(args[1] || '')) return { ok: true, value: { ...remote(42), labels: prLabels.map((name) => ({ name })) } };
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (/pulls\/42\/files\?/.test(endpoint)) return { ok: true, value: [[{ filename: 'lib/core.ts' }]] };
+      if (/labels\?per_page=100$/.test(endpoint)) return { ok: true, value: [[{ name: 'in: core' }, { name: 'in: stale' }]] };
+      if (args[1] === 'graphql' && args.some((arg) => arg.includes('closingIssuesReferences'))) {
+        return { ok: true, value: { data: { repository: { pullRequest: {
+          closingIssuesReferences: { nodes: [{ number: 7 }], pageInfo: { hasNextPage: false, endCursor: null } }
+        } } } } };
+      }
+      if (/issues\/7$/.test(args[1] || '')) return { ok: true, value: {
+        number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/o/r/issues/7', state: 'open', title: 'Issue', body: '',
+        labels: issueLabels.map((name) => ({ name })), assignees: [], milestone: null
+      } };
+      if (args.includes('PUT') && /issues\/7\/labels$/.test(args[1] || '')) {
+        issueLabels = JSON.parse(options.input || '{}').labels;
+        return { ok: true, value: {} };
+      }
+      if (args.includes('PUT') && /issues\/42\/labels$/.test(args[1] || '')) {
+        prLabels = JSON.parse(options.input || '{}').labels;
+        return { ok: true, value: {} };
+      }
+      return { ok: false, error: { code: 'PLATFORM_REQUEST_FAILED', message: joined, retryable: false } };
+    },
+    text() { return { ok: true, value: '' }; }
+  } as unknown as GitHubClient;
+  try {
+    const result = syncPlatformPullRequestInLabels(42, { cwd: root, client });
+    assert.equal(result.status, 'applied', JSON.stringify({ error: result.error, operations: result.operations, resources: result.resources, calls }));
+    assert.deepEqual(issueLabels, ['in: core', 'keep']);
+    assert.deepEqual(prLabels, ['in: core', 'type: feature']);
+    assert.ok(calls.findIndex((call) => /issues\/7\/labels/.test(call)) < calls.findIndex((call) => /issues\/42\/labels/.test(call)));
+    assert.deepEqual(result.evidence?.pullRequestFiles, ['lib/core.ts']);
+    assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'applied']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPullRequestWrite?: boolean } = {}) {
+  const root = prByNumberFixture();
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
+    platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
+  }));
+  let issueLabels = ['in: stale', 'keep'];
+  let prLabels = ['in: stale', 'type: feature'];
+  const calls: string[] = [];
+  const client: GitHubClient = {
+    version() { return { ok: true, value: '2.72.0' }; },
+    json(args: string[], request: RequestOptions = {}) {
+      const joined = args.join(' ');
+      calls.push(joined);
+      if (args[1] === 'graphql' && args.some((arg) => arg.includes('viewer { login }'))) {
+        return { ok: true, value: { data: { viewer: { login: 'codex' } } } };
+      }
+      if (args[0] === 'api' && args[1] === 'repos/o/r') {
+        return { ok: true, value: { full_name: 'o/r', fork: false, permissions: { triage: true, push: true, admin: false } } };
+      }
+      if (/pulls\/42$/.test(args[1] || '')) return { ok: true, value: { ...remote(42), labels: prLabels.map((name) => ({ name })) } };
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (/pulls\/42\/files\?/.test(endpoint)) return { ok: true, value: [[{ filename: 'lib/core.ts' }]] };
+      if (/labels\?per_page=100$/.test(endpoint)) return { ok: true, value: [[{ name: 'in: core' }, { name: 'in: stale' }]] };
+      if (args[1] === 'graphql' && args.some((arg) => arg.includes('closingIssuesReferences'))) {
+        return { ok: true, value: { data: { repository: { pullRequest: {
+          closingIssuesReferences: { nodes: closingIssues.map((number) => ({ number })), pageInfo: { hasNextPage: false, endCursor: null } }
+        } } } } };
+      }
+      if (/issues\/7$/.test(args[1] || '')) return { ok: true, value: {
+        number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/o/r/issues/7', state: 'open', title: 'Issue', body: '',
+        labels: issueLabels.map((name) => ({ name })), assignees: [], milestone: null
+      } };
+      if (args.includes('PUT') && /issues\/7\/labels$/.test(args[1] || '')) {
+        issueLabels = JSON.parse(request.input || '{}').labels;
+        return { ok: true, value: {} };
+      }
+      if (args.includes('PUT') && /issues\/42\/labels$/.test(args[1] || '')) {
+        if (fixtureOptions.failPullRequestWrite) return { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'network timeout', retryable: true } };
+        prLabels = JSON.parse(request.input || '{}').labels;
+        return { ok: true, value: {} };
+      }
+      return { ok: false, error: { code: 'PLATFORM_REQUEST_FAILED', message: joined, retryable: false } };
+    },
+    text() { return { ok: true, value: '' }; }
+  } as unknown as GitHubClient;
+  return { root, client, calls, getPrLabels: () => prLabels, getIssueLabels: () => issueLabels };
+}
+
+test('in-label PR sync updates only the PR when no unique closing Issue exists', () => {
+  for (const closingIssues of [[], [7, 8]]) {
+    const fixture = prOnlyInLabelFixture(closingIssues);
+    try {
+      const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
+      assert.equal(result.status, 'degraded');
+      assert.deepEqual(fixture.getPrLabels(), ['in: core', 'type: feature']);
+      assert.equal(fixture.calls.some((call) => /issues\/7|issues\/8/.test(call)), false);
+      assert.equal(result.resources?.length, 1);
+      assert.equal(result.resources?.[0]?.kind, 'pull-request');
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('in-label PR sync blocks with partial evidence when the PR write is uncertain after Issue convergence', () => {
+  const fixture = prOnlyInLabelFixture([7], { failPullRequestWrite: true });
+  try {
+    const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
+    assert.deepEqual(fixture.getIssueLabels(), ['in: core', 'keep']);
+    assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'unknown']);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 
 import {
   inspectPlatformPullRequestByNumber,
@@ -12,10 +12,12 @@ import {
   resolveGitHubChangeRequestGitEvidence,
   selectExternalPullRequest,
   selectPullRequest,
+  syncPlatformPullRequest,
   syncPlatformPullRequestInLabels,
   warningResultForPrimary
 } from '../../../lib/platform/pull-requests.ts';
 import type { GitHubClient, RequestOptions } from '../../../lib/platform/github-client.ts';
+import { buildBoundFact, encodePrDeliveryFact } from '../../../lib/task/pr-delivery-fact.ts';
 
 const remote = (number: number, head = 'feature', base = 'main') => ({
   number,
@@ -151,12 +153,16 @@ test('in-label PR sync derives one target from PR files, updates Issue before PR
         number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/o/r/issues/7', state: 'open', title: 'Issue', body: '',
         labels: issueLabels.map((name) => ({ name })), assignees: [], milestone: null
       } };
-      if (args.includes('PUT') && /issues\/7\/labels$/.test(args[1] || '')) {
-        issueLabels = JSON.parse(options.input || '{}').labels;
+      if (args.includes('DELETE') && /issues\/(7|42)\/labels\//.test(endpoint)) {
+        const name = decodeURIComponent(endpoint.split('/labels/')[1]!);
+        if (endpoint.includes('/issues/7/')) issueLabels = issueLabels.filter((label) => label !== name);
+        else prLabels = prLabels.filter((label) => label !== name);
         return { ok: true, value: {} };
       }
-      if (args.includes('PUT') && /issues\/42\/labels$/.test(args[1] || '')) {
-        prLabels = JSON.parse(options.input || '{}').labels;
+      if (args.includes('POST') && /issues\/(7|42)\/labels$/.test(endpoint)) {
+        const labels = JSON.parse(options.input || '{}').labels as string[];
+        if (endpoint.includes('/issues/7/')) issueLabels.push(...labels);
+        else prLabels.push(...labels);
         return { ok: true, value: {} };
       }
       return { ok: false, error: { code: 'PLATFORM_REQUEST_FAILED', message: joined, retryable: false } };
@@ -166,8 +172,8 @@ test('in-label PR sync derives one target from PR files, updates Issue before PR
   try {
     const result = syncPlatformPullRequestInLabels(42, { cwd: root, client });
     assert.equal(result.status, 'applied', JSON.stringify({ error: result.error, operations: result.operations, resources: result.resources, calls }));
-    assert.deepEqual(issueLabels, ['in: core', 'keep']);
-    assert.deepEqual(prLabels, ['in: core', 'type: feature']);
+    assert.deepEqual([...issueLabels].sort(), ['in: core', 'keep']);
+    assert.deepEqual([...prLabels].sort(), ['in: core', 'type: feature']);
     assert.ok(calls.findIndex((call) => /issues\/7\/labels/.test(call)) < calls.findIndex((call) => /issues\/42\/labels/.test(call)));
     assert.deepEqual(result.evidence?.pullRequestFiles, ['lib/core.ts']);
     assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'applied']);
@@ -176,7 +182,7 @@ test('in-label PR sync derives one target from PR files, updates Issue before PR
   }
 });
 
-function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPullRequestWrite?: boolean } = {}) {
+function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPullRequestWrite?: boolean; injectConcurrentUnrelatedLabel?: boolean } = {}) {
   const root = prByNumberFixture();
   fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
     platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
@@ -208,13 +214,20 @@ function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPul
         number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/o/r/issues/7', state: 'open', title: 'Issue', body: '',
         labels: issueLabels.map((name) => ({ name })), assignees: [], milestone: null
       } };
-      if (args.includes('PUT') && /issues\/7\/labels$/.test(args[1] || '')) {
-        issueLabels = JSON.parse(request.input || '{}').labels;
+      if (args.includes('DELETE') && /issues\/(7|42)\/labels\//.test(endpoint)) {
+        if (fixtureOptions.injectConcurrentUnrelatedLabel && endpoint.includes('/issues/42/') && !prLabels.includes('unrelated: concurrent')) {
+          prLabels.push('unrelated: concurrent');
+        }
+        const name = decodeURIComponent(endpoint.split('/labels/')[1]!);
+        if (endpoint.includes('/issues/7/')) issueLabels = issueLabels.filter((label) => label !== name);
+        else prLabels = prLabels.filter((label) => label !== name);
         return { ok: true, value: {} };
       }
-      if (args.includes('PUT') && /issues\/42\/labels$/.test(args[1] || '')) {
-        if (fixtureOptions.failPullRequestWrite) return { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'network timeout', retryable: true } };
-        prLabels = JSON.parse(request.input || '{}').labels;
+      if (args.includes('POST') && /issues\/(7|42)\/labels$/.test(endpoint)) {
+        if (fixtureOptions.failPullRequestWrite && endpoint.includes('/issues/42/')) return { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'network timeout', retryable: true } };
+        const labels = JSON.parse(request.input || '{}').labels as string[];
+        if (endpoint.includes('/issues/7/')) issueLabels.push(...labels);
+        else prLabels.push(...labels);
         return { ok: true, value: {} };
       }
       return { ok: false, error: { code: 'PLATFORM_REQUEST_FAILED', message: joined, retryable: false } };
@@ -224,13 +237,146 @@ function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPul
   return { root, client, calls, getPrLabels: () => prLabels, getIssueLabels: () => issueLabels };
 }
 
+function boundPullRequestFixture(options: { milestoneFailure?: boolean; failPullRequestLabel?: boolean; prLabels?: string[] } = {}) {
+  const root = prByNumberFixture();
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  fs.writeFileSync(path.join(root, 'base.txt'), 'base\n');
+  execFileSync('git', ['add', 'base.txt'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+  fs.mkdirSync(path.join(root, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'lib', 'core.ts'), 'change\n');
+  execFileSync('git', ['add', 'lib/core.ts'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'change'], { cwd: root });
+  fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
+    platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
+  }));
+  const taskId = 'TASK-20260101-000001';
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  const fact = buildBoundFact({
+    identity: {
+      repository: 'o/r', number: 42, nodeId: 'PR_42', url: 'https://github.com/o/r/pull/42',
+      head: { repository: 'o/r', ref: 'feature', sha: 'sha-42' },
+      base: { repository: 'o/r', ref: 'main', sha: 'base-42' }
+    }, source: 'created', verifiedAt: '2026-01-01T00:00:00.000Z', remoteState: 'open', issueNumber: 7
+  });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), [
+    '---', `id: ${taskId}`, 'type: feature', 'status: active', 'issue_number: 7',
+    'delivery_base_ref: HEAD~1', `pr_delivery_fact: ${JSON.stringify(encodePrDeliveryFact(fact))}`, '---', ''
+  ].join('\n'));
+  let issueLabels = ['in: stale', 'keep'];
+  let prLabels = options.prLabels || ['in: stale', 'type: feature'];
+  let prBody = 'Body';
+  const issueMilestone = options.milestoneFailure ? '1.0.1' : '1.0.0';
+  const writes: string[] = [];
+  const client: GitHubClient = {
+    version() { return { ok: true, value: '2.72.0' }; },
+    json(args: string[], request: RequestOptions = {}) {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) || '';
+      if (args[1] === 'graphql' && args.some((arg) => arg.includes('viewer { login }'))) {
+        return { ok: true, value: { data: { viewer: { login: 'codex' } } } };
+      }
+      if (args[0] === 'api' && args[1] === 'repos/o/r') {
+        return { ok: true, value: { full_name: 'o/r', fork: false, permissions: { triage: true, push: false, admin: false } } };
+      }
+      if (/pulls\/42$/.test(args[1] || '')) return { ok: true, value: { ...remote(42), body: prBody, labels: prLabels.map((name) => ({ name })) } };
+      if (/labels\?per_page=100$/.test(endpoint)) return { ok: true, value: [[{ name: 'in: core' }, { name: 'in: stale' }]] };
+      if (/issues\/7$/.test(args[1] || '')) return { ok: true, value: {
+        number: 7, id: 70, node_id: 'I_7', html_url: 'https://github.com/o/r/issues/7', state: 'open', title: 'Issue', body: '',
+        labels: issueLabels.map((name) => ({ name })), assignees: [{ login: 'codex' }], milestone: { title: issueMilestone }
+      } };
+      if (/milestones\?state=open/.test(endpoint)) {
+        if (options.milestoneFailure) return { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'milestone lookup failed', retryable: true } };
+        return { ok: true, value: [[{ title: '1.0.0', number: 100 }, { title: '1.0.1', number: 101 }]] };
+      }
+      if (args.includes('DELETE') && /issues\/(7|42)\/labels\//.test(endpoint)) {
+        const name = decodeURIComponent(endpoint.split('/labels/')[1]!);
+        if (endpoint.includes('/issues/7/')) issueLabels = issueLabels.filter((label) => label !== name);
+        else prLabels = prLabels.filter((label) => label !== name);
+        writes.push(`DELETE ${endpoint}`);
+        return { ok: true, value: {} };
+      }
+      if (args.includes('POST') && /issues\/(7|42)\/labels$/.test(endpoint)) {
+        if (options.failPullRequestLabel && endpoint.includes('/issues/42/')) {
+          writes.push(`POST ${endpoint}`);
+          return { ok: false, error: { code: 'PLATFORM_REQUEST_INVALID', message: 'label rejected', retryable: false } };
+        }
+        const labels = JSON.parse(request.input || '{}').labels as string[];
+        if (endpoint.includes('/issues/7/')) issueLabels.push(...labels);
+        else prLabels.push(...labels);
+        writes.push(`POST ${endpoint}`);
+        return { ok: true, value: {} };
+      }
+      if (args.includes('PATCH') && /issues\/42$/.test(endpoint)) {
+        writes.push(`PATCH ${endpoint}`);
+        const payload = JSON.parse(request.input || '{}') as { body?: string };
+        if (payload.body !== undefined) prBody = payload.body;
+        return { ok: true, value: {} };
+      }
+      return { ok: false, error: { code: 'PLATFORM_REQUEST_FAILED', message: args.join(' '), retryable: false } };
+    },
+    text() { return { ok: true, value: '' }; }
+  } as unknown as GitHubClient;
+  return { root, taskId, client, writes, getIssueLabels: () => issueLabels, getPrLabels: () => prLabels };
+}
+
+test('task-bound PR sync reads milestone prerequisites before writing Issue labels', () => {
+  const fixture = boundPullRequestFixture({ milestoneFailure: true });
+  try {
+    const result = syncPlatformPullRequest(fixture.taskId, {
+      cwd: fixture.root, agent: 'codex', metadata: true, primaryResult: 'no_op', client: fixture.client
+    });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'NETWORK_TRANSIENT');
+    assert.deepEqual(fixture.writes, []);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('task-bound PR sync blocks with partial evidence on a nonretryable PR label failure', () => {
+  const fixture = boundPullRequestFixture({ failPullRequestLabel: true, prLabels: ['type: feature'] });
+  try {
+    const result = syncPlatformPullRequest(fixture.taskId, {
+      cwd: fixture.root, agent: 'codex', metadata: true, primaryResult: 'no_op', client: fixture.client
+    });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
+    assert.equal(result.changed, true);
+    assert.deepEqual(fixture.getIssueLabels().sort(), ['in: core', 'keep']);
+    assert.deepEqual(fixture.getPrLabels(), ['type: feature']);
+    assert.equal(result.warnings?.length, 0);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('task-bound PR metadata and in-label sync replay as no-op after convergence', () => {
+  const fixture = boundPullRequestFixture();
+  try {
+    const first = syncPlatformPullRequest(fixture.taskId, {
+      cwd: fixture.root, agent: 'codex', metadata: true, primaryResult: 'no_op', client: fixture.client
+    });
+    assert.equal(first.status, 'applied', JSON.stringify({ error: first.error, writes: fixture.writes }));
+    const writes = fixture.writes.length;
+    const second = syncPlatformPullRequest(fixture.taskId, {
+      cwd: fixture.root, agent: 'codex', metadata: true, primaryResult: 'no_op', client: fixture.client
+    });
+    assert.equal(second.status, 'no-op');
+    assert.equal(fixture.writes.length, writes);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test('in-label PR sync updates only the PR when no unique closing Issue exists', () => {
   for (const closingIssues of [[], [7, 8]]) {
     const fixture = prOnlyInLabelFixture(closingIssues);
     try {
       const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
       assert.equal(result.status, 'degraded');
-      assert.deepEqual(fixture.getPrLabels(), ['in: core', 'type: feature']);
+      assert.deepEqual([...fixture.getPrLabels()].sort(), ['in: core', 'type: feature']);
       assert.equal(fixture.calls.some((call) => /issues\/7|issues\/8/.test(call)), false);
       assert.equal(result.resources?.length, 1);
       assert.equal(result.resources?.[0]?.kind, 'pull-request');
@@ -246,8 +392,19 @@ test('in-label PR sync blocks with partial evidence when the PR write is uncerta
     const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
     assert.equal(result.status, 'blocked');
     assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
-    assert.deepEqual(fixture.getIssueLabels(), ['in: core', 'keep']);
+    assert.deepEqual([...fixture.getIssueLabels()].sort(), ['in: core', 'keep']);
     assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'unknown']);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('in-label PR sync preserves an unrelated label added after the initial read', () => {
+  const fixture = prOnlyInLabelFixture([], { injectConcurrentUnrelatedLabel: true });
+  try {
+    const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
+    assert.equal(result.status, 'degraded');
+    assert.deepEqual([...fixture.getPrLabels()].sort(), ['in: core', 'type: feature', 'unrelated: concurrent']);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/tests/unit/platform/pull-requests.test.ts
+++ b/tests/unit/platform/pull-requests.test.ts
@@ -182,13 +182,13 @@ test('in-label PR sync derives one target from PR files, updates Issue before PR
   }
 });
 
-function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPullRequestWrite?: boolean; injectConcurrentUnrelatedLabel?: boolean } = {}) {
+function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPullRequestWrite?: boolean; failPullRequestDeterministic?: boolean; injectConcurrentUnrelatedLabel?: boolean; prLabels?: string[] } = {}) {
   const root = prByNumberFixture();
   fs.writeFileSync(path.join(root, '.agents', '.airc.json'), JSON.stringify({
     platform: { type: 'github' }, labels: { in: { core: ['lib/'] } }
   }));
   let issueLabels = ['in: stale', 'keep'];
-  let prLabels = ['in: stale', 'type: feature'];
+  let prLabels = fixtureOptions.prLabels || ['in: stale', 'type: feature'];
   const calls: string[] = [];
   const client: GitHubClient = {
     version() { return { ok: true, value: '2.72.0' }; },
@@ -224,7 +224,11 @@ function prOnlyInLabelFixture(closingIssues: number[], fixtureOptions: { failPul
         return { ok: true, value: {} };
       }
       if (args.includes('POST') && /issues\/(7|42)\/labels$/.test(endpoint)) {
-        if (fixtureOptions.failPullRequestWrite && endpoint.includes('/issues/42/')) return { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'network timeout', retryable: true } };
+        if (fixtureOptions.failPullRequestWrite && endpoint.includes('/issues/42/')) {
+          return fixtureOptions.failPullRequestDeterministic
+            ? { ok: false, error: { code: 'PLATFORM_REQUEST_INVALID', message: 'label rejected', retryable: false } }
+            : { ok: false, error: { code: 'NETWORK_TRANSIENT', message: 'network timeout', retryable: true } };
+        }
         const labels = JSON.parse(request.input || '{}').labels as string[];
         if (endpoint.includes('/issues/7/')) issueLabels.push(...labels);
         else prLabels.push(...labels);
@@ -394,6 +398,23 @@ test('in-label PR sync blocks with partial evidence when the PR write is uncerta
     assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
     assert.deepEqual([...fixture.getIssueLabels()].sort(), ['in: core', 'keep']);
     assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'unknown']);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('in-label PR sync upgrades a deterministic PR failure after Issue convergence to partial', () => {
+  const fixture = prOnlyInLabelFixture([7], {
+    failPullRequestWrite: true, failPullRequestDeterministic: true, prLabels: ['type: feature']
+  });
+  try {
+    const result = syncPlatformPullRequestInLabels(42, { cwd: fixture.root, client: fixture.client });
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.error?.code, 'IN_LABEL_SYNC_PARTIAL');
+    assert.equal(result.changed, true);
+    assert.deepEqual([...fixture.getIssueLabels()].sort(), ['in: core', 'keep']);
+    assert.deepEqual(fixture.getPrLabels(), ['type: feature']);
+    assert.deepEqual(result.resources?.map((resource) => resource.effect), ['applied', 'no-op']);
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- 修复 code-task checkpoint、Issue 同步、PR 元数据同步和完成校验之间的 `in:*` 标签事实链路。
- 将 `in:*` 计算与增量同步收敛到共享 typed 平台路径，保护 `type:*`、`status:*` 和其他无关标签。
- 修复多资源同步在已有成功写入后发生确定性失败时的 partial 状态和 `changed` 证据丢失。
- 历史数据回填保持为 PR 创建后、合入后执行的一次性人工审计，不新增历史回填代码或长期扫描器。

## Implementation

- 为 Issue、PR 及验证门禁补充基于实际 diff、任务绑定和 `labels.in` 映射的 `in:*` target 计算与一致性检查。
- 更新 root/template workflow 和双语协作文档，使 `in:*` 写入遵循单一权威路径，并保留精确包版本发布后的模板激活边界。
- 增加 Issue/PR 部分写入、并发保护、空集合和 workflow 执行链的单元、集成及端到端覆盖。
- Round 3 补充 Issue 状态成功后标签失败、写后重读失败，以及 Issue 成功后 PR 失败的回归测试。

## Validation

- 定向平台测试：31 passed, 0 failed。
- 核心测试：2424 passed, 6 skipped, 0 failed。
- 完整测试：2755 passed, 7 skipped, 0 failed。
- 最终代码审查：Approved；0 blocker、0 major、0 minor。

## Manual validation required

1. 合入后发布与 `package.json` 一致的精确 npm 版本，在 clean runner 执行模板 smoke，成功后再激活模板 workflow。
2. 按 HD-1/HDR-3 窗口逐项审计 Issue/PR 的 `in:*` 标签，记录 before/expected/after 和排除理由，完成必要的一次性回填，并以第二次运行 no-op 收尾；不得修改 `type:*`、`status:*` 或 NOT_PLANNED 明确清理的标签。

Closes #950

Generated with AI assistance
