### PR TITLE
refactor(task): 扩展模型驱动恢复协议到其他生命周期阶段


### DIFF
--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -29,7 +29,7 @@
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — `run-task` 的 fresh executor/reviewer、一次性 receipt、暂停恢复与安全终点规则。
 - [`review-handshake.md`](review-handshake.md) — 三阶段双向审查握手协议：四态处置、对称证据、分歧账本、收敛与 post-review commit 门禁。
 - [`review-method.md`](review-method.md) — 三阶段共享检视方法：多遍检视、风险镜头、追踪与 finding 证据契约。
-- [`local-artifact-repair.md`](local-artifact-repair.md) — review artifact 失败后的模型逐例修复、机械安全门、动态收敛与结果输出契约。
+- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
 - [`human-decision-context.md`](human-decision-context.md) — 新建人工裁决详情的自足上下文与规范结构。
 - [`task-short-id.md`](task-short-id.md) — 裸数字任务短号的解析、分配与生命周期。
 - [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。

--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -29,7 +29,7 @@
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — `run-task` 的 fresh executor/reviewer、一次性 receipt、暂停恢复与安全终点规则。
 - [`review-handshake.md`](review-handshake.md) — 三阶段双向审查握手协议：四态处置、对称证据、分歧账本、收敛与 post-review commit 门禁。
 - [`review-method.md`](review-method.md) — 三阶段共享检视方法：多遍检视、风险镜头、追踪与 finding 证据契约。
-- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
+- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan/code completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
 - [`human-decision-context.md`](human-decision-context.md) — 新建人工裁决详情的自足上下文与规范结构。
 - [`task-short-id.md`](task-short-id.md) — 裸数字任务短号的解析、分配与生命周期。
 - [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。

--- a/.agents/rules/local-artifact-repair.md
+++ b/.agents/rules/local-artifact-repair.md
@@ -1,10 +1,10 @@
 # 通用规则 - 模型驱动的本地产物修复
 
-本规则适用于 `analyze-task`、`plan-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+本规则适用于 `analyze-task`、`plan-task`、`code-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
 
-## 分析和方案产物完成前门禁
+## 分析、方案和代码产物完成前门禁
 
-- `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
+- `analyze-task`、`plan-task` 和 `code-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
 - `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
 - 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并在写 task.md 前原子转换为 `consumed` 状态。消费失败时不得写任务；转换后的 intent 是可重试的 durable 记录，成功写入后不再执行可能失败的后置删除。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。

--- a/.agents/rules/local-artifact-repair.md
+++ b/.agents/rules/local-artifact-repair.md
@@ -1,12 +1,18 @@
 # 通用规则 - 模型驱动的本地产物修复
 
-本规则只适用于 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+本规则适用于 `analyze-task`、`plan-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+
+## 分析和方案产物完成前门禁
+
+- `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
+- `finalize-local` 是只读校验。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界
 
 - finalizer 只负责读取事实、校验状态、规范化成功结果和原子写入；它不维护可修复错误码白名单，不推断 repairability，也不自动选择要删除的报告内容。
 - 首次 finalizer 调用不计入修复次数。只有在机械安全门通过后，模型明确判断当前问题能通过最小、可解释的 artifact 修改解决时，才允许编辑。
-- 模型只能修改当前 review skill 声明的一个普通 review artifact，且该文件必须位于当前 task 目录。不得修改 task.md、审查分歧账本、receipt、源码、其他报告或远端资源。
+- 模型只能修改当前 skill 声明的一个普通本地产物，且该文件必须位于当前 task 目录。不得修改 task.md、审查分歧账本、receipt、源码、其他报告或远端资源。
 - `changed=false`、错误码或某个格式形状只是诊断事实，不是自动批准。模型必须结合完整诊断、artifact 内容和上下文逐例判断。
 
 ## 不可绕过的机械安全门

--- a/.agents/rules/local-artifact-repair.md
+++ b/.agents/rules/local-artifact-repair.md
@@ -6,7 +6,7 @@
 
 - `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
 - `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
-- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并消费同一 intent。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
+- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并在写 task.md 前原子转换为 `consumed` 状态。消费失败时不得写任务；转换后的 intent 是可重试的 durable 记录，成功写入后不再执行可能失败的后置删除。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界

--- a/.agents/rules/local-artifact-repair.md
+++ b/.agents/rules/local-artifact-repair.md
@@ -5,7 +5,8 @@
 ## 分析和方案产物完成前门禁
 
 - `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
-- `finalize-local` 是只读校验。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并消费同一 intent。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -208,9 +208,9 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
   ```bash
   agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
   ```
-  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`；finalizer 已记录对应的一次性本地 provenance intent。
   - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
-  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+  - 首次可修复失败的 `semanticDigest` 由 finalizer 保留为基线；重试后的 `status=passed` 必须匹配该基线。基线不匹配、其他失败、无进展或重复诊断：停止，不发布 completed 事件。
 - 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -204,7 +204,14 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
   - 用新值覆盖 frontmatter 的 `priority` 字段
   - 在本轮分析产物 `{analysis-artifact}` 中追加 `## 优先级重估` 段，记录一条：`priority {old} → {new} (rationale: {基于本轮分析的简短依据})`
   若重估值与当前值一致，跳过：不写入 `## 优先级重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
-- 完成业务内容更新后执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} {execution-flag}`，由核心原子登记链接、阶段、代理、时间、版本和 Activity Log。
+- 完成本地产物后，先执行本地完成前门禁：
+  ```bash
+  agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
+  ```
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
+  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+- 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status pending-design-work --fields`

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -19,6 +19,7 @@ description: >
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 实现前读取 `.agents/rules/compatibility-policy.md`；只实现方案明确批准的兼容预算，不以“稳妥”为由保留旧分支、旧结果契约或迁移 shim
 - 修复模式逐条核实最新 `review-code` 的发现：成立则修复，判定为不成立/幻觉则在报告中反驳并记入 unresolved；不擅自扩大到审查未列出的问题；manual-validation 项不在修复范围
+- 实现报告在 `code.completed` 前必须通过 `task-artifact ... finalize-local --family code`；按 `.agents/rules/local-artifact-repair.md` 处理同一报告内可证明安全的最小结构修复，并只把同一次通过结果的摘要传给完成事件
 - 实现中遇到方案未覆盖的关键设计决策时，先调用 `agent-infra-internal task-ledger {task-id} decision-next-id` 取得 `HD-N`，按 `.agents/rules/human-decision-context.md` 写入实现报告的 `## 人工裁决待办` 详情块并判断是否需要实现，再调用 `decision-upsert --id {HD-N} --stage code --artifact {code-artifact} --needs-implementation {true|false}`；不得扫描编号、手写账本行、中途提问或擅自扩范围
 - 不调用 `commit` 技能，也不推送远端；测试通过后直接调用共享 commit core 的 `delivery: { mode: 'local' }` 创建本地 checkpoint。checkpoint 使用 durable intent，只有 checkpoint 与 task 状态同步成功后才发送 `code.completed`
 - 每轮实现都创建新的实现产物，不覆盖旧文件
@@ -87,7 +88,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 **必须执行，不得跳过。** 如果 task.md 中存在有效的 `issue_number`，调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --milestone specific`；里程碑推断、权限降级与幂等写入由 internal core 处理。
 
-> 若跳过或收窄后仍为 `X.Y.x`，步骤 11 的 `task-verify code.completed` 会通过 typed milestone check 截停本轮。
+> 若跳过或收窄后仍为 `X.Y.x`，步骤 12 的 `task-verify code.completed` 会通过 typed milestone check 截停本轮。
 
 ### 4. 确定模式与轮次
 
@@ -152,22 +153,38 @@ echo "$result"
 
 > 报告结构、必填章节和完整模板见 `reference/report-template.md`。写报告前先读取 `reference/report-template.md`。
 
-### 10. 更新任务状态
+### 10. 报告完成前门禁
+
+报告写入后、发布 `code.completed` 前，读取并遵循 `.agents/rules/local-artifact-repair.md`，执行：
+
+```bash
+finalizer=$(agent-infra-internal task-artifact {task-id} finalize-local --family code --artifact {code-artifact})
+status=$?
+echo "$finalizer"
+```
+
+- `status=0` 且 `finalizer.status="passed"`：绑定这一次返回的 `{artifact-sha256}` 和 `{semantic-digest}`。
+- `status=1` 且返回 `repairable=true`、诊断明确为当前报告中的单行替换：确认任务、轮次、产物和 provenance 未变化后，只编辑该 `code*.md` 一次，确认字节确实变化，再完整重跑同一命令。
+- 其他失败、无进展、诊断重复或达到 8 次实际报告编辑：停止，不发布 `code.completed`。
+
+不得重新扫描或手工补写摘要；完成事件必须携带本次 `passed` 结果的 `--artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest}`。
+
+### 11. 更新任务状态
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 产物链接、阶段与完成日志由 completed 事件统一登记
 - 完成业务内容更新后声明完成事件：
-  - 初次实现：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --files-modified {n} --tests-passed {n} {execution-flag}`
-  - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
-  - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
+  - 初次实现：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --files-modified {n} --tests-passed {n} {execution-flag}`
+  - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
+  - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则记录 warning 并继续；Issue 元数据边界仍见 `.agents/rules/issue-sync.md`）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`
 
-### 11. 完成校验
+### 12. 完成校验
 
 运行完成校验，确认任务产物和同步状态符合规范：
 
@@ -182,7 +199,7 @@ agent-infra-internal task-verify {task-id} code.completed --artifact {code-artif
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-### 12. 告知用户
+### 13. 告知用户
 
 > 仅在校验通过后执行本步骤。
 

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -118,9 +118,9 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
   ```bash
   agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
   ```
-  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`；finalizer 已记录对应的一次性本地 provenance intent。
   - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
-  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+  - 首次可修复失败的 `semanticDigest` 由 finalizer 保留为基线；重试后的 `status=passed` 必须匹配该基线。基线不匹配、其他失败、无进展或重复诊断：停止，不发布 completed 事件。
 - 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -114,7 +114,14 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
   - 用新值覆盖 frontmatter 的 `effort` 字段
   - 在本轮方案产物 `{plan-artifact}` 中追加 `## 工作量重估` 段，记录一条：`effort {old} → {new} (rationale: {基于本轮方案的简短依据})`
   若重估值与当前值一致，跳过：不写入 `## 工作量重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
-- 完成业务内容更新后执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} {execution-flag}`，由核心原子登记链接、阶段、代理、时间、版本和 Activity Log。
+- 完成本地产物后，先执行本地完成前门禁：
+  ```bash
+  agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
+  ```
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
+  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+- 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status pending-design-work --fields`

--- a/lib/internal/task-artifact.ts
+++ b/lib/internal/task-artifact.ts
@@ -4,7 +4,7 @@ import type { LocalArtifactFamily } from '../task/local-artifact-finalization.ts
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { loadVerificationConfig } from '../task/verification-config.ts';
 
-const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan artifact without changing task state.\n`;
+const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan|code> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan/code artifact without changing task state.\n`;
 
 function failUsage(message: string): void {
   process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'ARTIFACT_PAYLOAD_INVALID', message } })}\n`);
@@ -54,11 +54,11 @@ function taskArtifact(args: string[] = []): void {
     return;
   }
   if (!artifact) { failUsage("option '--artifact' is required"); return; }
-  if (family !== 'analysis' && family !== 'plan') {
-    failUsage("finalize-local only supports 'analysis' and 'plan'");
+  if (family !== 'analysis' && family !== 'plan' && family !== 'code') {
+    failUsage("finalize-local only supports 'analysis', 'plan', and 'code'");
     return;
   }
-  const skillName = family === 'analysis' ? 'analyze-task' : 'plan-task';
+  const skillName = family === 'analysis' ? 'analyze-task' : family === 'plan' ? 'plan-task' : 'code-task';
   const resolved = resolveTaskRef(args[0]!);
   const repositoryRoot = resolved.ok ? resolved.repoRoot : process.cwd();
   let config: { requiredSections?: readonly string[]; requiredPatterns?: readonly string[] } = {};

--- a/lib/internal/task-artifact.ts
+++ b/lib/internal/task-artifact.ts
@@ -1,6 +1,7 @@
 import { resolveArtifactContext } from '../task/artifact-lifecycle.ts';
 import { finalizeLocalArtifact } from '../task/local-artifact-finalization.ts';
 import type { LocalArtifactFamily } from '../task/local-artifact-finalization.ts';
+import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { loadVerificationConfig } from '../task/verification-config.ts';
 
 const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan artifact without changing task state.\n`;
@@ -58,9 +59,11 @@ function taskArtifact(args: string[] = []): void {
     return;
   }
   const skillName = family === 'analysis' ? 'analyze-task' : 'plan-task';
+  const resolved = resolveTaskRef(args[0]!);
+  const repositoryRoot = resolved.ok ? resolved.repoRoot : process.cwd();
   let config: { requiredSections?: readonly string[]; requiredPatterns?: readonly string[] } = {};
   try {
-    const loaded = loadVerificationConfig(process.cwd(), skillName);
+    const loaded = loadVerificationConfig(repositoryRoot, skillName);
     const artifactConfig = loaded.checks.artifact;
     if (artifactConfig && typeof artifactConfig === 'object' && !Array.isArray(artifactConfig)) {
       const sections = artifactConfig.required_sections;
@@ -77,6 +80,7 @@ function taskArtifact(args: string[] = []): void {
     taskRef: args[0]!,
     family: family as LocalArtifactFamily,
     artifact,
+    repoRoot: repositoryRoot,
     ...config
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/lib/internal/task-artifact.ts
+++ b/lib/internal/task-artifact.ts
@@ -1,6 +1,9 @@
 import { resolveArtifactContext } from '../task/artifact-lifecycle.ts';
+import { finalizeLocalArtifact } from '../task/local-artifact-finalization.ts';
+import type { LocalArtifactFamily } from '../task/local-artifact-finalization.ts';
+import { loadVerificationConfig } from '../task/verification-config.ts';
 
-const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n\nInspect one workflow artifact family and print a read-only JSON context.\n`;
+const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan artifact without changing task state.\n`;
 
 function failUsage(message: string): void {
   process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'ARTIFACT_PAYLOAD_INVALID', message } })}\n`);
@@ -11,37 +14,73 @@ function failUsage(message: string): void {
 function taskArtifact(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args.length < 2) { failUsage('task ref and operation are required'); return; }
-  if (args[1] !== 'inspect') { failUsage(`unknown operation '${args[1]}'`); return; }
+  const operation = args[1];
+  if (operation !== 'inspect' && operation !== 'finalize-local') { failUsage(`unknown operation '${operation}'`); return; }
   let family = '';
+  let artifact = '';
   const seen = new Set<string>();
   for (let index = 2; index < args.length; index += 1) {
     const flag = args[index]!;
-    if (flag !== '--family') { failUsage(`unknown option '${flag}'`); return; }
+    if (flag !== '--family' && flag !== '--artifact') { failUsage(`unknown option '${flag}'`); return; }
     if (seen.has(flag)) { failUsage(`duplicate option '${flag}'`); return; }
     const value = args[++index];
     if (!value || value.startsWith('--')) { failUsage(`option '${flag}' requires a value`); return; }
     seen.add(flag);
-    family = value;
+    if (flag === '--family') family = value;
+    else artifact = value;
   }
   if (!family) { failUsage("option '--family' is required"); return; }
-  const result = resolveArtifactContext(args[0]!, family);
-  const output = family === 'code' && result.codeMode ? {
-    ...result,
-    mode: result.codeMode.mode,
-    code_max: result.codeMode.codeMax,
-    rev_max: result.codeMode.reviewMax,
-    verdict: result.codeMode.verdict,
-    next_round: result.next?.round ?? null,
-    next_artifact: result.next?.name ?? null,
-    review_artifact: result.codeMode.reviewArtifact,
-    implementation_input: result.codeMode.implementationInput,
-    decision_id: result.codeMode.decisionId,
-    decision_evidence: result.codeMode.decisionEvidence,
-    message: result.codeMode.message
-  } : result;
-  process.stdout.write(`${JSON.stringify(output)}\n`);
-  if (result.status === 'refused') process.exitCode = 1;
-  else if (result.status === 'failed') process.exitCode = 2;
+  if (operation === 'inspect') {
+    if (artifact) { failUsage("option '--artifact' is only valid for finalize-local"); return; }
+    const result = resolveArtifactContext(args[0]!, family);
+    const output = family === 'code' && result.codeMode ? {
+      ...result,
+      mode: result.codeMode.mode,
+      code_max: result.codeMode.codeMax,
+      rev_max: result.codeMode.reviewMax,
+      verdict: result.codeMode.verdict,
+      next_round: result.next?.round ?? null,
+      next_artifact: result.next?.name ?? null,
+      review_artifact: result.codeMode.reviewArtifact,
+      implementation_input: result.codeMode.implementationInput,
+      decision_id: result.codeMode.decisionId,
+      decision_evidence: result.codeMode.decisionEvidence,
+      message: result.codeMode.message
+    } : result;
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+    if (result.status === 'refused') process.exitCode = 1;
+    else if (result.status === 'failed') process.exitCode = 2;
+    return;
+  }
+  if (!artifact) { failUsage("option '--artifact' is required"); return; }
+  if (family !== 'analysis' && family !== 'plan') {
+    failUsage("finalize-local only supports 'analysis' and 'plan'");
+    return;
+  }
+  const skillName = family === 'analysis' ? 'analyze-task' : 'plan-task';
+  let config: { requiredSections?: readonly string[]; requiredPatterns?: readonly string[] } = {};
+  try {
+    const loaded = loadVerificationConfig(process.cwd(), skillName);
+    const artifactConfig = loaded.checks.artifact;
+    if (artifactConfig && typeof artifactConfig === 'object' && !Array.isArray(artifactConfig)) {
+      const sections = artifactConfig.required_sections;
+      const patterns = artifactConfig.required_patterns;
+      config = {
+        requiredSections: Array.isArray(sections) ? sections.filter((value): value is string => typeof value === 'string') : undefined,
+        requiredPatterns: Array.isArray(patterns) ? patterns.filter((value): value is string => typeof value === 'string') : undefined
+      };
+    }
+  } catch {
+    // Isolated fixture repositories may not contain the project's verification config.
+  }
+  const result = finalizeLocalArtifact({
+    taskRef: args[0]!,
+    family: family as LocalArtifactFamily,
+    artifact,
+    ...config
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (result.status === 'failed') process.exitCode = 1;
 }
 
 export { taskArtifact };

--- a/lib/internal/task-event.ts
+++ b/lib/internal/task-event.ts
@@ -13,6 +13,7 @@ Events: ${eventCatalog.join(', ')}
 
 const FLAGS: Record<string, keyof TaskEventRequest> = {
   '--agent': 'agent', '--round': 'round', '--question': 'question', '--artifact': 'artifact',
+  '--artifact-sha256': 'artifactSha256', '--semantic-digest': 'semanticDigest',
   '--fix-for': 'fixFor', '--implementation-input': 'implementationInput',
   '--verdict': 'verdict', '--blockers': 'blockers', '--major': 'major',
   '--minor': 'minor', '--manual-validation': 'manualValidation', '--files-modified': 'filesModified',

--- a/lib/task/decision-details.ts
+++ b/lib/task/decision-details.ts
@@ -270,11 +270,15 @@ export {
   normalizeDecisionDetailForDisplay,
   parseDecisionDetailBlocks,
   parseDecisionEvidence,
-  resolveDecisionDetail
+  resolveDecisionDetail,
+  scanVisibleMarkdown
 };
 export type {
   DecisionDetailBlock,
   DecisionDetailDuplicate,
   DecisionDetailInspection,
-  DecisionDetailResolution
+  DecisionDetailResolution,
+  SourceLine,
+  VisibleHeading,
+  VisibleMarkdown
 };

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -36,8 +36,8 @@ import { allowsManualOverride } from './guard-override.ts';
 import {
   LOCAL_ARTIFACT_REQUIRED_PATTERNS,
   LOCAL_ARTIFACT_REQUIRED_SECTIONS,
+  consumeLocalArtifactFinalizationIntent,
   readLocalArtifactFinalizationIntent,
-  removeLocalArtifactFinalizationIntent,
   validateLocalArtifact
 } from './local-artifact-finalization.ts';
 import type { LocalArtifactFinalizationIntent } from './local-artifact-finalization.ts';
@@ -499,7 +499,7 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
           message: `cannot read local finalizer provenance for ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}`
         }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
       }
-      if (!localFinalizationIntent || localFinalizationIntent.state !== 'passed') {
+      if (!localFinalizationIntent || !['passed', 'consumed'].includes(localFinalizationIntent.state)) {
         return failed(normalized, {
           code: 'EVENT_ARTIFACT_CONFLICT',
           message: `local finalizer provenance is missing or incomplete for ${completedArtifact.name}`
@@ -623,6 +623,24 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
     });
   }
   mutations.push({ kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: section.heading, body });
+  if (!normalized.dryRun && localFinalizationIntent && completedArtifact && localFinalizationIntent.state === 'passed') {
+    try {
+      localFinalizationIntent = consumeLocalArtifactFinalizationIntent(resolved.repoRoot, localFinalizationIntent);
+    } catch (error) {
+      return failed(normalized, {
+        code: 'EVENT_ARTIFACT_CONFLICT',
+        message: `local finalizer provenance could not be consumed before task write for ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}`
+      }, {
+        taskId: resolved.taskId,
+        taskMdPath: resolved.taskMdPath,
+        fromStep: currentStep,
+        toStep: step,
+        action: eventIdentity.action,
+        phase: eventIdentity.phase,
+        artifactContext
+      });
+    }
+  }
   const result = writeTask({ taskRef: normalized.taskRef, expectedState: stateOverride ? resolved.state : 'active', dryRun: normalized.dryRun, mutations }, { ...options, metadataProvider: () => metadata });
   if (result.status === 'failed') return failed(normalized, result.error, { taskId: result.taskId, taskMdPath: result.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, timestamp: result.timestamp, agentInfraVersion: result.agentInfraVersion, operations: result.operations, artifactContext });
   if (!normalized.dryRun && orchestrationCompletion) {
@@ -632,32 +650,6 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
       return failed(normalized, {
         code: 'EVENT_ORCHESTRATION_COMMIT_FAILED',
         message: `task.md was written but orchestration completion could not be persisted; manual recovery is required: ${error instanceof Error ? error.message : String(error)}`
-      }, {
-        taskId: result.taskId,
-        taskMdPath: result.taskMdPath,
-        fromStep: currentStep,
-        toStep: step,
-        action: eventIdentity.action,
-        phase: eventIdentity.phase,
-        timestamp: result.timestamp,
-        agentInfraVersion: result.agentInfraVersion,
-        operations: result.operations,
-        artifactContext
-      });
-    }
-  }
-  if (!normalized.dryRun && localFinalizationIntent && completedArtifact) {
-    try {
-      removeLocalArtifactFinalizationIntent(
-        resolved.repoRoot,
-        resolved.taskId,
-        localFinalizationIntent.family,
-        completedArtifact.name
-      );
-    } catch (error) {
-      return failed(normalized, {
-        code: 'EVENT_ARTIFACT_CONFLICT',
-        message: `local finalizer provenance could not be consumed for ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}`
       }, {
         taskId: result.taskId,
         taskMdPath: result.taskMdPath,

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -40,7 +40,7 @@ import {
   readLocalArtifactFinalizationIntent,
   validateLocalArtifact
 } from './local-artifact-finalization.ts';
-import type { LocalArtifactFinalizationIntent } from './local-artifact-finalization.ts';
+import type { LocalArtifactFamily, LocalArtifactFinalizationIntent } from './local-artifact-finalization.ts';
 import { loadVerificationConfig } from './verification-config.ts';
 
 const eventCatalog = [
@@ -99,7 +99,7 @@ const SCHEMAS: Record<TaskEventName, { required?: string[]; optional?: string[] 
   'review-plan.started': { optional: ['round'] },
   'review-plan.completed': { required: ['artifact', 'verdict', 'blockers', 'major', 'minor', 'manualValidation'], optional: ['round', 'orchestrated'] },
   'code.started': { optional: ['round', 'fixFor', 'implementationInput'] },
-  'code.completed': { required: ['artifact'], optional: ['round', 'fixFor', 'implementationInput', 'filesModified', 'testsPassed', 'blockers', 'major', 'minor', 'manualValidation', 'orchestrated'] },
+  'code.completed': { required: ['artifact', 'artifactSha256', 'semanticDigest'], optional: ['round', 'fixFor', 'implementationInput', 'filesModified', 'testsPassed', 'blockers', 'major', 'minor', 'manualValidation', 'orchestrated'] },
   'review-code.started': { optional: ['round'] },
   'review-code.completed': { required: ['artifact', 'verdict', 'blockers', 'major', 'minor', 'manualValidation'], optional: ['round', 'orchestrated'] },
   'manual-validation.started': { optional: ['round'] },
@@ -108,12 +108,12 @@ const SCHEMAS: Record<TaskEventName, { required?: string[]; optional?: string[] 
   'validation-run.completed': { required: ['artifact'], optional: ['round'] }
 };
 
-function localArtifactValidationConfig(repoRoot: string, family: 'analysis' | 'plan') {
+function localArtifactValidationConfig(repoRoot: string, family: LocalArtifactFamily) {
   const fallback = {
     requiredSections: LOCAL_ARTIFACT_REQUIRED_SECTIONS[family],
     requiredPatterns: LOCAL_ARTIFACT_REQUIRED_PATTERNS
   };
-  const skillName = family === 'analysis' ? 'analyze-task' : 'plan-task';
+  const skillName = family === 'analysis' ? 'analyze-task' : family === 'plan' ? 'plan-task' : 'code-task';
   try {
     const artifact = loadVerificationConfig(repoRoot, skillName).checks.artifact;
     if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return fallback;
@@ -457,8 +457,10 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
     const validated = validateCompletedArtifact(resolved.taskDir, FAMILY[eventIdentity.family].artifact, normalized.artifact!, normalized.round);
     if (!validated.ok) return failed(normalized, validated.error, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
     completedArtifact = validated.artifact;
-    if (eventIdentity.family === 'analyze' || eventIdentity.family === 'plan') {
-      const localFamily = eventIdentity.family === 'analyze' ? 'analysis' : 'plan';
+    if (eventIdentity.family === 'analyze' || eventIdentity.family === 'plan' || eventIdentity.family === 'code') {
+      const localFamily = eventIdentity.family === 'analyze'
+        ? 'analysis'
+        : eventIdentity.family === 'plan' ? 'plan' : 'code';
       let artifactContent: string;
       try { artifactContent = fs.readFileSync(completedArtifact.path, 'utf8'); }
       catch (error) {

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -36,8 +36,11 @@ import { allowsManualOverride } from './guard-override.ts';
 import {
   LOCAL_ARTIFACT_REQUIRED_PATTERNS,
   LOCAL_ARTIFACT_REQUIRED_SECTIONS,
+  readLocalArtifactFinalizationIntent,
+  removeLocalArtifactFinalizationIntent,
   validateLocalArtifact
 } from './local-artifact-finalization.ts';
+import type { LocalArtifactFinalizationIntent } from './local-artifact-finalization.ts';
 import { loadVerificationConfig } from './verification-config.ts';
 
 const eventCatalog = [
@@ -440,6 +443,7 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
   const completedRows = matchingRows.filter((item) => item.done);
   const row = manual ? openRows.at(-1) : matchingRows[0];
   let completedArtifact: ArtifactIdentity | null = null;
+  let localFinalizationIntent: LocalArtifactFinalizationIntent | null = null;
   if (eventIdentity.phase === 'started' && row) {
     if (row.agent !== normalized.agent) return failed(normalized, { code: 'EVENT_LOG_CONFLICT', message: 'open started event has a different agent' }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath });
     return successNoOp(normalized, resolved.taskId, resolved.taskMdPath, currentStep, eventIdentity, row.started, frontmatter, artifactContext);
@@ -483,6 +487,28 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
         return failed(normalized, {
           code: 'EVENT_ARTIFACT_CONFLICT',
           message: `semantic digest does not match finalizer result for ${completedArtifact.name}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      try {
+        localFinalizationIntent = readLocalArtifactFinalizationIntent(
+          resolved.repoRoot, resolved.taskId, localFamily, completedArtifact.name
+        );
+      } catch (error) {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `cannot read local finalizer provenance for ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      if (!localFinalizationIntent || localFinalizationIntent.state !== 'passed') {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `local finalizer provenance is missing or incomplete for ${completedArtifact.name}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      if (localFinalizationIntent.artifactSha256 !== actualSha256 || localFinalizationIntent.semanticDigest !== local.semanticDigest) {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `local finalizer provenance does not match ${completedArtifact.name}`
         }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
       }
     }
@@ -606,6 +632,32 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
       return failed(normalized, {
         code: 'EVENT_ORCHESTRATION_COMMIT_FAILED',
         message: `task.md was written but orchestration completion could not be persisted; manual recovery is required: ${error instanceof Error ? error.message : String(error)}`
+      }, {
+        taskId: result.taskId,
+        taskMdPath: result.taskMdPath,
+        fromStep: currentStep,
+        toStep: step,
+        action: eventIdentity.action,
+        phase: eventIdentity.phase,
+        timestamp: result.timestamp,
+        agentInfraVersion: result.agentInfraVersion,
+        operations: result.operations,
+        artifactContext
+      });
+    }
+  }
+  if (!normalized.dryRun && localFinalizationIntent && completedArtifact) {
+    try {
+      removeLocalArtifactFinalizationIntent(
+        resolved.repoRoot,
+        resolved.taskId,
+        localFinalizationIntent.family,
+        completedArtifact.name
+      );
+    } catch (error) {
+      return failed(normalized, {
+        code: 'EVENT_ARTIFACT_CONFLICT',
+        message: `local finalizer provenance could not be consumed for ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}`
       }, {
         taskId: result.taskId,
         taskMdPath: result.taskMdPath,

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -33,6 +33,12 @@ import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-
 import { captureTaskWriteMetadata, writeTask } from './write.ts';
 import type { TaskOperationSummary, TaskWriteErrorCode, TaskWriteOptions } from './write.ts';
 import { allowsManualOverride } from './guard-override.ts';
+import {
+  LOCAL_ARTIFACT_REQUIRED_PATTERNS,
+  LOCAL_ARTIFACT_REQUIRED_SECTIONS,
+  validateLocalArtifact
+} from './local-artifact-finalization.ts';
+import { loadVerificationConfig } from './verification-config.ts';
 
 const eventCatalog = [
   'analyze.started', 'analyze.awaiting-input', 'analyze.completed',
@@ -57,6 +63,7 @@ type TaskEventRequest = {
   taskRef: string; event: TaskEventName | string; agent: string; dryRun?: boolean; orchestrated?: boolean;
   overrideTicket?: string; overrideTarget?: string; overrideScope?: string;
   round?: number; question?: number; artifact?: string; fixFor?: string; implementationInput?: string;
+  artifactSha256?: string; semanticDigest?: string;
   verdict?: Verdict; blockers?: number; major?: number; minor?: number;
   manualValidation?: number; filesModified?: number; testsPassed?: number;
   summaryResult?: string;
@@ -81,11 +88,11 @@ const BASE_FIELDS = new Set(['taskRef', 'event', 'agent', 'dryRun', 'overrideTic
 const SCHEMAS: Record<TaskEventName, { required?: string[]; optional?: string[] }> = {
   'analyze.started': { optional: ['round'] },
   'analyze.awaiting-input': { required: ['question'] },
-  'analyze.completed': { required: ['artifact'], optional: ['round', 'orchestrated'] },
+  'analyze.completed': { required: ['artifact', 'artifactSha256', 'semanticDigest'], optional: ['round', 'orchestrated'] },
   'review-analysis.started': { optional: ['round'] },
   'review-analysis.completed': { required: ['artifact', 'verdict', 'blockers', 'major', 'minor', 'manualValidation'], optional: ['round', 'orchestrated'] },
   'plan.started': { optional: ['round'] },
-  'plan.completed': { required: ['artifact'], optional: ['round', 'orchestrated'] },
+  'plan.completed': { required: ['artifact', 'artifactSha256', 'semanticDigest'], optional: ['round', 'orchestrated'] },
   'review-plan.started': { optional: ['round'] },
   'review-plan.completed': { required: ['artifact', 'verdict', 'blockers', 'major', 'minor', 'manualValidation'], optional: ['round', 'orchestrated'] },
   'code.started': { optional: ['round', 'fixFor', 'implementationInput'] },
@@ -97,6 +104,30 @@ const SCHEMAS: Record<TaskEventName, { required?: string[]; optional?: string[] 
   'validation-run.started': { optional: ['round'] },
   'validation-run.completed': { required: ['artifact'], optional: ['round'] }
 };
+
+function localArtifactValidationConfig(repoRoot: string, family: 'analysis' | 'plan') {
+  const fallback = {
+    requiredSections: LOCAL_ARTIFACT_REQUIRED_SECTIONS[family],
+    requiredPatterns: LOCAL_ARTIFACT_REQUIRED_PATTERNS
+  };
+  const skillName = family === 'analysis' ? 'analyze-task' : 'plan-task';
+  try {
+    const artifact = loadVerificationConfig(repoRoot, skillName).checks.artifact;
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return fallback;
+    const sections = artifact.required_sections;
+    const patterns = artifact.required_patterns;
+    return {
+      requiredSections: Array.isArray(sections)
+        ? sections.filter((value): value is string => typeof value === 'string')
+        : fallback.requiredSections,
+      requiredPatterns: Array.isArray(patterns)
+        ? patterns.filter((value): value is string => typeof value === 'string')
+        : fallback.requiredPatterns
+    };
+  } catch {
+    return fallback;
+  }
+}
 
 function validateTaskEventRequest(request: TaskEventRequest): TaskEventError | null {
   if (!eventCatalog.includes(request.event as TaskEventName)) return { code: 'EVENT_UNKNOWN', message: `unknown task event '${request.event}'` };
@@ -121,6 +152,8 @@ function validateTaskEventRequest(request: TaskEventRequest): TaskEventError | n
   }
   if (request.fixFor && !/^review-code(?:-r(?:[2-9]|[1-9]\d+))?\.md$/.test(request.fixFor)) return { code: 'EVENT_PAYLOAD_INVALID', message: 'fixFor must reference a canonical review-code artifact' };
   if (request.implementationInput && !/^II-[1-9]\d*$/.test(request.implementationInput)) return { code: 'EVENT_PAYLOAD_INVALID', message: 'implementationInput must be a canonical II-N id' };
+  if (request.artifactSha256 !== undefined && !/^[0-9a-f]{64}$/i.test(request.artifactSha256)) return { code: 'EVENT_PAYLOAD_INVALID', message: 'artifactSha256 must be a 64-character hexadecimal digest' };
+  if (request.semanticDigest !== undefined && !/^[0-9a-f]{64}$/i.test(request.semanticDigest)) return { code: 'EVENT_PAYLOAD_INVALID', message: 'semanticDigest must be a 64-character hexadecimal digest' };
   if (request.fixFor && request.implementationInput) return { code: 'EVENT_PAYLOAD_INVALID', message: 'fixFor and implementationInput are mutually exclusive' };
   if (request.summaryResult !== undefined && (!request.summaryResult.trim() || /[\r\n]/.test(request.summaryResult))) return { code: 'EVENT_PAYLOAD_INVALID', message: 'summaryResult must be a non-empty single line' };
   return null;
@@ -420,6 +453,39 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
     const validated = validateCompletedArtifact(resolved.taskDir, FAMILY[eventIdentity.family].artifact, normalized.artifact!, normalized.round);
     if (!validated.ok) return failed(normalized, validated.error, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
     completedArtifact = validated.artifact;
+    if (eventIdentity.family === 'analyze' || eventIdentity.family === 'plan') {
+      const localFamily = eventIdentity.family === 'analyze' ? 'analysis' : 'plan';
+      let artifactContent: string;
+      try { artifactContent = fs.readFileSync(completedArtifact.path, 'utf8'); }
+      catch (error) {
+        return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot read ${completedArtifact.name}: ${String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      const validationConfig = localArtifactValidationConfig(resolved.repoRoot, localFamily);
+      const local = validateLocalArtifact(artifactContent, {
+        family: localFamily,
+        requiredSections: validationConfig.requiredSections,
+        requiredPatterns: validationConfig.requiredPatterns
+      });
+      if (!local.ok) {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `LOCAL_ARTIFACT_INVALID: ${local.diagnostics.map((item) => `${item.code}: ${item.message}`).join('; ')}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      const actualSha256 = sha256File(completedArtifact.path);
+      if (actualSha256 !== normalized.artifactSha256) {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `artifact SHA-256 does not match finalizer result for ${completedArtifact.name}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      if (local.semanticDigest !== normalized.semanticDigest) {
+        return failed(normalized, {
+          code: 'EVENT_ARTIFACT_CONFLICT',
+          message: `semantic digest does not match finalizer result for ${completedArtifact.name}`
+        }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+    }
   }
   if (eventIdentity.phase === 'waiting' && section.entries.some((entry) => entry.step === eventIdentity.action && entry.note === eventIdentity.note)) {
     const existing = section.entries.find((entry) => entry.step === eventIdentity.action && entry.note === eventIdentity.note)!;

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -1,0 +1,344 @@
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+
+import {
+  inspectDecisionDetailDuplicates,
+  scanVisibleMarkdown
+} from './decision-details.ts';
+import type { VisibleHeading } from './decision-details.ts';
+import {
+  parseArtifactName,
+  validateCompletedArtifact
+} from './artifact-lifecycle.ts';
+import { resolveTaskRef } from './resolve-ref.ts';
+
+type LocalArtifactFamily = 'analysis' | 'plan';
+
+const LOCAL_ARTIFACT_REQUIRED_SECTIONS: Readonly<Record<LocalArtifactFamily, readonly string[]>> = {
+  analysis: [
+    '需求来源', '需求理解', '相关文件', '影响评估', '技术风险',
+    '工作量和复杂度评估', '状态核对'
+  ],
+  plan: [
+    '问题理解', '约束条件', '方案对比', '技术方法', '实施步骤',
+    '文件清单', '验证策略', '状态核对'
+  ]
+};
+
+const LOCAL_ARTIFACT_REQUIRED_PATTERNS = ['^\\$ '];
+
+type LocalArtifactDiagnosticCode =
+  | 'LOCAL_ARTIFACT_EMPTY'
+  | 'LOCAL_ARTIFACT_MISSING_SECTION'
+  | 'LOCAL_ARTIFACT_DUPLICATE_SECTION'
+  | 'LOCAL_STATUS_COMMAND_MISSING'
+  | 'LOCAL_DECISION_DETAIL_DUPLICATE'
+  | 'LOCAL_REQUIRED_PATTERN_MISSING'
+  | 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION';
+
+type LocalArtifactDiagnostic = {
+  code: LocalArtifactDiagnosticCode;
+  message: string;
+  repairable: boolean;
+  line: number | null;
+  from?: string;
+  to?: string;
+  operation?: 'replace-line';
+};
+
+type LocalArtifactValidationOptions = {
+  family: LocalArtifactFamily;
+  requiredSections?: readonly string[];
+  requiredPatterns?: readonly string[];
+};
+
+type LocalArtifactValidationResult = {
+  ok: boolean;
+  family: LocalArtifactFamily;
+  semanticDigest: string;
+  repairable: boolean;
+  diagnostics: readonly LocalArtifactDiagnostic[];
+};
+
+type LocalArtifactFinalizationRequest = {
+  taskRef: string;
+  family: LocalArtifactFamily;
+  artifact: string;
+  repoRoot?: string;
+  requiredSections?: readonly string[];
+  requiredPatterns?: readonly string[];
+};
+
+type LocalArtifactFinalizationResult = {
+  status: 'passed' | 'failed';
+  changed: false;
+  taskId: string | null;
+  taskDir: string | null;
+  family: LocalArtifactFamily;
+  artifact: string;
+  artifactSha256: string | null;
+  semanticDigest: string | null;
+  repairable: boolean;
+  diagnostics: readonly LocalArtifactDiagnostic[];
+  error: { code: string; message: string } | null;
+};
+
+function requiredSections(family: LocalArtifactFamily): readonly string[] {
+  return LOCAL_ARTIFACT_REQUIRED_SECTIONS[family];
+}
+
+function lineNumber(content: string, offset: number): number {
+  return content.slice(0, offset).split('\n').length;
+}
+
+function sectionBody(content: string, heading: VisibleHeading): string {
+  const next = scanVisibleMarkdown(content).headings.find((candidate) => (
+    candidate.start > heading.start && candidate.level <= 2
+  ));
+  return content.slice(heading.end, next?.start ?? content.length);
+}
+
+function semanticDigest(content: string, candidate?: VisibleHeading): string {
+  let normalized = content;
+  if (candidate) {
+    const raw = content.slice(candidate.start, candidate.end);
+    const marker = raw.match(/([:：])\s*$/);
+    if (marker?.index !== undefined) {
+      const canonical = raw.slice(0, marker.index) + raw.slice(marker.index + 1);
+      normalized = `${content.slice(0, candidate.start)}${canonical}${content.slice(candidate.end)}`;
+    }
+  }
+  return createHash('sha256').update(normalized.replace(/\s+/g, ''), 'utf8').digest('hex');
+}
+
+function sha256Content(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function visibleSectionHeadings(content: string, section: string): VisibleHeading[] {
+  return scanVisibleMarkdown(content).headings.filter((heading) => (
+    heading.level === 2 && heading.text === section
+  ));
+}
+
+function trailingPunctuationCandidates(content: string, section: string): VisibleHeading[] {
+  return scanVisibleMarkdown(content).headings.filter((heading) => (
+    heading.level === 2 && (
+      heading.text === `${section}:` || heading.text === `${section}：`
+    )
+  ));
+}
+
+function diagnostic(
+  code: LocalArtifactDiagnosticCode,
+  message: string,
+  content: string,
+  heading?: VisibleHeading,
+  extra: Partial<LocalArtifactDiagnostic> = {}
+): LocalArtifactDiagnostic {
+  return {
+    code, message, repairable: false,
+    line: heading ? lineNumber(content, heading.start) : null,
+    ...extra
+  };
+}
+
+function isStatusPattern(pattern: string): boolean {
+  return pattern === '^\\$ ';
+}
+
+function validateLocalArtifact(
+  content: string,
+  options: LocalArtifactValidationOptions
+): LocalArtifactValidationResult {
+  const sections = options.requiredSections ?? requiredSections(options.family);
+  const patterns = options.requiredPatterns ?? LOCAL_ARTIFACT_REQUIRED_PATTERNS;
+  const diagnostics: LocalArtifactDiagnostic[] = [];
+  const candidates: VisibleHeading[] = [];
+  const scanned = scanVisibleMarkdown(content);
+
+  if (!content.trim()) {
+    diagnostics.push(diagnostic('LOCAL_ARTIFACT_EMPTY', 'artifact is empty', content));
+  }
+
+  for (const section of sections) {
+    const exact = scanned.headings.filter((heading) => heading.level === 2 && heading.text === section);
+    const punctuated = trailingPunctuationCandidates(content, section);
+    if (exact.length > 1 || punctuated.length > 0 && exact.length > 0 || punctuated.length > 1) {
+      const first = exact[1] ?? punctuated[0] ?? exact[0];
+      diagnostics.push(diagnostic(
+        'LOCAL_ARTIFACT_DUPLICATE_SECTION',
+        `required section '${section}' is duplicated or has an ambiguous punctuation variant`,
+        content, first
+      ));
+    } else if (exact.length === 0 && punctuated.length === 1) {
+      candidates.push(punctuated[0]!);
+    } else if (exact.length === 0) {
+      diagnostics.push(diagnostic(
+        'LOCAL_ARTIFACT_MISSING_SECTION',
+        `required section '${section}' is missing`,
+        content
+      ));
+    }
+  }
+
+  const statusSection = sections.find((section) => section === '状态核对' || section.toLowerCase() === 'state check');
+  if (statusSection) {
+    const statusHeading = visibleSectionHeadings(content, statusSection)[0]
+      ?? candidates.find((heading) => heading.text === `${statusSection}:` || heading.text === `${statusSection}：`);
+    if (statusHeading) {
+      const body = sectionBody(content, statusHeading);
+      for (const pattern of patterns.filter(isStatusPattern)) {
+        if (!new RegExp(pattern, 'm').test(body)) {
+          diagnostics.push(diagnostic(
+            'LOCAL_STATUS_COMMAND_MISSING',
+            `status section '${statusSection}' is missing required command output`,
+            content, statusHeading
+          ));
+        }
+      }
+    }
+  }
+
+  for (const pattern of patterns.filter((item) => !isStatusPattern(item))) {
+    if (!new RegExp(pattern, 'm').test(content)) {
+      diagnostics.push(diagnostic(
+        'LOCAL_REQUIRED_PATTERN_MISSING',
+        `artifact is missing required pattern '${pattern}'`,
+        content
+      ));
+    }
+  }
+
+  const decisionDetails = inspectDecisionDetailDuplicates(content);
+  if (!decisionDetails.ok) {
+    diagnostics.push(diagnostic(
+      'LOCAL_DECISION_DETAIL_DUPLICATE',
+      decisionDetails.message,
+      content,
+      decisionDetails.duplicates[0]?.blocks[0]
+        ? scanned.headings.find((heading) => heading.start === decisionDetails.duplicates[0]!.blocks[0]!.start)
+        : undefined
+    ));
+  }
+
+  if (candidates.length === 1 && diagnostics.length === 0) {
+    const candidate = candidates[0]!;
+    const section = candidate.text.slice(0, -1);
+    const repair = diagnostic(
+      'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION',
+      `visible required H2 '${candidate.text}' may be normalized to '${section}'`,
+      content,
+      candidate,
+      {
+        repairable: true,
+        from: candidate.text,
+        to: section,
+        operation: 'replace-line'
+      }
+    );
+    return {
+      ok: false,
+      family: options.family,
+      semanticDigest: semanticDigest(content, candidate),
+      repairable: true,
+      diagnostics: [repair]
+    };
+  }
+
+  if (candidates.length > 0) {
+    for (const candidate of candidates) {
+      const section = candidate.text.slice(0, -1);
+      diagnostics.push(diagnostic(
+        'LOCAL_ARTIFACT_MISSING_SECTION',
+        `required section '${section}' is missing and cannot be repaired while other structural defects exist`,
+        content, candidate
+      ));
+    }
+  }
+
+  return {
+    ok: diagnostics.length === 0,
+    family: options.family,
+    semanticDigest: semanticDigest(content),
+    repairable: false,
+    diagnostics
+  };
+}
+
+function failedFinalization(
+  request: LocalArtifactFinalizationRequest,
+  error: { code: string; message: string },
+  extra: Partial<LocalArtifactFinalizationResult> = {}
+): LocalArtifactFinalizationResult {
+  return {
+    status: 'failed', changed: false,
+    taskId: null, taskDir: null,
+    family: request.family, artifact: request.artifact,
+    artifactSha256: null, semanticDigest: null,
+    repairable: false, diagnostics: [], error, ...extra
+  };
+}
+
+function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): LocalArtifactFinalizationResult {
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot: request.repoRoot });
+  if (!resolved.ok) return failedFinalization(request, { code: resolved.code, message: resolved.message });
+  const parsed = parseArtifactName(request.artifact);
+  if (!parsed || parsed.family !== request.family) {
+    return failedFinalization(request, {
+      code: 'ARTIFACT_IDENTITY_INVALID',
+      message: `artifact '${request.artifact}' does not match ${request.family}`
+    }, { taskId: resolved.taskId, taskDir: resolved.taskDir });
+  }
+  const validated = validateCompletedArtifact(resolved.taskDir, request.family, request.artifact, parsed.round);
+  if (!validated.ok) {
+    return failedFinalization(request, validated.error, { taskId: resolved.taskId, taskDir: resolved.taskDir });
+  }
+  let content: string;
+  try { content = fs.readFileSync(validated.artifact.path, 'utf8'); }
+  catch (error) {
+    return failedFinalization(request, { code: 'ARTIFACT_NOT_READABLE', message: String(error) }, {
+      taskId: resolved.taskId, taskDir: resolved.taskDir
+    });
+  }
+  const result = validateLocalArtifact(content, {
+    family: request.family,
+    requiredSections: request.requiredSections,
+    requiredPatterns: request.requiredPatterns
+  });
+  const artifactSha256 = sha256Content(content);
+  return {
+    status: result.ok ? 'passed' : 'failed',
+    changed: false,
+    taskId: resolved.taskId,
+    taskDir: resolved.taskDir,
+    family: request.family,
+    artifact: request.artifact,
+    artifactSha256,
+    semanticDigest: result.semanticDigest,
+    repairable: result.repairable,
+    diagnostics: result.diagnostics,
+    error: result.ok ? null : {
+      code: 'LOCAL_ARTIFACT_INVALID',
+      message: result.diagnostics.map((item) => `${item.code}: ${item.message}`).join('; ')
+    }
+  };
+}
+
+export {
+  LOCAL_ARTIFACT_REQUIRED_PATTERNS,
+  LOCAL_ARTIFACT_REQUIRED_SECTIONS,
+  finalizeLocalArtifact,
+  semanticDigest,
+  sha256Content,
+  validateLocalArtifact
+};
+export type {
+  LocalArtifactDiagnostic,
+  LocalArtifactDiagnosticCode,
+  LocalArtifactFamily,
+  LocalArtifactFinalizationRequest,
+  LocalArtifactFinalizationResult,
+  LocalArtifactValidationOptions,
+  LocalArtifactValidationResult
+};

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { createHash } from 'node:crypto';
+import path from 'node:path';
 
 import {
   inspectDecisionDetailDuplicates,
@@ -34,7 +35,9 @@ type LocalArtifactDiagnosticCode =
   | 'LOCAL_STATUS_COMMAND_MISSING'
   | 'LOCAL_DECISION_DETAIL_DUPLICATE'
   | 'LOCAL_REQUIRED_PATTERN_MISSING'
-  | 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION';
+  | 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION'
+  | 'LOCAL_REPAIR_PROVENANCE_CONFLICT'
+  | 'LOCAL_REPAIR_BASELINE_MISMATCH';
 
 type LocalArtifactDiagnostic = {
   code: LocalArtifactDiagnosticCode;
@@ -83,6 +86,80 @@ type LocalArtifactFinalizationResult = {
   error: { code: string; message: string } | null;
 };
 
+type LocalArtifactFinalizationIntent = Readonly<{
+  version: 1;
+  taskId: string;
+  family: LocalArtifactFamily;
+  artifact: string;
+  state: 'awaiting-repair' | 'passed';
+  baselineSemanticDigest: string | null;
+  artifactSha256: string;
+  semanticDigest: string;
+}>;
+
+function finalizationIntentRoot(repoRoot: string): string {
+  return path.join(repoRoot, '.agents', 'workspace', '.local-artifact-finalization-intents');
+}
+
+function finalizationIntentPath(repoRoot: string, taskId: string, family: LocalArtifactFamily, artifact: string): string {
+  return path.join(finalizationIntentRoot(repoRoot), `${taskId}-${family}-${artifact}.json`);
+}
+
+function isFinalizationIntent(value: unknown): value is LocalArtifactFinalizationIntent {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const intent = value as Record<string, unknown>;
+  return intent.version === 1
+    && typeof intent.taskId === 'string' && intent.taskId.length > 0
+    && (intent.family === 'analysis' || intent.family === 'plan')
+    && typeof intent.artifact === 'string' && intent.artifact.length > 0
+    && (intent.state === 'awaiting-repair' || intent.state === 'passed')
+    && (intent.baselineSemanticDigest === null || (typeof intent.baselineSemanticDigest === 'string' && /^[a-f0-9]{64}$/.test(intent.baselineSemanticDigest)))
+    && typeof intent.artifactSha256 === 'string' && /^[a-f0-9]{64}$/.test(intent.artifactSha256)
+    && typeof intent.semanticDigest === 'string' && /^[a-f0-9]{64}$/.test(intent.semanticDigest)
+    && (intent.state === 'awaiting-repair' ? intent.baselineSemanticDigest === intent.semanticDigest : true);
+}
+
+function readLocalArtifactFinalizationIntent(
+  repoRoot: string,
+  taskId: string,
+  family: LocalArtifactFamily,
+  artifact: string
+): LocalArtifactFinalizationIntent | null {
+  const target = finalizationIntentPath(repoRoot, taskId, family, artifact);
+  if (!fs.existsSync(target)) return null;
+  const value = JSON.parse(fs.readFileSync(target, 'utf8')) as unknown;
+  if (!isFinalizationIntent(value) || value.taskId !== taskId || value.family !== family || value.artifact !== artifact) {
+    throw new Error('LOCAL_FINALIZATION_INTENT_INVALID: finalization provenance schema is invalid');
+  }
+  return value;
+}
+
+function writeLocalArtifactFinalizationIntent(repoRoot: string, value: LocalArtifactFinalizationIntent): void {
+  if (!isFinalizationIntent(value)) throw new Error('LOCAL_FINALIZATION_INTENT_INVALID: finalization provenance schema is invalid');
+  const directory = finalizationIntentRoot(repoRoot);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const target = finalizationIntentPath(repoRoot, value.taskId, value.family, value.artifact);
+  const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+  try { fs.renameSync(temporary, target); }
+  catch (error) {
+    try { fs.unlinkSync(temporary); } catch { /* preserve primary error */ }
+    throw error;
+  }
+}
+
+function removeLocalArtifactFinalizationIntent(
+  repoRoot: string,
+  taskId: string,
+  family: LocalArtifactFamily,
+  artifact: string
+): void {
+  const target = finalizationIntentPath(repoRoot, taskId, family, artifact);
+  try { fs.unlinkSync(target); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
 function requiredSections(family: LocalArtifactFamily): readonly string[] {
   return LOCAL_ARTIFACT_REQUIRED_SECTIONS[family];
 }
@@ -108,7 +185,7 @@ function semanticDigest(content: string, candidate?: VisibleHeading): string {
       normalized = `${content.slice(0, candidate.start)}${canonical}${content.slice(candidate.end)}`;
     }
   }
-  return createHash('sha256').update(normalized.replace(/\s+/g, ''), 'utf8').digest('hex');
+  return createHash('sha256').update(normalized, 'utf8').digest('hex');
 }
 
 function sha256Content(content: string): string {
@@ -280,6 +357,24 @@ function failedFinalization(
   };
 }
 
+function provenanceFailure(
+  request: LocalArtifactFinalizationRequest,
+  resolved: { taskId: string; taskDir: string },
+  content: string,
+  artifactSha256: string,
+  semanticDigestValue: string,
+  code: LocalArtifactDiagnosticCode,
+  message: string
+): LocalArtifactFinalizationResult {
+  return failedFinalization(request, { code, message }, {
+    taskId: resolved.taskId,
+    taskDir: resolved.taskDir,
+    artifactSha256,
+    semanticDigest: semanticDigestValue,
+    diagnostics: [diagnostic(code, message, content)]
+  });
+}
+
 function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): LocalArtifactFinalizationResult {
   const resolved = resolveTaskRef(request.taskRef, { repoRoot: request.repoRoot });
   if (!resolved.ok) return failedFinalization(request, { code: resolved.code, message: resolved.message });
@@ -307,6 +402,108 @@ function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): Local
     requiredPatterns: request.requiredPatterns
   });
   const artifactSha256 = sha256Content(content);
+  let intent: LocalArtifactFinalizationIntent | null;
+  try {
+    intent = readLocalArtifactFinalizationIntent(resolved.repoRoot, resolved.taskId, request.family, request.artifact);
+  } catch (error) {
+    return failedFinalization(request, {
+      code: 'LOCAL_FINALIZATION_INTENT_INVALID',
+      message: error instanceof Error ? error.message : String(error)
+    }, { taskId: resolved.taskId, taskDir: resolved.taskDir, artifactSha256, semanticDigest: result.semanticDigest });
+  }
+  if (result.repairable) {
+    if (intent && (intent.state !== 'awaiting-repair' || intent.baselineSemanticDigest !== result.semanticDigest)) {
+      return provenanceFailure(
+        request, resolved, content, artifactSha256, result.semanticDigest,
+        'LOCAL_REPAIR_PROVENANCE_CONFLICT',
+        'a different local repair baseline is already recorded for this artifact'
+      );
+    }
+    if (!intent) {
+      try {
+        writeLocalArtifactFinalizationIntent(resolved.repoRoot, {
+          version: 1,
+          taskId: resolved.taskId,
+          family: request.family,
+          artifact: request.artifact,
+          state: 'awaiting-repair',
+          baselineSemanticDigest: result.semanticDigest,
+          artifactSha256,
+          semanticDigest: result.semanticDigest
+        });
+      } catch (error) {
+        return failedFinalization(request, {
+          code: 'LOCAL_FINALIZATION_INTENT_WRITE_FAILED',
+          message: error instanceof Error ? error.message : String(error)
+        }, { taskId: resolved.taskId, taskDir: resolved.taskDir, artifactSha256, semanticDigest: result.semanticDigest });
+      }
+    }
+    return {
+      status: 'failed',
+      changed: false,
+      taskId: resolved.taskId,
+      taskDir: resolved.taskDir,
+      family: request.family,
+      artifact: request.artifact,
+      artifactSha256,
+      semanticDigest: result.semanticDigest,
+      repairable: true,
+      diagnostics: result.diagnostics,
+      error: {
+        code: 'LOCAL_ARTIFACT_INVALID',
+        message: result.diagnostics.map((item) => `${item.code}: ${item.message}`).join('; ')
+      }
+    };
+  }
+  if (!result.ok) {
+    return {
+      status: 'failed',
+      changed: false,
+      taskId: resolved.taskId,
+      taskDir: resolved.taskDir,
+      family: request.family,
+      artifact: request.artifact,
+      artifactSha256,
+      semanticDigest: result.semanticDigest,
+      repairable: false,
+      diagnostics: result.diagnostics,
+      error: {
+        code: 'LOCAL_ARTIFACT_INVALID',
+        message: result.diagnostics.map((item) => `${item.code}: ${item.message}`).join('; ')
+      }
+    };
+  }
+  if (intent?.state === 'awaiting-repair' && intent.baselineSemanticDigest !== result.semanticDigest) {
+    return provenanceFailure(
+      request, resolved, content, artifactSha256, result.semanticDigest,
+      'LOCAL_REPAIR_BASELINE_MISMATCH',
+      'the repaired artifact semantic digest does not match the recorded repair baseline'
+    );
+  }
+  if (intent?.state === 'passed' && (intent.artifactSha256 !== artifactSha256 || intent.semanticDigest !== result.semanticDigest)) {
+    return provenanceFailure(
+      request, resolved, content, artifactSha256, result.semanticDigest,
+      'LOCAL_REPAIR_PROVENANCE_CONFLICT',
+      'the artifact changed after its finalization provenance was recorded'
+    );
+  }
+  try {
+    writeLocalArtifactFinalizationIntent(resolved.repoRoot, {
+      version: 1,
+      taskId: resolved.taskId,
+      family: request.family,
+      artifact: request.artifact,
+      state: 'passed',
+      baselineSemanticDigest: intent?.baselineSemanticDigest ?? null,
+      artifactSha256,
+      semanticDigest: result.semanticDigest
+    });
+  } catch (error) {
+    return failedFinalization(request, {
+      code: 'LOCAL_FINALIZATION_INTENT_WRITE_FAILED',
+      message: error instanceof Error ? error.message : String(error)
+    }, { taskId: resolved.taskId, taskDir: resolved.taskDir, artifactSha256, semanticDigest: result.semanticDigest });
+  }
   return {
     status: result.ok ? 'passed' : 'failed',
     changed: false,
@@ -329,6 +526,8 @@ export {
   LOCAL_ARTIFACT_REQUIRED_PATTERNS,
   LOCAL_ARTIFACT_REQUIRED_SECTIONS,
   finalizeLocalArtifact,
+  readLocalArtifactFinalizationIntent,
+  removeLocalArtifactFinalizationIntent,
   semanticDigest,
   sha256Content,
   validateLocalArtifact
@@ -339,6 +538,7 @@ export type {
   LocalArtifactFamily,
   LocalArtifactFinalizationRequest,
   LocalArtifactFinalizationResult,
+  LocalArtifactFinalizationIntent,
   LocalArtifactValidationOptions,
   LocalArtifactValidationResult
 };

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -13,7 +13,7 @@ import {
 } from './artifact-lifecycle.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
 
-type LocalArtifactFamily = 'analysis' | 'plan';
+type LocalArtifactFamily = 'analysis' | 'plan' | 'code';
 
 const LOCAL_ARTIFACT_REQUIRED_SECTIONS: Readonly<Record<LocalArtifactFamily, readonly string[]>> = {
   analysis: [
@@ -23,6 +23,10 @@ const LOCAL_ARTIFACT_REQUIRED_SECTIONS: Readonly<Record<LocalArtifactFamily, rea
   plan: [
     '问题理解', '约束条件', '方案对比', '技术方法', '实施步骤',
     '文件清单', '验证策略', '状态核对'
+  ],
+  code: [
+    '实现输入', '变更文件', '关键代码说明', '测试结果', '与方案的差异',
+    '供审查关注的内容', '状态核对', '证据原文'
   ]
 };
 
@@ -110,7 +114,7 @@ function isFinalizationIntent(value: unknown): value is LocalArtifactFinalizatio
   const intent = value as Record<string, unknown>;
   return intent.version === 1
     && typeof intent.taskId === 'string' && intent.taskId.length > 0
-    && (intent.family === 'analysis' || intent.family === 'plan')
+    && (intent.family === 'analysis' || intent.family === 'plan' || intent.family === 'code')
     && typeof intent.artifact === 'string' && intent.artifact.length > 0
     && (intent.state === 'awaiting-repair' || intent.state === 'passed' || intent.state === 'consumed')
     && (intent.baselineSemanticDigest === null || (typeof intent.baselineSemanticDigest === 'string' && /^[a-f0-9]{64}$/.test(intent.baselineSemanticDigest)))

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -91,7 +91,7 @@ type LocalArtifactFinalizationIntent = Readonly<{
   taskId: string;
   family: LocalArtifactFamily;
   artifact: string;
-  state: 'awaiting-repair' | 'passed';
+  state: 'awaiting-repair' | 'passed' | 'consumed';
   baselineSemanticDigest: string | null;
   artifactSha256: string;
   semanticDigest: string;
@@ -112,7 +112,7 @@ function isFinalizationIntent(value: unknown): value is LocalArtifactFinalizatio
     && typeof intent.taskId === 'string' && intent.taskId.length > 0
     && (intent.family === 'analysis' || intent.family === 'plan')
     && typeof intent.artifact === 'string' && intent.artifact.length > 0
-    && (intent.state === 'awaiting-repair' || intent.state === 'passed')
+    && (intent.state === 'awaiting-repair' || intent.state === 'passed' || intent.state === 'consumed')
     && (intent.baselineSemanticDigest === null || (typeof intent.baselineSemanticDigest === 'string' && /^[a-f0-9]{64}$/.test(intent.baselineSemanticDigest)))
     && typeof intent.artifactSha256 === 'string' && /^[a-f0-9]{64}$/.test(intent.artifactSha256)
     && typeof intent.semanticDigest === 'string' && /^[a-f0-9]{64}$/.test(intent.semanticDigest)
@@ -148,16 +148,15 @@ function writeLocalArtifactFinalizationIntent(repoRoot: string, value: LocalArti
   }
 }
 
-function removeLocalArtifactFinalizationIntent(
+function consumeLocalArtifactFinalizationIntent(
   repoRoot: string,
-  taskId: string,
-  family: LocalArtifactFamily,
-  artifact: string
-): void {
-  const target = finalizationIntentPath(repoRoot, taskId, family, artifact);
-  try { fs.unlinkSync(target); } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-  }
+  intent: LocalArtifactFinalizationIntent
+): LocalArtifactFinalizationIntent {
+  if (intent.state === 'consumed') return intent;
+  if (intent.state !== 'passed') throw new Error('LOCAL_FINALIZATION_INTENT_INVALID: only passed provenance can be consumed');
+  const consumed = { ...intent, state: 'consumed' as const };
+  writeLocalArtifactFinalizationIntent(repoRoot, consumed);
+  return consumed;
 }
 
 function requiredSections(family: LocalArtifactFamily): readonly string[] {
@@ -480,12 +479,28 @@ function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): Local
       'the repaired artifact semantic digest does not match the recorded repair baseline'
     );
   }
-  if (intent?.state === 'passed' && (intent.artifactSha256 !== artifactSha256 || intent.semanticDigest !== result.semanticDigest)) {
+  if ((intent?.state === 'passed' || intent?.state === 'consumed')
+    && (intent.artifactSha256 !== artifactSha256 || intent.semanticDigest !== result.semanticDigest)) {
     return provenanceFailure(
       request, resolved, content, artifactSha256, result.semanticDigest,
       'LOCAL_REPAIR_PROVENANCE_CONFLICT',
       'the artifact changed after its finalization provenance was recorded'
     );
+  }
+  if (intent?.state === 'consumed') {
+    return {
+      status: 'passed',
+      changed: false,
+      taskId: resolved.taskId,
+      taskDir: resolved.taskDir,
+      family: request.family,
+      artifact: request.artifact,
+      artifactSha256,
+      semanticDigest: result.semanticDigest,
+      repairable: false,
+      diagnostics: result.diagnostics,
+      error: null
+    };
   }
   try {
     writeLocalArtifactFinalizationIntent(resolved.repoRoot, {
@@ -525,9 +540,9 @@ function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): Local
 export {
   LOCAL_ARTIFACT_REQUIRED_PATTERNS,
   LOCAL_ARTIFACT_REQUIRED_SECTIONS,
+  consumeLocalArtifactFinalizationIntent,
   finalizeLocalArtifact,
   readLocalArtifactFinalizationIntent,
-  removeLocalArtifactFinalizationIntent,
   semanticDigest,
   sha256Content,
   validateLocalArtifact

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -600,7 +600,9 @@ function checkArtifact({ taskDir, config, artifactFile, skillName }: any): any {
 
   const content = fs.readFileSync(artifactPath, "utf8");
   const requiredSections = config.required_sections || [];
-  const localFamily = skillName === "analyze-task" ? "analysis" : skillName === "plan-task" ? "plan" : null;
+  const localFamily = skillName === "analyze-task"
+    ? "analysis"
+    : skillName === "plan-task" ? "plan" : skillName === "code-task" ? "code" : null;
   if (localFamily) {
     const local = validateLocalArtifact(content, {
       family: localFamily,

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -34,6 +34,7 @@ import { snapshotReview } from "../git/review-snapshot.ts";
 import { OrchestrationStateError, readRun } from "./orchestration.ts";
 import { resolveDeliveryTarget } from "./delivery-target.ts";
 import { readPrDeliveryFact } from "./pr-delivery-fact.ts";
+import { validateLocalArtifact } from "./local-artifact-finalization.ts";
 
 const TASK_ENUMS = {
   type: ["feature", "bugfix", "refactor", "docs", "chore"],
@@ -581,7 +582,7 @@ function loadProjectName(): any {
   }
 }
 
-function checkArtifact({ taskDir, config, artifactFile }: any): any {
+function checkArtifact({ taskDir, config, artifactFile, skillName }: any): any {
   const resolvedArtifact = resolveArtifactPath(taskDir, config.file_pattern, artifactFile);
   if (!resolvedArtifact.ok) {
     return failResult("artifact", resolvedArtifact.message);
@@ -599,6 +600,24 @@ function checkArtifact({ taskDir, config, artifactFile }: any): any {
 
   const content = fs.readFileSync(artifactPath, "utf8");
   const requiredSections = config.required_sections || [];
+  const localFamily = skillName === "analyze-task" ? "analysis" : skillName === "plan-task" ? "plan" : null;
+  if (localFamily) {
+    const local = validateLocalArtifact(content, {
+      family: localFamily,
+      requiredSections: requiredSections.filter((section: unknown): section is string => typeof section === "string"),
+      requiredPatterns: (config.required_patterns || []).filter((pattern: unknown): pattern is string => typeof pattern === "string")
+    });
+    if (!local.ok) {
+      return failResult(
+        "artifact",
+        `${path.basename(artifactPath)} has local structural errors: ${local.diagnostics.map((item) => `${item.code}: ${item.message}`).join('; ')}`
+      );
+    }
+    return passResult(
+      "artifact",
+      `${path.basename(artifactPath)} passed (${requiredSections.length} sections)`
+    );
+  }
   const missingSections = requiredSections.filter(
     (section: any) => !new RegExp(`^##\\s+${escapeRegExp(section)}\\s*$`, "m").test(content)
   );

--- a/templates/.agents/rules/README.en.md
+++ b/templates/.agents/rules/README.en.md
@@ -30,7 +30,7 @@ so you can quickly find "which ones to read" without opening each file.
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — Fresh executor/reviewer, one-use receipt, pause/recovery, and safe endpoint rules for `run-task`.
 - [`review-handshake.md`](review-handshake.md) — Three-stage bidirectional review handshake: four-state disposition, symmetric evidence, disagreement ledger, convergence and post-review commit gate.
 - [`review-method.md`](review-method.md) — Shared three-stage review method: multi-pass review, risk lenses, traceability, and finding evidence.
-- [`local-artifact-repair.md`](local-artifact-repair.md) — Pre-completion local artifact validation for analysis/plan and model-per-case repair, safety gates, and convergence for failed review artifacts.
+- [`local-artifact-repair.md`](local-artifact-repair.md) — Pre-completion local artifact validation for analysis/plan/code and model-per-case repair, safety gates, and convergence for failed review artifacts.
 - [`human-decision-context.md`](human-decision-context.md) — Self-contained context and canonical structure for new human-decision details.
 - [`task-short-id.md`](task-short-id.md) — Resolution, allocation and lifecycle of bare-number short ids.
 - [`milestone-inference.md`](milestone-inference.md) — Milestone inference for create-task / code-task / create-pr.

--- a/templates/.agents/rules/README.en.md
+++ b/templates/.agents/rules/README.en.md
@@ -30,7 +30,7 @@ so you can quickly find "which ones to read" without opening each file.
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — Fresh executor/reviewer, one-use receipt, pause/recovery, and safe endpoint rules for `run-task`.
 - [`review-handshake.md`](review-handshake.md) — Three-stage bidirectional review handshake: four-state disposition, symmetric evidence, disagreement ledger, convergence and post-review commit gate.
 - [`review-method.md`](review-method.md) — Shared three-stage review method: multi-pass review, risk lenses, traceability, and finding evidence.
-- [`local-artifact-repair.md`](local-artifact-repair.md) — Model-per-case repair, mechanical safety gates, dynamic convergence, and result-output contract for failed review artifacts.
+- [`local-artifact-repair.md`](local-artifact-repair.md) — Pre-completion local artifact validation for analysis/plan and model-per-case repair, safety gates, and convergence for failed review artifacts.
 - [`human-decision-context.md`](human-decision-context.md) — Self-contained context and canonical structure for new human-decision details.
 - [`task-short-id.md`](task-short-id.md) — Resolution, allocation and lifecycle of bare-number short ids.
 - [`milestone-inference.md`](milestone-inference.md) — Milestone inference for create-task / code-task / create-pr.

--- a/templates/.agents/rules/README.zh-CN.md
+++ b/templates/.agents/rules/README.zh-CN.md
@@ -29,7 +29,7 @@
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — `run-task` 的 fresh executor/reviewer、一次性 receipt、暂停恢复与安全终点规则。
 - [`review-handshake.md`](review-handshake.md) — 三阶段双向审查握手协议：四态处置、对称证据、分歧账本、收敛与 post-review commit 门禁。
 - [`review-method.md`](review-method.md) — 三阶段共享检视方法：多遍检视、风险镜头、追踪与 finding 证据契约。
-- [`local-artifact-repair.md`](local-artifact-repair.md) — review artifact 失败后的模型逐例修复、机械安全门、动态收敛与结果输出契约。
+- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
 - [`human-decision-context.md`](human-decision-context.md) — 新建人工裁决详情的自足上下文与规范结构。
 - [`task-short-id.md`](task-short-id.md) — 裸数字任务短号的解析、分配与生命周期。
 - [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。

--- a/templates/.agents/rules/README.zh-CN.md
+++ b/templates/.agents/rules/README.zh-CN.md
@@ -29,7 +29,7 @@
 - [`lifecycle-orchestration.md`](lifecycle-orchestration.md) — `run-task` 的 fresh executor/reviewer、一次性 receipt、暂停恢复与安全终点规则。
 - [`review-handshake.md`](review-handshake.md) — 三阶段双向审查握手协议：四态处置、对称证据、分歧账本、收敛与 post-review commit 门禁。
 - [`review-method.md`](review-method.md) — 三阶段共享检视方法：多遍检视、风险镜头、追踪与 finding 证据契约。
-- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
+- [`local-artifact-repair.md`](local-artifact-repair.md) — analysis/plan/code completed 前的本地产物校验、review artifact 失败后的模型逐例修复、机械安全门与收敛契约。
 - [`human-decision-context.md`](human-decision-context.md) — 新建人工裁决详情的自足上下文与规范结构。
 - [`task-short-id.md`](task-short-id.md) — 裸数字任务短号的解析、分配与生命周期。
 - [`milestone-inference.md`](milestone-inference.md) — create-task / code-task / create-pr 的 milestone 推断。

--- a/templates/.agents/rules/local-artifact-repair.en.md
+++ b/templates/.agents/rules/local-artifact-repair.en.md
@@ -1,10 +1,10 @@
 # General Rule - Model-Driven Local Artifact Repair
 
-This rule applies when `analyze-task` or `plan-task` handles **the same controlled local artifact** before its completed event, and when `review-analysis`, `review-plan`, or `review-code` handles a finalizer failure for **the same controlled review artifact**. It does not apply to `task.md`, the ledger, receipts, source code, Git, platform resources, or lifecycle state.
+This rule applies when `analyze-task`, `plan-task`, or `code-task` handles **the same controlled local artifact** before its completed event, and when `review-analysis`, `review-plan`, or `review-code` handles a finalizer failure for **the same controlled review artifact**. It does not apply to `task.md`, the ledger, receipts, source code, Git, platform resources, or lifecycle state.
 
-## Pre-completion gate for analysis and plan artifacts
+## Pre-completion gate for analysis, plan, and code artifacts
 
-- `analyze-task` and `plan-task` must call `task-artifact ... finalize-local` before publishing a completed event; pass only that call's `artifactSha256` and `semanticDigest` to the completed event.
+- `analyze-task`, `plan-task`, and `code-task` must call `task-artifact ... finalize-local` before publishing a completed event; pass only that call's `artifactSha256` and `semanticDigest` to the completed event.
 - `finalize-local` does not modify the artifact or task state, but it writes a one-shot local provenance intent in the repository workspace. After `failed`, the model may make one minimal edit in the same artifact only when `repairable=true` and the diagnostic explicitly describes a one-line replacement, then rerun the same call completely; count each byte-changing edit, up to 8.
 - The first repairable failure's semantic digest is retained in that intent; a later `passed` result must match the baseline, and the completed event must verify and atomically transition the same intent to `consumed` before writing `task.md` under the task lock. A consumption failure must not write the task; the consumed intent is durable and retryable, so no failure-prone post-write deletion is attempted. Do not replace a failed baseline with a newly computed digest or publish a completed event without the finalizer.
 - After `failed`, no progress, or a repeated diagnostic or fingerprint, do not publish a completed event. After `passed`, do not rescan or manually write summary data.

--- a/templates/.agents/rules/local-artifact-repair.en.md
+++ b/templates/.agents/rules/local-artifact-repair.en.md
@@ -1,12 +1,18 @@
 # General Rule - Model-Driven Local Artifact Repair
 
-This rule applies only when `review-analysis`, `review-plan`, or `review-code` handles a finalizer failure for **the same controlled review artifact**. It does not apply to `task.md`, the ledger, receipts, source code, Git, platform resources, or lifecycle state.
+This rule applies when `analyze-task` or `plan-task` handles **the same controlled local artifact** before its completed event, and when `review-analysis`, `review-plan`, or `review-code` handles a finalizer failure for **the same controlled review artifact**. It does not apply to `task.md`, the ledger, receipts, source code, Git, platform resources, or lifecycle state.
+
+## Pre-completion gate for analysis and plan artifacts
+
+- `analyze-task` and `plan-task` must call `task-artifact ... finalize-local` before publishing a completed event; pass only that call's `artifactSha256` and `semanticDigest` to the completed event.
+- `finalize-local` is read-only validation. After `failed`, the model may make one minimal edit in the same artifact only when `repairable=true` and the diagnostic explicitly describes a one-line replacement, then rerun the same call completely; count each byte-changing edit, up to 8.
+- After `failed`, no progress, or a repeated diagnostic or fingerprint, do not publish a completed event. After `passed`, do not rescan or manually write summary data.
 
 ## Authorization Boundary
 
 - The finalizer only reads facts, validates state, normalizes successful results, and performs atomic writes. It does not maintain a recoverable-error allowlist, infer repairability, or choose report content to delete.
 - The initial finalizer call is not counted as a repair attempt. Editing is allowed only after the mechanical safety gates pass and the model explicitly determines that the current problem can be solved by a minimal, explainable artifact change.
-- The model may edit only the one ordinary review artifact declared by the current review skill, and the file must be inside the current task directory. It must not edit `task.md`, the review disagreement ledger, receipts, source code, other reports, or remote resources.
+- The model may edit only the one ordinary local artifact declared by the current skill, and the file must be inside the current task directory. It must not edit `task.md`, the review disagreement ledger, receipts, source code, other reports, or remote resources.
 - `changed=false`, an error code, or a format shape is diagnostic evidence, not automatic authorization. The model must judge each case using the complete diagnostic, artifact content, and context.
 
 ## Non-bypassable Mechanical Safety Gates

--- a/templates/.agents/rules/local-artifact-repair.en.md
+++ b/templates/.agents/rules/local-artifact-repair.en.md
@@ -5,7 +5,8 @@ This rule applies when `analyze-task` or `plan-task` handles **the same controll
 ## Pre-completion gate for analysis and plan artifacts
 
 - `analyze-task` and `plan-task` must call `task-artifact ... finalize-local` before publishing a completed event; pass only that call's `artifactSha256` and `semanticDigest` to the completed event.
-- `finalize-local` is read-only validation. After `failed`, the model may make one minimal edit in the same artifact only when `repairable=true` and the diagnostic explicitly describes a one-line replacement, then rerun the same call completely; count each byte-changing edit, up to 8.
+- `finalize-local` does not modify the artifact or task state, but it writes a one-shot local provenance intent in the repository workspace. After `failed`, the model may make one minimal edit in the same artifact only when `repairable=true` and the diagnostic explicitly describes a one-line replacement, then rerun the same call completely; count each byte-changing edit, up to 8.
+- The first repairable failure's semantic digest is retained in that intent; a later `passed` result must match the baseline, and the completed event must verify and consume the same intent under the task lock. Do not replace a failed baseline with a newly computed digest or publish a completed event without the finalizer.
 - After `failed`, no progress, or a repeated diagnostic or fingerprint, do not publish a completed event. After `passed`, do not rescan or manually write summary data.
 
 ## Authorization Boundary

--- a/templates/.agents/rules/local-artifact-repair.en.md
+++ b/templates/.agents/rules/local-artifact-repair.en.md
@@ -6,7 +6,7 @@ This rule applies when `analyze-task` or `plan-task` handles **the same controll
 
 - `analyze-task` and `plan-task` must call `task-artifact ... finalize-local` before publishing a completed event; pass only that call's `artifactSha256` and `semanticDigest` to the completed event.
 - `finalize-local` does not modify the artifact or task state, but it writes a one-shot local provenance intent in the repository workspace. After `failed`, the model may make one minimal edit in the same artifact only when `repairable=true` and the diagnostic explicitly describes a one-line replacement, then rerun the same call completely; count each byte-changing edit, up to 8.
-- The first repairable failure's semantic digest is retained in that intent; a later `passed` result must match the baseline, and the completed event must verify and consume the same intent under the task lock. Do not replace a failed baseline with a newly computed digest or publish a completed event without the finalizer.
+- The first repairable failure's semantic digest is retained in that intent; a later `passed` result must match the baseline, and the completed event must verify and atomically transition the same intent to `consumed` before writing `task.md` under the task lock. A consumption failure must not write the task; the consumed intent is durable and retryable, so no failure-prone post-write deletion is attempted. Do not replace a failed baseline with a newly computed digest or publish a completed event without the finalizer.
 - After `failed`, no progress, or a repeated diagnostic or fingerprint, do not publish a completed event. After `passed`, do not rescan or manually write summary data.
 
 ## Authorization Boundary

--- a/templates/.agents/rules/local-artifact-repair.zh-CN.md
+++ b/templates/.agents/rules/local-artifact-repair.zh-CN.md
@@ -1,10 +1,10 @@
 # 通用规则 - 模型驱动的本地产物修复
 
-本规则适用于 `analyze-task`、`plan-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+本规则适用于 `analyze-task`、`plan-task`、`code-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
 
-## 分析和方案产物完成前门禁
+## 分析、方案和代码产物完成前门禁
 
-- `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
+- `analyze-task`、`plan-task` 和 `code-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
 - `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
 - 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并在写 task.md 前原子转换为 `consumed` 状态。消费失败时不得写任务；转换后的 intent 是可重试的 durable 记录，成功写入后不再执行可能失败的后置删除。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。

--- a/templates/.agents/rules/local-artifact-repair.zh-CN.md
+++ b/templates/.agents/rules/local-artifact-repair.zh-CN.md
@@ -1,12 +1,18 @@
 # 通用规则 - 模型驱动的本地产物修复
 
-本规则只适用于 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+本规则适用于 `analyze-task`、`plan-task` 在 completed 事件前处理**同一个受控本地产物**，以及 `review-analysis`、`review-plan`、`review-code` 在 finalizer 失败后处理**同一个受控 review artifact** 的场景。它不适用于 task.md、账本、receipt、源码、Git、平台资源或生命周期状态。
+
+## 分析和方案产物完成前门禁
+
+- `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
+- `finalize-local` 是只读校验。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界
 
 - finalizer 只负责读取事实、校验状态、规范化成功结果和原子写入；它不维护可修复错误码白名单，不推断 repairability，也不自动选择要删除的报告内容。
 - 首次 finalizer 调用不计入修复次数。只有在机械安全门通过后，模型明确判断当前问题能通过最小、可解释的 artifact 修改解决时，才允许编辑。
-- 模型只能修改当前 review skill 声明的一个普通 review artifact，且该文件必须位于当前 task 目录。不得修改 task.md、审查分歧账本、receipt、源码、其他报告或远端资源。
+- 模型只能修改当前 skill 声明的一个普通本地产物，且该文件必须位于当前 task 目录。不得修改 task.md、审查分歧账本、receipt、源码、其他报告或远端资源。
 - `changed=false`、错误码或某个格式形状只是诊断事实，不是自动批准。模型必须结合完整诊断、artifact 内容和上下文逐例判断。
 
 ## 不可绕过的机械安全门

--- a/templates/.agents/rules/local-artifact-repair.zh-CN.md
+++ b/templates/.agents/rules/local-artifact-repair.zh-CN.md
@@ -6,7 +6,7 @@
 
 - `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
 - `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
-- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并消费同一 intent。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
+- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并在写 task.md 前原子转换为 `consumed` 状态。消费失败时不得写任务；转换后的 intent 是可重试的 durable 记录，成功写入后不再执行可能失败的后置删除。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界

--- a/templates/.agents/rules/local-artifact-repair.zh-CN.md
+++ b/templates/.agents/rules/local-artifact-repair.zh-CN.md
@@ -5,7 +5,8 @@
 ## 分析和方案产物完成前门禁
 
 - `analyze-task` 和 `plan-task` 必须在发布 completed 事件前调用 `task-artifact ... finalize-local`；只有同一次返回的 `artifactSha256` 和 `semanticDigest` 才能传给 completed 事件。
-- `finalize-local` 是只读校验。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- `finalize-local` 不修改产物或任务状态，但会在仓库工作区写入一次性的本地 provenance intent。返回 `failed` 时，只有 `repairable=true` 且诊断明确为单行替换，模型才可在同一产物中执行一次最小编辑，然后完整重跑同一调用；每次实际字节修改计一次，最多 8 次。
+- 首次可修复失败的 semantic digest 会保存在该 intent 中；后续 `passed` 必须匹配该基线，completed event 还必须在任务锁内验证并消费同一 intent。不得用重新计算的新摘要替换失败基线，也不得绕过 finalizer 直接发布 completed event。
 - 返回 `failed`、无进展、诊断或指纹重复时不得发布 completed 事件；返回 `passed` 后也不得重新扫描或手工补写摘要。
 
 ## 授权边界

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -209,9 +209,9 @@ After writing the local artifact, run the pre-completion gate:
 agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
 ```
 
-- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`.
+- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`; the finalizer has recorded the matching one-shot local provenance intent.
 - On `status=failed` with `repairable=true`, apply only the diagnostic's `replace-line` operation once, then rerun the same command completely; count an attempt only after bytes change, up to 8 attempts.
-- On any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
+- The first repairable failure's `semanticDigest` is retained as the baseline; a retried `status=passed` result must match it. On baseline mismatch, any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
 
 Use the digests from that same `status=passed` result in `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}` so the core records the link, stage, agent, metadata, and Activity Log atomically.
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -203,7 +203,17 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   - Overwrite the `priority` field in frontmatter with the new value
   - Append a `## Priority Re-estimate` section to this round's analysis artifact `{analysis-artifact}`, recording: `priority {old} → {new} (rationale: {short basis grounded in this analysis})`
   If the re-estimated value matches the current value, skip it: do not write the `## Priority Re-estimate` section. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
-After the business fields are updated, run `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} {execution-flag}` so the core atomically records the link, stage, agent, metadata, and Activity Log.
+After writing the local artifact, run the pre-completion gate:
+
+```bash
+agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
+```
+
+- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`.
+- On `status=failed` with `repairable=true`, apply only the diagnostic's `replace-line` operation once, then rerun the same command completely; count an attempt only after bytes change, up to 8 attempts.
+- On any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
+
+Use the digests from that same `status=passed` result in `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}` so the core records the link, stage, agent, metadata, and Activity Log atomically.
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Analyze Task (Round {N})** by {agent} — Analysis completed → {analysis-artifact}
   ```
 

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -208,9 +208,9 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
   ```bash
   agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
   ```
-  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`；finalizer 已记录对应的一次性本地 provenance intent。
   - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
-  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+  - 首次可修复失败的 `semanticDigest` 由 finalizer 保留为基线；重试后的 `status=passed` 必须匹配该基线。基线不匹配、其他失败、无进展或重复诊断：停止，不发布 completed 事件。
 - 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -204,7 +204,14 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
   - 用新值覆盖 frontmatter 的 `priority` 字段
   - 在本轮分析产物 `{analysis-artifact}` 中追加 `## 优先级重估` 段，记录一条：`priority {old} → {new} (rationale: {基于本轮分析的简短依据})`
   若重估值与当前值一致，跳过：不写入 `## 优先级重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
-- 完成业务内容更新后执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} {execution-flag}`，由核心原子登记链接、阶段、代理、时间、版本和 Activity Log。
+- 完成本地产物后，先执行本地完成前门禁：
+  ```bash
+  agent-infra-internal task-artifact {task-id} finalize-local --family analysis --artifact {analysis-artifact}
+  ```
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
+  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+- 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} analyze.completed --agent {standard-agent-token} --artifact {analysis-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status pending-design-work --fields`

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -19,6 +19,7 @@ Implement the approved plan and produce `code.md` or `code-r{N}.md`. This skill 
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body
 - Read `.agents/rules/compatibility-policy.md` before implementation. Implement only the compatibility budget explicitly approved by the plan; never retain old branches, result contracts, or migration shims merely to be “safe”
 - Fix mode verifies each finding of the latest `review-code` one by one: fix it if it holds, or rebut it and record it under unresolved if it is unfounded/hallucinated; do not expand to issues the review did not list; manual-validation items are out of scope
+- Before `code.completed`, the implementation report must pass `task-artifact ... finalize-local --family code`; follow `.agents/rules/local-artifact-repair.md` for any provably safe minimal structural repair in that same report, and pass only that successful call's digests to the completion event
 - If implementation encounters a key design decision not covered by the plan, run `agent-infra-internal task-ledger {task-id} decision-next-id`, write the returned `HD-N` detail block per `.agents/rules/human-decision-context.md` and determine whether implementation is required, then run `decision-upsert --id {HD-N} --stage code --artifact {code-artifact} --needs-implementation {true|false}`. Do not scan ids, assemble ledger rows, ask mid-flow, or silently expand scope
 - Do not invoke the `commit` skill or push to a remote; after tests pass, call the shared commit core with `delivery: { mode: 'local' }` to create the local checkpoint. The durable intent must close only after the checkpoint and task state sync succeed; only then emit `code.completed`
 - Create a new code artifact for each round and never overwrite an older one
@@ -60,7 +61,7 @@ Read `reference/branch-management.md`, ensure the current branch matches the tas
 
 **Mandatory; do not skip.** If task.md has a valid `issue_number`, run `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --milestone specific`.
 
-> If the milestone remains `X.Y.x`, step 11 `task-verify code.completed` blocks through the typed milestone check.
+> If the milestone remains `X.Y.x`, step 12 `task-verify code.completed` blocks through the typed milestone check.
 
 ### 4. Determine Mode and Round
 
@@ -112,22 +113,38 @@ Create `.agents/workspace/active/{task-id}/{code-artifact}`.
 
 > Read `reference/report-template.md` before writing the report.
 
-### 10. Update Task Status
+### 10. Pre-completion Report Gate
 
-After requirement checkboxes are updated, run the initial event `agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --files-modified {n} --tests-passed {n} {execution-flag}`; in fix mode use `--fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}` instead; in decision mode add `--implementation-input {input-id}` to the initial counts. The core atomically records the artifact link, stage, metadata, done log, and decision-input consumption.
+After writing the report and before publishing `code.completed`, read and follow `.agents/rules/local-artifact-repair.md` and run:
+
+```bash
+finalizer=$(agent-infra-internal task-artifact {task-id} finalize-local --family code --artifact {code-artifact})
+status=$?
+echo "$finalizer"
+```
+
+- `status=0` with `finalizer.status="passed"`: bind `{artifact-sha256}` and `{semantic-digest}` from this result.
+- `status=1` with `repairable=true` and a diagnostic explicitly describing a one-line replacement: confirm task, round, artifact, and provenance are unchanged; edit only that `code*.md` once, confirm the bytes changed, then rerun the same command completely.
+- For any other failure, lack of progress, repeated diagnostic, or eight actual report edits, stop without publishing `code.completed`.
+
+Do not rescan or manually write digest data; the completion event must include `--artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest}` from the successful finalizer result.
+
+### 11. Update Task Status
+
+After requirement checkboxes are updated, run the initial event `agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --files-modified {n} --tests-passed {n} {execution-flag}`; in fix mode add `--fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}` instead; in decision mode add `--implementation-input {input-id}` to the initial counts. The core atomically records the artifact link, stage, metadata, done log, and decision-input consumption.
 
 If task.md has a valid `issue_number`, read `.agents/rules/issue-sync.md`, then:
 - Run `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - Run `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - Run `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`
 
-### 11. Run Completion Gate
+### 12. Run Completion Gate
 
 ```bash
 agent-infra-internal task-verify {task-id} code.completed --artifact {code-artifact} --format text
 ```
 
-### 12. Tell the User
+### 13. Tell the User
 
 Use `reference/output-template.md` (or `reference/fix-mode.md` in fix mode) and render the selected next-step commands through the shared helper. Do not push, create a PR, or invoke the `commit` skill here.
 

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -19,6 +19,7 @@ description: >
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 实现前读取 `.agents/rules/compatibility-policy.md`；只实现方案明确批准的兼容预算，不以“稳妥”为由保留旧分支、旧结果契约或迁移 shim
 - 修复模式逐条核实最新 `review-code` 的发现：成立则修复，判定为不成立/幻觉则在报告中反驳并记入 unresolved；不擅自扩大到审查未列出的问题；manual-validation 项不在修复范围
+- 实现报告在 `code.completed` 前必须通过 `task-artifact ... finalize-local --family code`；按 `.agents/rules/local-artifact-repair.md` 处理同一报告内可证明安全的最小结构修复，并只把同一次通过结果的摘要传给完成事件
 - 实现中遇到方案未覆盖的关键设计决策时，先调用 `agent-infra-internal task-ledger {task-id} decision-next-id` 取得 `HD-N`，按 `.agents/rules/human-decision-context.md` 写入实现报告的 `## 人工裁决待办` 详情块并判断是否需要实现，再调用 `decision-upsert --id {HD-N} --stage code --artifact {code-artifact} --needs-implementation {true|false}`；不得扫描编号、手写账本行、中途提问或擅自扩范围
 - 不调用 `commit` 技能，也不推送远端；测试通过后直接调用共享 commit core 的 `delivery: { mode: 'local' }` 创建本地 checkpoint。checkpoint 使用 durable intent，只有 checkpoint 与 task 状态同步成功后才发送 `code.completed`
 - 每轮实现都创建新的实现产物，不覆盖旧文件
@@ -87,7 +88,7 @@ agent-infra-internal task-snapshot {task-id} --format text
 
 **必须执行，不得跳过。** 如果 task.md 中存在有效的 `issue_number`，调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --milestone specific`；里程碑推断、权限降级与幂等写入由 internal core 处理。
 
-> 若跳过或收窄后仍为 `X.Y.x`，步骤 11 的 `task-verify code.completed` 会通过 typed milestone check 截停本轮。
+> 若跳过或收窄后仍为 `X.Y.x`，步骤 12 的 `task-verify code.completed` 会通过 typed milestone check 截停本轮。
 
 ### 4. 确定模式与轮次
 
@@ -152,22 +153,38 @@ echo "$result"
 
 > 报告结构、必填章节和完整模板见 `reference/report-template.md`。写报告前先读取 `reference/report-template.md`。
 
-### 10. 更新任务状态
+### 10. 报告完成前门禁
+
+报告写入后、发布 `code.completed` 前，读取并遵循 `.agents/rules/local-artifact-repair.md`，执行：
+
+```bash
+finalizer=$(agent-infra-internal task-artifact {task-id} finalize-local --family code --artifact {code-artifact})
+status=$?
+echo "$finalizer"
+```
+
+- `status=0` 且 `finalizer.status="passed"`：绑定这一次返回的 `{artifact-sha256}` 和 `{semantic-digest}`。
+- `status=1` 且返回 `repairable=true`、诊断明确为当前报告中的单行替换：确认任务、轮次、产物和 provenance 未变化后，只编辑该 `code*.md` 一次，确认字节确实变化，再完整重跑同一命令。
+- 其他失败、无进展、诊断重复或达到 8 次实际报告编辑：停止，不发布 `code.completed`。
+
+不得重新扫描或手工补写摘要；完成事件必须携带本次 `passed` 结果的 `--artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest}`。
+
+### 11. 更新任务状态
 
 更新 `.agents/workspace/active/{task-id}/task.md`：
 - 审查 `## 需求` 段落，仅把本轮已由代码实现且有测试通过支撑的条目从 `- [ ]` 勾为 `- [x]`
 - 产物链接、阶段与完成日志由 completed 事件统一登记
 - 完成业务内容更新后声明完成事件：
-  - 初次实现：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --files-modified {n} --tests-passed {n} {execution-flag}`
-  - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
-  - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
+  - 初次实现：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --files-modified {n} --tests-passed {n} {execution-flag}`
+  - 修复模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --fix-for {review-artifact} --blockers {n} --major {n} --minor {n} --manual-validation {n} {execution-flag}`
+  - 裁决模式：`agent-infra-internal task-event {task-id} code.completed --agent {standard-agent-token} --artifact {code-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} --implementation-input {input-id} --files-modified {n} --tests-passed {n} {execution-flag}`
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则记录 warning 并继续；Issue 元数据边界仍见 `.agents/rules/issue-sync.md`）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status in-progress`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind task --agent {standard-agent-token}`
 - 调用 `agent-infra-internal platform-comment sync {task-id} --kind artifact --artifact {code-artifact} --agent {standard-agent-token}`
 
-### 11. 完成校验
+### 12. 完成校验
 
 运行完成校验，确认任务产物和同步状态符合规范：
 
@@ -182,7 +199,7 @@ agent-infra-internal task-verify {task-id} code.completed --artifact {code-artif
 
 将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
 
-### 12. 告知用户
+### 13. 告知用户
 
 > 仅在校验通过后执行本步骤。
 

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -121,9 +121,9 @@ After writing the local artifact, run the pre-completion gate:
 agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
 ```
 
-- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`.
+- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`; the finalizer has recorded the matching one-shot local provenance intent.
 - On `status=failed` with `repairable=true`, apply only the diagnostic's `replace-line` operation once, then rerun the same command completely; count an attempt only after bytes change, up to 8 attempts.
-- On any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
+- The first repairable failure's `semanticDigest` is retained as the baseline; a retried `status=passed` result must match it. On baseline mismatch, any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
 
 Use the digests from that same `status=passed` result in `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}` so the core records the link, stage, agent, metadata, and Activity Log atomically.
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -115,7 +115,17 @@ Update `.agents/workspace/active/{task-id}/task.md`:
   - Overwrite the `effort` field in frontmatter with the new value
   - Append a `## Effort Re-estimate` section to this round's plan artifact `{plan-artifact}`, recording: `effort {old} → {new} (rationale: {short basis grounded in this plan})`
   If the re-estimated value matches the current value, skip it: do not write the `## Effort Re-estimate` section. The Flow A sync that follows reads the possibly updated frontmatter and propagates the new value to the Issue automatically.
-After the business fields are updated, run `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} {execution-flag}` so the core atomically records the link, stage, agent, metadata, and Activity Log.
+After writing the local artifact, run the pre-completion gate:
+
+```bash
+agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
+```
+
+- On `status=passed`, save that result's `artifactSha256` and `semanticDigest`.
+- On `status=failed` with `repairable=true`, apply only the diagnostic's `replace-line` operation once, then rerun the same command completely; count an attempt only after bytes change, up to 8 attempts.
+- On any other failure, no progress, or a repeated diagnostic, stop without publishing a completed event.
+
+Use the digests from that same `status=passed` result in `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}` so the core records the link, stage, agent, metadata, and Activity Log atomically.
   - {YYYY-MM-DD HH:mm:ss±HH:MM} — **Plan Task (Round {N})** by {agent} — Plan completed, awaiting human review → {artifact-filename}
   ```
 

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -118,9 +118,9 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
   ```bash
   agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
   ```
-  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`；finalizer 已记录对应的一次性本地 provenance intent。
   - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
-  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+  - 首次可修复失败的 `semanticDigest` 由 finalizer 保留为基线；重试后的 `status=passed` 必须匹配该基线。基线不匹配、其他失败、无进展或重复诊断：停止，不发布 completed 事件。
 - 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -114,7 +114,14 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
   - 用新值覆盖 frontmatter 的 `effort` 字段
   - 在本轮方案产物 `{plan-artifact}` 中追加 `## 工作量重估` 段，记录一条：`effort {old} → {new} (rationale: {基于本轮方案的简短依据})`
   若重估值与当前值一致，跳过：不写入 `## 工作量重估` 段。后续 Flow A 同步会读取可能更新过的 frontmatter，并自动把新值同步到 Issue。
-- 完成业务内容更新后执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} {execution-flag}`，由核心原子登记链接、阶段、代理、时间、版本和 Activity Log。
+- 完成本地产物后，先执行本地完成前门禁：
+  ```bash
+  agent-infra-internal task-artifact {task-id} finalize-local --family plan --artifact {plan-artifact}
+  ```
+  - `status=passed`：保存本次返回的 `artifactSha256` 和 `semanticDigest`。
+  - `status=failed` 且 `repairable=true`：仅按诊断中的 `replace-line` 操作做一次最小修改，然后完整重跑同一命令；实际字节发生变化才计一次 `repairAttempts`，最多 8 次。
+  - 其他失败、无进展或重复诊断：停止，不发布 completed 事件。
+- 使用同一次 `status=passed` 返回的摘要执行 `agent-infra-internal task-event {task-id} plan.completed --agent {standard-agent-token} --artifact {plan-artifact} --artifact-sha256 {artifact-sha256} --semantic-digest {semantic-digest} {execution-flag}`，由核心登记链接、阶段、代理、时间、版本和 Activity Log。
 
 如果 task.md 中存在有效的 `issue_number`，执行以下同步操作（任一失败则跳过并继续）：
 - 调用 `agent-infra-internal platform-issue sync {task-id} --agent {standard-agent-token} --status pending-design-work --fields`

--- a/tests/e2e/core/validate-artifact.test.ts
+++ b/tests/e2e/core/validate-artifact.test.ts
@@ -385,7 +385,7 @@ test("validate-artifact artifact check fails when a required section is missing"
 
     const result = runValidator(["check", "artifact", taskDir, "code.md", "--skill", "code-task"]);
     assert.equal(result.status, 1);
-    assertPayloadStatus(result, { type: "artifact", status: "fail", message: /missing sections/i });
+    assertPayloadStatus(result, { type: "artifact", status: "fail", message: /LOCAL_ARTIFACT_MISSING_SECTION/ });
   })
 ));
 

--- a/tests/integration/cli/task-artifact.test.ts
+++ b/tests/integration/cli/task-artifact.test.ts
@@ -22,16 +22,16 @@ function run(root: string, args: string[]) {
   return spawnSync('node', [INTERNAL_CLI_PATH, 'task-artifact', ...args], { cwd: root, encoding: 'utf8' });
 }
 
-function localArtifact(family: 'analysis' | 'plan', suffix = ''): string {
+function localArtifact(family: 'analysis' | 'plan' | 'code', suffix = ''): string {
   const sections = family === 'analysis'
     ? ['需求来源', '需求理解', '相关文件', '影响评估', '技术风险', '工作量和复杂度评估', '状态核对']
-    : ['问题理解', '约束条件', '方案对比', '技术方法', '实施步骤', '文件清单', '验证策略', '状态核对'];
+    : family === 'plan'
+      ? ['问题理解', '约束条件', '方案对比', '技术方法', '实施步骤', '文件清单', '验证策略', '状态核对']
+      : ['实现输入', '变更文件', '关键代码说明', '测试结果', '与方案的差异', '供审查关注的内容'];
   return [
     `# ${family}`,
     ...sections.flatMap((section) => [`## ${section}`, '内容']),
-    '```text',
-    '$ git status -s',
-    '```',
+    ...(family === 'code' ? ['## 状态核对', '```text', '$ git status -s', '```', '## 证据原文', '验证输出'] : ['```text', '$ git status -s', '```']),
     suffix
   ].join('\n');
 }
@@ -119,6 +119,25 @@ test('task-artifact finalize-local reports one-line heading repair and revalidat
 
   fs.writeFileSync(artifact, fs.readFileSync(artifact, 'utf8').replace('## 需求来源：\n', '## 需求来源\n'));
   const passed = run(f.root, [f.id, 'finalize-local', '--family', 'analysis', '--artifact', 'analysis.md']);
+  assert.equal(passed.status, 0, passed.stderr);
+  const success = JSON.parse(passed.stdout);
+  assert.equal(success.status, 'passed');
+  assert.equal(success.semanticDigest, failure.semanticDigest);
+});
+
+test('task-artifact finalize-local supports code reports and preserves the repair baseline', () => {
+  const f = fixture();
+  const artifact = path.join(f.dir, 'code.md');
+  fs.writeFileSync(artifact, localArtifact('code').replace('## 测试结果\n', '## 测试结果：\n'));
+
+  const failed = run(f.root, [f.id, 'finalize-local', '--family', 'code', '--artifact', 'code.md']);
+  assert.equal(failed.status, 1);
+  const failure = JSON.parse(failed.stdout);
+  assert.equal(failure.repairable, true);
+  assert.equal(failure.diagnostics[0].code, 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION');
+
+  fs.writeFileSync(artifact, fs.readFileSync(artifact, 'utf8').replace('## 测试结果：', '## 测试结果'));
+  const passed = run(f.root, [f.id, 'finalize-local', '--family', 'code', '--artifact', 'code.md']);
   assert.equal(passed.status, 0, passed.stderr);
   const success = JSON.parse(passed.stdout);
   assert.equal(success.status, 'passed');

--- a/tests/integration/cli/task-artifact.test.ts
+++ b/tests/integration/cli/task-artifact.test.ts
@@ -22,6 +22,20 @@ function run(root: string, args: string[]) {
   return spawnSync('node', [INTERNAL_CLI_PATH, 'task-artifact', ...args], { cwd: root, encoding: 'utf8' });
 }
 
+function localArtifact(family: 'analysis' | 'plan', suffix = ''): string {
+  const sections = family === 'analysis'
+    ? ['需求来源', '需求理解', '相关文件', '影响评估', '技术风险', '工作量和复杂度评估', '状态核对']
+    : ['问题理解', '约束条件', '方案对比', '技术方法', '实施步骤', '文件清单', '验证策略', '状态核对'];
+  return [
+    `# ${family}`,
+    ...sections.flatMap((section) => [`## ${section}`, '内容']),
+    '```text',
+    '$ git status -s',
+    '```',
+    suffix
+  ].join('\n');
+}
+
 test('task-artifact inspect returns one read-only JSON context', () => {
   const f = fixture();
   const before = fs.readdirSync(f.dir).sort();
@@ -43,4 +57,77 @@ test('task-artifact reports usage and domain failures with nonzero exit codes', 
   const unknown = run(f.root, [f.id, 'inspect', '--family', 'unknown']);
   assert.equal(unknown.status, 2);
   assert.equal(JSON.parse(unknown.stdout).error.code, 'ARTIFACT_FAMILY_UNKNOWN');
+});
+
+test('task-artifact finalize-local returns stable digests without mutating a valid artifact', () => {
+  const f = fixture();
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, localArtifact('plan'));
+  const before = fs.readFileSync(artifact);
+
+  const out = run(f.root, [f.id, 'finalize-local', '--family', 'plan', '--artifact', 'plan.md']);
+
+  assert.equal(out.status, 0, out.stderr);
+  const result = JSON.parse(out.stdout);
+  assert.equal(result.status, 'passed');
+  assert.equal(result.changed, false);
+  assert.match(result.artifactSha256, /^[0-9a-f]{64}$/);
+  assert.match(result.semanticDigest, /^[0-9a-f]{64}$/);
+  assert.deepEqual(fs.readFileSync(artifact), before);
+});
+
+test('task-artifact finalize-local reports one-line heading repair and revalidates after the edit', () => {
+  const f = fixture();
+  const artifact = path.join(f.dir, 'analysis.md');
+  fs.writeFileSync(artifact, localArtifact('analysis').replace('## 需求来源\n', '## 需求来源：\n'));
+
+  const failed = run(f.root, [f.id, 'finalize-local', '--family', 'analysis', '--artifact', 'analysis.md']);
+  assert.equal(failed.status, 1);
+  const failure = JSON.parse(failed.stdout);
+  assert.equal(failure.status, 'failed');
+  assert.equal(failure.repairable, true);
+  assert.equal(failure.diagnostics[0].code, 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION');
+  assert.equal(failure.diagnostics[0].operation, 'replace-line');
+  assert.equal(failure.diagnostics[0].from, '需求来源：');
+  assert.equal(failure.diagnostics[0].to, '需求来源');
+
+  fs.writeFileSync(artifact, fs.readFileSync(artifact, 'utf8').replace('## 需求来源：\n', '## 需求来源\n'));
+  const passed = run(f.root, [f.id, 'finalize-local', '--family', 'analysis', '--artifact', 'analysis.md']);
+  assert.equal(passed.status, 0, passed.stderr);
+  const success = JSON.parse(passed.stdout);
+  assert.equal(success.status, 'passed');
+  assert.equal(success.semanticDigest, failure.semanticDigest);
+});
+
+test('task-artifact finalize-local ignores fenced headings and commands', () => {
+  const f = fixture();
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, [
+    '# plan',
+    '```markdown',
+    '## 问题理解',
+    '```',
+    '## 约束条件',
+    '内容',
+    '## 方案对比',
+    '内容',
+    '## 技术方法',
+    '内容',
+    '## 实施步骤',
+    '内容',
+    '## 文件清单',
+    '内容',
+    '## 验证策略',
+    '内容',
+    '## 状态核对',
+    '```text',
+    '$ git status -s',
+    '```'
+  ].join('\n'));
+
+  const out = run(f.root, [f.id, 'finalize-local', '--family', 'plan', '--artifact', 'plan.md']);
+  assert.equal(out.status, 1);
+  const result = JSON.parse(out.stdout);
+  assert.equal(result.repairable, false);
+  assert.ok(result.diagnostics.some((item: { code: string }) => item.code === 'LOCAL_ARTIFACT_MISSING_SECTION'));
 });

--- a/tests/integration/cli/task-artifact.test.ts
+++ b/tests/integration/cli/task-artifact.test.ts
@@ -40,7 +40,7 @@ test('task-artifact inspect returns one read-only JSON context', () => {
   const f = fixture();
   const before = fs.readdirSync(f.dir).sort();
   const out = run(f.root, [f.id, 'inspect', '--family', 'plan']);
-  assert.equal(out.status, 0, out.stderr);
+  assert.equal(out.status, 0, `${out.stderr}\n${out.stdout}`);
   const result = JSON.parse(out.stdout);
   assert.equal(result.status, 'ready');
   assert.equal(result.changed, false);
@@ -74,6 +74,32 @@ test('task-artifact finalize-local returns stable digests without mutating a val
   assert.match(result.artifactSha256, /^[0-9a-f]{64}$/);
   assert.match(result.semanticDigest, /^[0-9a-f]{64}$/);
   assert.deepEqual(fs.readFileSync(artifact), before);
+});
+
+test('task-artifact finalize-local uses repository config from a nested working directory', () => {
+  const f = fixture();
+  const sections = ['Problem Understanding', 'Constraints', 'Options Comparison', 'Technical Approach', 'Implementation Steps', 'File List', 'Verification Strategy', 'State Check'];
+  const configDir = path.join(f.root, '.agents', 'skills', 'plan-task', 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'verify.json'), JSON.stringify({
+    checks: { artifact: { required_sections: sections, required_patterns: ['^\\$ '] } }
+  }));
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), [
+    '# Technical Plan',
+    ...sections.flatMap((section) => [`## ${section}`, 'content']),
+    '```text',
+    '$ git status -s',
+    '```'
+  ].join('\n'));
+  const nested = path.join(f.root, 'nested');
+  fs.mkdirSync(nested);
+
+  const out = run(nested, [f.id, 'finalize-local', '--family', 'plan', '--artifact', 'plan.md']);
+
+  assert.equal(out.status, 0, `${out.stderr}\n${out.stdout}`);
+  const result = JSON.parse(out.stdout);
+  assert.equal(result.status, 'passed');
+  assert.deepEqual(result.diagnostics, []);
 });
 
 test('task-artifact finalize-local reports one-line heading repair and revalidates after the edit', () => {

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -11,7 +11,11 @@ import { applyTaskEvent } from '../../../lib/task/events.ts';
 import { prepareOrchestrationDelegation } from '../../../lib/task/orchestration.ts';
 import { upsertArtifactReceipt, type ArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
 import { upsertSection } from '../../../lib/task/sections.ts';
-import { validateLocalArtifact, type LocalArtifactFamily } from '../../../lib/task/local-artifact-finalization.ts';
+import {
+  finalizeLocalArtifact,
+  validateLocalArtifact,
+  type LocalArtifactFamily
+} from '../../../lib/task/local-artifact-finalization.ts';
 
 function fixture(step = 'requirement-analysis-review') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-event-'));
@@ -137,9 +141,14 @@ function localArtifact(family: LocalArtifactFamily, suffix = '') {
 
 function completionDigestArgs(dir: string, artifact: string, family: LocalArtifactFamily): string[] {
   const file = path.join(dir, artifact);
-  const result = validateLocalArtifact(fs.readFileSync(file, 'utf8'), { family });
-  assert.equal(result.ok, true, result.diagnostics.map((item) => item.message).join('; '));
-  return ['--artifact-sha256', sha256File(file), '--semantic-digest', result.semanticDigest];
+  const result = finalizeLocalArtifact({
+    taskRef: path.basename(dir),
+    repoRoot: path.resolve(dir, '../../../..'),
+    family,
+    artifact
+  });
+  assert.equal(result.status, 'passed', result.error?.message);
+  return ['--artifact-sha256', result.artifactSha256!, '--semantic-digest', result.semanticDigest!];
 }
 
 function addReceipt(file: string, receipt: ArtifactReceipt) {
@@ -397,6 +406,57 @@ test('local completion rejects a stale finalizer digest before mutating task sta
   }
 });
 
+test('local completion rejects a valid artifact without finalizer provenance', () => {
+  const f = fixture();
+  assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, localArtifact('plan'));
+  const local = validateLocalArtifact(fs.readFileSync(artifact, 'utf8'), { family: 'plan' });
+  assert.equal(local.ok, true);
+  const before = fs.readFileSync(f.file);
+
+  const completed = run(f.root, [
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md',
+    '--artifact-sha256', sha256File(artifact), '--semantic-digest', local.semanticDigest
+  ]);
+
+  assert.equal(completed.status, 1);
+  assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('local repair provenance rejects semantic mutation between finalizer retries and completion', () => {
+  const f = fixture();
+  assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, localArtifact('plan').replace('## 验证策略\n', '## 验证策略：\n'));
+
+  const first = inspect(f.root, [f.id, 'finalize-local', '--family', 'plan', '--artifact', 'plan.md']);
+  assert.equal(first.status, 1, first.stderr);
+  const firstResult = JSON.parse(first.stdout);
+  assert.equal(firstResult.repairable, true);
+
+  fs.writeFileSync(artifact, fs.readFileSync(artifact, 'utf8')
+    .replace('## 验证策略：', '## 验证策略')
+    .replace('$ git status -s', '$ git status --porcelain'));
+  const second = inspect(f.root, [f.id, 'finalize-local', '--family', 'plan', '--artifact', 'plan.md']);
+  assert.equal(second.status, 1, second.stderr);
+  const secondResult = JSON.parse(second.stdout);
+  assert.equal(secondResult.repairable, false);
+  assert.ok(secondResult.diagnostics.some((item: { code: string }) => item.code === 'LOCAL_REPAIR_BASELINE_MISMATCH'));
+
+  const before = fs.readFileSync(f.file);
+  const local = validateLocalArtifact(fs.readFileSync(artifact, 'utf8'), { family: 'plan' });
+  assert.equal(local.ok, true);
+  const completed = run(f.root, [
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md',
+    '--artifact-sha256', sha256File(artifact), '--semantic-digest', local.semanticDigest
+  ]);
+  assert.equal(completed.status, 1);
+  assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
 test('local completion uses the repository verification config for its language', () => {
   const f = fixture();
   const sections = ['Problem Understanding', 'Constraints', 'Options Comparison', 'Technical Approach', 'Implementation Steps', 'File List', 'Verification Strategy', 'State Check'];
@@ -411,10 +471,19 @@ test('local completion uses the repository verification config for its language'
   const content = fs.readFileSync(artifact, 'utf8');
   const local = validateLocalArtifact(content, { family: 'plan', requiredSections: sections, requiredPatterns: ['^\\$ '] });
   assert.equal(local.ok, true, local.diagnostics.map((item) => item.message).join('; '));
+  const finalized = finalizeLocalArtifact({
+    taskRef: f.id,
+    repoRoot: f.root,
+    family: 'plan',
+    artifact: 'plan.md',
+    requiredSections: sections,
+    requiredPatterns: ['^\\$ ']
+  });
+  assert.equal(finalized.status, 'passed', finalized.error?.message);
 
   const completed = run(f.root, [
     f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md',
-    '--artifact-sha256', sha256File(artifact), '--semantic-digest', local.semanticDigest
+    '--artifact-sha256', finalized.artifactSha256!, '--semantic-digest', finalized.semanticDigest!
   ]);
 
   assert.equal(completed.status, 0, completed.stderr || completed.stdout);
@@ -581,6 +650,13 @@ test('orchestrated completion reports a distinct partial-write error when the ru
   fs.writeFileSync(runPath, `${JSON.stringify(currentRun(f.id, {
     pendingDelegation: orchestrationReceipt(f.id)
   }), null, 2)}\n`);
+  const finalized = finalizeLocalArtifact({
+    taskRef: f.id,
+    repoRoot: f.root,
+    family: 'plan',
+    artifact: 'plan.md'
+  });
+  assert.equal(finalized.status, 'passed', finalized.error?.message);
   const taskBefore = fs.readFileSync(f.file);
 
   const result = applyTaskEvent({
@@ -588,8 +664,8 @@ test('orchestrated completion reports a distinct partial-write error when the ru
     event: 'plan.completed',
     agent: 'codex',
     artifact: 'plan.md',
-    artifactSha256: sha256File(path.join(f.dir, 'plan.md')),
-    semanticDigest: validateLocalArtifact(fs.readFileSync(path.join(f.dir, 'plan.md'), 'utf8'), { family: 'plan' }).semanticDigest,
+    artifactSha256: finalized.artifactSha256!,
+    semanticDigest: finalized.semanticDigest!,
     orchestrated: true
   }, {
     repoRoot: f.root,

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -11,6 +11,7 @@ import { applyTaskEvent } from '../../../lib/task/events.ts';
 import { prepareOrchestrationDelegation } from '../../../lib/task/orchestration.ts';
 import { upsertArtifactReceipt, type ArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
 import { upsertSection } from '../../../lib/task/sections.ts';
+import { validateLocalArtifact, type LocalArtifactFamily } from '../../../lib/task/local-artifact-finalization.ts';
 
 function fixture(step = 'requirement-analysis-review') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-event-'));
@@ -116,6 +117,31 @@ function sha256File(filePath: string) {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
+function localArtifact(family: LocalArtifactFamily, suffix = '') {
+  const sections = family === 'plan'
+    ? [
+        ['问题理解', '范围说明'], ['约束条件', '当前契约'], ['方案对比', '采用方案 A'],
+        ['技术方法', '实现方法'], ['实施步骤', '步骤一'], ['文件清单', '文件列表'],
+        ['验证策略', '验证方法']
+      ]
+    : [
+        ['需求来源', '用户描述'], ['需求理解', '范围说明'], ['相关文件', '文件列表'],
+        ['影响评估', '影响说明'], ['技术风险', '风险说明'], ['工作量和复杂度评估', '复杂度说明']
+      ];
+  return [
+    family === 'plan' ? '# 技术方案' : '# 需求分析报告', '',
+    ...sections.flatMap(([heading, body]) => [`## ${heading}`, body, '']),
+    '## 状态核对', '```text', '$ git status -s', '```', suffix
+  ].join('\n');
+}
+
+function completionDigestArgs(dir: string, artifact: string, family: LocalArtifactFamily): string[] {
+  const file = path.join(dir, artifact);
+  const result = validateLocalArtifact(fs.readFileSync(file, 'utf8'), { family });
+  assert.equal(result.ok, true, result.diagnostics.map((item) => item.message).join('; '));
+  return ['--artifact-sha256', sha256File(file), '--semantic-digest', result.semanticDigest];
+}
+
 function addReceipt(file: string, receipt: ArtifactReceipt) {
   const content = fs.readFileSync(file, 'utf8');
   const mutation = upsertArtifactReceipt(content, receipt);
@@ -191,7 +217,7 @@ function completeReview(
 
 function decisionFixture() {
   const f = fixture('code-review');
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   fs.writeFileSync(path.join(f.dir, 'code.md'), '# Code\n');
   fs.writeFileSync(path.join(f.dir, 'review-code.md'), `## 审查摘要\n\n- **总体结论**：通过\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要 / **人工校验**：0\n`);
   fs.writeFileSync(f.file, `---
@@ -328,8 +354,8 @@ test('internal task-event applies a started/completed pair and replays as no-op'
   assert.equal(JSON.parse(started.stdout).status, 'applied');
   const repeated = run(f.root, [f.id, 'plan.started', '--agent', 'codex', '--round', '1']);
   assert.equal(JSON.parse(repeated.stdout).status, 'no-op');
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
-  const done = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md']);
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
+  const done = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan')]);
   assert.equal(done.status, 0, done.stderr);
   assert.equal(JSON.parse(done.stdout).toStep, 'technical-design');
   const content = fs.readFileSync(f.file, 'utf8');
@@ -345,19 +371,63 @@ test('started derives its round and completion rejects an unlanded artifact', ()
   assert.equal(startedResult.round, 1);
   assert.equal(startedResult.artifact, 'plan.md');
   const before = fs.readFileSync(f.file);
-  const done = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md']);
+  const done = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', '--artifact-sha256', '0'.repeat(64), '--semantic-digest', '0'.repeat(64)]);
   assert.equal(done.status, 1);
   assert.equal(JSON.parse(done.stdout).error.code, 'ARTIFACT_NOT_FOUND');
   assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('local completion rejects a stale finalizer digest before mutating task state', () => {
+  for (const kind of ['artifactSha256', 'semanticDigest'] as const) {
+    const f = fixture();
+    assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
+    const artifact = path.join(f.dir, 'plan.md');
+    fs.writeFileSync(artifact, localArtifact('plan'));
+    const digests = completionDigestArgs(f.dir, 'plan.md', 'plan');
+    const stale = kind === 'artifactSha256'
+      ? ['--artifact-sha256', '0'.repeat(64), '--semantic-digest', digests[3]!]
+      : ['--artifact-sha256', digests[1]!, '--semantic-digest', '0'.repeat(64)];
+    const before = fs.readFileSync(f.file);
+
+    const completed = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...stale]);
+
+    assert.equal(completed.status, 1);
+    assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+    assert.deepEqual(fs.readFileSync(f.file), before);
+  }
+});
+
+test('local completion uses the repository verification config for its language', () => {
+  const f = fixture();
+  const sections = ['Problem Understanding', 'Constraints', 'Options Comparison', 'Technical Approach', 'Implementation Steps', 'File List', 'Verification Strategy', 'State Check'];
+  const configDir = path.join(f.root, '.agents', 'skills', 'plan-task', 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'verify.json'), JSON.stringify({
+    checks: { artifact: { required_sections: sections, required_patterns: ['^\\$ '] } }
+  }));
+  assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, ['# Technical Plan', '', ...sections.flatMap((section) => [`## ${section}`, 'content']), '```text', '$ git status -s', '```'].join('\n'));
+  const content = fs.readFileSync(artifact, 'utf8');
+  const local = validateLocalArtifact(content, { family: 'plan', requiredSections: sections, requiredPatterns: ['^\\$ '] });
+  assert.equal(local.ok, true, local.diagnostics.map((item) => item.message).join('; '));
+
+  const completed = run(f.root, [
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md',
+    '--artifact-sha256', sha256File(artifact), '--semantic-digest', local.semanticDigest
+  ]);
+
+  assert.equal(completed.status, 0, completed.stderr || completed.stdout);
+  assert.equal(JSON.parse(completed.stdout).status, 'applied');
 });
 
 test('completed event preserves source @ content without blocking task state', () => {
   const f = fixture();
   const started = run(f.root, [f.id, 'plan.started', '--agent', 'codex']);
   assert.equal(started.status, 0, started.stderr);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n\n@2x\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan', '\n@2x\n'));
   const before = fs.readFileSync(f.file);
-  const completed = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md']);
+  const completed = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan')]);
   assert.equal(completed.status, 0, completed.stderr);
   assert.notDeepEqual(fs.readFileSync(f.file), before);
 });
@@ -366,7 +436,7 @@ test('started replay keeps the open identity after its artifact lands', () => {
   const f = fixture();
   const started = run(f.root, [f.id, 'plan.started', '--agent', 'codex']);
   assert.equal(started.status, 0, started.stderr);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const repeated = run(f.root, [f.id, 'plan.started', '--agent', 'codex']);
   const result = JSON.parse(repeated.stdout);
   assert.equal(result.status, 'no-op');
@@ -388,9 +458,9 @@ test('plan event reopens technical design after commit preparation', () => {
   assert.equal(startedResult.round, 2);
   assert.equal(startedResult.artifact, 'plan-r2.md');
 
-  fs.writeFileSync(path.join(f.dir, 'plan-r2.md'), '# Plan round 2\n');
+  fs.writeFileSync(path.join(f.dir, 'plan-r2.md'), localArtifact('plan'));
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan-r2.md'
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan-r2.md', ...completionDigestArgs(f.dir, 'plan-r2.md', 'plan')
   ]);
   assert.equal(completed.status, 0, completed.stdout || completed.stderr);
   assert.equal(JSON.parse(completed.stdout).toStep, 'technical-design');
@@ -403,7 +473,7 @@ test('plan event reopens technical design after commit preparation', () => {
 test('completed event validates orchestration provenance before writing task state', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'claude-code']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   spawnSync('git', ['config', 'user.name', 'Test'], { cwd: f.root });
   spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: f.root });
   spawnSync('git', ['add', '.'], { cwd: f.root });
@@ -433,7 +503,7 @@ test('completed event validates orchestration provenance before writing task sta
 
   const before = fs.readFileSync(f.file);
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'claude-code', '--artifact', 'plan.md', '--orchestrated'
+    f.id, 'plan.completed', '--agent', 'claude-code', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan'), '--orchestrated'
   ]);
   assert.equal(completed.status, 1);
   assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_TRANSITION_INVALID');
@@ -443,7 +513,7 @@ test('completed event validates orchestration provenance before writing task sta
 test('standalone completion ignores a current orchestration run without a pending delegation', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   fs.writeFileSync(path.join(f.dir, 'orchestration.json'), `${JSON.stringify(currentRun(f.id, {
     status: 'paused', nextStage: null,
     pause: { code: 'ORCHESTRATION_RETRYABLE', message: 'retry later', recoverable: true }
@@ -451,7 +521,7 @@ test('standalone completion ignores a current orchestration run without a pendin
   const runBefore = fs.readFileSync(path.join(f.dir, 'orchestration.json'));
 
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md'
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan')
   ]);
 
   assert.equal(completed.status, 0, completed.stderr || completed.stdout);
@@ -462,7 +532,7 @@ test('standalone completion ignores a current orchestration run without a pendin
 test('standalone completion fails before writing when a delegation is pending', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const runPath = path.join(f.dir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(currentRun(f.id, {
     pendingDelegation: orchestrationReceipt(f.id, {
@@ -476,7 +546,7 @@ test('standalone completion fails before writing when a delegation is pending', 
   const runBefore = fs.readFileSync(runPath);
 
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md'
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan')
   ]);
 
   assert.equal(completed.status, 1);
@@ -488,14 +558,14 @@ test('standalone completion fails before writing when a delegation is pending', 
 test('orchestrated completion advances one matching activated delegation', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const runPath = path.join(f.dir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(currentRun(f.id, {
     pendingDelegation: orchestrationReceipt(f.id)
   }), null, 2)}\n`);
 
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', '--orchestrated'
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan'), '--orchestrated'
   ]);
 
   assert.equal(completed.status, 0, completed.stderr || completed.stdout);
@@ -506,7 +576,7 @@ test('orchestrated completion advances one matching activated delegation', () =>
 test('orchestrated completion reports a distinct partial-write error when the run commit fails', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const runPath = path.join(f.dir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(currentRun(f.id, {
     pendingDelegation: orchestrationReceipt(f.id)
@@ -518,6 +588,8 @@ test('orchestrated completion reports a distinct partial-write error when the ru
     event: 'plan.completed',
     agent: 'codex',
     artifact: 'plan.md',
+    artifactSha256: sha256File(path.join(f.dir, 'plan.md')),
+    semanticDigest: validateLocalArtifact(fs.readFileSync(path.join(f.dir, 'plan.md'), 'utf8'), { family: 'plan' }).semanticDigest,
     orchestrated: true
   }, {
     repoRoot: f.root,
@@ -581,9 +653,9 @@ test('dry-run returns planned without changing task bytes for start and completi
 
   const started = run(f.root, [f.id, 'plan.started', '--agent', 'codex']);
   assert.equal(started.status, 0, started.stderr);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const beforeCompletion = fs.readFileSync(f.file);
-  const completed = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', '--dry-run']);
+  const completed = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan'), '--dry-run']);
   const completedResult = JSON.parse(completed.stdout);
   assert.equal(completedResult.status, 'planned');
   assert.equal(completedResult.operations.length, 4);
@@ -593,7 +665,7 @@ test('dry-run returns planned without changing task bytes for start and completi
 test('orchestrated completion dry-run reports a provenance mismatch without pausing the run', () => {
   const f = fixture();
   assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
-  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), localArtifact('plan'));
   const runPath = path.join(f.dir, 'orchestration.json');
   fs.writeFileSync(runPath, `${JSON.stringify(currentRun(f.id, {
     pendingDelegation: orchestrationReceipt(f.id, {
@@ -607,7 +679,7 @@ test('orchestrated completion dry-run reports a provenance mismatch without paus
   const runBefore = fs.readFileSync(runPath);
 
   const completed = run(f.root, [
-    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', '--orchestrated', '--dry-run'
+    f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan'), '--orchestrated', '--dry-run'
   ]);
 
   assert.equal(completed.status, 1);
@@ -629,7 +701,7 @@ test('task-event timestamps keep an ASCII offset in negative-offset timezones', 
 test('completion without an open start fails without changing the file', () => {
   const f = fixture();
   const before = fs.readFileSync(f.file);
-  const out = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md']);
+  const out = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md', '--artifact-sha256', '0'.repeat(64), '--semantic-digest', '0'.repeat(64)]);
   assert.equal(out.status, 1);
   assert.equal(JSON.parse(out.stdout).error.code, 'EVENT_START_MISSING');
   assert.deepEqual(fs.readFileSync(f.file), before);
@@ -660,9 +732,9 @@ test('analysis can restart from code when task requirements expand', () => {
   assert.equal(startedResult.round, 2);
   assert.equal(startedResult.artifact, 'analysis-r2.md');
 
-  fs.writeFileSync(path.join(f.dir, 'analysis-r2.md'), '# Analysis round 2\n');
+  fs.writeFileSync(path.join(f.dir, 'analysis-r2.md'), localArtifact('analysis'));
   const completed = run(f.root, [
-    f.id, 'analyze.completed', '--agent', 'codex', '--artifact', 'analysis-r2.md'
+    f.id, 'analyze.completed', '--agent', 'codex', '--artifact', 'analysis-r2.md', ...completionDigestArgs(f.dir, 'analysis-r2.md', 'analysis')
   ]);
   assert.equal(completed.status, 0, completed.stderr);
   assert.equal(JSON.parse(completed.stdout).toStep, 'requirement-analysis');

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -6,7 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-import { INTERNAL_CLI_PATH, sandboxControlSafeEnv } from '../../helpers.ts';
+import { INTERNAL_CLI_PATH, onPlatforms, sandboxControlSafeEnv } from '../../helpers.ts';
 import { applyTaskEvent } from '../../../lib/task/events.ts';
 import { prepareOrchestrationDelegation } from '../../../lib/task/orchestration.ts';
 import { upsertArtifactReceipt, type ArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
@@ -367,6 +367,8 @@ test('internal task-event applies a started/completed pair and replays as no-op'
   const done = run(f.root, [f.id, 'plan.completed', '--agent', 'codex', '--round', '1', '--artifact', 'plan.md', ...completionDigestArgs(f.dir, 'plan.md', 'plan')]);
   assert.equal(done.status, 0, done.stderr);
   assert.equal(JSON.parse(done.stdout).toStep, 'technical-design');
+  const intentPath = path.join(f.root, '.agents', 'workspace', '.local-artifact-finalization-intents', `${f.id}-plan-plan.md.json`);
+  assert.equal(JSON.parse(fs.readFileSync(intentPath, 'utf8')).state, 'consumed');
   const content = fs.readFileSync(f.file, 'utf8');
   assert.match(content, /Plan Task \(Round 1\) \[started\]/);
   assert.match(content, /current_step: technical-design/);
@@ -423,6 +425,37 @@ test('local completion rejects a valid artifact without finalizer provenance', (
   assert.equal(completed.status, 1);
   assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
   assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('local completion rejects intent consumption failure before mutating task state', onPlatforms('linux', 'darwin'), () => {
+  const f = fixture();
+  assert.equal(run(f.root, [f.id, 'plan.started', '--agent', 'codex']).status, 0);
+  const artifact = path.join(f.dir, 'plan.md');
+  fs.writeFileSync(artifact, localArtifact('plan'));
+  const finalized = finalizeLocalArtifact({
+    taskRef: f.id,
+    repoRoot: f.root,
+    family: 'plan',
+    artifact: 'plan.md'
+  });
+  assert.equal(finalized.status, 'passed', finalized.error?.message);
+  const intentDir = path.join(f.root, '.agents', 'workspace', '.local-artifact-finalization-intents');
+  const before = fs.readFileSync(f.file);
+
+  fs.chmodSync(intentDir, 0o500);
+  try {
+    const completed = run(f.root, [
+      f.id, 'plan.completed', '--agent', 'codex', '--artifact', 'plan.md',
+      '--artifact-sha256', finalized.artifactSha256!, '--semantic-digest', finalized.semanticDigest!
+    ]);
+
+    assert.equal(completed.status, 1);
+    assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+    assert.deepEqual(fs.readFileSync(f.file), before);
+    assert.equal(fs.readdirSync(intentDir).length, 1);
+  } finally {
+    fs.chmodSync(intentDir, 0o700);
+  }
 });
 
 test('local repair provenance rejects semantic mutation between finalizer retries and completion', () => {

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -128,14 +128,21 @@ function localArtifact(family: LocalArtifactFamily, suffix = '') {
         ['技术方法', '实现方法'], ['实施步骤', '步骤一'], ['文件清单', '文件列表'],
         ['验证策略', '验证方法']
       ]
-    : [
-        ['需求来源', '用户描述'], ['需求理解', '范围说明'], ['相关文件', '文件列表'],
-        ['影响评估', '影响说明'], ['技术风险', '风险说明'], ['工作量和复杂度评估', '复杂度说明']
-      ];
+    : family === 'code'
+      ? [
+          ['实现输入', '本轮实现输入'], ['变更文件', '文件列表'], ['关键代码说明', '实现说明'],
+          ['测试结果', '测试通过'], ['与方案的差异', '无'], ['供审查关注的内容', '完成门禁'],
+        ]
+      : [
+          ['需求来源', '用户描述'], ['需求理解', '范围说明'], ['相关文件', '文件列表'],
+          ['影响评估', '影响说明'], ['技术风险', '风险说明'], ['工作量和复杂度评估', '复杂度说明']
+        ];
   return [
-    family === 'plan' ? '# 技术方案' : '# 需求分析报告', '',
+    family === 'plan' ? '# 技术方案' : family === 'code' ? '# 实现报告' : '# 需求分析报告', '',
     ...sections.flatMap(([heading, body]) => [`## ${heading}`, body, '']),
-    '## 状态核对', '```text', '$ git status -s', '```', suffix
+    ...(family === 'code' ? [] : ['## 状态核对']),
+    ...(family === 'code' ? ['## 状态核对', '```text', '$ git status -s', '```', '## 证据原文', '验证输出'] : ['```text', '$ git status -s', '```']),
+    suffix
   ].join('\n');
 }
 
@@ -158,7 +165,7 @@ function addReceipt(file: string, receipt: ArtifactReceipt) {
 }
 
 function codeReport(plan = 'plan.md') {
-  return `# Implementation Report\n\n## Implementation Input\n\n- **Plan Input**: \`${plan}\`\n`;
+  return localArtifact('code').replace('本轮实现输入', `- **模式**：init\n- **方案输入**：\`${plan}\`\n- **审查输入**：\`N/A\`\n- **裁决输入**：N/A\n- **账本 ID**：N/A\n- **裁决证据**：N/A\n- **需求摘要**：完成实现报告门禁\n`);
 }
 
 type ReviewCounts = { blockers: number; major: number; minor: number };
@@ -1220,9 +1227,10 @@ test('decision code event clears the review baseline and consumes its input on c
   assert.match(content, /\| II-1 .*\| pending \|\s*\|/);
 
   fs.writeFileSync(path.join(f.dir, 'code-r2.md'), codeReport());
+  const digests = completionDigestArgs(f.dir, 'code-r2.md', 'code');
   const completed = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
-    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4'
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4', ...digests
   ]);
   assert.equal(completed.status, 0, completed.stderr);
   assert.equal(JSON.parse(completed.stdout).implementationInput, 'II-1');
@@ -1233,7 +1241,7 @@ test('decision code event clears the review baseline and consumes its input on c
 
   const repeated = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
-    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4'
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '4', ...digests
   ]);
   assert.equal(JSON.parse(repeated.stdout).status, 'no-op');
 });
@@ -1242,11 +1250,12 @@ test('code completion rejects a report without a canonical plan input', () => {
   const f = decisionFixture();
   const started = run(f.root, [f.id, 'code.started', '--agent', 'codex', '--implementation-input', 'II-1']);
   assert.equal(started.status, 0, started.stderr);
-  fs.writeFileSync(path.join(f.dir, 'code-r2.md'), '# Code round 2\n');
+  fs.writeFileSync(path.join(f.dir, 'code-r2.md'), codeReport('missing-plan.md'));
+  const digests = completionDigestArgs(f.dir, 'code-r2.md', 'code');
   const before = fs.readFileSync(f.file);
   const completed = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
-    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '1'
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '1', ...digests
   ]);
   assert.equal(completed.status, 1);
   assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
@@ -1265,12 +1274,47 @@ test('code completion rejects a plan changed after code started', () => {
   assert.equal(started.status, 0, started.stderr);
   fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan v2\n');
   fs.writeFileSync(path.join(f.dir, 'code.md'), codeReport());
+  const digests = completionDigestArgs(f.dir, 'code.md', 'code');
   const before = fs.readFileSync(f.file);
   const completed = run(f.root, [
     f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code.md',
-    '--files-modified', '1', '--tests-passed', '1'
+    '--files-modified', '1', '--tests-passed', '1', ...digests
   ]);
   assert.equal(completed.status, 1);
   assert.equal(JSON.parse(completed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+  assert.deepEqual(fs.readFileSync(f.file), before);
+});
+
+test('code completion requires current finalizer provenance and rejects a semantic mutation', () => {
+  const f = decisionFixture();
+  const started = run(f.root, [f.id, 'code.started', '--agent', 'codex', '--implementation-input', 'II-1']);
+  assert.equal(started.status, 0, started.stderr);
+  const artifact = path.join(f.dir, 'code-r2.md');
+  fs.writeFileSync(artifact, codeReport());
+  const content = fs.readFileSync(artifact, 'utf8');
+  const local = validateLocalArtifact(content, { family: 'code' });
+  assert.equal(local.ok, true, local.diagnostics.map((item) => item.message).join('; '));
+
+  const withoutProvenance = run(f.root, [
+    f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '1',
+    '--artifact-sha256', sha256File(artifact), '--semantic-digest', local.semanticDigest
+  ]);
+  assert.equal(withoutProvenance.status, 1);
+  assert.equal(JSON.parse(withoutProvenance.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
+
+  const finalized = finalizeLocalArtifact({
+    taskRef: f.id, repoRoot: f.root, family: 'code', artifact: 'code-r2.md'
+  });
+  assert.equal(finalized.status, 'passed', finalized.error?.message);
+  fs.appendFileSync(artifact, '\nsemantic mutation\n');
+  const before = fs.readFileSync(f.file);
+  const changed = run(f.root, [
+    f.id, 'code.completed', '--agent', 'codex', '--artifact', 'code-r2.md',
+    '--implementation-input', 'II-1', '--files-modified', '1', '--tests-passed', '1',
+    '--artifact-sha256', finalized.artifactSha256!, '--semantic-digest', finalized.semanticDigest!
+  ]);
+  assert.equal(changed.status, 1);
+  assert.equal(JSON.parse(changed.stdout).error.code, 'EVENT_ARTIFACT_CONFLICT');
   assert.deepEqual(fs.readFileSync(f.file), before);
 });

--- a/tests/integration/cli/task-verify.test.ts
+++ b/tests/integration/cli/task-verify.test.ts
@@ -52,6 +52,38 @@ test('internal task-verify resolves task identity and invokes the typed engine',
   }
 });
 
+test('code artifact verification applies the local structural contract', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-verify-code-artifact-'));
+  try {
+    spawnSync('git', ['init', '-q'], { cwd: root });
+    const id = 'TASK-20260101-000001';
+    const dir = path.join(root, '.agents', 'workspace', 'active', id);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'task.md'), `---\nid: ${id}\n---\n`);
+    fs.writeFileSync(path.join(dir, 'code.md'), fs.readFileSync('tests/fixtures/validate-artifact/valid-code.md'));
+    writeJson(path.join(root, '.agents/skills/code-task/config/verify.json'), {
+      skill: 'code-task', checks: {
+        artifact: {
+          file_pattern: 'code.md|code-r{N}.md',
+          required_sections: ['实现输入', '变更文件', '关键代码说明', '测试结果', '与方案的差异', '供审查关注的内容', '状态核对', '证据原文'],
+          required_patterns: ['^\\$ ']
+        }
+      }
+    });
+
+    const passed = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-verify', id, 'code.completed', '--artifact', 'code.md', '--format', 'text'], { cwd: root, encoding: 'utf8' });
+    assert.equal(passed.status, 0, passed.stderr);
+    assert.match(passed.stdout, /Verification: pass \| Skill: code-task/);
+
+    fs.writeFileSync(path.join(dir, 'code.md'), fs.readFileSync(path.join(dir, 'code.md'), 'utf8').replace('## 测试结果', '## 测试结果：'));
+    const failed = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-verify', id, 'code.completed', '--artifact', 'code.md', '--format', 'text'], { cwd: root, encoding: 'utf8' });
+    assert.equal(failed.status, 1);
+    assert.match(failed.stdout, /LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('required PR delivery gates on normalized merged state and platform availability', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'required-pr-delivery-'));
   const id = 'TASK-20260101-000001';

--- a/tests/unit/cli/task-events.test.ts
+++ b/tests/unit/cli/task-events.test.ts
@@ -19,15 +19,19 @@ test('event payload validation rejects fields outside an event schema', () => {
   assert.equal(result?.code, 'EVENT_PAYLOAD_INVALID');
 });
 
-test('local analysis and plan completions require both artifact digests', () => {
-  for (const event of ['analyze.completed', 'plan.completed'] as const) {
+test('executor completions require both artifact digests', () => {
+  for (const [event, artifact] of [
+    ['analyze.completed', 'analysis.md'],
+    ['plan.completed', 'plan.md'],
+    ['code.completed', 'code.md']
+  ] as const) {
     const missing = validateTaskEventRequest({
-      taskRef: '1', event, agent: 'codex', artifact: event.startsWith('analyze') ? 'analysis.md' : 'plan.md'
+      taskRef: '1', event, agent: 'codex', artifact
     });
     assert.equal(missing?.code, 'EVENT_PAYLOAD_INVALID');
 
     const malformed = validateTaskEventRequest({
-      taskRef: '1', event, agent: 'codex', artifact: event.startsWith('analyze') ? 'analysis.md' : 'plan.md',
+      taskRef: '1', event, agent: 'codex', artifact,
       artifactSha256: '0', semanticDigest: '0'
     });
     assert.equal(malformed?.code, 'EVENT_PAYLOAD_INVALID');

--- a/tests/unit/cli/task-events.test.ts
+++ b/tests/unit/cli/task-events.test.ts
@@ -19,6 +19,21 @@ test('event payload validation rejects fields outside an event schema', () => {
   assert.equal(result?.code, 'EVENT_PAYLOAD_INVALID');
 });
 
+test('local analysis and plan completions require both artifact digests', () => {
+  for (const event of ['analyze.completed', 'plan.completed'] as const) {
+    const missing = validateTaskEventRequest({
+      taskRef: '1', event, agent: 'codex', artifact: event.startsWith('analyze') ? 'analysis.md' : 'plan.md'
+    });
+    assert.equal(missing?.code, 'EVENT_PAYLOAD_INVALID');
+
+    const malformed = validateTaskEventRequest({
+      taskRef: '1', event, agent: 'codex', artifact: event.startsWith('analyze') ? 'analysis.md' : 'plan.md',
+      artifactSha256: '0', semanticDigest: '0'
+    });
+    assert.equal(malformed?.code, 'EVENT_PAYLOAD_INVALID');
+  }
+});
+
 test('code fix completion requires its review identity', () => {
   const result = validateTaskEventRequest({
     taskRef: '1', event: 'code.completed', agent: 'codex', round: 2,

--- a/tests/unit/task/local-artifact-finalization.test.ts
+++ b/tests/unit/task/local-artifact-finalization.test.ts
@@ -64,6 +64,10 @@ test('non-whitelisted content changes and ambiguous candidates fail closed', () 
   assert.equal(changed.ok, true);
   assert.notEqual(changed.semanticDigest, valid.semanticDigest);
 
+  const changedWhitespace = validateLocalArtifact(artifact().replace('$ git status -s', '$ git status  -s'), { family: 'plan' });
+  assert.equal(changedWhitespace.ok, true);
+  assert.notEqual(changedWhitespace.semanticDigest, valid.semanticDigest);
+
   const duplicateCandidate = artifact().replace(
     '## 验证策略\n',
     '## 验证策略：\n'

--- a/tests/unit/task/local-artifact-finalization.test.ts
+++ b/tests/unit/task/local-artifact-finalization.test.ts
@@ -17,7 +17,21 @@ const PLAN_SECTIONS = [
   ['状态核对', '```text\n$ git status -s\n```']
 ] as const;
 
+const CODE_SECTIONS = [
+  ['实现输入', '本轮实现输入'],
+  ['变更文件', '文件列表'],
+  ['关键代码说明', '实现说明'],
+  ['测试结果', '测试通过'],
+  ['与方案的差异', '无'],
+  ['供审查关注的内容', '完成门禁'],
+  ['状态核对', '```text\n$ git status -s\n```'],
+  ['证据原文', '验证输出']
+] as const;
+
 function artifact(family: LocalArtifactFamily = 'plan'): string {
+  if (family === 'code') {
+    return ['# 实现报告', '', ...CODE_SECTIONS.flatMap(([heading, body]) => [`## ${heading}`, body, ''])].join('\n');
+  }
   const title = family === 'plan' ? '# 技术方案' : '# 需求分析报告';
   return [title, '', ...PLAN_SECTIONS.flatMap(([heading, body]) => [`## ${heading}`, body, ''])].join('\n');
 }
@@ -78,4 +92,18 @@ test('non-whitelisted content changes and ambiguous candidates fail closed', () 
   const duplicate = validateLocalArtifact(duplicateCandidate, { family: 'plan' });
   const duplicateDiagnostic = diagnostic(duplicate, 'LOCAL_ARTIFACT_DUPLICATE_SECTION');
   assert.equal(duplicateDiagnostic.repairable, false);
+});
+
+test('code reports support the same one-line heading repair and semantic baseline', () => {
+  const malformed = artifact('code').replace('## 测试结果\n', '## 测试结果：\n');
+  const failed = validateLocalArtifact(malformed, { family: 'code' });
+  const repair = diagnostic(failed, 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION');
+
+  assert.equal(repair.repairable, true);
+  assert.equal(repair.from, '测试结果：');
+  assert.equal(repair.to, '测试结果');
+
+  const repaired = validateLocalArtifact(malformed.replace('## 测试结果：', '## 测试结果'), { family: 'code' });
+  assert.equal(repaired.ok, true);
+  assert.equal(repaired.semanticDigest, failed.semanticDigest);
 });

--- a/tests/unit/task/local-artifact-finalization.test.ts
+++ b/tests/unit/task/local-artifact-finalization.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateLocalArtifact,
+  type LocalArtifactFamily
+} from '../../../lib/task/local-artifact-finalization.ts';
+
+const PLAN_SECTIONS = [
+  ['问题理解', '范围说明'],
+  ['约束条件', '当前契约'],
+  ['方案对比', '采用方案 A'],
+  ['技术方法', '实现方法'],
+  ['实施步骤', '步骤一'],
+  ['文件清单', '文件列表'],
+  ['验证策略', '验证方法'],
+  ['状态核对', '```text\n$ git status -s\n```']
+] as const;
+
+function artifact(family: LocalArtifactFamily = 'plan'): string {
+  const title = family === 'plan' ? '# 技术方案' : '# 需求分析报告';
+  return [title, '', ...PLAN_SECTIONS.flatMap(([heading, body]) => [`## ${heading}`, body, ''])].join('\n');
+}
+
+function diagnostic(result: ReturnType<typeof validateLocalArtifact>, code: string) {
+  assert.equal(result.ok, false);
+  const match = result.diagnostics.find((item) => item.code === code);
+  assert.ok(match, `expected diagnostic ${code}`);
+  return match;
+}
+
+test('local artifact validation ignores fenced headings and commands', () => {
+  const content = artifact().replace(
+    '## 验证策略\n验证方法',
+    '```md\n## 验证策略：\n$ fake command\n```'
+  );
+
+  const result = validateLocalArtifact(content, { family: 'plan' });
+
+  const missing = diagnostic(result, 'LOCAL_ARTIFACT_MISSING_SECTION');
+  assert.equal(missing.repairable, false);
+});
+
+test('one visible required H2 with one trailing colon is repairable and preserves semantic digest', () => {
+  const malformed = artifact().replace('## 验证策略\n', '## 验证策略：\n');
+  const failed = validateLocalArtifact(malformed, { family: 'plan' });
+  const repair = diagnostic(failed, 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION');
+
+  assert.equal(repair.repairable, true);
+  assert.equal(repair.from, '验证策略：');
+  assert.equal(repair.to, '验证策略');
+  assert.equal(repair.line, 21);
+
+  const repaired = validateLocalArtifact(malformed.replace('## 验证策略：', '## 验证策略'), { family: 'plan' });
+  assert.equal(repaired.ok, true);
+  assert.equal(repaired.semanticDigest, failed.semanticDigest);
+});
+
+test('non-whitelisted content changes and ambiguous candidates fail closed', () => {
+  const valid = validateLocalArtifact(artifact(), { family: 'plan' });
+  assert.equal(valid.ok, true);
+
+  const changed = validateLocalArtifact(artifact().replace('验证方法', '验证方法已改变'), { family: 'plan' });
+  assert.equal(changed.ok, true);
+  assert.notEqual(changed.semanticDigest, valid.semanticDigest);
+
+  const duplicateCandidate = artifact().replace(
+    '## 验证策略\n',
+    '## 验证策略：\n'
+  ).replace(
+    '## 状态核对\n',
+    '## 验证策略：\n验证方法\n\n## 状态核对\n'
+  );
+  const duplicate = validateLocalArtifact(duplicateCandidate, { family: 'plan' });
+  const duplicateDiagnostic = diagnostic(duplicate, 'LOCAL_ARTIFACT_DUPLICATE_SECTION');
+  assert.equal(duplicateDiagnostic.repairable, false);
+});

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1317,10 +1317,11 @@ test("artifact lifecycle skills use core context and events in every language va
   }
 });
 
-test("analysis and plan skills hand finalizer digests to their completed events", () => {
+test("executor skills hand finalizer digests to their completed events", () => {
   const stages = [
     { skill: "analyze-task", family: "analysis", artifact: "analysis-artifact", event: "analyze.completed" },
-    { skill: "plan-task", family: "plan", artifact: "plan-artifact", event: "plan.completed" }
+    { skill: "plan-task", family: "plan", artifact: "plan-artifact", event: "plan.completed" },
+    { skill: "code-task", family: "code", artifact: "code-artifact", event: "code.completed" }
   ];
 
   for (const { skill, family, artifact, event } of stages) {

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -1317,6 +1317,29 @@ test("artifact lifecycle skills use core context and events in every language va
   }
 });
 
+test("analysis and plan skills hand finalizer digests to their completed events", () => {
+  const stages = [
+    { skill: "analyze-task", family: "analysis", artifact: "analysis-artifact", event: "analyze.completed" },
+    { skill: "plan-task", family: "plan", artifact: "plan-artifact", event: "plan.completed" }
+  ];
+
+  for (const { skill, family, artifact, event } of stages) {
+    for (const relativePath of skillDocPaths(skill)) {
+      const content = read(relativePath);
+      const finalizer = `agent-infra-internal task-artifact {task-id} finalize-local --family ${family} --artifact {${artifact}}`;
+      const completion = `agent-infra-internal task-event {task-id} ${event}`;
+      const finalizerIndex = content.indexOf(finalizer);
+      const completionIndex = content.indexOf(completion);
+
+      assert.equal(content.split(finalizer).length - 1, 1, `${relativePath} should declare one local finalizer`);
+      assert.ok(finalizerIndex >= 0 && completionIndex > finalizerIndex, `${relativePath} should finalize before completion`);
+      const completionLine = content.slice(completionIndex, content.indexOf("\n", completionIndex));
+      assert.match(completionLine, /--artifact-sha256 \{artifact-sha256\}/, `${relativePath} should pass the byte digest`);
+      assert.match(completionLine, /--semantic-digest \{semantic-digest\}/, `${relativePath} should pass the semantic digest`);
+    }
+  }
+});
+
 test("review handshake skills submit ledger changes through structured intents", () => {
   for (const skill of ["review-analysis", "review-plan", "review-code"]) {
     for (const relativePath of skillDocPaths(skill)) {


### PR DESCRIPTION
## Summary

- 为 analyze-task 和 plan-task 本地产物增加受控 finalizer 与安全修复闭环，限制修复范围、次数和语义变更。
- 使用 artifact SHA-256、semantic digest 与本地 provenance intent 绑定 finalizer 结果，防止绕过校验或在任务状态写入后遗留不可重试的部分写入。
- 将 intent 消费改为写入 task.md 前持久化转换为 `consumed`，消费失败保持任务状态不变，写入失败支持可识别重试。
- 同步本地修复规则及英文/简体中文模板，并补充 finalizer、嵌套工作目录配置、语义基线和消费失败回归测试。

## Implementation

- 扩展本地产物生命周期校验，保留首次可修复失败的 semantic baseline，仅允许安全的标题末尾标点修复。
- 在 analysis/plan completed event 中验证 finalizer 的精确摘要和 intent provenance，并在 task writer 前完成 durable consumption。
- 保持 task.md、ledger、receipt、源码、Git 和远端平台不由 finalizer 修改；运行时 intent 留在被忽略的 workspace 目录。

## Validation

- 定向 task-event 测试：63 passed, 0 failed。
- Smoke 测试：1418 passed, 0 failed。
- 核心测试：2419 passed, 6 skipped, 0 failed。
- 完整测试：2750 passed, 7 skipped, 0 failed。
- `npm run typecheck` — passed。
- `git diff --check` — passed。

## Review context

- `review-code-r2.md` identified CD-3: intent consumption could fail after task.md had already been written.
- Round 3 moves consumption before task writing, records the response in the task ledger, and adds a deterministic permission-failure regression test.

Closes #947

Generated with AI assistance
