### PR TITLE
chore(workflow): 完善人工裁决与约束审计机制


### DIFF
--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -14,6 +14,7 @@
 - [`compatibility-policy.md`](compatibility-policy.md) — 兼容性默认关闭：准入证据、实现边界、退出条件与生命周期审查要求。
 - [`evidence-reporting.md`](evidence-reporting.md) — 生命周期报告的状态核对、成功摘要、异常证据、身份字段和敏感信息边界。
 - [`sync-content-generation.md`](sync-content-generation.md) — 同步到 Issue 的任务和生命周期 Markdown 生成约束。
+- [`decision-qualification.md`](decision-qualification.md) — 约束、候选、人工确认和六类 artifact 资格审计契约。
 
 ## Issue / PR
 

--- a/.agents/rules/decision-qualification.md
+++ b/.agents/rules/decision-qualification.md
@@ -1,0 +1,22 @@
+# 决策资格与约束审计
+
+涉及“是否需要人工裁决”的分析、方案、实现或审查，必须先基于 `task.md` 的规范化约束和候选表完成资格审计，再决定是否创建 `HD-N`。
+
+## 唯一事实源
+
+- `task.md` 的 `### 约束` 和 `### 候选与否决方案` 是唯一约束/候选事实源。
+- 约束表必须使用 `constraint_id`、`statement`、`status`、`authority`、`source`、`evidence`、`derived_from`、`approval_evidence`；候选表必须使用 `candidate_id`、`statement`、`status`、`constraint_ids`、`impact`、`evidence`。
+- 六类阶段产物都要在 `## 资格审计` 中声明实际约束依赖、候选资格、分类结果、上游关系和依赖快照。上游关系必须保存 artifact 的 family、文件名、round 和 SHA-256。
+
+## 状态与确认
+
+- `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
+- `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
+- 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
+- `ai qualify` 是流程声明式人工确认入口；`human-declared` 是审计标签，不是身份认证。QCR 由核心生成并绑定当前 digest、request id、时间和单行理由。
+
+## 失效与审查
+
+约束变化时，只有声明受影响 `C-N` 的 artifact 才能成为直接失效种子，并沿真实上游关系的下游闭包传播；六类 artifact（含 review）对等处理。快照、关系图或变化分类无法证明为纯约束变化时，回退既有全量失效路径。新完成的 source artifact、自身 receipt 和派生快照不作为旧图目标。
+
+缺失、未知引用、digest 不匹配、悬空关系或环都必须 fail closed。排版变化不应改变语义 digest；语义、来源、状态、候选或上游 identity 变化必须触发重新审计。

--- a/.agents/rules/decision-qualification.md
+++ b/.agents/rules/decision-qualification.md
@@ -13,7 +13,7 @@
 - `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
 - `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
 - 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
-- `ai qualify` 是流程声明式人工确认、替代和撤销入口；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
+- `agent-infra-internal task-qualification` 是供 Agent/skill 使用的内部确认、替代和撤销入口，不向普通用户暴露 constraint digest 协议；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
 
 ## 失效与审查
 

--- a/.agents/rules/decision-qualification.md
+++ b/.agents/rules/decision-qualification.md
@@ -13,7 +13,7 @@
 - `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
 - `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
 - 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
-- `ai qualify` 是流程声明式人工确认入口；`human-declared` 是审计标签，不是身份认证。QCR 由核心生成并绑定当前 digest、request id、时间和单行理由。
+- `ai qualify` 是流程声明式人工确认、替代和撤销入口；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
 
 ## 失效与审查
 

--- a/.agents/skills/analyze-task/SKILL.md
+++ b/.agents/skills/analyze-task/SKILL.md
@@ -17,6 +17,7 @@ description: >
 
 生成分析报告时，先读取 `.agents/rules/evidence-reporting.md`。状态核对和成功检查记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议才附决定性原文摘录。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在分析产物记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 本技能仅产出需求分析文档（`analysis.md` 或 `analysis-r{N}.md`）—— 不修改任何业务代码
 - 严格基于 `task.md` 中已有的任务输入、需求、上下文和来源信息展开分析
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
@@ -176,6 +177,10 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
 
 ## 依赖关系
 - {需要的依赖和与其他模块的协调}
+
+## 资格审计
+
+> 按 `.agents/rules/decision-qualification.md` 填写约束依赖、候选资格、分类结果、上游关系、依赖快照五张表；没有 artifact 上游时保留空表头，不虚构关系。
 
 ## 假设
 

--- a/.agents/skills/code-task/SKILL.md
+++ b/.agents/skills/code-task/SKILL.md
@@ -19,6 +19,7 @@ description: >
 
 生成实现报告时，先读取 `.agents/rules/evidence-reporting.md`。成功测试记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议保留复现入口、准确位置和决定性摘录，不默认粘贴完整成功 stdout。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在实现报告记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 严格遵循最新方案产物：`plan.md` 或 `plan-r{N}.md`
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 实现前读取 `.agents/rules/compatibility-policy.md`；只实现方案明确批准的兼容预算，不以“稳妥”为由保留旧分支、旧结果契约或迁移 shim

--- a/.agents/skills/code-task/reference/dual-mode.md
+++ b/.agents/skills/code-task/reference/dual-mode.md
@@ -20,7 +20,7 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 |---|---|---:|---|
 | 无 code 产物，且最新 review-plan 精确为 `Approved` 并引用最新 plan | `init` | 0 | 初次实现，产物为 `code.md`；缺少匹配审批或为 `Approved-with-issues` 时返回 error |
 | 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，而最新 code 的完成 receipt 未绑定相同 plan 摘要 | `init` | 0 | plan 内容在 code 输入之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准；缺失或无效 receipt 失败关闭 |
-| `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
+| 最新 review-code 的完成收据未绑定最新 code identity/SHA | `error` | 2 | 最新代码未审查，先运行 `review-code`；code 与 review-code 的 family 轮次可独立增长 |
 | 最新 review-code 为 Approved 且存在审查完成后产生的 pending 实现输入 | `decision` | 0 | 选择最早 `II-N`，进入裁决驱动实现；false/not-required 与 consumed 输入不触发 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |
 | 最新 review-code 为 Approved 但有 major/minor | `fix` | 0 | 可选修复模式 |

--- a/.agents/skills/code-task/reference/report-template.md
+++ b/.agents/skills/code-task/reference/report-template.md
@@ -20,6 +20,30 @@
 - **裁决证据**：`{decision-evidence 或 N/A}`
 - **需求摘要**：{本轮实现输入的范围摘要}
 
+## 资格审计
+
+> 按 `.agents/rules/decision-qualification.md` 填写以下五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 ## 状态核对
 
 > 记录状态核对命令、任务/产物范围、关键结果和未覆盖部分；每条命令以 `$ ` 开头。

--- a/.agents/skills/plan-task/SKILL.md
+++ b/.agents/skills/plan-task/SKILL.md
@@ -17,6 +17,7 @@ description: >
 
 生成方案报告时，先读取 `.agents/rules/evidence-reporting.md`。状态核对和验证记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议才附决定性原文摘录。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在方案产物记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 本技能仅产出技术方案文档（`plan.md` 或 `plan-r{N}.md`）—— 不修改任何业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 这是一个**强制性的人工审查检查点** —— 不要自动进入实现阶段
@@ -86,6 +87,8 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
 - 考虑边界情况和错误场景
 
 ### 5. 设计技术方案
+
+方案必须按 `.agents/rules/decision-qualification.md` 复核规范化约束和候选，并在方案产物保留五张资格审计表及真实上游关系；来源不明或未人工确认的约束不得自动排除候选。
 
 遵循 `.agents/workflows/feature-development.yaml` 中的 `technical-design` 步骤：
 

--- a/.agents/skills/review-analysis/SKILL.md
+++ b/.agents/skills/review-analysis/SKILL.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查分析产物并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/.agents/skills/review-analysis/reference/report-template.md
+++ b/.agents/skills/review-analysis/reference/report-template.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/.agents/skills/review-code/SKILL.md
+++ b/.agents/skills/review-code/SKILL.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查代码并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/.agents/skills/review-code/reference/report-template.md
+++ b/.agents/skills/review-code/reference/report-template.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查方案产物并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/.agents/skills/review-plan/reference/report-template.md
+++ b/.agents/skills/review-plan/reference/report-template.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/.agents/templates/task.md
+++ b/.agents/templates/task.md
@@ -36,9 +36,15 @@ delivery_remote_head:          # 最近一次成功交付到 remote 的任务分
 
 ### 约束
 
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
 ### 已确认决策
 
 ### 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
 
 ### 验收标准
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -19,6 +19,7 @@ Commands:
   cp <ssh-alias>  Copy local clipboard image to a remote macOS clipboard or Linux sandbox over SSH
   data            Capture, verify, audit, repair, and export process data
   decide          Record a ruling; code-stage decisions require explicit implementation intent
+  qualify         Confirm an audited constraint through the human-declared qualification flow
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another current workspace directory (active/blocked/completed/archive)
@@ -112,6 +113,13 @@ switch (command) {
     if (!imported) break;
     const { cmdDecide } = imported;
     await cmdDecide(process.argv.slice(3));
+    break;
+  }
+  case 'qualify': {
+    const imported = await importCommand('../lib/qualify.ts');
+    if (!imported) break;
+    const { cmdQualify } = imported;
+    await cmdQualify(process.argv.slice(3));
     break;
   }
   case 'init': {

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -19,7 +19,7 @@ Commands:
   cp <ssh-alias>  Copy local clipboard image to a remote macOS clipboard or Linux sandbox over SSH
   data            Capture, verify, audit, repair, and export process data
   decide          Record a ruling; code-stage decisions require explicit implementation intent
-  qualify         Confirm an audited constraint through the human-declared qualification flow
+  qualify         Confirm, supersede, or revoke an audited constraint
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another current workspace directory (active/blocked/completed/archive)

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -19,7 +19,6 @@ Commands:
   cp <ssh-alias>  Copy local clipboard image to a remote macOS clipboard or Linux sandbox over SSH
   data            Capture, verify, audit, repair, and export process data
   decide          Record a ruling; code-stage decisions require explicit implementation intent
-  qualify         Confirm, supersede, or revoke an audited constraint
   help            Show this help message
   init            Initialize a new project with update-agent-infra seed command
   merge           Merge tasks from another current workspace directory (active/blocked/completed/archive)
@@ -113,13 +112,6 @@ switch (command) {
     if (!imported) break;
     const { cmdDecide } = imported;
     await cmdDecide(process.argv.slice(3));
-    break;
-  }
-  case 'qualify': {
-    const imported = await importCommand('../lib/qualify.ts');
-    if (!imported) break;
-    const { cmdQualify } = imported;
-    await cmdQualify(process.argv.slice(3));
     break;
   }
   case 'init': {

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -153,6 +153,11 @@ if (taskControlCommand) {
     await taskLedger(process.argv.slice(3));
     break;
   }
+  case 'task-qualification': {
+    const { taskQualification } = await import('../lib/internal/task-qualification.ts');
+    await taskQualification(process.argv.slice(3));
+    break;
+  }
   case 'task-warning': {
     const { taskWarning } = await import('../lib/internal/task-warning.ts');
     await taskWarning(process.argv.slice(3));

--- a/lib/internal/task-qualification.ts
+++ b/lib/internal/task-qualification.ts
@@ -1,11 +1,13 @@
 import fs from 'node:fs';
 
+import { applyQualificationConfirmation } from '../task/qualification-confirmation.ts';
+import type { QualificationConfirmationRequest } from '../task/qualification-confirmation.ts';
 import { applyQualificationProposal } from '../task/qualification-intents.ts';
 import type { QualificationProposalRequest } from '../task/qualification-intents.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
 
-const USAGE = `Usage: agent-infra-internal task-qualification <task-ref> proposal --input <json-file> [--dry-run]\n\nInternal qualification proposals may only add or update unconfirmed constraints and pending candidates.\n`;
+const USAGE = `Usage: agent-infra-internal task-qualification <task-ref> <proposal|confirm|supersede|revoke> --input <json-file> [--dry-run]\n`;
 
 function fail(message: string, code = 'QUALIFICATION_PROPOSAL_INVALID'): void {
   process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code, message } })}\n`);
@@ -15,7 +17,7 @@ function fail(message: string, code = 'QUALIFICATION_PROPOSAL_INVALID'): void {
 
 async function taskQualification(args: string[] = []): Promise<void> {
   const [taskRef, operation] = args;
-  if (!taskRef || operation !== 'proposal') { fail('task ref and proposal operation are required'); return; }
+  if (!taskRef || !['proposal', 'confirm', 'supersede', 'revoke'].includes(operation ?? '')) { fail('task ref and a valid qualification operation are required'); return; }
   let inputPath = '';
   let dryRun = false;
   for (let index = 2; index < args.length; index += 1) {
@@ -28,13 +30,14 @@ async function taskQualification(args: string[] = []): Promise<void> {
   if (!inputPath) { fail("option '--input' is required"); return; }
   let payload: unknown;
   try { payload = JSON.parse(fs.readFileSync(inputPath, 'utf8')); }
-  catch (error) { fail(`cannot read proposal input: ${error instanceof Error ? error.message : String(error)}`); return; }
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) { fail('proposal input must be an object'); return; }
-  const request = { ...(payload as Record<string, unknown>), taskRef, dryRun } as QualificationProposalRequest;
+  catch (error) { fail(`cannot read qualification input: ${error instanceof Error ? error.message : String(error)}`); return; }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) { fail('qualification input must be an object'); return; }
   const resolved = resolveTaskRef(taskRef);
   if (!resolved.ok) { fail(resolved.message, resolved.code); return; }
   try {
-    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'task-qualification.proposal', () => applyQualificationProposal(request, { repoRoot: resolved.repoRoot }));
+    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, `task-qualification.${operation}`, () => operation === 'proposal'
+      ? applyQualificationProposal({ ...(payload as Record<string, unknown>), taskRef: resolved.taskId, dryRun } as QualificationProposalRequest, { repoRoot: resolved.repoRoot })
+      : applyQualificationConfirmation({ ...(payload as Record<string, unknown>), taskRef: resolved.taskId, operation, dryRun } as QualificationConfirmationRequest, { repoRoot: resolved.repoRoot }));
     process.stdout.write(`${JSON.stringify(result)}\n`);
     if (result.status === 'failed') process.exitCode = 1;
   } catch (error) {

--- a/lib/internal/task-qualification.ts
+++ b/lib/internal/task-qualification.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+
+import { applyQualificationProposal } from '../task/qualification-intents.ts';
+import type { QualificationProposalRequest } from '../task/qualification-intents.ts';
+import { resolveTaskRef } from '../task/resolve-ref.ts';
+import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+
+const USAGE = `Usage: agent-infra-internal task-qualification <task-ref> proposal --input <json-file> [--dry-run]\n\nInternal qualification proposals may only add or update unconfirmed constraints and pending candidates.\n`;
+
+function fail(message: string, code = 'QUALIFICATION_PROPOSAL_INVALID'): void {
+  process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code, message } })}\n`);
+  process.stderr.write(USAGE);
+  process.exitCode = 1;
+}
+
+async function taskQualification(args: string[] = []): Promise<void> {
+  const [taskRef, operation] = args;
+  if (!taskRef || operation !== 'proposal') { fail('task ref and proposal operation are required'); return; }
+  let inputPath = '';
+  let dryRun = false;
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === '--dry-run') { if (dryRun) { fail('duplicate option --dry-run'); return; } dryRun = true; continue; }
+    if (arg !== '--input' || inputPath) { fail(`unknown or duplicate option '${arg}'`); return; }
+    inputPath = args[++index] ?? '';
+    if (!inputPath || inputPath.startsWith('--')) { fail("option '--input' requires a value"); return; }
+  }
+  if (!inputPath) { fail("option '--input' is required"); return; }
+  let payload: unknown;
+  try { payload = JSON.parse(fs.readFileSync(inputPath, 'utf8')); }
+  catch (error) { fail(`cannot read proposal input: ${error instanceof Error ? error.message : String(error)}`); return; }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) { fail('proposal input must be an object'); return; }
+  const request = { ...(payload as Record<string, unknown>), taskRef, dryRun } as QualificationProposalRequest;
+  const resolved = resolveTaskRef(taskRef);
+  if (!resolved.ok) { fail(resolved.message, resolved.code); return; }
+  try {
+    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'task-qualification.proposal', () => applyQualificationProposal(request, { repoRoot: resolved.repoRoot }));
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (result.status === 'failed') process.exitCode = 1;
+  } catch (error) {
+    if (error instanceof TaskExecutionLockError) fail(`${error.code}: ${error.message}`, error.code);
+    else throw error;
+  }
+}
+
+export { taskQualification };

--- a/lib/qualify.ts
+++ b/lib/qualify.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+
+import { appendActivityEntry, locateActivityLog } from './task/activity-log.ts';
+import { CONFIRMATION_COLUMNS, CONFIRMATION_HEADINGS, parseQualificationConfirmations, parseTaskQualification } from './task/qualification-audit.ts';
+import type { QualificationConfirmation } from './task/qualification-audit.ts';
+import { findSectionHeading } from './task/sections.ts';
+import { resolveTaskRef } from './task/resolve-ref.ts';
+import { captureTaskWriteMetadata, writeTask } from './task/write.ts';
+import type { TaskOperationSummary, TaskWriteOptions } from './task/write.ts';
+
+type QualificationConfirmationRequest = {
+  taskRef: string;
+  constraintId: string;
+  expectedDigest: string;
+  rationale: string;
+  dryRun?: boolean;
+};
+type QualificationConfirmationResult = {
+  status: 'planned' | 'applied' | 'no-op' | 'failed';
+  changed: boolean;
+  taskId: string | null;
+  qcrId: string | null;
+  requestId: string | null;
+  operations: readonly TaskOperationSummary[];
+  error: { code: string; message: string } | null;
+};
+
+function failed(code: string, message: string, taskId: string | null = null): QualificationConfirmationResult {
+  return { status: 'failed', changed: false, taskId, qcrId: null, requestId: null, operations: [], error: { code, message } };
+}
+
+function nextQcrId(content: string): string {
+  let max = 0;
+  for (const match of content.matchAll(/^\|\s*(QCR-(\d+))\s*\|/gm)) max = Math.max(max, Number(match[2]));
+  return `QCR-${max + 1}`;
+}
+
+function requestIdFor(taskId: string, constraintId: string, expectedDigest: string, rationale: string, timestamp: string): string {
+  const hash = createHash('sha256').update(JSON.stringify([taskId, constraintId, expectedDigest, rationale, timestamp])).digest('hex');
+  return `QCR-REQUEST-${hash.slice(0, 20)}`;
+}
+
+function renderConfirmations(rows: readonly QualificationConfirmation[]): string {
+  return [
+    `| ${CONFIRMATION_COLUMNS.join(' | ')} |`,
+    `| ${CONFIRMATION_COLUMNS.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => [row.qcrId, row.constraintId, row.actor, row.entrypoint, row.requestId, row.approvedDigest, row.confirmedAt, row.rationale]
+      .map((value) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]/g, ' '))
+      .join(' | ')).map((line) => `| ${line} |`)
+  ].join('\n');
+}
+
+function applyQualificationConfirmation(request: QualificationConfirmationRequest, options: TaskWriteOptions = {}): QualificationConfirmationResult {
+  if (!request || typeof request !== 'object' || !request.taskRef || !/^C-[1-9]\d*$/.test(request.constraintId) || !/^[a-f0-9]{64}$/i.test(request.expectedDigest) || !request.rationale?.trim() || /[\r\n]/.test(request.rationale)) {
+    return failed('QUALIFICATION_CONFIRMATION_INVALID', 'taskRef, constraintId, expectedDigest, and a single-line rationale are required');
+  }
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return failed(resolved.code, resolved.message, resolved.taskId);
+  if (resolved.state !== 'active') return failed('TASK_STATE_MISMATCH', `task ${resolved.taskId} is ${resolved.state}, expected active`, resolved.taskId);
+  let content: string;
+  try { content = fs.readFileSync(resolved.taskMdPath, 'utf8'); }
+  catch (error) { return failed('TASK_READ_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId); }
+  const parsed = parseTaskQualification(content);
+  if (!parsed.ok) return failed(parsed.code, parsed.message, resolved.taskId);
+  if (!parsed.qualification.present) return failed('QUALIFICATION_TASK_CONTRACT_MISSING', 'task qualification contract is missing', resolved.taskId);
+  const constraint = parsed.qualification.constraints.find((row) => row.constraintId === request.constraintId);
+  if (!constraint) return failed('QUALIFICATION_CONSTRAINT_UNKNOWN', `unknown constraint '${request.constraintId}'`, resolved.taskId);
+  const existing = parseQualificationConfirmations(content);
+  if (!existing.ok) return failed(existing.code, existing.message, resolved.taskId);
+  const previous = existing.confirmations.find((row) => row.constraintId === request.constraintId);
+  if (constraint.status === 'confirmed') {
+    if (previous?.approvedDigest === request.expectedDigest && previous.rationale === request.rationale) {
+      return { status: 'no-op', changed: false, taskId: resolved.taskId, qcrId: previous.qcrId, requestId: previous.requestId, operations: [], error: null };
+    }
+    return failed('QUALIFICATION_CONFIRMATION_CONFLICT', `constraint '${request.constraintId}' is already confirmed with different evidence`, resolved.taskId);
+  }
+  if (parsed.qualification.constraintDigest !== request.expectedDigest) return failed('QUALIFICATION_DIGEST_CONFLICT', 'constraint digest changed before human confirmation', resolved.taskId);
+  if (previous) return failed('QUALIFICATION_CONFIRMATION_CONFLICT', `constraint '${request.constraintId}' already has a confirmation record`, resolved.taskId);
+  let metadata;
+  try { metadata = (options.metadataProvider ?? captureTaskWriteMetadata)(); }
+  catch (error) { return failed('METADATA_CAPTURE_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId); }
+  const qcrId = nextQcrId(content);
+  const requestId = requestIdFor(resolved.taskId, request.constraintId, request.expectedDigest, request.rationale.trim(), metadata.timestamp);
+  const confirmation = {
+    qcrId, constraintId: request.constraintId, actor: 'human-declared' as const, entrypoint: 'ai qualify' as const,
+    requestId, approvedDigest: request.expectedDigest, confirmedAt: metadata.timestamp, rationale: request.rationale.trim()
+  };
+  const confirmations = [...existing.confirmations, confirmation];
+  const activity = locateActivityLog(content);
+  if (!activity) return failed('QUALIFICATION_ACTIVITY_MISSING', 'task has no unique Activity Log section', resolved.taskId);
+  const mutations: Parameters<typeof writeTask>[0]['mutations'][number][] = [
+    {
+      kind: 'table-row', action: 'upsert', sectionAliases: ['约束', 'Constraints'], columns: ['constraint_id', 'statement', 'status', 'authority', 'source', 'evidence', 'derived_from', 'approval_evidence'], keyColumn: 'constraint_id', key: constraint.constraintId,
+      values: { statement: constraint.statement, status: 'confirmed', authority: 'human-declared', source: constraint.source, evidence: constraint.evidence, derived_from: constraint.derivedFrom.join(','), approval_evidence: qcrId }
+    },
+    { kind: 'section', aliases: CONFIRMATION_HEADINGS, heading: findSectionHeading(content, [...CONFIRMATION_HEADINGS]), body: renderConfirmations(confirmations) },
+    { kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: activity.heading, body: appendActivityEntry(activity, { time: metadata.timestamp, step: 'Qualification Confirmation', agent: 'human', note: `${request.constraintId} confirmed → ${qcrId}` }) }
+  ];
+  const result = writeTask({ taskRef: resolved.taskId, expectedState: 'active', mutations, dryRun: request.dryRun }, { ...options, taskLocation: { repoRoot: resolved.repoRoot, taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, state: resolved.state }, metadataProvider: () => metadata });
+  if (result.status === 'failed') return failed(result.error.code, result.error.message, result.taskId);
+  return { status: result.status, changed: result.changed, taskId: result.taskId, qcrId, requestId, operations: result.operations, error: null };
+}
+
+export async function qualify(args: string[], options: TaskWriteOptions = {}): Promise<number> {
+  let taskRef: string | undefined;
+  let constraintId: string | undefined;
+  let expectedDigest: string | undefined;
+  let dryRun = false;
+  const rationale: string[] = [];
+  try {
+    for (let index = 0; index < args.length; index += 1) {
+      const arg = args[index]!;
+      if (arg === '--task' || arg === '-t') taskRef = args[++index];
+      else if (arg === '--constraint' || arg === '--constraint-id' || arg === '--id') constraintId = args[++index];
+      else if (arg === '--digest' || arg === '--constraint-digest') expectedDigest = args[++index];
+      else if (arg === '--dry-run') dryRun = true;
+      else if (arg === '--help' || arg === '-h') { process.stdout.write('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> <rationale>\n'); return 0; }
+      else rationale.push(arg);
+    }
+    if (!taskRef || !constraintId || !expectedDigest || rationale.length === 0) throw new Error('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> <rationale>');
+    const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
+    if (!resolved.ok) throw new Error(resolved.message);
+    const { withTaskExecutionLock } = await import('./task/task-execution-lock.ts');
+    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'task-qualification.confirm', () => applyQualificationConfirmation({ taskRef: resolved.taskId, constraintId: constraintId!, expectedDigest: expectedDigest!, rationale: rationale.join(' '), dryRun }, options));
+    if (result.error) throw new Error(`${result.error.code}: ${result.error.message}`);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+export async function cmdQualify(args: string[]): Promise<void> {
+  process.exitCode = await qualify(args);
+}
+
+export { applyQualificationConfirmation };
+export type { QualificationConfirmationRequest, QualificationConfirmationResult };

--- a/lib/qualify.ts
+++ b/lib/qualify.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 
 import { appendActivityEntry, locateActivityLog } from './task/activity-log.ts';
-import { CONFIRMATION_COLUMNS, CONFIRMATION_HEADINGS, parseQualificationConfirmations, parseTaskQualification } from './task/qualification-audit.ts';
+import { CONFIRMATION_COLUMNS, CONFIRMATION_HEADINGS, constraintDigest, parseQualificationConfirmations, parseTaskQualification } from './task/qualification-audit.ts';
 import type { QualificationConfirmation } from './task/qualification-audit.ts';
 import { findSectionHeading } from './task/sections.ts';
 import { resolveTaskRef } from './task/resolve-ref.ts';
@@ -14,6 +14,7 @@ type QualificationConfirmationRequest = {
   constraintId: string;
   expectedDigest: string;
   rationale: string;
+  operation?: 'confirm' | 'supersede' | 'revoke';
   dryRun?: boolean;
 };
 type QualificationConfirmationResult = {
@@ -66,36 +67,46 @@ function applyQualificationConfirmation(request: QualificationConfirmationReques
   if (!parsed.qualification.present) return failed('QUALIFICATION_TASK_CONTRACT_MISSING', 'task qualification contract is missing', resolved.taskId);
   const constraint = parsed.qualification.constraints.find((row) => row.constraintId === request.constraintId);
   if (!constraint) return failed('QUALIFICATION_CONSTRAINT_UNKNOWN', `unknown constraint '${request.constraintId}'`, resolved.taskId);
+  const operation = request.operation ?? 'confirm';
   const existing = parseQualificationConfirmations(content);
   if (!existing.ok) return failed(existing.code, existing.message, resolved.taskId);
-  const previous = existing.confirmations.find((row) => row.constraintId === request.constraintId);
-  if (constraint.status === 'confirmed') {
-    if (previous?.approvedDigest === request.expectedDigest && previous.rationale === request.rationale) {
+  const previous = existing.confirmations.find((row) => row.qcrId === constraint.approvalEvidence);
+  if (operation === 'confirm' && constraint.status === 'confirmed') {
+    if (previous?.constraintId === constraint.constraintId && previous.approvedDigest === constraint.digest && previous.rationale === request.rationale.trim()) {
       return { status: 'no-op', changed: false, taskId: resolved.taskId, qcrId: previous.qcrId, requestId: previous.requestId, operations: [], error: null };
     }
     return failed('QUALIFICATION_CONFIRMATION_CONFLICT', `constraint '${request.constraintId}' is already confirmed with different evidence`, resolved.taskId);
   }
+  const transitionStatus = operation === 'supersede' ? 'superseded' : 'open';
+  if (operation !== 'confirm' && constraint.status === transitionStatus && !constraint.approvalEvidence) {
+    return { status: 'no-op', changed: false, taskId: resolved.taskId, qcrId: null, requestId: null, operations: [], error: null };
+  }
+  if (operation !== 'confirm' && constraint.status !== 'confirmed') return failed('QUALIFICATION_CONFIRMATION_REQUIRED', `constraint '${request.constraintId}' is not confirmed`, resolved.taskId);
   if (parsed.qualification.constraintDigest !== request.expectedDigest) return failed('QUALIFICATION_DIGEST_CONFLICT', 'constraint digest changed before human confirmation', resolved.taskId);
-  if (previous) return failed('QUALIFICATION_CONFIRMATION_CONFLICT', `constraint '${request.constraintId}' already has a confirmation record`, resolved.taskId);
   let metadata;
   try { metadata = (options.metadataProvider ?? captureTaskWriteMetadata)(); }
   catch (error) { return failed('METADATA_CAPTURE_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId); }
-  const qcrId = nextQcrId(content);
-  const requestId = requestIdFor(resolved.taskId, request.constraintId, request.expectedDigest, request.rationale.trim(), metadata.timestamp);
-  const confirmation = {
+  const qcrId = operation === 'confirm' ? nextQcrId(content) : null;
+  const requestId = operation === 'confirm' ? requestIdFor(resolved.taskId, request.constraintId, request.expectedDigest, request.rationale.trim(), metadata.timestamp) : null;
+  const confirmedConstraint = qcrId ? {
+    constraintId: constraint.constraintId, statement: constraint.statement, status: 'confirmed' as const,
+    authority: 'human-declared', source: constraint.source, evidence: constraint.evidence,
+    derivedFrom: constraint.derivedFrom, approvalEvidence: qcrId
+  } : null;
+  const confirmation = confirmedConstraint && qcrId && requestId ? {
     qcrId, constraintId: request.constraintId, actor: 'human-declared' as const, entrypoint: 'ai qualify' as const,
-    requestId, approvedDigest: request.expectedDigest, confirmedAt: metadata.timestamp, rationale: request.rationale.trim()
-  };
-  const confirmations = [...existing.confirmations, confirmation];
+    requestId, approvedDigest: constraintDigest(confirmedConstraint), confirmedAt: metadata.timestamp, rationale: request.rationale.trim()
+  } : null;
+  const confirmations = confirmation ? [...existing.confirmations, confirmation] : existing.confirmations;
   const activity = locateActivityLog(content);
   if (!activity) return failed('QUALIFICATION_ACTIVITY_MISSING', 'task has no unique Activity Log section', resolved.taskId);
   const mutations: Parameters<typeof writeTask>[0]['mutations'][number][] = [
     {
       kind: 'table-row', action: 'upsert', sectionAliases: ['约束', 'Constraints'], columns: ['constraint_id', 'statement', 'status', 'authority', 'source', 'evidence', 'derived_from', 'approval_evidence'], keyColumn: 'constraint_id', key: constraint.constraintId,
-      values: { statement: constraint.statement, status: 'confirmed', authority: 'human-declared', source: constraint.source, evidence: constraint.evidence, derived_from: constraint.derivedFrom.join(','), approval_evidence: qcrId }
+      values: { statement: constraint.statement, status: operation === 'confirm' ? 'confirmed' : transitionStatus, authority: operation === 'confirm' ? 'human-declared' : constraint.authority, source: constraint.source, evidence: constraint.evidence, derived_from: constraint.derivedFrom.join(','), approval_evidence: qcrId ?? '' }
     },
-    { kind: 'section', aliases: CONFIRMATION_HEADINGS, heading: findSectionHeading(content, [...CONFIRMATION_HEADINGS]), body: renderConfirmations(confirmations) },
-    { kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: activity.heading, body: appendActivityEntry(activity, { time: metadata.timestamp, step: 'Qualification Confirmation', agent: 'human', note: `${request.constraintId} confirmed → ${qcrId}` }) }
+    ...(operation === 'confirm' ? [{ kind: 'section' as const, aliases: CONFIRMATION_HEADINGS, heading: findSectionHeading(content, [...CONFIRMATION_HEADINGS]), body: renderConfirmations(confirmations) }] : []),
+    { kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: activity.heading, body: appendActivityEntry(activity, { time: metadata.timestamp, step: 'Qualification Confirmation', agent: 'human', note: operation === 'confirm' ? `${request.constraintId} confirmed → ${qcrId}` : `${request.constraintId} ${operation}d` }) }
   ];
   const result = writeTask({ taskRef: resolved.taskId, expectedState: 'active', mutations, dryRun: request.dryRun }, { ...options, taskLocation: { repoRoot: resolved.repoRoot, taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, state: resolved.state }, metadataProvider: () => metadata });
   if (result.status === 'failed') return failed(result.error.code, result.error.message, result.taskId);
@@ -107,6 +118,8 @@ export async function qualify(args: string[], options: TaskWriteOptions = {}): P
   let constraintId: string | undefined;
   let expectedDigest: string | undefined;
   let dryRun = false;
+  let operation: QualificationConfirmationRequest['operation'] = 'confirm';
+  let operationFlag = '';
   const rationale: string[] = [];
   try {
     for (let index = 0; index < args.length; index += 1) {
@@ -115,14 +128,19 @@ export async function qualify(args: string[], options: TaskWriteOptions = {}): P
       else if (arg === '--constraint' || arg === '--constraint-id' || arg === '--id') constraintId = args[++index];
       else if (arg === '--digest' || arg === '--constraint-digest') expectedDigest = args[++index];
       else if (arg === '--dry-run') dryRun = true;
-      else if (arg === '--help' || arg === '-h') { process.stdout.write('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> <rationale>\n'); return 0; }
+      else if (arg === '--supersede' || arg === '--revoke') {
+        if (operationFlag) throw new Error(`options '${operationFlag}' and '${arg}' cannot be combined`);
+        operationFlag = arg;
+        operation = arg === '--supersede' ? 'supersede' : 'revoke';
+      }
+      else if (arg === '--help' || arg === '-h') { process.stdout.write('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> [--supersede|--revoke] <rationale>\n'); return 0; }
       else rationale.push(arg);
     }
     if (!taskRef || !constraintId || !expectedDigest || rationale.length === 0) throw new Error('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> <rationale>');
     const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
     if (!resolved.ok) throw new Error(resolved.message);
     const { withTaskExecutionLock } = await import('./task/task-execution-lock.ts');
-    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, 'task-qualification.confirm', () => applyQualificationConfirmation({ taskRef: resolved.taskId, constraintId: constraintId!, expectedDigest: expectedDigest!, rationale: rationale.join(' '), dryRun }, options));
+    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, `task-qualification.${operation}`, () => applyQualificationConfirmation({ taskRef: resolved.taskId, constraintId: constraintId!, expectedDigest: expectedDigest!, rationale: rationale.join(' '), operation, dryRun }, options));
     if (result.error) throw new Error(`${result.error.code}: ${result.error.message}`);
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return 0;

--- a/lib/task/artifact-lifecycle.ts
+++ b/lib/task/artifact-lifecycle.ts
@@ -341,6 +341,7 @@ const OPTIONAL_CONTEXT: Partial<Record<ArtifactFamily, { family: ArtifactFamily;
   'manual-validation': { family: 'review-code' },
   'validation-run': { family: 'review-code' }
 };
+const QUALIFICATION_RECOVERY_OPTIONAL_CONTEXT_CONSUMERS = new Set<ArtifactFamily>(['analysis', 'plan']);
 
 function resolveArtifactContext(taskRef: string, family: string, options: InspectOptions = {}): ArtifactContextResult {
   const inventory = inspectTaskArtifacts(taskRef, family, options);
@@ -367,7 +368,9 @@ function resolveArtifactContext(taskRef: string, family: string, options: Inspec
         return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: `${context.latest.name} has no valid reviewed input` } };
       }
       const qualificationError = qualificationErrorForArtifact(context.latest);
-      if (qualificationError) return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: qualificationError } };
+      if (qualificationError && !QUALIFICATION_RECOVERY_OPTIONAL_CONTEXT_CONSUMERS.has(inventory.family as ArtifactFamily)) {
+        return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: qualificationError } };
+      }
       inputs.push(context.latest);
     }
   }

--- a/lib/task/artifact-lifecycle.ts
+++ b/lib/task/artifact-lifecycle.ts
@@ -10,6 +10,7 @@ import { extractSection, findSectionHeading } from './sections.ts';
 import { receiptForOutput, sha256File } from './artifact-receipts.ts';
 import { isArtifactInvalidated, parseInvalidationDocument } from './invalidation.ts';
 import type { InvalidationDocument } from './invalidation.ts';
+import { validateQualificationAudit } from './qualification-audit.ts';
 
 const artifactFamilyCatalog = [
   { family: 'analysis', sectionAliases: ['分析', 'Analysis'], heading: '分析', labels: ['需求分析报告', 'Requirements Analysis'] },
@@ -354,6 +355,8 @@ function resolveArtifactContext(taskRef: string, family: string, options: Inspec
     if (input.status === 'failed' || !input.latest) {
       return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_INPUT_MISSING', message: `latest ${required} artifact is required` } };
     }
+    const qualificationError = qualificationErrorForArtifact(input.latest);
+    if (qualificationError) return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: qualificationError } };
     inputs.push(input.latest);
   }
   const optional = OPTIONAL_CONTEXT[inventory.family as ArtifactFamily];
@@ -363,10 +366,23 @@ function resolveArtifactContext(taskRef: string, family: string, options: Inspec
       if (optional.requireReference && !context.reviewedInput) {
         return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: `${context.latest.name} has no valid reviewed input` } };
       }
+      const qualificationError = qualificationErrorForArtifact(context.latest);
+      if (qualificationError) return { ...inventory, status: 'failed', inputs, codeMode: null, error: { code: 'ARTIFACT_REFERENCE_INVALID', message: qualificationError } };
       inputs.push(context.latest);
     }
   }
   return { ...inventory, inputs, codeMode: null };
+}
+
+function qualificationErrorForArtifact(artifact: ArtifactIdentity): string | null {
+  try {
+    const taskContent = fs.readFileSync(path.join(path.dirname(artifact.path), 'task.md'), 'utf8');
+    const artifactContent = fs.readFileSync(artifact.path, 'utf8');
+    const result = validateQualificationAudit(taskContent, artifactContent);
+    return result.ok ? null : `${result.code}: ${result.message}`;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 }
 
 function resolveCodeContext(inventory: ArtifactInventoryResult, options: InspectOptions): ArtifactContextResult {
@@ -379,6 +395,16 @@ function resolveCodeContext(inventory: ArtifactInventoryResult, options: Inspect
   const codeMax = latestCode?.round ?? 0;
   const reviewMax = reviewCode.latest?.round ?? 0;
   const inputs = [plan.latest];
+  const planQualificationError = qualificationErrorForArtifact(plan.latest);
+  if (planQualificationError) return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', planQualificationError);
+  if (latestCode) {
+    const qualificationError = qualificationErrorForArtifact(latestCode);
+    if (qualificationError) return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', qualificationError, latestCode.name);
+  }
+  if (reviewCode.latest) {
+    const qualificationError = qualificationErrorForArtifact(reviewCode.latest);
+    if (qualificationError) return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', qualificationError, reviewCode.latest.name);
+  }
   if (!latestCode) {
     if (!reviewPlan.latest || reviewPlan.reviewedInput?.name !== plan.latest.name) {
       return contextFailure(inventory, 'ARTIFACT_INPUT_MISSING', `latest plan '${plan.latest.name}' requires a matching approved review-plan`);
@@ -397,6 +423,10 @@ function resolveCodeContext(inventory: ArtifactInventoryResult, options: Inspect
   }
   if (reviewPlan.latest && !reviewPlan.reviewedInput) {
     return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', `${reviewPlan.latest.name} has no valid reviewed input`, reviewPlan.latest.name);
+  }
+  if (reviewPlan.latest) {
+    const qualificationError = qualificationErrorForArtifact(reviewPlan.latest);
+    if (qualificationError) return contextFailure(inventory, 'ARTIFACT_REFERENCE_INVALID', qualificationError, reviewPlan.latest.name);
   }
   if (reviewPlan.latest && reviewPlan.reviewedInput?.name === plan.latest.name) {
     const verdict = parseVerdict(reviewPlan.latest.path);

--- a/lib/task/artifact-lifecycle.ts
+++ b/lib/task/artifact-lifecycle.ts
@@ -442,8 +442,8 @@ function resolveCodeContext(inventory: ArtifactInventoryResult, options: Inspect
         `Latest ${reviewPlan.latest.name} approves plan content not captured by the latest code input receipt. Entering replan-driven init.`);
     }
   }
-  if (reviewMax < codeMax) {
-    const expected = artifactName('review-code', codeMax);
+  if (!reviewCode.latest || reviewCode.reviewedInput?.name !== latestCode.name) {
+    const expected = reviewCode.next?.name ?? artifactName('review-code', reviewMax + 1);
     return contextFailure(inventory, 'ARTIFACT_INPUT_MISSING', `${expected} is required before another code round`, expected);
   }
   const review = reviewCode.latest;

--- a/lib/task/capabilities.ts
+++ b/lib/task/capabilities.ts
@@ -11,6 +11,10 @@ import { parseReworkIntentDocument } from './rework-intent.ts';
 import type { ReworkIntent } from './rework-intent.ts';
 import { sha256File } from './artifact-receipts.ts';
 import { hasOpenLifecycleExecution } from './activity-log.ts';
+import { parseQualificationAudit, parseTaskQualification } from './qualification-audit.ts';
+import type { QualificationAudit, TaskQualification } from './qualification-audit.ts';
+
+const ARTIFACT_AUDIT_FAMILIES = new Set(['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'review-code']);
 
 type LifecycleAction =
   | 'analysis' | 'review-analysis' | 'plan' | 'review-plan'
@@ -42,6 +46,8 @@ type LifecycleFacts = {
   unresolvedLedger: Record<'analysis' | 'plan' | 'code', number>;
   executionBusy: boolean;
   recommendedAction?: LifecycleAction | null;
+  qualificationStale?: boolean;
+  qualificationStaleArtifacts?: readonly string[];
 };
 type CapabilityResult = {
   allowed: boolean;
@@ -86,6 +92,7 @@ function canStart(action: LifecycleAction, facts: LifecycleFacts, trigger: Expli
   }
   if (facts.taskState !== 'active') return deny('TASK_NOT_ACTIVE', `state=${facts.taskState}`);
   if (invalidationBlocks(facts.invalidation)) return deny('INVALIDATION_INCOMPLETE');
+  if (facts.qualificationStale) return deny('QUALIFICATION_STALE', ...(facts.qualificationStaleArtifacts ?? ['qualification audit is stale']));
   if (facts.executionBusy) return deny('EXECUTION_BUSY');
 
   const implicit = trigger.explicitRequest === false;
@@ -152,6 +159,18 @@ function reviewedInputName(content: string, expectedFamily: 'analysis' | 'plan' 
 function reviewMatchesLatest(facts: LifecycleFacts, source: 'analysis' | 'plan' | 'code', review: 'review-analysis' | 'review-plan' | 'review-code'): boolean {
   const latestSource = latestArtifact(facts.artifacts[source] ?? []);
   return Boolean(latestSource && facts.reviewedInputs?.[review] === latestSource);
+}
+
+function qualificationCandidateSnapshotMatches(
+  audit: QualificationAudit,
+  qualification: TaskQualification
+): boolean {
+  const current = new Map(qualification.candidates.map((candidate) => [candidate.candidateId, candidate]));
+  return audit.candidateQualifications.length === current.size && audit.candidateQualifications.every((row) => {
+    const candidate = current.get(row.candidateId);
+    return Boolean(candidate && candidate.status === row.status && candidate.impact === row.impact
+      && candidate.evidence === row.evidence && candidate.constraintIds.join(',') === row.constraintIds.join(','));
+  });
 }
 
 function recommendNext(facts: LifecycleFacts): LifecycleRecommendation {
@@ -226,6 +245,27 @@ function buildLifecycleFacts(taskDir: string, content: string, taskState = 'acti
         family, files.filter((name) => artifactFamilies[family].test(name) && isArtifactInvalidated(invalidation.document, family, name))
       ])
     ) as Partial<Record<LifecycleAction, readonly string[]>>;
+    const qualification = parseTaskQualification(content);
+    if (!qualification.ok) return { ok: false, code: 'TASK_CAPABILITY_FACTS_INVALID', message: qualification.message };
+    const qualificationStaleArtifacts: string[] = [];
+    if (qualification.qualification.present) {
+      const constraints = new Map(qualification.qualification.constraints.map((row) => [row.constraintId, row.digest]));
+      for (const name of activeFiles) {
+        const family = familyFor(name);
+        if (!family || !ARTIFACT_AUDIT_FAMILIES.has(family)) continue;
+        let auditContent: string;
+        try { auditContent = fs.readFileSync(path.join(taskDir, name), 'utf8'); }
+        catch { qualificationStaleArtifacts.push(name); continue; }
+        const audit = parseQualificationAudit(auditContent);
+        if (!audit.ok || !audit.audit.present || !audit.audit.snapshot) { qualificationStaleArtifacts.push(name); continue; }
+        const constraintsChanged = audit.audit.constraintDependencies.some((dependency) => constraints.get(dependency.constraintId) !== dependency.constraintDigest);
+        const taskInputChanged = audit.audit.snapshot.taskInputDigest !== qualification.qualification.taskInputDigest;
+        if (audit.audit.snapshot.nonConstraintInputDigest !== qualification.qualification.nonConstraintInputDigest
+          || constraintsChanged
+          || (taskInputChanged && !constraintsChanged)
+          || (taskInputChanged && !qualificationCandidateSnapshotMatches(audit.audit, qualification.qualification))) qualificationStaleArtifacts.push(name);
+      }
+    }
     const reviews: LifecycleFacts['reviews'] = {};
     const reviewedInputs: NonNullable<LifecycleFacts['reviewedInputs']> = {};
     for (const family of ['review-analysis', 'review-plan', 'review-code'] as const) {
@@ -249,7 +289,11 @@ function buildLifecycleFacts(taskDir: string, content: string, taskState = 'acti
       taskState, currentStep: String(metadata.current_step ?? ''), artifacts, reviews,
       staleArtifacts, reviewedInputs, artifactHashes,
       invalidation: invalidation.document, reworkIntents: rework.intents,
-      unresolvedLedger, executionBusy: executionBusy || hasOpenLifecycleExecution(content), recommendedAction: null
+      unresolvedLedger,
+      executionBusy: executionBusy || hasOpenLifecycleExecution(content),
+      recommendedAction: null,
+      qualificationStale: qualificationStaleArtifacts.length > 0,
+      qualificationStaleArtifacts
     };
     facts.recommendedAction = recommendNext(facts).action;
     return { ok: true, facts };

--- a/lib/task/capabilities.ts
+++ b/lib/task/capabilities.ts
@@ -92,7 +92,9 @@ function canStart(action: LifecycleAction, facts: LifecycleFacts, trigger: Expli
   }
   if (facts.taskState !== 'active') return deny('TASK_NOT_ACTIVE', `state=${facts.taskState}`);
   if (invalidationBlocks(facts.invalidation)) return deny('INVALIDATION_INCOMPLETE');
-  if (facts.qualificationStale) return deny('QUALIFICATION_STALE', ...(facts.qualificationStaleArtifacts ?? ['qualification audit is stale']));
+  if (facts.qualificationStale && facts.recommendedAction !== action) {
+    return deny('QUALIFICATION_STALE', ...(facts.qualificationStaleArtifacts ?? ['qualification audit is stale']));
+  }
   if (facts.executionBusy) return deny('EXECUTION_BUSY');
 
   const implicit = trigger.explicitRequest === false;
@@ -173,8 +175,30 @@ function qualificationCandidateSnapshotMatches(
   });
 }
 
+const QUALIFICATION_RECOVERY_ORDER: ReadonlyArray<{ action: LifecycleAction; pattern: RegExp }> = [
+  { action: 'analysis', pattern: /^analysis(?:-r\d+)?\.md$/ },
+  { action: 'review-analysis', pattern: /^review-analysis(?:-r\d+)?\.md$/ },
+  { action: 'plan', pattern: /^plan(?:-r\d+)?\.md$/ },
+  { action: 'review-plan', pattern: /^review-plan(?:-r\d+)?\.md$/ },
+  { action: 'code', pattern: /^code(?:-r\d+)?\.md$/ },
+  { action: 'review-code', pattern: /^review-code(?:-r\d+)?\.md$/ }
+];
+
+function qualificationRecoveryAction(facts: LifecycleFacts): LifecycleAction | null {
+  const stale = facts.qualificationStaleArtifacts ?? [];
+  return QUALIFICATION_RECOVERY_ORDER.find(({ pattern }) => stale.some((name) => pattern.test(name)))?.action ?? null;
+}
+
 function recommendNext(facts: LifecycleFacts): LifecycleRecommendation {
   if (invalidationBlocks(facts.invalidation)) return { action: null, reasonCode: 'INVALIDATION_INCOMPLETE', evidence: ['reconcile task invalidation before routing'] };
+  if (facts.qualificationStale) {
+    const action = qualificationRecoveryAction(facts);
+    return {
+      action,
+      reasonCode: 'QUALIFICATION_RECOVERY_REQUIRED',
+      evidence: facts.qualificationStaleArtifacts ?? ['qualification audit is stale']
+    };
+  }
   const pendingIntent = (facts.reworkIntents ?? []).find((intent) => intent.status === 'pending');
   if (pendingIntent) return { action: pendingIntent.target, reasonCode: 'REWORK_INTENT_PENDING', evidence: [pendingIntent.intentId, pendingIntent.findingId] };
   if (!hasArtifact(facts, 'analysis')) return { action: 'analysis', reasonCode: 'ANALYSIS_ARTIFACT_MISSING', evidence: ['analysis artifact is absent'] };
@@ -250,9 +274,10 @@ function buildLifecycleFacts(taskDir: string, content: string, taskState = 'acti
     const qualificationStaleArtifacts: string[] = [];
     if (qualification.qualification.present) {
       const constraints = new Map(qualification.qualification.constraints.map((row) => [row.constraintId, row.digest]));
-      for (const name of activeFiles) {
-        const family = familyFor(name);
-        if (!family || !ARTIFACT_AUDIT_FAMILIES.has(family)) continue;
+      for (const family of Object.keys(artifactFamilies) as Array<keyof typeof artifactFamilies>) {
+        if (!ARTIFACT_AUDIT_FAMILIES.has(family)) continue;
+        const name = latestArtifact(artifacts[family] ?? []);
+        if (!name) continue;
         let auditContent: string;
         try { auditContent = fs.readFileSync(path.join(taskDir, name), 'utf8'); }
         catch { qualificationStaleArtifacts.push(name); continue; }

--- a/lib/task/create.ts
+++ b/lib/task/create.ts
@@ -7,6 +7,7 @@ import { loadShortIdByTaskId, mutateShortIdRegistry } from './short-id.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
 import { readDeliveryDefaults, validateBaseRef, validateRemote } from './delivery-target.ts';
 import { buildUnboundFact, encodePrDeliveryFact } from './pr-delivery-fact.ts';
+import { CANDIDATE_COLUMNS, CONSTRAINT_COLUMNS } from './qualification-audit.ts';
 
 const AGENTS = ['claude', 'codex', 'antigravity', 'opencode', 'cursor'] as const;
 const TYPES = ['feature', 'bugfix', 'refactor', 'docs', 'chore'] as const;
@@ -178,6 +179,25 @@ function renderList(items: readonly string[]): string {
   return items.map((item) => `- ${item}`).join('\n');
 }
 
+function tableCell(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]/g, ' ');
+}
+
+function renderTable(columns: readonly string[], rows: readonly (readonly string[])[]): string {
+  return [
+    `| ${columns.join(' | ')} |`,
+    `| ${columns.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.map(tableCell).join(' | ')} |`)
+  ].join('\n');
+}
+
+function appendCanonicalRows(content: string, columns: readonly string[], rows: readonly (readonly string[])[]): string {
+  if (rows.length === 0) return content;
+  const table = renderTable(columns, rows);
+  const separator = `| ${columns.map(() => '---').join(' | ')} |`;
+  return content.replace(separator, `${separator}\n${table.split('\n').slice(2).join('\n')}`);
+}
+
 function replaceEmptySubsection(content: string, heading: string, items: readonly string[]): string {
   if (items.length === 0) return content;
   return content.replace(`${heading}\n`, `${heading}\n\n${renderList(items)}\n`);
@@ -231,6 +251,13 @@ function renderTask(params: Readonly<{
     ['### 验收标准', 'acceptanceCriteria'], ['### 未决事项', 'openQuestions']
   ];
   for (const [heading, key] of sections) content = replaceEmptySubsection(content, heading, candidate.taskInput[key]);
+  const constraintIds = candidate.taskInput.constraints.map((_, index) => `C-${index + 1}`);
+  content = appendCanonicalRows(content, CONSTRAINT_COLUMNS, candidate.taskInput.constraints.map((statement, index) => [
+    constraintIds[index]!, statement, 'assumption', 'create-task', 'taskInput', 'create-task input', '', ''
+  ]));
+  content = appendCanonicalRows(content, CANDIDATE_COLUMNS, candidate.taskInput.alternatives.map((statement, index) => [
+    String.fromCharCode(65 + index), statement, 'pending', constraintIds.join(','), 'requires qualification', 'create-task input'
+  ]));
   content = content.replace('- **关联 Issue**：#XXX', '- **关联 Issue**：N/A');
   content = content.replace('- **关联 PR**：#XXX', '- **关联 PR**：N/A');
   content = content.replace('- **分支**：`feature/xxx`', `- **分支**：\`${branch}\``);

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -48,6 +48,8 @@ import type { ExplicitTrigger, LifecycleAction, TriggerInitiator, TriggerReason 
 import { createInvalidationOperation, invalidationMutation, parseInvalidationDocument, targetIdFor, upsertInvalidation } from './invalidation.ts';
 import type { InvalidationTargetKind } from './invalidation.ts';
 import { consumeReworkIntents, parseReworkIntentDocument, reworkIntentMutation, supersedeReworkIntents } from './rework-intent.ts';
+import { ARTIFACT_FAMILIES, parseQualificationAudit, parseTaskQualification, upstreamArtifactDigest, validateQualificationAudit } from './qualification-audit.ts';
+import type { QualificationAudit } from './qualification-audit.ts';
 
 const eventCatalog = [
   'analyze.started', 'analyze.awaiting-input', 'analyze.completed',
@@ -381,49 +383,118 @@ function invalidationMutationForCompletion(
     code: ['review-code']
   };
   const sourceFamily = family as 'analyze' | 'plan' | 'code';
+  const sourceArtifactFamily = sourceFamily === 'analyze' ? 'analysis' : sourceFamily;
   let receipts: readonly ArtifactReceipt[] = [];
   try {
     receipts = parseArtifactReceipts(content).rows;
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
   }
-  const targets = downstream[sourceFamily].flatMap((targetFamily: string) => {
-    const names = fs.readdirSync(taskDir).filter((name) => {
-      const pattern = targetFamily === 'review-analysis' ? /^review-analysis(?:-r\d+)?\.md$/
-        : targetFamily === 'review-plan' ? /^review-plan(?:-r\d+)?\.md$/
-          : targetFamily === 'review-code' ? /^review-code(?:-r\d+)?\.md$/
-            : new RegExp(`^${targetFamily}(?:-r\\d+)?\\.md$`);
-      return pattern.test(name);
-    });
-    return names.flatMap((name) => {
-      try {
-        const stat = fs.lstatSync(path.join(taskDir, name));
-        if (!stat.isFile() || stat.isSymbolicLink()) return [];
-        const targetRound = parseArtifactName(name)?.round ?? 1;
-        const targetSha256 = sha256File(path.join(taskDir, name));
-        const shapes: Array<{ targetKind: InvalidationTargetKind; targetFamily: string; targetArtifact: string; targetRound: number; targetSha256: string }> = [
-          { targetKind: 'artifact', targetFamily, targetArtifact: name, targetRound, targetSha256 }
-        ];
-        const receipt = receipts.find((candidate) => candidate.output === name);
-        if (receipt) shapes.push({
-          targetKind: 'receipt', targetFamily, targetArtifact: name, targetRound,
-          targetSha256: receipt.inputSha256
-        });
-        if (targetFamily.startsWith('review-')) {
-          shapes.push({ targetKind: 'approval', targetFamily, targetArtifact: name, targetRound, targetSha256 });
-        }
-        if (targetFamily === 'review-code') {
-          shapes.push({ targetKind: 'reviewed-snapshot', targetFamily, targetArtifact: name, targetRound, targetSha256 });
-        }
-        return shapes.map((targetShape) => ({
-          ...targetShape,
-          targetId: targetIdFor('pending', targetShape), operationId: 'pending', status: 'pending' as const,
-          reasonCode: 'upstream-replaced', updatedAt: timestamp
-        }));
-      } catch (error) {
-        throw new Error(`cannot inspect invalidation target '${name}': ${error instanceof Error ? error.message : String(error)}`);
+  const inventory = fs.readdirSync(taskDir).flatMap((name) => {
+    const identity = parseArtifactName(name);
+    if (!identity || !(ARTIFACT_FAMILIES as readonly string[]).includes(identity.family)) return [];
+    try {
+      const stat = fs.lstatSync(path.join(taskDir, name));
+      if (!stat.isFile() || stat.isSymbolicLink()) return [];
+      return [{ family: identity.family, name, round: identity.round, sha256: sha256File(path.join(taskDir, name)) }];
+    } catch (error) {
+      throw new Error(`cannot inspect invalidation artifact '${name}': ${error instanceof Error ? error.message : String(error)}`);
+    }
+  });
+  const taskQualification = parseTaskQualification(content);
+  if (!taskQualification.ok) return { error: taskQualification.message };
+  const nodeMap = new Map(inventory.map((node) => [`${node.family}/${node.name}`, node]));
+  const audits = new Map<string, QualificationAudit>();
+  let taskInputChanged = false;
+  let graphUsable = taskQualification.qualification.present;
+  if (graphUsable) {
+    for (const node of inventory) {
+      const artifactContent = fs.readFileSync(path.join(taskDir, node.name), 'utf8');
+      const parsedAudit = parseQualificationAudit(artifactContent);
+      if (!parsedAudit.ok || !parsedAudit.audit.present || !parsedAudit.audit.snapshot) { graphUsable = false; break; }
+      audits.set(`${node.family}/${node.name}`, parsedAudit.audit);
+      if (parsedAudit.audit.snapshot.taskInputDigest !== taskQualification.qualification.taskInputDigest) taskInputChanged = true;
+      if (parsedAudit.audit.snapshot.nonConstraintInputDigest !== taskQualification.qualification.nonConstraintInputDigest) {
+        graphUsable = false;
+        break;
       }
-    });
+      if (parsedAudit.audit.snapshot.upstreamArtifactDigest !== upstreamArtifactDigest(parsedAudit.audit.upstreamRelations)) {
+        graphUsable = false;
+        break;
+      }
+      for (const relation of parsedAudit.audit.upstreamRelations) {
+        const upstream = nodeMap.get(`${relation.upstreamFamily}/${relation.upstreamArtifact}`);
+        if (!upstream || upstream.round !== relation.upstreamRound || upstream.sha256 !== relation.upstreamSha256) { graphUsable = false; break; }
+      }
+      if (!graphUsable) break;
+    }
+  }
+  const selected = new Set<string>();
+  const reasonCode = graphUsable ? 'qualification-changed' : 'upstream-replaced';
+  if (graphUsable) {
+    const changedConstraints = new Set<string>();
+    for (const audit of audits.values()) {
+      for (const dependency of audit.constraintDependencies) {
+        const current = taskQualification.qualification.constraints.find((row) => row.constraintId === dependency.constraintId);
+        if (!current || current.digest !== dependency.constraintDigest) changedConstraints.add(dependency.constraintId);
+      }
+    }
+    const currentCandidates = new Map(taskQualification.qualification.candidates.map((candidate) => [candidate.candidateId, candidate]));
+    const candidateSnapshotMatches = [...audits.values()].every((audit) => audit.candidateQualifications.length === currentCandidates.size && audit.candidateQualifications.every((row) => {
+      const current = currentCandidates.get(row.candidateId);
+      return Boolean(current && current.status === row.status && current.impact === row.impact
+        && current.evidence === row.evidence && current.constraintIds.join(',') === row.constraintIds.join(','));
+    }));
+    // A task-input digest also covers candidates. A narrowed invalidation graph
+    // is safe only when the old audit rows show that the candidate projection
+    // stayed unchanged and the change is explained by at least one constraint.
+    if (taskInputChanged && (changedConstraints.size === 0 || !candidateSnapshotMatches)) graphUsable = false;
+    for (const node of inventory) {
+      const audit = audits.get(`${node.family}/${node.name}`)!;
+      if (audit.constraintDependencies.some((dependency) => changedConstraints.has(dependency.constraintId))) selected.add(`${node.family}/${node.name}`);
+      if (audit.upstreamRelations.some((relation) => relation.upstreamFamily === sourceArtifactFamily)) selected.add(`${node.family}/${node.name}`);
+    }
+    // Relation rows point from a consumer to its actual upstream artifact. Walk
+    // that reverse edge so review-only seeds and multi-hop consumers receive the
+    // same derived targets as ordinary executor seeds.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const node of inventory) {
+        const key = `${node.family}/${node.name}`;
+        const audit = audits.get(key)!;
+        if (audit.upstreamRelations.some((relation) => selected.has(`${relation.upstreamFamily}/${relation.upstreamArtifact}`)) && !selected.has(key)) {
+          selected.add(key);
+          changed = true;
+        }
+      }
+    }
+    // A relation cycle cannot establish a safe downstream closure.
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+    const hasCycle = (key: string): boolean => {
+      if (visiting.has(key)) return true;
+      if (visited.has(key)) return false;
+      visiting.add(key);
+      const cycle = audits.get(key)?.upstreamRelations.some((relation) => hasCycle(`${relation.upstreamFamily}/${relation.upstreamArtifact}`)) ?? false;
+      visiting.delete(key); visited.add(key);
+      return cycle;
+    };
+    if ([...nodeMap.keys()].some(hasCycle)) graphUsable = false;
+  }
+  const targetNodes = (graphUsable
+    ? inventory.filter((node) => selected.has(`${node.family}/${node.name}`))
+    : inventory.filter((node) => downstream[sourceFamily].includes(node.family)))
+    .filter((node) => !(node.family === FAMILY[family].artifact && node.name === artifact.name));
+  const targets = targetNodes.flatMap((node) => {
+    const shapes: Array<{ targetKind: InvalidationTargetKind; targetFamily: string; targetArtifact: string; targetRound: number; targetSha256: string }> = [
+      { targetKind: 'artifact', targetFamily: node.family, targetArtifact: node.name, targetRound: node.round, targetSha256: node.sha256 }
+    ];
+    const receipt = receipts.find((candidate) => candidate.output === node.name);
+    if (receipt) shapes.push({ targetKind: 'receipt', targetFamily: node.family, targetArtifact: node.name, targetRound: node.round, targetSha256: receipt.inputSha256 });
+    if (node.family.startsWith('review-')) shapes.push({ targetKind: 'approval', targetFamily: node.family, targetArtifact: node.name, targetRound: node.round, targetSha256: node.sha256 });
+    if (node.family === 'review-code') shapes.push({ targetKind: 'reviewed-snapshot', targetFamily: node.family, targetArtifact: node.name, targetRound: node.round, targetSha256: node.sha256 });
+    return shapes.map((targetShape) => ({ ...targetShape, targetId: targetIdFor('pending', targetShape), operationId: 'pending', status: 'pending' as const, reasonCode, updatedAt: timestamp }));
   });
   if (targets.length === 0) return { mutation: null };
   const source = {
@@ -598,6 +669,20 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
     const validated = validateCompletedArtifact(resolved.taskDir, FAMILY[eventIdentity.family].artifact, normalized.artifact!, normalized.round);
     if (!validated.ok) return failed(normalized, validated.error, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
     completedArtifact = validated.artifact;
+    if (eventIdentity.family.startsWith('review-')) {
+      let reviewContent: string;
+      try { reviewContent = fs.readFileSync(completedArtifact.path, 'utf8'); }
+      catch (error) {
+        return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot read qualification audit from ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+      const qualification = validateQualificationAudit(content, reviewContent, {
+        family: eventIdentity.family as 'review-analysis' | 'review-plan' | 'review-code',
+        artifact: completedArtifact.name
+      });
+      if (!qualification.ok) {
+        return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `${qualification.code}: ${qualification.message}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
+    }
     if (eventIdentity.family === 'analyze' || eventIdentity.family === 'plan' || eventIdentity.family === 'code') {
       const localFamily = eventIdentity.family === 'analyze'
         ? 'analysis'
@@ -611,7 +696,9 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
       const local = validateLocalArtifact(artifactContent, {
         family: localFamily,
         requiredSections: validationConfig.requiredSections,
-        requiredPatterns: validationConfig.requiredPatterns
+        requiredPatterns: validationConfig.requiredPatterns,
+        taskContent: content,
+        artifact: completedArtifact.name
       });
       if (!local.ok) {
         return failed(normalized, {

--- a/lib/task/events.ts
+++ b/lib/task/events.ts
@@ -48,8 +48,8 @@ import type { ExplicitTrigger, LifecycleAction, TriggerInitiator, TriggerReason 
 import { createInvalidationOperation, invalidationMutation, parseInvalidationDocument, targetIdFor, upsertInvalidation } from './invalidation.ts';
 import type { InvalidationTargetKind } from './invalidation.ts';
 import { consumeReworkIntents, parseReworkIntentDocument, reworkIntentMutation, supersedeReworkIntents } from './rework-intent.ts';
-import { ARTIFACT_FAMILIES, parseQualificationAudit, parseTaskQualification, upstreamArtifactDigest, validateQualificationAudit } from './qualification-audit.ts';
-import type { QualificationAudit } from './qualification-audit.ts';
+import { ARTIFACT_FAMILIES, expectedQualificationRelations, parseQualificationAudit, parseTaskQualification, upstreamArtifactDigest, validateQualificationAudit } from './qualification-audit.ts';
+import type { QualificationAudit, UpstreamRelation } from './qualification-audit.ts';
 
 const eventCatalog = [
   'analyze.started', 'analyze.awaiting-input', 'analyze.completed',
@@ -349,6 +349,25 @@ function reviewInputFamily(family: EventFamily): ArtifactFamily {
   return family === 'review-analysis' ? 'analysis' : family === 'review-plan' ? 'plan' : 'code';
 }
 
+function relationForStartedInput(family: EventFamily, input: ArtifactIdentity): UpstreamRelation['relation'] {
+  if (family.startsWith('review-')) {
+    return input.family === reviewInputFamily(family) ? 'reviewed-input' : 'approval-context';
+  }
+  const consumer = family === 'analyze' ? 'analysis' : family;
+  if ((consumer === 'plan' && input.family === 'analysis') || (consumer === 'code' && input.family === 'plan')) return 'required-input';
+  return 'review-context';
+}
+
+function qualificationRelationsForStarted(family: EventFamily, inputs: readonly ArtifactIdentity[]): UpstreamRelation[] {
+  return inputs.map((input) => ({
+    upstreamFamily: input.family as UpstreamRelation['upstreamFamily'],
+    upstreamArtifact: input.name,
+    upstreamRound: input.round,
+    upstreamSha256: sha256File(input.path),
+    relation: relationForStartedInput(family, input)
+  }));
+}
+
 function lifecycleAction(family: EventFamily): LifecycleAction {
   return family === 'analyze' ? 'analysis' : family;
 }
@@ -430,7 +449,6 @@ function invalidationMutationForCompletion(
     }
   }
   const selected = new Set<string>();
-  const reasonCode = graphUsable ? 'qualification-changed' : 'upstream-replaced';
   if (graphUsable) {
     const changedConstraints = new Set<string>();
     for (const audit of audits.values()) {
@@ -482,6 +500,7 @@ function invalidationMutationForCompletion(
     };
     if ([...nodeMap.keys()].some(hasCycle)) graphUsable = false;
   }
+  const reasonCode = graphUsable ? 'qualification-changed' : 'upstream-replaced';
   const targetNodes = (graphUsable
     ? inventory.filter((node) => selected.has(`${node.family}/${node.name}`))
     : inventory.filter((node) => downstream[sourceFamily].includes(node.family)))
@@ -675,9 +694,14 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
       catch (error) {
         return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot read qualification audit from ${completedArtifact.name}: ${error instanceof Error ? error.message : String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
       }
+      const expected = expectedQualificationRelations(content, eventIdentity.family as 'review-analysis' | 'review-plan' | 'review-code');
+      if (!expected.ok) {
+        return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `${expected.code}: ${expected.message}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
+      }
       const qualification = validateQualificationAudit(content, reviewContent, {
         family: eventIdentity.family as 'review-analysis' | 'review-plan' | 'review-code',
-        artifact: completedArtifact.name
+        artifact: completedArtifact.name,
+        expectedUpstreamRelations: expected.relations
       });
       if (!qualification.ok) {
         return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `${qualification.code}: ${qualification.message}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: currentStep, action: eventIdentity.action, phase: eventIdentity.phase });
@@ -817,6 +841,13 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
   const body = appendActivityEntry(section, { time: metadata.timestamp, step: logStep, agent: normalized.agent, note: eventIdentity.note });
   const frontmatterSet: Record<string, string> = { current_step: step, assigned_to: normalized.agent };
   let frontmatterRemove: string[] | undefined;
+  if (eventIdentity.phase === 'started' && artifactContext) {
+    try {
+      frontmatterSet.qualification_input_relations = JSON.stringify(qualificationRelationsForStarted(eventIdentity.family, artifactContext.inputs));
+    } catch (error) {
+      return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: `cannot capture qualification input relations: ${error instanceof Error ? error.message : String(error)}` }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
+    }
+  }
   if (eventIdentity.phase === 'started' && eventIdentity.family === 'code') {
     const planInput = artifactContext?.inputs.find((input) => input.family === 'plan');
     if (!planInput) return failed(normalized, { code: 'EVENT_ARTIFACT_CONFLICT', message: 'code.started plan input context is unavailable' }, { taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, fromStep: currentStep, toStep: step, action: eventIdentity.action, phase: eventIdentity.phase, artifactContext });
@@ -841,6 +872,7 @@ function applyTaskEventUnlocked(request: TaskEventRequest, options: TaskEventOpt
   } else if (eventIdentity.phase === 'completed' && eventIdentity.family.startsWith('review-')) {
     frontmatterRemove = ['review_input_artifact', 'review_input_sha256'];
   }
+  if (eventIdentity.phase === 'completed') frontmatterRemove = [...(frontmatterRemove ?? []), 'qualification_input_relations'];
   if (eventIdentity.phase === 'started' && normalized.implementationInput) frontmatterSet.last_reviewed_commit = '';
   const mutations: Parameters<typeof writeTask>[0]['mutations'][number][] = [
     { kind: 'frontmatter', set: frontmatterSet, remove: frontmatterRemove }

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -12,6 +12,7 @@ import {
   validateCompletedArtifact
 } from './artifact-lifecycle.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
+import { validateQualificationAudit } from './qualification-audit.ts';
 
 type LocalArtifactFamily = 'analysis' | 'plan' | 'code';
 
@@ -41,7 +42,8 @@ type LocalArtifactDiagnosticCode =
   | 'LOCAL_REQUIRED_PATTERN_MISSING'
   | 'LOCAL_SECTION_HEADING_TRAILING_PUNCTUATION'
   | 'LOCAL_REPAIR_PROVENANCE_CONFLICT'
-  | 'LOCAL_REPAIR_BASELINE_MISMATCH';
+  | 'LOCAL_REPAIR_BASELINE_MISMATCH'
+  | 'LOCAL_QUALIFICATION_AUDIT_INVALID';
 
 type LocalArtifactDiagnostic = {
   code: LocalArtifactDiagnosticCode;
@@ -57,6 +59,8 @@ type LocalArtifactValidationOptions = {
   family: LocalArtifactFamily;
   requiredSections?: readonly string[];
   requiredPatterns?: readonly string[];
+  taskContent?: string;
+  artifact?: string;
 };
 
 type LocalArtifactValidationResult = {
@@ -302,6 +306,20 @@ function validateLocalArtifact(
     ));
   }
 
+  if (options.taskContent !== undefined) {
+    const qualification = validateQualificationAudit(options.taskContent, content, {
+      family: options.family === 'analysis' ? 'analysis' : options.family === 'plan' ? 'plan' : 'code',
+      artifact: options.artifact
+    });
+    if (!qualification.ok) {
+      diagnostics.push(diagnostic(
+        'LOCAL_QUALIFICATION_AUDIT_INVALID',
+        `${qualification.code}: ${qualification.message}`,
+        content
+      ));
+    }
+  }
+
   if (candidates.length === 1 && diagnostics.length === 0) {
     const candidate = candidates[0]!;
     const section = candidate.text.slice(0, -1);
@@ -399,10 +417,19 @@ function finalizeLocalArtifact(request: LocalArtifactFinalizationRequest): Local
       taskId: resolved.taskId, taskDir: resolved.taskDir
     });
   }
+  let taskContent: string;
+  try { taskContent = fs.readFileSync(resolved.taskMdPath, 'utf8'); }
+  catch (error) {
+    return failedFinalization(request, { code: 'TASK_READ_FAILED', message: error instanceof Error ? error.message : String(error) }, {
+      taskId: resolved.taskId, taskDir: resolved.taskDir
+    });
+  }
   const result = validateLocalArtifact(content, {
     family: request.family,
     requiredSections: request.requiredSections,
-    requiredPatterns: request.requiredPatterns
+    requiredPatterns: request.requiredPatterns,
+    taskContent,
+    artifact: request.artifact
   });
   const artifactSha256 = sha256Content(content);
   let intent: LocalArtifactFinalizationIntent | null;

--- a/lib/task/local-artifact-finalization.ts
+++ b/lib/task/local-artifact-finalization.ts
@@ -12,7 +12,7 @@ import {
   validateCompletedArtifact
 } from './artifact-lifecycle.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
-import { validateQualificationAudit } from './qualification-audit.ts';
+import { expectedQualificationRelations, validateQualificationAudit } from './qualification-audit.ts';
 
 type LocalArtifactFamily = 'analysis' | 'plan' | 'code';
 
@@ -307,9 +307,14 @@ function validateLocalArtifact(
   }
 
   if (options.taskContent !== undefined) {
+    const expected = expectedQualificationRelations(options.taskContent, options.family);
+    if (!expected.ok) {
+      diagnostics.push(diagnostic('LOCAL_QUALIFICATION_AUDIT_INVALID', `${expected.code}: ${expected.message}`, content));
+    }
     const qualification = validateQualificationAudit(options.taskContent, content, {
       family: options.family === 'analysis' ? 'analysis' : options.family === 'plan' ? 'plan' : 'code',
-      artifact: options.artifact
+      artifact: options.artifact,
+      expectedUpstreamRelations: expected.ok ? expected.relations : undefined
     });
     if (!qualification.ok) {
       diagnostics.push(diagnostic(

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -186,8 +186,18 @@ function stripSection(content: string, aliases: readonly string[]): string {
   return normalizeText(content.replace(new RegExp(`^##\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^##\\s+|$)`, 'm'), ''));
 }
 
+function stripFrontmatter(content: string): string {
+  const opening = /^---(?:\r?\n)/.exec(content);
+  if (!opening) return content;
+  const closing = /^---\r?$/gm;
+  closing.lastIndex = opening[0].length;
+  const match = closing.exec(content);
+  return match ? content.slice(match.index + match[0].length) : content;
+}
+
 function nonConstraintInputDigest(content: string): string {
-  let projection = stripTaskInputSection(content, TASK_CONSTRAINT_HEADINGS);
+  let projection = stripFrontmatter(content);
+  projection = stripTaskInputSection(projection, TASK_CONSTRAINT_HEADINGS);
   projection = stripTaskInputSection(projection, TASK_CANDIDATE_HEADINGS);
   projection = [
     ['活动日志', 'Activity Log'],

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 
+import { parseTypedTaskFrontmatter } from './frontmatter.ts';
 import { parseTable } from './sections.ts';
 
 const TASK_CONSTRAINT_HEADINGS = ['约束', 'Constraints'] as const;
@@ -323,6 +324,59 @@ function upstreamArtifactDigest(rows: readonly UpstreamRelation[]): string {
     `${a.upstreamFamily}/${a.upstreamArtifact}/${a.relation}`.localeCompare(`${b.upstreamFamily}/${b.upstreamArtifact}/${b.relation}`)));
 }
 
+function validateUpstreamRelation(row: UpstreamRelation): void {
+  const identity = parseArtifactName(row.upstreamArtifact);
+  if (!ARTIFACT_FAMILIES.includes(row.upstreamFamily) || !identity || identity.family !== row.upstreamFamily
+    || identity.round !== row.upstreamRound || !Number.isSafeInteger(row.upstreamRound)
+    || !/^[a-f0-9]{64}$/i.test(row.upstreamSha256) || !RELATIONS.includes(row.relation)) {
+    throw new Error(`invalid qualification upstream relation '${row.upstreamArtifact}'`);
+  }
+}
+
+function expectedQualificationRelations(
+  taskContent: string,
+  family: ArtifactFamily
+): { ok: true; relations: readonly UpstreamRelation[] | undefined } | { ok: false; code: string; message: string } {
+  let frontmatter;
+  try { frontmatter = parseTypedTaskFrontmatter(taskContent); }
+  catch (error) { return { ok: false, code: 'QUALIFICATION_STARTED_INPUT_INVALID', message: error instanceof Error ? error.message : String(error) }; }
+  const encoded = frontmatter.qualification_input_relations;
+  if (typeof encoded === 'string' && encoded) {
+    try {
+      const parsed = JSON.parse(encoded) as unknown;
+      if (!Array.isArray(parsed)) throw new Error('qualification_input_relations must be an array');
+      const relations = parsed.map((value) => {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('qualification input relation must be an object');
+        const row = value as Record<string, unknown>;
+        const relation: UpstreamRelation = {
+          upstreamFamily: row.upstreamFamily as ArtifactFamily,
+          upstreamArtifact: String(row.upstreamArtifact ?? ''),
+          upstreamRound: Number(row.upstreamRound),
+          upstreamSha256: String(row.upstreamSha256 ?? ''),
+          relation: row.relation as QualificationRelation
+        };
+        validateUpstreamRelation(relation);
+        return relation;
+      });
+      return { ok: true, relations };
+    } catch (error) {
+      return { ok: false, code: 'QUALIFICATION_STARTED_INPUT_INVALID', message: error instanceof Error ? error.message : String(error) };
+    }
+  }
+  const inputName = family === 'code' ? frontmatter.code_input_artifact : family.startsWith('review-') ? frontmatter.review_input_artifact : '';
+  const inputSha256 = family === 'code' ? frontmatter.code_input_sha256 : family.startsWith('review-') ? frontmatter.review_input_sha256 : '';
+  if (typeof inputName !== 'string' || !inputName || typeof inputSha256 !== 'string' || !inputSha256) return { ok: true, relations: undefined };
+  const identity = parseArtifactName(inputName);
+  if (!identity) return { ok: false, code: 'QUALIFICATION_STARTED_INPUT_INVALID', message: `started input '${inputName}' is not canonical` };
+  const relation: UpstreamRelation = {
+    upstreamFamily: identity.family, upstreamArtifact: inputName, upstreamRound: identity.round,
+    upstreamSha256: inputSha256, relation: family === 'code' ? 'required-input' : 'reviewed-input'
+  };
+  try { validateUpstreamRelation(relation); }
+  catch (error) { return { ok: false, code: 'QUALIFICATION_STARTED_INPUT_INVALID', message: error instanceof Error ? error.message : String(error) }; }
+  return { ok: true, relations: [relation] };
+}
+
 function parseQualificationAudit(content: string): { ok: true; audit: QualificationAudit } | { ok: false; code: string; message: string } {
   if (sectionBody(content, AUDIT_HEADINGS) === null) return { ok: true, audit: { present: false, constraintDependencies: [], candidateQualifications: [], classifications: [], upstreamRelations: [], snapshot: null } };
   try {
@@ -348,10 +402,9 @@ function parseQualificationAudit(content: string): { ok: true; audit: Qualificat
       return { decisionId: row.decision_id, classification: row.classification as QualificationClassification, evidence: row.evidence };
     });
     const upstreamRelations = relations.map((row) => {
-      const identity = parseArtifactName(row.upstream_artifact ?? '');
-      const round = Number(row.upstream_round);
-      if (!ARTIFACT_FAMILIES.includes(row.upstream_family as ArtifactFamily) || !identity || identity.family !== row.upstream_family || identity.round !== round || !Number.isSafeInteger(round) || !/^[a-f0-9]{64}$/i.test(row.upstream_sha256 ?? '') || !RELATIONS.includes(row.relation as QualificationRelation)) throw new Error(`invalid qualification upstream relation '${row.upstream_artifact ?? ''}'`);
-      return { upstreamFamily: row.upstream_family as ArtifactFamily, upstreamArtifact: row.upstream_artifact!, upstreamRound: round, upstreamSha256: row.upstream_sha256!, relation: row.relation as QualificationRelation };
+      const relation = { upstreamFamily: row.upstream_family as ArtifactFamily, upstreamArtifact: row.upstream_artifact ?? '', upstreamRound: Number(row.upstream_round), upstreamSha256: row.upstream_sha256 ?? '', relation: row.relation as QualificationRelation };
+      validateUpstreamRelation(relation);
+      return relation;
     });
     const snapshotRow = snapshots[0]!;
     if (!/^[a-f0-9]{64}$/i.test(snapshotRow.task_input_digest ?? '') || !/^[a-f0-9]{64}$/i.test(snapshotRow.non_constraint_input_digest ?? '') || !/^[a-f0-9]{64}$/i.test(snapshotRow.upstream_artifact_digest ?? '')) throw new Error('qualification dependency snapshot has invalid digest');
@@ -395,7 +448,12 @@ function parseQualificationConfirmations(content: string): { ok: true; confirmat
 function validateQualificationAudit(
   taskContent: string,
   artifactContent: string,
-  options: { family?: ArtifactFamily; artifact?: string; require?: boolean } = {}
+  options: {
+    family?: ArtifactFamily;
+    artifact?: string;
+    require?: boolean;
+    expectedUpstreamRelations?: readonly UpstreamRelation[];
+  } = {}
 ): QualificationValidationResult {
   const task = parseTaskQualification(taskContent);
   if (!task.ok) return task;
@@ -407,11 +465,18 @@ function validateQualificationAudit(
   const constraintMap = new Map(task.qualification.constraints.map((row) => [row.constraintId, row]));
   const confirmations = parseQualificationConfirmations(taskContent);
   if (!confirmations.ok) return confirmations;
-  const confirmationMap = new Map(confirmations.confirmations.map((row) => [row.constraintId, row]));
+  const confirmationIds = new Set<string>();
+  for (const confirmation of confirmations.confirmations) {
+    if (confirmationIds.has(confirmation.qcrId)) return { ok: false, code: 'QUALIFICATION_CONFIRMATION_DUPLICATE', message: `qualification confirmation '${confirmation.qcrId}' is duplicated` };
+    confirmationIds.add(confirmation.qcrId);
+    if (!constraintMap.has(confirmation.constraintId)) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_UNKNOWN', message: `qualification confirmation references unknown constraint '${confirmation.constraintId}'` };
+  }
+  const confirmationMap = new Map(confirmations.confirmations.map((row) => [row.qcrId, row]));
   for (const constraint of task.qualification.constraints) {
     if (constraint.status !== 'confirmed') continue;
-    const confirmation = confirmationMap.get(constraint.constraintId);
-    if (!confirmation || constraint.approvalEvidence !== confirmation.qcrId) return { ok: false, code: 'QUALIFICATION_CONFIRMATION_MISSING', message: `confirmed constraint '${constraint.constraintId}' has no matching QCR` };
+    const confirmation = confirmationMap.get(constraint.approvalEvidence);
+    if (!confirmation || confirmation.constraintId !== constraint.constraintId) return { ok: false, code: 'QUALIFICATION_CONFIRMATION_MISSING', message: `confirmed constraint '${constraint.constraintId}' has no matching QCR` };
+    if (confirmation.approvedDigest !== constraint.digest) return { ok: false, code: 'QUALIFICATION_CONFIRMATION_DIGEST_MISMATCH', message: `qualification confirmation for '${constraint.constraintId}' is stale` };
   }
   for (const row of audit.audit.constraintDependencies) {
     const constraint = constraintMap.get(row.constraintId);
@@ -419,14 +484,26 @@ function validateQualificationAudit(
     if (constraint.digest !== row.constraintDigest) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_DIGEST_MISMATCH', message: `qualification audit digest does not match '${row.constraintId}'` };
   }
   const candidateMap = new Map(task.qualification.candidates.map((row) => [row.candidateId, row]));
+  const candidateIds = new Set<string>();
   for (const row of audit.audit.candidateQualifications) {
-    if (!candidateMap.has(row.candidateId)) return { ok: false, code: 'QUALIFICATION_CANDIDATE_UNKNOWN', message: `qualification audit references unknown candidate '${row.candidateId}'` };
+    if (candidateIds.has(row.candidateId)) return { ok: false, code: 'QUALIFICATION_CANDIDATE_MISMATCH', message: `qualification candidate '${row.candidateId}' is duplicated` };
+    candidateIds.add(row.candidateId);
+    const current = candidateMap.get(row.candidateId);
+    if (!current) return { ok: false, code: 'QUALIFICATION_CANDIDATE_UNKNOWN', message: `qualification audit references unknown candidate '${row.candidateId}'` };
     if (row.constraintIds.some((id) => !constraintMap.has(id))) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_UNKNOWN', message: `candidate '${row.candidateId}' references unknown qualification constraint` };
+    if (row.status !== current.status || row.impact !== current.impact || row.evidence !== current.evidence || row.constraintIds.join(',') !== current.constraintIds.join(',')) {
+      return { ok: false, code: 'QUALIFICATION_CANDIDATE_MISMATCH', message: `qualification candidate '${row.candidateId}' does not match task input` };
+    }
   }
+  if (candidateIds.size !== candidateMap.size) return { ok: false, code: 'QUALIFICATION_CANDIDATE_MISMATCH', message: 'qualification audit does not contain the complete task candidate set' };
   const snapshot = audit.audit.snapshot!;
   if (snapshot.taskInputDigest !== task.qualification.taskInputDigest) return { ok: false, code: 'QUALIFICATION_TASK_DIGEST_MISMATCH', message: 'qualification audit task input digest is stale' };
   if (snapshot.nonConstraintInputDigest !== task.qualification.nonConstraintInputDigest) return { ok: false, code: 'QUALIFICATION_NON_CONSTRAINT_DIGEST_MISMATCH', message: 'qualification audit non-constraint input digest is stale' };
   if (snapshot.upstreamArtifactDigest !== upstreamArtifactDigest(audit.audit.upstreamRelations)) return { ok: false, code: 'QUALIFICATION_UPSTREAM_DIGEST_MISMATCH', message: 'qualification audit upstream digest does not match its relation rows' };
+  if (options.expectedUpstreamRelations && (
+    options.expectedUpstreamRelations.length !== audit.audit.upstreamRelations.length
+    || upstreamArtifactDigest(options.expectedUpstreamRelations) !== upstreamArtifactDigest(audit.audit.upstreamRelations)
+  )) return { ok: false, code: 'QUALIFICATION_UPSTREAM_RELATION_MISMATCH', message: 'qualification audit upstream relations do not match the started artifact inputs' };
   if (options.family && options.artifact) {
     const identity = parseArtifactName(options.artifact);
     if (!identity || identity.family !== options.family) return { ok: false, code: 'QUALIFICATION_ARTIFACT_IDENTITY_INVALID', message: `artifact '${options.artifact}' is not canonical for '${options.family}'` };
@@ -487,6 +564,7 @@ export {
   RELATION_COLUMNS,
   SNAPSHOT_COLUMNS,
   constraintDigest,
+  expectedQualificationRelations,
   buildQualificationAudit,
   nonConstraintInputDigest,
   parseQualificationAudit,

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -200,15 +200,23 @@ function nonConstraintInputDigest(content: string): string {
   projection = stripTaskInputSection(projection, TASK_CONSTRAINT_HEADINGS);
   projection = stripTaskInputSection(projection, TASK_CANDIDATE_HEADINGS);
   projection = [
+    ['上下文', 'Context'],
+    ['需求', 'Requirements'],
+    ['分析', 'Analysis'],
+    ['设计', 'Design'],
+    ['实现备注', 'Implementation Notes'],
+    ['审查反馈', 'Review Feedback'],
+    ['审查分歧账本', 'Review Disagreement Ledger'],
+    ['人工裁决', 'Human Rulings', 'Decision Records'],
     ['活动日志', 'Activity Log'],
     ['产物生命周期收据', 'Artifact Lifecycle Receipts'],
     ['产物失效记录', 'Artifact Invalidation'],
     ['账本', 'Ledger'],
-    ['决策记录', 'Decision Records'],
     ['实现输入', 'Implementation Inputs'],
-    ['警告', 'Warnings'],
+    ['工作流告警', 'Warnings', 'Workflow Warnings'],
     ['返工意图', 'Rework Intents'],
-    CONFIRMATION_HEADINGS
+    CONFIRMATION_HEADINGS,
+    ['完成检查清单', 'Completion Checklist']
   ].reduce((value, aliases) => stripSection(value, aliases), projection);
   return digest(projection);
 }

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -1,0 +1,501 @@
+import { createHash } from 'node:crypto';
+
+import { parseTable } from './sections.ts';
+
+const TASK_CONSTRAINT_HEADINGS = ['约束', 'Constraints'] as const;
+const TASK_CANDIDATE_HEADINGS = ['候选与否决方案', 'Candidate and Rejected Options', 'Candidates and Rejected Options', 'Candidates and Rejected Alternatives'] as const;
+const AUDIT_HEADINGS = ['资格审计', 'Qualification Audit'] as const;
+const CONFIRMATION_HEADINGS = ['资格确认记录', 'Qualification Confirmations'] as const;
+const AUDIT_SUBSECTIONS = ['约束依赖', '候选资格', '分类结果', '上游关系', '依赖快照'] as const;
+const AUDIT_SUBSECTION_HEADINGS: Record<(typeof AUDIT_SUBSECTIONS)[number], readonly string[]> = {
+  '约束依赖': ['约束依赖', 'Constraint Dependencies'],
+  '候选资格': ['候选资格', 'Candidate Qualification'],
+  '分类结果': ['分类结果', 'Classification Results'],
+  '上游关系': ['上游关系', 'Upstream Relations'],
+  '依赖快照': ['依赖快照', 'Dependency Snapshot']
+};
+
+const CONSTRAINT_COLUMNS = ['constraint_id', 'statement', 'status', 'authority', 'source', 'evidence', 'derived_from', 'approval_evidence'] as const;
+const CANDIDATE_COLUMNS = ['candidate_id', 'statement', 'status', 'constraint_ids', 'impact', 'evidence'] as const;
+const DEPENDENCY_COLUMNS = ['constraint_id', 'constraint_digest', 'role', 'evidence'] as const;
+const QUALIFICATION_COLUMNS = ['candidate_id', 'status', 'impact', 'constraint_ids', 'evidence'] as const;
+const CLASSIFICATION_COLUMNS = ['decision_id', 'classification', 'evidence'] as const;
+const RELATION_COLUMNS = ['upstream_family', 'upstream_artifact', 'upstream_round', 'upstream_sha256', 'relation'] as const;
+const SNAPSHOT_COLUMNS = ['task_input_digest', 'non_constraint_input_digest', 'upstream_artifact_digest'] as const;
+const CONFIRMATION_COLUMNS = ['qcr_id', 'constraint_id', 'actor', 'entrypoint', 'request_id', 'approved_digest', 'confirmed_at', 'rationale'] as const;
+
+const ARTIFACT_FAMILIES = ['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'review-code'] as const;
+const RELATIONS = ['required-input', 'reviewed-input', 'review-context', 'approval-context'] as const;
+const CONSTRAINT_STATUSES = ['confirmed', 'derived', 'assumption', 'open', 'conflicted', 'superseded'] as const;
+const CANDIDATE_STATUSES = ['qualified', 'rejected', 'pending', 'needs-human-decision', 'confirmed', 'excluded'] as const;
+const CLASSIFICATIONS = ['deterministic', 'qualified', 'rejected', 'needs-human-decision', 'not-applicable'] as const;
+const ROLES = ['required', 'inherited', 'context', 'filter'] as const;
+
+type ConstraintStatus = (typeof CONSTRAINT_STATUSES)[number];
+type CandidateStatus = (typeof CANDIDATE_STATUSES)[number];
+type QualificationClassification = (typeof CLASSIFICATIONS)[number];
+type ArtifactFamily = (typeof ARTIFACT_FAMILIES)[number];
+type QualificationRelation = (typeof RELATIONS)[number];
+type QualificationRole = (typeof ROLES)[number];
+
+type Constraint = {
+  constraintId: string;
+  statement: string;
+  status: ConstraintStatus;
+  authority: string;
+  source: string;
+  evidence: string;
+  derivedFrom: readonly string[];
+  approvalEvidence: string;
+  digest: string;
+};
+type Candidate = {
+  candidateId: string;
+  statement: string;
+  status: CandidateStatus;
+  constraintIds: readonly string[];
+  impact: string;
+  evidence: string;
+};
+type TaskQualification = {
+  present: boolean;
+  constraints: readonly Constraint[];
+  candidates: readonly Candidate[];
+  constraintDigest: string;
+  taskInputDigest: string;
+  nonConstraintInputDigest: string;
+};
+type ConstraintDependency = {
+  constraintId: string;
+  constraintDigest: string;
+  role: QualificationRole;
+  evidence: string;
+};
+type CandidateQualification = {
+  candidateId: string;
+  status: CandidateStatus;
+  impact: string;
+  constraintIds: readonly string[];
+  evidence: string;
+};
+type QualificationClassificationRow = {
+  decisionId: string;
+  classification: QualificationClassification;
+  evidence: string;
+};
+type UpstreamRelation = {
+  upstreamFamily: ArtifactFamily;
+  upstreamArtifact: string;
+  upstreamRound: number;
+  upstreamSha256: string;
+  relation: QualificationRelation;
+};
+type DependencySnapshot = {
+  taskInputDigest: string;
+  nonConstraintInputDigest: string;
+  upstreamArtifactDigest: string;
+};
+type QualificationAudit = {
+  present: boolean;
+  constraintDependencies: readonly ConstraintDependency[];
+  candidateQualifications: readonly CandidateQualification[];
+  classifications: readonly QualificationClassificationRow[];
+  upstreamRelations: readonly UpstreamRelation[];
+  snapshot: DependencySnapshot | null;
+};
+type QualificationConfirmation = {
+  qcrId: string;
+  constraintId: string;
+  actor: 'human-declared';
+  entrypoint: 'ai qualify';
+  requestId: string;
+  approvedDigest: string;
+  confirmedAt: string;
+  rationale: string;
+};
+type QualificationValidationError = { code: string; message: string };
+type QualificationValidationResult =
+  | { ok: true; qualification: TaskQualification; audit: QualificationAudit }
+  | { ok: false; code: string; message: string };
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex');
+}
+
+function normalizeText(value: string): string {
+  return value.normalize('NFC').replace(/\r\n?/g, '\n').trim();
+}
+
+function canonicalList(value: string): string[] {
+  return normalizeText(value)
+    .split(/[,\s]+/u)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+function canonicalConstraintShape(row: Omit<Constraint, 'digest'>): Record<string, unknown> {
+  return {
+    constraintId: row.constraintId,
+    statement: normalizeText(row.statement),
+    status: row.status,
+    authority: normalizeText(row.authority),
+    source: normalizeText(row.source),
+    evidence: normalizeText(row.evidence),
+    derivedFrom: [...row.derivedFrom].sort(),
+    approvalEvidence: normalizeText(row.approvalEvidence)
+  };
+}
+
+function constraintDigest(row: Omit<Constraint, 'digest'>): string {
+  return digest(canonicalConstraintShape(row));
+}
+
+function canonicalTaskInput(qualification: Pick<TaskQualification, 'constraints' | 'candidates'>): Record<string, unknown> {
+  return {
+    constraints: [...qualification.constraints].map(({ digest: _digest, ...row }) => canonicalConstraintShape(row)).sort((a, b) => String(a.constraintId).localeCompare(String(b.constraintId))),
+    candidates: [...qualification.candidates].map((row) => ({
+      candidateId: row.candidateId,
+      statement: normalizeText(row.statement),
+      status: row.status,
+      constraintIds: [...row.constraintIds].sort(),
+      impact: normalizeText(row.impact),
+      evidence: normalizeText(row.evidence)
+    })).sort((a, b) => a.candidateId.localeCompare(b.candidateId))
+  };
+}
+
+function taskInputDigest(qualification: Pick<TaskQualification, 'constraints' | 'candidates'>): string {
+  return digest(canonicalTaskInput(qualification));
+}
+
+function sectionBody(content: string, aliases: readonly string[], level = 2): string | null {
+  const heading = aliases.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const marker = '#'.repeat(level);
+  const match = new RegExp(`^${marker}\\s+(${heading})\\s*$`, 'm').exec(content);
+  if (!match) return null;
+  const rest = content.slice((match.index ?? 0) + match[0].length);
+  const end = rest.search(new RegExp(`^#{2,${level}}\\s+`, 'm'));
+  return rest.slice(0, end < 0 ? rest.length : end);
+}
+
+function stripSection(content: string, aliases: readonly string[]): string {
+  const body = sectionBody(content, aliases);
+  if (body === null) return normalizeText(content);
+  const heading = aliases.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  return normalizeText(content.replace(new RegExp(`^##\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^##\\s+|$)`, 'm'), ''));
+}
+
+function nonConstraintInputDigest(content: string): string {
+  let projection = stripTaskInputSection(content, TASK_CONSTRAINT_HEADINGS);
+  projection = stripTaskInputSection(projection, TASK_CANDIDATE_HEADINGS);
+  projection = [
+    ['活动日志', 'Activity Log'],
+    ['产物生命周期收据', 'Artifact Lifecycle Receipts'],
+    ['产物失效记录', 'Artifact Invalidation'],
+    ['账本', 'Ledger'],
+    ['决策记录', 'Decision Records'],
+    ['实现输入', 'Implementation Inputs'],
+    ['警告', 'Warnings'],
+    ['返工意图', 'Rework Intents'],
+    CONFIRMATION_HEADINGS
+  ].reduce((value, aliases) => stripSection(value, aliases), projection);
+  return digest(projection);
+}
+
+function taskInputSection(content: string, aliases: readonly string[]): string | null {
+  return sectionBody(content, aliases, 3) ?? sectionBody(content, aliases, 2);
+}
+
+function stripTaskInputSection(content: string, aliases: readonly string[]): string {
+  let result = stripSectionAtLevel(content, aliases, 3);
+  return stripSectionAtLevel(result, aliases, 2);
+}
+
+function stripSectionAtLevel(content: string, aliases: readonly string[], level: number): string {
+  const body = sectionBody(content, aliases, level);
+  if (body === null) return normalizeText(content);
+  const heading = aliases.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const marker = '#'.repeat(level);
+  return normalizeText(content.replace(new RegExp(`^${marker}\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^#{2,${level}}\\s+|$)`, 'm'), ''));
+}
+
+function parseTaskQualification(content: string): { ok: true; qualification: TaskQualification } | { ok: false; code: string; message: string } {
+  const hasConstraintHeading = taskInputSection(content, TASK_CONSTRAINT_HEADINGS) !== null;
+  const hasCandidateHeading = taskInputSection(content, TASK_CANDIDATE_HEADINGS) !== null;
+  if (!hasConstraintHeading && !hasCandidateHeading) {
+    return { ok: true, qualification: { present: false, constraints: [], candidates: [], constraintDigest: digest([]), taskInputDigest: digest({ constraints: [], candidates: [] }), nonConstraintInputDigest: nonConstraintInputDigest(content) } };
+  }
+  if (!hasConstraintHeading || !hasCandidateHeading) {
+    const hasCanonicalTable = new RegExp(`\\|\\s*${CONSTRAINT_COLUMNS.join('\\s*\\|\\s*')}\\s*\\|`).test(content)
+      || new RegExp(`\\|\\s*${CANDIDATE_COLUMNS.join('\\s*\\|\\s*')}\\s*\\|`).test(content);
+    if (hasCanonicalTable) return { ok: false, code: 'QUALIFICATION_TASK_CONTRACT_INVALID', message: 'task qualification requires both constraints and candidates sections' };
+    return { ok: true, qualification: { present: false, constraints: [], candidates: [], constraintDigest: digest([]), taskInputDigest: digest({ constraints: [], candidates: [] }), nonConstraintInputDigest: nonConstraintInputDigest(content) } };
+  }
+  try {
+    const constraintBody = taskInputSection(content, TASK_CONSTRAINT_HEADINGS);
+    const candidateBody = taskInputSection(content, TASK_CANDIDATE_HEADINGS);
+    const constraintTable = constraintBody === null ? null : parseTable(`## 约束\n${constraintBody}`, { sectionAliases: ['约束'], columns: CONSTRAINT_COLUMNS });
+    const candidateTable = candidateBody === null ? null : parseTable(`## 候选与否决方案\n${candidateBody}`, { sectionAliases: ['候选与否决方案'], columns: CANDIDATE_COLUMNS });
+    if (!constraintTable || !candidateTable) return { ok: false, code: 'QUALIFICATION_TASK_CONTRACT_INVALID', message: 'task qualification requires canonical constraints and candidates tables' };
+    const constraints = constraintTable.rows.map(({ values }) => {
+      const row = {
+        constraintId: values.constraint_id ?? '', statement: values.statement ?? '', status: values.status as ConstraintStatus,
+        authority: values.authority ?? '', source: values.source ?? '', evidence: values.evidence ?? '',
+        derivedFrom: canonicalList(values.derived_from ?? ''), approvalEvidence: values.approval_evidence ?? ''
+      } satisfies Omit<Constraint, 'digest'>;
+      validateConstraint(row);
+      return { ...row, digest: constraintDigest(row) };
+    });
+    const ids = new Set(constraints.map((row) => row.constraintId));
+    for (const row of constraints) for (const parent of row.derivedFrom) if (!ids.has(parent)) throw new Error(`constraint '${row.constraintId}' references unknown derived constraint '${parent}'`);
+    const candidates = candidateTable.rows.map(({ values }) => {
+      const row: Candidate = {
+        candidateId: values.candidate_id ?? '', statement: values.statement ?? '', status: values.status as CandidateStatus,
+        constraintIds: canonicalList(values.constraint_ids ?? ''), impact: values.impact ?? '', evidence: values.evidence ?? ''
+      };
+      validateCandidate(row);
+      for (const id of row.constraintIds) if (!ids.has(id)) throw new Error(`candidate '${row.candidateId}' references unknown constraint '${id}'`);
+      return row;
+    });
+    const qualification: TaskQualification = {
+      present: true, constraints, candidates,
+      constraintDigest: digest(constraints.map((row) => canonicalConstraintShape(row)).sort((a, b) => String(a.constraintId).localeCompare(String(b.constraintId)))),
+      taskInputDigest: taskInputDigest({ constraints, candidates }),
+      nonConstraintInputDigest: nonConstraintInputDigest(content)
+    };
+    return { ok: true, qualification };
+  } catch (error) {
+    return { ok: false, code: 'QUALIFICATION_TASK_CONTRACT_INVALID', message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function validateConstraint(row: Omit<Constraint, 'digest'>): void {
+  if (!/^C-[1-9]\d*$/.test(row.constraintId)) throw new Error(`constraint id '${row.constraintId}' is invalid`);
+  if (!normalizeText(row.statement)) throw new Error(`constraint '${row.constraintId}' statement is required`);
+  if (!CONSTRAINT_STATUSES.includes(row.status)) throw new Error(`constraint '${row.constraintId}' status is invalid`);
+  if (!normalizeText(row.authority) || !normalizeText(row.source) || !normalizeText(row.evidence)) throw new Error(`constraint '${row.constraintId}' authority, source, and evidence are required`);
+  if (row.status === 'confirmed' && !normalizeText(row.approvalEvidence)) throw new Error(`confirmed constraint '${row.constraintId}' requires approval_evidence`);
+}
+
+function validateCandidate(row: Pick<Candidate, 'candidateId' | 'status' | 'impact' | 'evidence'> & Partial<Pick<Candidate, 'statement'>>): void {
+  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(row.candidateId)) throw new Error(`candidate id '${row.candidateId}' is invalid`);
+  if ('statement' in row && !normalizeText(row.statement ?? '')) throw new Error(`candidate '${row.candidateId}' statement is required`);
+  if (!CANDIDATE_STATUSES.includes(row.status)) throw new Error(`candidate '${row.candidateId}' status is invalid`);
+  if (!normalizeText(row.impact) || !normalizeText(row.evidence)) throw new Error(`candidate '${row.candidateId}' impact and evidence are required`);
+}
+
+function parseAuditTable(content: string, heading: (typeof AUDIT_SUBSECTIONS)[number], columns: readonly string[]): Record<string, string>[] | null {
+  const body = sectionBody(content, AUDIT_HEADINGS);
+  if (body === null) return null;
+  const subsection = sectionBody(body, AUDIT_SUBSECTION_HEADINGS[heading], 3);
+  if (subsection === null) return null;
+  const table = parseTable(`## Qualification Audit Body\n${subsection}`, { sectionAliases: ['Qualification Audit Body'], columns });
+  return table?.rows.map((row) => ({ ...row.values })) ?? null;
+}
+
+function parseArtifactName(value: string): { family: ArtifactFamily; round: number } | null {
+  const match = /^(analysis|review-analysis|plan|review-plan|code|review-code)(?:-r([2-9]|[1-9]\d+))?\.md$/.exec(value);
+  if (!match) return null;
+  return { family: match[1] as ArtifactFamily, round: match[2] ? Number(match[2]) : 1 };
+}
+
+function upstreamArtifactDigest(rows: readonly UpstreamRelation[]): string {
+  return digest([...rows].map((row) => ({ ...row })).sort((a, b) =>
+    `${a.upstreamFamily}/${a.upstreamArtifact}/${a.relation}`.localeCompare(`${b.upstreamFamily}/${b.upstreamArtifact}/${b.relation}`)));
+}
+
+function parseQualificationAudit(content: string): { ok: true; audit: QualificationAudit } | { ok: false; code: string; message: string } {
+  if (sectionBody(content, AUDIT_HEADINGS) === null) return { ok: true, audit: { present: false, constraintDependencies: [], candidateQualifications: [], classifications: [], upstreamRelations: [], snapshot: null } };
+  try {
+    const dependencies = parseAuditTable(content, '约束依赖', DEPENDENCY_COLUMNS);
+    const qualifications = parseAuditTable(content, '候选资格', QUALIFICATION_COLUMNS);
+    const classifications = parseAuditTable(content, '分类结果', CLASSIFICATION_COLUMNS);
+    const relations = parseAuditTable(content, '上游关系', RELATION_COLUMNS);
+    const snapshots = parseAuditTable(content, '依赖快照', SNAPSHOT_COLUMNS);
+    if (!dependencies || !qualifications || !classifications || !relations || !snapshots || snapshots.length !== 1) {
+      throw new Error('qualification audit requires all five canonical tables and exactly one dependency snapshot');
+    }
+    const constraintDependencies = dependencies.map((row) => {
+      if (!/^C-[1-9]\d*$/.test(row.constraint_id ?? '') || !/^[a-f0-9]{64}$/i.test(row.constraint_digest ?? '') || !ROLES.includes(row.role as QualificationRole) || !row.evidence?.trim()) throw new Error(`invalid qualification constraint dependency '${row.constraint_id ?? ''}'`);
+      return { constraintId: row.constraint_id!, constraintDigest: row.constraint_digest!, role: row.role as QualificationRole, evidence: row.evidence! };
+    });
+    const candidateQualifications = qualifications.map((row) => {
+      const parsed: CandidateQualification = { candidateId: row.candidate_id ?? '', status: row.status as CandidateStatus, impact: row.impact ?? '', constraintIds: canonicalList(row.constraint_ids ?? ''), evidence: row.evidence ?? '' };
+      validateCandidate(parsed);
+      return parsed;
+    });
+    const classificationRows = classifications.map((row) => {
+      if (!row.decision_id?.trim() || !CLASSIFICATIONS.includes(row.classification as QualificationClassification) || !row.evidence?.trim()) throw new Error(`invalid qualification classification '${row.decision_id ?? ''}'`);
+      return { decisionId: row.decision_id, classification: row.classification as QualificationClassification, evidence: row.evidence };
+    });
+    const upstreamRelations = relations.map((row) => {
+      const identity = parseArtifactName(row.upstream_artifact ?? '');
+      const round = Number(row.upstream_round);
+      if (!ARTIFACT_FAMILIES.includes(row.upstream_family as ArtifactFamily) || !identity || identity.family !== row.upstream_family || identity.round !== round || !Number.isSafeInteger(round) || !/^[a-f0-9]{64}$/i.test(row.upstream_sha256 ?? '') || !RELATIONS.includes(row.relation as QualificationRelation)) throw new Error(`invalid qualification upstream relation '${row.upstream_artifact ?? ''}'`);
+      return { upstreamFamily: row.upstream_family as ArtifactFamily, upstreamArtifact: row.upstream_artifact!, upstreamRound: round, upstreamSha256: row.upstream_sha256!, relation: row.relation as QualificationRelation };
+    });
+    const snapshotRow = snapshots[0]!;
+    if (!/^[a-f0-9]{64}$/i.test(snapshotRow.task_input_digest ?? '') || !/^[a-f0-9]{64}$/i.test(snapshotRow.non_constraint_input_digest ?? '') || !/^[a-f0-9]{64}$/i.test(snapshotRow.upstream_artifact_digest ?? '')) throw new Error('qualification dependency snapshot has invalid digest');
+    return {
+      ok: true,
+      audit: {
+        present: true, constraintDependencies, candidateQualifications,
+        classifications: classificationRows, upstreamRelations,
+        snapshot: { taskInputDigest: snapshotRow.task_input_digest!, nonConstraintInputDigest: snapshotRow.non_constraint_input_digest!, upstreamArtifactDigest: snapshotRow.upstream_artifact_digest! }
+      }
+    };
+  } catch (error) {
+    return { ok: false, code: 'QUALIFICATION_AUDIT_INVALID', message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function parseQualificationConfirmations(content: string): { ok: true; confirmations: readonly QualificationConfirmation[] } | { ok: false; code: string; message: string } {
+  const body = sectionBody(content, CONFIRMATION_HEADINGS);
+  if (body === null) return { ok: true, confirmations: [] };
+  try {
+    const table = parseTable(content, { sectionAliases: CONFIRMATION_HEADINGS, columns: CONFIRMATION_COLUMNS });
+    if (!table) throw new Error('qualification confirmation section requires a canonical table');
+    const seen = new Set<string>();
+    const confirmations = table.rows.map(({ values }) => {
+      const row: QualificationConfirmation = {
+        qcrId: values.qcr_id ?? '', constraintId: values.constraint_id ?? '', actor: values.actor as 'human-declared',
+        entrypoint: values.entrypoint as 'ai qualify', requestId: values.request_id ?? '', approvedDigest: values.approved_digest ?? '',
+        confirmedAt: values.confirmed_at ?? '', rationale: values.rationale ?? ''
+      };
+      if (!/^QCR-[1-9]\d*$/.test(row.qcrId) || !/^C-[1-9]\d*$/.test(row.constraintId) || row.actor !== 'human-declared' || row.entrypoint !== 'ai qualify' || !row.requestId || !/^[a-f0-9]{64}$/.test(row.approvedDigest) || !row.confirmedAt || Number.isNaN(Date.parse(row.confirmedAt.replace(' ', 'T'))) || !row.rationale || /[\r\n]/.test(row.rationale)) throw new Error(`qualification confirmation '${row.qcrId}' is invalid`);
+      if (seen.has(row.qcrId)) throw new Error(`duplicate qualification confirmation '${row.qcrId}'`);
+      seen.add(row.qcrId);
+      return row;
+    });
+    return { ok: true, confirmations };
+  } catch (error) {
+    return { ok: false, code: 'QUALIFICATION_CONFIRMATION_INVALID', message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function validateQualificationAudit(
+  taskContent: string,
+  artifactContent: string,
+  options: { family?: ArtifactFamily; artifact?: string; require?: boolean } = {}
+): QualificationValidationResult {
+  const task = parseTaskQualification(taskContent);
+  if (!task.ok) return task;
+  const audit = parseQualificationAudit(artifactContent);
+  if (!audit.ok) return audit;
+  if (!task.qualification.present && !options.require) return { ok: true, qualification: task.qualification, audit: audit.audit };
+  if (!task.qualification.present) return { ok: false, code: 'QUALIFICATION_TASK_CONTRACT_MISSING', message: 'task qualification contract is missing' };
+  if (!audit.audit.present) return { ok: false, code: 'QUALIFICATION_AUDIT_MISSING', message: 'artifact qualification audit is missing' };
+  const constraintMap = new Map(task.qualification.constraints.map((row) => [row.constraintId, row]));
+  const confirmations = parseQualificationConfirmations(taskContent);
+  if (!confirmations.ok) return confirmations;
+  const confirmationMap = new Map(confirmations.confirmations.map((row) => [row.constraintId, row]));
+  for (const constraint of task.qualification.constraints) {
+    if (constraint.status !== 'confirmed') continue;
+    const confirmation = confirmationMap.get(constraint.constraintId);
+    if (!confirmation || constraint.approvalEvidence !== confirmation.qcrId) return { ok: false, code: 'QUALIFICATION_CONFIRMATION_MISSING', message: `confirmed constraint '${constraint.constraintId}' has no matching QCR` };
+  }
+  for (const row of audit.audit.constraintDependencies) {
+    const constraint = constraintMap.get(row.constraintId);
+    if (!constraint) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_UNKNOWN', message: `qualification audit references unknown constraint '${row.constraintId}'` };
+    if (constraint.digest !== row.constraintDigest) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_DIGEST_MISMATCH', message: `qualification audit digest does not match '${row.constraintId}'` };
+  }
+  const candidateMap = new Map(task.qualification.candidates.map((row) => [row.candidateId, row]));
+  for (const row of audit.audit.candidateQualifications) {
+    if (!candidateMap.has(row.candidateId)) return { ok: false, code: 'QUALIFICATION_CANDIDATE_UNKNOWN', message: `qualification audit references unknown candidate '${row.candidateId}'` };
+    if (row.constraintIds.some((id) => !constraintMap.has(id))) return { ok: false, code: 'QUALIFICATION_CONSTRAINT_UNKNOWN', message: `candidate '${row.candidateId}' references unknown qualification constraint` };
+  }
+  const snapshot = audit.audit.snapshot!;
+  if (snapshot.taskInputDigest !== task.qualification.taskInputDigest) return { ok: false, code: 'QUALIFICATION_TASK_DIGEST_MISMATCH', message: 'qualification audit task input digest is stale' };
+  if (snapshot.nonConstraintInputDigest !== task.qualification.nonConstraintInputDigest) return { ok: false, code: 'QUALIFICATION_NON_CONSTRAINT_DIGEST_MISMATCH', message: 'qualification audit non-constraint input digest is stale' };
+  if (snapshot.upstreamArtifactDigest !== upstreamArtifactDigest(audit.audit.upstreamRelations)) return { ok: false, code: 'QUALIFICATION_UPSTREAM_DIGEST_MISMATCH', message: 'qualification audit upstream digest does not match its relation rows' };
+  if (options.family && options.artifact) {
+    const identity = parseArtifactName(options.artifact);
+    if (!identity || identity.family !== options.family) return { ok: false, code: 'QUALIFICATION_ARTIFACT_IDENTITY_INVALID', message: `artifact '${options.artifact}' is not canonical for '${options.family}'` };
+  }
+  return { ok: true, qualification: task.qualification, audit: audit.audit };
+}
+
+function renderQualificationAudit(audit: QualificationAudit): string {
+  const table = (columns: readonly string[], rows: readonly (readonly string[])[]) => [
+    `| ${columns.join(' | ')} |`,
+    `| ${columns.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.map((value) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]/g, ' ')).join(' | ')} |`)
+  ].join('\n');
+  const list = (values: readonly string[]) => values.join(',');
+  const snapshot = audit.snapshot ?? { taskInputDigest: '', nonConstraintInputDigest: '', upstreamArtifactDigest: upstreamArtifactDigest(audit.upstreamRelations) };
+  return [
+    '### 约束依赖', '', table(DEPENDENCY_COLUMNS, audit.constraintDependencies.map((row) => [row.constraintId, row.constraintDigest, row.role, row.evidence])), '',
+    '### 候选资格', '', table(QUALIFICATION_COLUMNS, audit.candidateQualifications.map((row) => [row.candidateId, row.status, row.impact, list(row.constraintIds), row.evidence])), '',
+    '### 分类结果', '', table(CLASSIFICATION_COLUMNS, audit.classifications.map((row) => [row.decisionId, row.classification, row.evidence])), '',
+    '### 上游关系', '', table(RELATION_COLUMNS, audit.upstreamRelations.map((row) => [row.upstreamFamily, row.upstreamArtifact, String(row.upstreamRound), row.upstreamSha256, row.relation])), '',
+    '### 依赖快照', '', table(SNAPSHOT_COLUMNS, [[snapshot.taskInputDigest, snapshot.nonConstraintInputDigest, snapshot.upstreamArtifactDigest]])
+  ].join('\n');
+}
+
+function buildQualificationAudit(
+  taskContent: string,
+  input: { constraints?: readonly string[]; candidates?: readonly string[]; classifications?: readonly QualificationClassificationRow[]; upstreamRelations?: readonly UpstreamRelation[] } = {}
+): { ok: true; audit: QualificationAudit } | { ok: false; code: string; message: string } {
+  const parsed = parseTaskQualification(taskContent);
+  if (!parsed.ok) return parsed;
+  if (!parsed.qualification.present) return { ok: false, code: 'QUALIFICATION_TASK_CONTRACT_MISSING', message: 'task qualification contract is missing' };
+  const ids = new Set(input.constraints ?? parsed.qualification.constraints.map((row) => row.constraintId));
+  const candidates = input.candidates ?? parsed.qualification.candidates.map((row) => row.candidateId);
+  const constraintDependencies = parsed.qualification.constraints.filter((row) => ids.has(row.constraintId)).map((row) => ({ constraintId: row.constraintId, constraintDigest: row.digest, role: 'required' as const, evidence: row.evidence }));
+  const candidateQualifications = parsed.qualification.candidates.filter((row) => candidates.includes(row.candidateId)).map((row) => ({ candidateId: row.candidateId, status: row.status, impact: row.impact, constraintIds: row.constraintIds, evidence: row.evidence }));
+  const upstreamRelations = [...(input.upstreamRelations ?? [])];
+  return {
+    ok: true,
+    audit: {
+      present: true, constraintDependencies, candidateQualifications,
+      classifications: input.classifications ?? [], upstreamRelations,
+      snapshot: { taskInputDigest: parsed.qualification.taskInputDigest, nonConstraintInputDigest: parsed.qualification.nonConstraintInputDigest, upstreamArtifactDigest: upstreamArtifactDigest(upstreamRelations) }
+    }
+  };
+}
+
+export {
+  ARTIFACT_FAMILIES,
+  AUDIT_HEADINGS,
+  AUDIT_SUBSECTIONS,
+  CONFIRMATION_COLUMNS,
+  CONFIRMATION_HEADINGS,
+  CANDIDATE_COLUMNS,
+  CONSTRAINT_COLUMNS,
+  DEPENDENCY_COLUMNS,
+  QUALIFICATION_COLUMNS,
+  CLASSIFICATION_COLUMNS,
+  RELATION_COLUMNS,
+  SNAPSHOT_COLUMNS,
+  constraintDigest,
+  buildQualificationAudit,
+  nonConstraintInputDigest,
+  parseQualificationAudit,
+  parseQualificationConfirmations,
+  parseTaskQualification,
+  renderQualificationAudit,
+  taskInputDigest,
+  upstreamArtifactDigest,
+  validateQualificationAudit
+};
+export type {
+  Candidate,
+  CandidateQualification,
+  CandidateStatus,
+  Constraint,
+  ConstraintDependency,
+  ConstraintStatus,
+  DependencySnapshot,
+  QualificationAudit,
+  QualificationConfirmation,
+  QualificationClassification,
+  QualificationClassificationRow,
+  QualificationRelation,
+  QualificationRole,
+  QualificationValidationError,
+  QualificationValidationResult,
+  TaskQualification,
+  UpstreamRelation,
+  ArtifactFamily
+};

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -183,7 +183,7 @@ function stripSection(content: string, aliases: readonly string[]): string {
   const body = sectionBody(content, aliases);
   if (body === null) return normalizeText(content);
   const heading = aliases.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-  return normalizeText(content.replace(new RegExp(`^##\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^##\\s+|$)`, 'm'), ''));
+  return normalizeText(content.replace(new RegExp(`^##\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^##\\s+|(?![\\s\\S]))`, 'm'), ''));
 }
 
 function stripFrontmatter(content: string): string {
@@ -227,7 +227,7 @@ function stripSectionAtLevel(content: string, aliases: readonly string[], level:
   if (body === null) return normalizeText(content);
   const heading = aliases.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
   const marker = '#'.repeat(level);
-  return normalizeText(content.replace(new RegExp(`^${marker}\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^#{2,${level}}\\s+|$)`, 'm'), ''));
+  return normalizeText(content.replace(new RegExp(`^${marker}\\s+(?:${heading})\\s*$[\\s\\S]*?(?=^#{2,${level}}\\s+|(?![\\s\\S]))`, 'm'), ''));
 }
 
 function parseTaskQualification(content: string): { ok: true; qualification: TaskQualification } | { ok: false; code: string; message: string } {

--- a/lib/task/qualification-audit.ts
+++ b/lib/task/qualification-audit.ts
@@ -108,7 +108,7 @@ type QualificationConfirmation = {
   qcrId: string;
   constraintId: string;
   actor: 'human-declared';
-  entrypoint: 'ai qualify';
+  entrypoint: 'task-qualification';
   requestId: string;
   approvedDigest: string;
   confirmedAt: string;
@@ -431,10 +431,10 @@ function parseQualificationConfirmations(content: string): { ok: true; confirmat
     const confirmations = table.rows.map(({ values }) => {
       const row: QualificationConfirmation = {
         qcrId: values.qcr_id ?? '', constraintId: values.constraint_id ?? '', actor: values.actor as 'human-declared',
-        entrypoint: values.entrypoint as 'ai qualify', requestId: values.request_id ?? '', approvedDigest: values.approved_digest ?? '',
+        entrypoint: values.entrypoint as 'task-qualification', requestId: values.request_id ?? '', approvedDigest: values.approved_digest ?? '',
         confirmedAt: values.confirmed_at ?? '', rationale: values.rationale ?? ''
       };
-      if (!/^QCR-[1-9]\d*$/.test(row.qcrId) || !/^C-[1-9]\d*$/.test(row.constraintId) || row.actor !== 'human-declared' || row.entrypoint !== 'ai qualify' || !row.requestId || !/^[a-f0-9]{64}$/.test(row.approvedDigest) || !row.confirmedAt || Number.isNaN(Date.parse(row.confirmedAt.replace(' ', 'T'))) || !row.rationale || /[\r\n]/.test(row.rationale)) throw new Error(`qualification confirmation '${row.qcrId}' is invalid`);
+      if (!/^QCR-[1-9]\d*$/.test(row.qcrId) || !/^C-[1-9]\d*$/.test(row.constraintId) || row.actor !== 'human-declared' || row.entrypoint !== 'task-qualification' || !row.requestId || !/^[a-f0-9]{64}$/.test(row.approvedDigest) || !row.confirmedAt || Number.isNaN(Date.parse(row.confirmedAt.replace(' ', 'T'))) || !row.rationale || /[\r\n]/.test(row.rationale)) throw new Error(`qualification confirmation '${row.qcrId}' is invalid`);
       if (seen.has(row.qcrId)) throw new Error(`duplicate qualification confirmation '${row.qcrId}'`);
       seen.add(row.qcrId);
       return row;

--- a/lib/task/qualification-confirmation.ts
+++ b/lib/task/qualification-confirmation.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 
-import { appendActivityEntry, locateActivityLog } from './task/activity-log.ts';
-import { CONFIRMATION_COLUMNS, CONFIRMATION_HEADINGS, constraintDigest, parseQualificationConfirmations, parseTaskQualification } from './task/qualification-audit.ts';
-import type { QualificationConfirmation } from './task/qualification-audit.ts';
-import { findSectionHeading } from './task/sections.ts';
-import { resolveTaskRef } from './task/resolve-ref.ts';
-import { captureTaskWriteMetadata, writeTask } from './task/write.ts';
-import type { TaskOperationSummary, TaskWriteOptions } from './task/write.ts';
+import { appendActivityEntry, locateActivityLog } from './activity-log.ts';
+import { CONFIRMATION_COLUMNS, CONFIRMATION_HEADINGS, constraintDigest, parseQualificationConfirmations, parseTaskQualification } from './qualification-audit.ts';
+import type { QualificationConfirmation } from './qualification-audit.ts';
+import { findSectionHeading } from './sections.ts';
+import { resolveTaskRef } from './resolve-ref.ts';
+import { captureTaskWriteMetadata, writeTask } from './write.ts';
+import type { TaskOperationSummary, TaskWriteOptions } from './write.ts';
 
 type QualificationConfirmationRequest = {
   taskRef: string;
@@ -94,7 +94,7 @@ function applyQualificationConfirmation(request: QualificationConfirmationReques
     derivedFrom: constraint.derivedFrom, approvalEvidence: qcrId
   } : null;
   const confirmation = confirmedConstraint && qcrId && requestId ? {
-    qcrId, constraintId: request.constraintId, actor: 'human-declared' as const, entrypoint: 'ai qualify' as const,
+    qcrId, constraintId: request.constraintId, actor: 'human-declared' as const, entrypoint: 'task-qualification' as const,
     requestId, approvedDigest: constraintDigest(confirmedConstraint), confirmedAt: metadata.timestamp, rationale: request.rationale.trim()
   } : null;
   const confirmations = confirmation ? [...existing.confirmations, confirmation] : existing.confirmations;
@@ -111,47 +111,6 @@ function applyQualificationConfirmation(request: QualificationConfirmationReques
   const result = writeTask({ taskRef: resolved.taskId, expectedState: 'active', mutations, dryRun: request.dryRun }, { ...options, taskLocation: { repoRoot: resolved.repoRoot, taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, state: resolved.state }, metadataProvider: () => metadata });
   if (result.status === 'failed') return failed(result.error.code, result.error.message, result.taskId);
   return { status: result.status, changed: result.changed, taskId: result.taskId, qcrId, requestId, operations: result.operations, error: null };
-}
-
-export async function qualify(args: string[], options: TaskWriteOptions = {}): Promise<number> {
-  let taskRef: string | undefined;
-  let constraintId: string | undefined;
-  let expectedDigest: string | undefined;
-  let dryRun = false;
-  let operation: QualificationConfirmationRequest['operation'] = 'confirm';
-  let operationFlag = '';
-  const rationale: string[] = [];
-  try {
-    for (let index = 0; index < args.length; index += 1) {
-      const arg = args[index]!;
-      if (arg === '--task' || arg === '-t') taskRef = args[++index];
-      else if (arg === '--constraint' || arg === '--constraint-id' || arg === '--id') constraintId = args[++index];
-      else if (arg === '--digest' || arg === '--constraint-digest') expectedDigest = args[++index];
-      else if (arg === '--dry-run') dryRun = true;
-      else if (arg === '--supersede' || arg === '--revoke') {
-        if (operationFlag) throw new Error(`options '${operationFlag}' and '${arg}' cannot be combined`);
-        operationFlag = arg;
-        operation = arg === '--supersede' ? 'supersede' : 'revoke';
-      }
-      else if (arg === '--help' || arg === '-h') { process.stdout.write('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> [--supersede|--revoke] <rationale>\n'); return 0; }
-      else rationale.push(arg);
-    }
-    if (!taskRef || !constraintId || !expectedDigest || rationale.length === 0) throw new Error('Usage: ai qualify [--task <ref>] --constraint <C-N> --digest <sha256> <rationale>');
-    const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
-    if (!resolved.ok) throw new Error(resolved.message);
-    const { withTaskExecutionLock } = await import('./task/task-execution-lock.ts');
-    const result = await withTaskExecutionLock(resolved.repoRoot, resolved.taskId, `task-qualification.${operation}`, () => applyQualificationConfirmation({ taskRef: resolved.taskId, constraintId: constraintId!, expectedDigest: expectedDigest!, rationale: rationale.join(' '), operation, dryRun }, options));
-    if (result.error) throw new Error(`${result.error.code}: ${result.error.message}`);
-    process.stdout.write(`${JSON.stringify(result)}\n`);
-    return 0;
-  } catch (error) {
-    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
-    return 1;
-  }
-}
-
-export async function cmdQualify(args: string[]): Promise<void> {
-  process.exitCode = await qualify(args);
 }
 
 export { applyQualificationConfirmation };

--- a/lib/task/qualification-intents.ts
+++ b/lib/task/qualification-intents.ts
@@ -124,7 +124,7 @@ function applyQualificationProposal(request: QualificationProposalRequest, optio
   }
   for (const row of values.constraints) {
     const current = currentConstraintMap.get(row.constraintId);
-    if (current?.status === 'confirmed') return failed('QUALIFICATION_CONFIRMATION_REQUIRED', `confirmed constraint '${row.constraintId}' must be superseded or revoked through ai qualify`, resolved.taskId);
+    if (current?.status === 'confirmed') return failed('QUALIFICATION_CONFIRMATION_REQUIRED', `confirmed constraint '${row.constraintId}' must be superseded or revoked through task-qualification`, resolved.taskId);
   }
   const knownConstraintIds = new Set([...parsed.qualification.constraints.map((row) => row.constraintId), ...values.constraints.map((row) => row.constraintId)]);
   for (const row of values.constraints) for (const parent of row.derivedFrom) if (!knownConstraintIds.has(parent)) return failed('QUALIFICATION_CONSTRAINT_UNKNOWN', `constraint proposal '${row.constraintId}' references unknown '${parent}'`, resolved.taskId);

--- a/lib/task/qualification-intents.ts
+++ b/lib/task/qualification-intents.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+
+import { CONSTRAINT_COLUMNS, CANDIDATE_COLUMNS, parseTaskQualification } from './qualification-audit.ts';
+import type { CandidateStatus, ConstraintStatus } from './qualification-audit.ts';
+import { resolveTaskRef } from './resolve-ref.ts';
+import { captureTaskWriteMetadata, writeTask } from './write.ts';
+import type { TaskOperationSummary, TaskWriteOptions } from './write.ts';
+
+type QualificationConstraintProposal = {
+  constraintId: string;
+  statement: string;
+  status: Exclude<ConstraintStatus, 'confirmed'>;
+  authority: string;
+  source: string;
+  evidence: string;
+  derivedFrom: readonly string[];
+  approvalEvidence: string;
+};
+type QualificationCandidateProposal = {
+  candidateId: string;
+  statement: string;
+  status: Extract<CandidateStatus, 'pending'>;
+  constraintIds: readonly string[];
+  impact: string;
+  evidence: string;
+};
+type QualificationProposalRequest = {
+  taskRef: string;
+  expectedTaskInputDigest: string;
+  constraints?: readonly QualificationConstraintProposal[];
+  candidates?: readonly QualificationCandidateProposal[];
+  dryRun?: boolean;
+};
+type QualificationProposalResult = {
+  status: 'planned' | 'applied' | 'no-op' | 'failed';
+  changed: boolean;
+  taskId: string | null;
+  operations: readonly TaskOperationSummary[];
+  error: { code: string; message: string } | null;
+};
+
+function failed(code: string, message: string, taskId: string | null = null): QualificationProposalResult {
+  return { status: 'failed', changed: false, taskId, operations: [], error: { code, message } };
+}
+
+function validSingleLine(value: unknown): value is string {
+  return typeof value === 'string' && Boolean(value.trim()) && !/[\r\n]/.test(value);
+}
+
+function assertProposalKeys(value: unknown, keys: readonly string[], label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  const record = value as Record<string, unknown>;
+  const unexpected = Object.keys(record).find((key) => !keys.includes(key));
+  if (unexpected) throw new Error(`${label} does not accept '${unexpected}'`);
+  return record;
+}
+
+function parseConstraintProposal(value: unknown): QualificationConstraintProposal {
+  const row = assertProposalKeys(value, ['constraintId', 'statement', 'status', 'authority', 'source', 'evidence', 'derivedFrom', 'approvalEvidence'], 'constraint proposal');
+  for (const key of ['constraintId', 'statement', 'status', 'authority', 'source', 'evidence', 'approvalEvidence']) {
+    if (typeof row[key] !== 'string' || /[\r\n]/.test(row[key] as string)) throw new Error(`constraint proposal '${key}' must be a single-line string`);
+  }
+  if (!/^C-[1-9]\d*$/.test(row.constraintId as string)) throw new Error(`constraint proposal id '${row.constraintId as string}' is invalid`);
+  if (row.status === 'confirmed' || !['derived', 'assumption', 'open', 'conflicted', 'superseded'].includes(row.status as string)) throw new Error('proposal cannot write confirmed constraint status');
+  if ((row.approvalEvidence as string) !== '') throw new Error('proposal cannot write approval_evidence');
+  if (!Array.isArray(row.derivedFrom) || row.derivedFrom.some((item) => typeof item !== 'string' || !/^C-[1-9]\d*$/.test(item))) throw new Error('constraint proposal derivedFrom is invalid');
+  return {
+    constraintId: row.constraintId as string, statement: row.statement as string, status: row.status as Exclude<ConstraintStatus, 'confirmed'>,
+    authority: row.authority as string, source: row.source as string, evidence: row.evidence as string,
+    derivedFrom: [...row.derivedFrom as string[]], approvalEvidence: ''
+  };
+}
+
+function parseCandidateProposal(value: unknown): QualificationCandidateProposal {
+  const row = assertProposalKeys(value, ['candidateId', 'statement', 'status', 'constraintIds', 'impact', 'evidence'], 'candidate proposal');
+  for (const key of ['candidateId', 'statement', 'status', 'impact', 'evidence']) if (!validSingleLine(row[key])) throw new Error(`candidate proposal '${key}' must be a non-empty single-line string`);
+  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(row.candidateId as string)) throw new Error(`candidate proposal id '${row.candidateId as string}' is invalid`);
+  if (row.status !== 'pending') throw new Error('proposal can only write pending candidate status');
+  if (!Array.isArray(row.constraintIds) || row.constraintIds.some((item) => typeof item !== 'string' || !/^C-[1-9]\d*$/.test(item))) throw new Error('candidate proposal constraintIds is invalid');
+  return row as unknown as QualificationCandidateProposal;
+}
+
+function proposalValues(request: QualificationProposalRequest): { constraints: QualificationConstraintProposal[]; candidates: QualificationCandidateProposal[] } {
+  if (!/^[a-f0-9]{64}$/i.test(request.expectedTaskInputDigest)) throw new Error('expectedTaskInputDigest must be a sha256 digest');
+  if (Object.keys(request).some((key) => !['taskRef', 'expectedTaskInputDigest', 'constraints', 'candidates', 'dryRun'].includes(key))) throw new Error('proposal contains an unsupported field');
+  if (!Array.isArray(request.constraints) && request.constraints !== undefined) throw new Error('constraints must be an array');
+  if (!Array.isArray(request.candidates) && request.candidates !== undefined) throw new Error('candidates must be an array');
+  return {
+    constraints: (request.constraints ?? []).map(parseConstraintProposal),
+    candidates: (request.candidates ?? []).map(parseCandidateProposal)
+  };
+}
+
+function applyQualificationProposal(request: QualificationProposalRequest, options: TaskWriteOptions = {}): QualificationProposalResult {
+  if (!request || typeof request !== 'object' || !validSingleLine(request.taskRef)) return failed('QUALIFICATION_PROPOSAL_INVALID', 'taskRef is required');
+  let values: ReturnType<typeof proposalValues>;
+  try { values = proposalValues(request); }
+  catch (error) { return failed('QUALIFICATION_PROPOSAL_INVALID', error instanceof Error ? error.message : String(error)); }
+  if (values.constraints.length === 0 && values.candidates.length === 0) return failed('QUALIFICATION_PROPOSAL_INVALID', 'proposal must contain a constraint or candidate');
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return failed(resolved.code, resolved.message, resolved.taskId);
+  if (resolved.state !== 'active') return failed('TASK_STATE_MISMATCH', `task ${resolved.taskId} is ${resolved.state}, expected active`, resolved.taskId);
+  let content: string;
+  try { content = fs.readFileSync(resolved.taskMdPath, 'utf8'); }
+  catch (error) { return failed('TASK_READ_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId); }
+  const parsed = parseTaskQualification(content);
+  if (!parsed.ok) return failed(parsed.code, parsed.message, resolved.taskId);
+  if (!parsed.qualification.present) return failed('QUALIFICATION_TASK_CONTRACT_MISSING', 'task qualification contract is missing', resolved.taskId);
+  const currentConstraintMap = new Map(parsed.qualification.constraints.map((row) => [row.constraintId, row]));
+  const currentCandidateMap = new Map(parsed.qualification.candidates.map((row) => [row.candidateId, row]));
+  const proposalAlreadyApplied = values.constraints.every((row) => {
+    const current = currentConstraintMap.get(row.constraintId);
+    return current && current.statement === row.statement && current.status === row.status && current.authority === row.authority
+      && current.source === row.source && current.evidence === row.evidence && current.derivedFrom.join(',') === row.derivedFrom.join(',') && current.approvalEvidence === '';
+  }) && values.candidates.every((row) => {
+    const current = currentCandidateMap.get(row.candidateId);
+    return current && current.statement === row.statement && current.status === row.status && current.constraintIds.join(',') === row.constraintIds.join(',')
+      && current.impact === row.impact && current.evidence === row.evidence;
+  });
+  if (parsed.qualification.taskInputDigest !== request.expectedTaskInputDigest) {
+    return proposalAlreadyApplied
+      ? { status: 'no-op', changed: false, taskId: resolved.taskId, operations: [], error: null }
+      : failed('QUALIFICATION_DIGEST_CONFLICT', 'task qualification input changed before proposal was applied', resolved.taskId);
+  }
+  for (const row of values.constraints) {
+    const current = currentConstraintMap.get(row.constraintId);
+    if (current?.status === 'confirmed') return failed('QUALIFICATION_CONFIRMATION_REQUIRED', `confirmed constraint '${row.constraintId}' must be superseded or revoked through ai qualify`, resolved.taskId);
+  }
+  const knownConstraintIds = new Set([...parsed.qualification.constraints.map((row) => row.constraintId), ...values.constraints.map((row) => row.constraintId)]);
+  for (const row of values.constraints) for (const parent of row.derivedFrom) if (!knownConstraintIds.has(parent)) return failed('QUALIFICATION_CONSTRAINT_UNKNOWN', `constraint proposal '${row.constraintId}' references unknown '${parent}'`, resolved.taskId);
+  for (const row of values.candidates) for (const id of row.constraintIds) if (!knownConstraintIds.has(id)) return failed('QUALIFICATION_CONSTRAINT_UNKNOWN', `candidate proposal '${row.candidateId}' references unknown '${id}'`, resolved.taskId);
+  const mutations: Parameters<typeof writeTask>[0]['mutations'][number][] = [];
+  for (const row of values.constraints) {
+    mutations.push({ kind: 'table-row', action: 'upsert', sectionAliases: ['约束', 'Constraints'], columns: CONSTRAINT_COLUMNS, keyColumn: 'constraint_id', key: row.constraintId, values: { statement: row.statement, status: row.status, authority: row.authority, source: row.source, evidence: row.evidence, derived_from: row.derivedFrom.join(','), approval_evidence: '' } });
+  }
+  for (const row of values.candidates) {
+    mutations.push({ kind: 'table-row', action: 'upsert', sectionAliases: ['候选与否决方案', 'Candidate and Rejected Options', 'Candidates and Rejected Options', 'Candidates and Rejected Alternatives'], columns: CANDIDATE_COLUMNS, keyColumn: 'candidate_id', key: row.candidateId, values: { statement: row.statement, status: row.status, constraint_ids: row.constraintIds.join(','), impact: row.impact, evidence: row.evidence } });
+  }
+  // Only the submitted rows are mutated; no actor, confirmation, or QCR fields
+  // can be smuggled into this internal proposal operation.
+  let metadata;
+  try { metadata = (options.metadataProvider ?? captureTaskWriteMetadata)(); }
+  catch (error) { return failed('METADATA_CAPTURE_FAILED', error instanceof Error ? error.message : String(error), resolved.taskId); }
+  const result = writeTask({ taskRef: resolved.taskId, expectedState: 'active', mutations, dryRun: request.dryRun }, { ...options, taskLocation: { repoRoot: resolved.repoRoot, taskId: resolved.taskId, taskMdPath: resolved.taskMdPath, state: resolved.state }, metadataProvider: () => metadata });
+  if (result.status === 'failed') return failed(result.error.code, result.error.message, result.taskId);
+  return { status: result.status, changed: result.changed, taskId: result.taskId, operations: result.operations, error: null };
+}
+
+export { applyQualificationProposal };
+export type { QualificationCandidateProposal, QualificationConstraintProposal, QualificationProposalRequest, QualificationProposalResult };

--- a/lib/task/sections.ts
+++ b/lib/task/sections.ts
@@ -175,16 +175,18 @@ function matchingSections(content: string, aliases: readonly string[]) {
   const allowed = new Set(aliases);
   return linesOf(content)
     .map((line, index, lines) => {
-      const match = /^##\s+(.+?)\s*$/.exec(line.text);
-      if (!match?.[1] || !allowed.has(match[1])) return null;
+      const match = /^(#{2,3})\s+(.+?)\s*$/.exec(line.text);
+      if (!match?.[2] || !allowed.has(match[2])) return null;
+      const level = match[1]!.length;
       let end = content.length;
       for (let i = index + 1; i < lines.length; i += 1) {
-        if (/^##\s+/.test(lines[i]!.text)) {
+        const nextHeading = /^(#{2,3})\s+/.exec(lines[i]!.text);
+        if (nextHeading && nextHeading[1]!.length <= level) {
           end = lines[i]!.start;
           break;
         }
       }
-      return { heading: match[1], line, bodyStart: line.end, end };
+      return { heading: match[2]!, line, bodyStart: line.end, end };
     })
     .filter((match): match is NonNullable<typeof match> => match !== null);
 }

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -35,6 +35,7 @@ import { OrchestrationStateError, readRun } from "./orchestration.ts";
 import { resolveDeliveryTarget } from "./delivery-target.ts";
 import { readPrDeliveryFact } from "./pr-delivery-fact.ts";
 import { validateLocalArtifact } from "./local-artifact-finalization.ts";
+import { validateQualificationAudit } from "./qualification-audit.ts";
 
 const TASK_ENUMS = {
   type: ["feature", "bugfix", "refactor", "docs", "chore"],
@@ -600,6 +601,19 @@ function checkArtifact({ taskDir, config, artifactFile, skillName }: any): any {
   }
 
   const content = fs.readFileSync(artifactPath, "utf8");
+  let taskContent = "";
+  const taskPath = path.join(taskDir, "task.md");
+  if (fs.existsSync(taskPath)) {
+    try {
+      taskContent = fs.readFileSync(taskPath, "utf8");
+    } catch (error) {
+      return failResult("artifact", `Cannot read task qualification contract: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (taskContent && /^review-(?:analysis|plan|code)$/.test(skillName)) {
+    const qualification = validateQualificationAudit(taskContent, content, { artifact: path.basename(artifactPath) });
+    if (!qualification.ok) return failResult("artifact", `${path.basename(artifactPath)} has qualification audit errors: ${qualification.code}: ${qualification.message}`);
+  }
   const requiredSections = config.required_sections || [];
   const localFamily = skillName === "analyze-task"
     ? "analysis"
@@ -608,7 +622,9 @@ function checkArtifact({ taskDir, config, artifactFile, skillName }: any): any {
     const local = validateLocalArtifact(content, {
       family: localFamily,
       requiredSections: requiredSections.filter((section: unknown): section is string => typeof section === "string"),
-      requiredPatterns: (config.required_patterns || []).filter((pattern: unknown): pattern is string => typeof pattern === "string")
+      requiredPatterns: (config.required_patterns || []).filter((pattern: unknown): pattern is string => typeof pattern === "string"),
+      ...(taskContent ? { taskContent } : {}),
+      artifact: path.basename(artifactPath)
     });
     if (!local.ok) {
       return failResult(

--- a/lib/task/verification-engine.ts
+++ b/lib/task/verification-engine.ts
@@ -802,6 +802,7 @@ function checkActivityLog({ taskDir, config }: any): any {
   let previousTimestamp = "";
   let latestAction = "";
   let latestTimestamp = "";
+  const doneActions: string[] = [];
 
   for (const entry of entries) {
     const match = entry.match(ACTIVITY_LOG_PATTERN);
@@ -821,6 +822,16 @@ function checkActivityLog({ taskDir, config }: any): any {
     if (!ACTIVITY_LOG_STARTED_RE.test(action)) {
       latestTimestamp = timestamp;
       latestAction = action;
+      doneActions.push(action);
+    }
+  }
+
+  if (config.expected_action_pattern && !new RegExp(config.expected_action_pattern).test(latestAction)) {
+    const expected = new RegExp(config.expected_action_pattern);
+    let index = doneActions.length - 1;
+    while (index >= 0 && doneActions[index] === 'Commit' && !expected.test(doneActions[index]!)) index -= 1;
+    if (index >= 0 && expected.test(doneActions[index]!)) {
+      latestAction = doneActions[index]!;
     }
   }
 

--- a/templates/.agents/rules/README.en.md
+++ b/templates/.agents/rules/README.en.md
@@ -15,6 +15,7 @@ so you can quickly find "which ones to read" without opening each file.
 - [`compatibility-policy.md`](compatibility-policy.md) — Compatibility by exception: admission evidence, implementation boundaries, exit conditions, and lifecycle review requirements.
 - [`evidence-reporting.md`](evidence-reporting.md) — Minimum evidence semantics for state checks, successful summaries, exceptional results, identity fields, and sensitive data boundaries.
 - [`sync-content-generation.md`](sync-content-generation.md) — Producer-side Markdown constraints for task and lifecycle content synchronized to Issues.
+- [`decision-qualification.md`](decision-qualification.md) — Constraint, candidate, human-confirmation, and six-artifact qualification-audit contract.
 
 ## Issue / PR
 

--- a/templates/.agents/rules/README.zh-CN.md
+++ b/templates/.agents/rules/README.zh-CN.md
@@ -14,6 +14,7 @@
 - [`compatibility-policy.md`](compatibility-policy.md) — 兼容性默认关闭：准入证据、实现边界、退出条件与生命周期审查要求。
 - [`evidence-reporting.md`](evidence-reporting.md) — 生命周期报告的状态核对、成功摘要、异常证据、身份字段和敏感信息边界。
 - [`sync-content-generation.md`](sync-content-generation.md) — 同步到 Issue 的任务和生命周期 Markdown 生成约束。
+- [`decision-qualification.md`](decision-qualification.md) — 约束、候选、人工确认和六类 artifact 资格审计契约。
 
 ## Issue / PR
 

--- a/templates/.agents/rules/decision-qualification.en.md
+++ b/templates/.agents/rules/decision-qualification.en.md
@@ -13,7 +13,7 @@ Any analysis, plan, implementation, or review that decides whether a human decis
 - A `confirmed` constraint requires source evidence, the current semantic digest, and a qualification confirmation record; a confirmation for an old digest cannot be reused.
 - `derived`, `assumption`, `open`, `conflicted`, and `superseded` are pending facts and cannot automatically exclude a candidate.
 - The internal proposal entry point may write only non-confirmed constraints and `pending` candidates. It cannot write actor, QCR, confirmed, or approval fields.
-- `ai qualify` is a declarative process-level human-confirmation entry point. `human-declared` is an audit label, not identity authentication. The core generates the QCR and binds it to the current digest, request id, time, and a single-line rationale.
+- `ai qualify` is the declarative process-level entry point for human confirmation, supersession, and revocation. `human-declared` is an audit label, not identity authentication. On confirmation, the core generates the QCR and binds it to the current post-write per-constraint digest, request id, time, and a single-line rationale. Supersession and revocation move the constraint to `superseded` and `open`, respectively, clear current approval evidence, and retain historical QCRs.
 
 ## Invalidation and review
 

--- a/templates/.agents/rules/decision-qualification.en.md
+++ b/templates/.agents/rules/decision-qualification.en.md
@@ -1,0 +1,22 @@
+# Decision Qualification and Constraint Audit
+
+Any analysis, plan, implementation, or review that decides whether a human decision is needed must audit qualification from the normalized constraints and candidates in `task.md` before creating `HD-N`.
+
+## Single source of truth
+
+- The `### Constraints` and `### Candidate and Rejected Options` tables in `task.md` are the only constraint and candidate fact source.
+- The constraint table uses `constraint_id`, `statement`, `status`, `authority`, `source`, `evidence`, `derived_from`, and `approval_evidence`; the candidate table uses `candidate_id`, `statement`, `status`, `constraint_ids`, `impact`, and `evidence`.
+- All six artifact families must include `## Qualification Audit` with actual constraint dependencies, candidate qualification, classification results, upstream relations, and a dependency snapshot. Each upstream relation records family, file name, round, and SHA-256.
+
+## Status and confirmation
+
+- A `confirmed` constraint requires source evidence, the current semantic digest, and a qualification confirmation record; a confirmation for an old digest cannot be reused.
+- `derived`, `assumption`, `open`, `conflicted`, and `superseded` are pending facts and cannot automatically exclude a candidate.
+- The internal proposal entry point may write only non-confirmed constraints and `pending` candidates. It cannot write actor, QCR, confirmed, or approval fields.
+- `ai qualify` is a declarative process-level human-confirmation entry point. `human-declared` is an audit label, not identity authentication. The core generates the QCR and binds it to the current digest, request id, time, and a single-line rationale.
+
+## Invalidation and review
+
+When a constraint changes, only artifacts declaring the affected `C-N` can be direct invalidation seeds; the change then follows the real downstream closure. All six families, including reviews, are symmetric. If snapshots, relations, or change classification cannot prove a pure constraint change, use the existing full invalidation path. The newly completed source artifact, its receipt, and its derived snapshot are excluded from the old target graph.
+
+Missing or unknown references, digest mismatches, dangling relations, and cycles fail closed. Formatting-only changes must not change semantic digests; changes to meaning, provenance, status, candidates, or upstream identity require a new audit.

--- a/templates/.agents/rules/decision-qualification.en.md
+++ b/templates/.agents/rules/decision-qualification.en.md
@@ -13,7 +13,7 @@ Any analysis, plan, implementation, or review that decides whether a human decis
 - A `confirmed` constraint requires source evidence, the current semantic digest, and a qualification confirmation record; a confirmation for an old digest cannot be reused.
 - `derived`, `assumption`, `open`, `conflicted`, and `superseded` are pending facts and cannot automatically exclude a candidate.
 - The internal proposal entry point may write only non-confirmed constraints and `pending` candidates. It cannot write actor, QCR, confirmed, or approval fields.
-- `ai qualify` is the declarative process-level entry point for human confirmation, supersession, and revocation. `human-declared` is an audit label, not identity authentication. On confirmation, the core generates the QCR and binds it to the current post-write per-constraint digest, request id, time, and a single-line rationale. Supersession and revocation move the constraint to `superseded` and `open`, respectively, clear current approval evidence, and retain historical QCRs.
+- `agent-infra-internal task-qualification` is the internal confirmation, supersession, and revocation entry point for agents and skills; ordinary users are not exposed to the constraint-digest protocol. `human-declared` is an audit label, not identity authentication. On confirmation, the core generates the QCR and binds it to the current post-write per-constraint digest, request id, time, and a single-line rationale. Supersession and revocation move the constraint to `superseded` and `open`, respectively, clear current approval evidence, and retain historical QCRs.
 
 ## Invalidation and review
 

--- a/templates/.agents/rules/decision-qualification.zh-CN.md
+++ b/templates/.agents/rules/decision-qualification.zh-CN.md
@@ -1,0 +1,22 @@
+# 决策资格与约束审计
+
+涉及“是否需要人工裁决”的分析、方案、实现或审查，必须先基于 `task.md` 的规范化约束和候选表完成资格审计，再决定是否创建 `HD-N`。
+
+## 唯一事实源
+
+- `task.md` 的 `### 约束` 和 `### 候选与否决方案` 是唯一约束/候选事实源。
+- 约束表必须使用 `constraint_id`、`statement`、`status`、`authority`、`source`、`evidence`、`derived_from`、`approval_evidence`；候选表必须使用 `candidate_id`、`statement`、`status`、`constraint_ids`、`impact`、`evidence`。
+- 六类阶段产物都要在 `## 资格审计` 中声明实际约束依赖、候选资格、分类结果、上游关系和依赖快照。上游关系必须保存 artifact 的 family、文件名、round 和 SHA-256。
+
+## 状态与确认
+
+- `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
+- `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
+- 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
+- `ai qualify` 是流程声明式人工确认入口；`human-declared` 是审计标签，不是身份认证。QCR 由核心生成并绑定当前 digest、request id、时间和单行理由。
+
+## 失效与审查
+
+约束变化时，只有声明受影响 `C-N` 的 artifact 才能成为直接失效种子，并沿真实上游关系的下游闭包传播；六类 artifact（含 review）对等处理。快照、关系图或变化分类无法证明为纯约束变化时，回退既有全量失效路径。新完成的 source artifact、自身 receipt 和派生快照不作为旧图目标。
+
+缺失、未知引用、digest 不匹配、悬空关系或环都必须 fail closed。排版变化不应改变语义 digest；语义、来源、状态、候选或上游 identity 变化必须触发重新审计。

--- a/templates/.agents/rules/decision-qualification.zh-CN.md
+++ b/templates/.agents/rules/decision-qualification.zh-CN.md
@@ -13,7 +13,7 @@
 - `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
 - `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
 - 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
-- `ai qualify` 是流程声明式人工确认、替代和撤销入口；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
+- `agent-infra-internal task-qualification` 是供 Agent/skill 使用的内部确认、替代和撤销入口，不向普通用户暴露 constraint digest 协议；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
 
 ## 失效与审查
 

--- a/templates/.agents/rules/decision-qualification.zh-CN.md
+++ b/templates/.agents/rules/decision-qualification.zh-CN.md
@@ -13,7 +13,7 @@
 - `confirmed` 约束必须有来源证据、当前语义 digest 和 `资格确认记录`；旧 digest 的确认不能复用。
 - `derived`、`assumption`、`open`、`conflicted`、`superseded` 只能作为待审事实，不能自动排除候选。
 - 内部 proposal 入口只能写入非 confirmed 约束和 `pending` 候选，不能写 actor、QCR、confirmed 或 approval 字段。
-- `ai qualify` 是流程声明式人工确认入口；`human-declared` 是审计标签，不是身份认证。QCR 由核心生成并绑定当前 digest、request id、时间和单行理由。
+- `ai qualify` 是流程声明式人工确认、替代和撤销入口；`human-declared` 是审计标签，不是身份认证。确认时 QCR 由核心生成并绑定确认写入后的当前单约束 digest、request id、时间和单行理由；替代与撤销分别把约束转为 `superseded` 与 `open`，清空当前 approval evidence，并保留历史 QCR。
 
 ## 失效与审查
 

--- a/templates/.agents/skills/analyze-task/SKILL.en.md
+++ b/templates/.agents/skills/analyze-task/SKILL.en.md
@@ -17,6 +17,7 @@ If the entry operands contain `--orchestrated`, bind `{execution-flag}` to `--or
 
 Before generating the analysis report, read `.agents/rules/evidence-reporting.md`. Record the command, target scope, status or structured result, actual result, and uncovered parts for state checks and successful checks; include decisive raw excerpts only for failures, blocking conditions, or disputes.
 
+- When evaluating candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md`, audit normalized task constraints/candidates, and record the five qualification-audit tables in the analysis artifact; unknown or unconfirmed constraints must not automatically exclude a candidate
 - This skill only outputs a requirements analysis document (`analysis.md` or `analysis-r{N}.md`) and does not modify any business code
 - Base the analysis strictly on the existing task input, requirements, context, and source information in `task.md`
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body

--- a/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/analyze-task/SKILL.zh-CN.md
@@ -17,6 +17,7 @@ description: >
 
 生成分析报告时，先读取 `.agents/rules/evidence-reporting.md`。状态核对和成功检查记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议才附决定性原文摘录。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在分析产物记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 本技能仅产出需求分析文档（`analysis.md` 或 `analysis-r{N}.md`）—— 不修改任何业务代码
 - 严格基于 `task.md` 中已有的任务输入、需求、上下文和来源信息展开分析
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
@@ -176,6 +177,10 @@ agent-infra-internal task-event {task-id} analyze.started --agent {standard-agen
 
 ## 依赖关系
 - {需要的依赖和与其他模块的协调}
+
+## 资格审计
+
+> 按 `.agents/rules/decision-qualification.md` 填写约束依赖、候选资格、分类结果、上游关系、依赖快照五张表；没有 artifact 上游时保留空表头，不虚构关系。
 
 ## 假设
 

--- a/templates/.agents/skills/code-task/SKILL.en.md
+++ b/templates/.agents/skills/code-task/SKILL.en.md
@@ -19,6 +19,7 @@ Implement the approved plan and produce `code.md` or `code-r{N}.md`. This skill 
 
 Before generating the implementation report, read `.agents/rules/evidence-reporting.md`. Successful tests record the command, target scope, status or structured result, actual result, and uncovered parts; failures, blocking conditions, or disputes retain a reproducible entry point, exact location, and decisive excerpt instead of complete successful stdout.
 
+- When evaluating candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md`, audit normalized task constraints/candidates, and record the five qualification-audit tables in the implementation report; unknown or unconfirmed constraints must not automatically exclude a candidate
 - Follow the latest plan artifact: `plan.md` or `plan-r{N}.md`
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body
 - Read `.agents/rules/compatibility-policy.md` before implementation. Implement only the compatibility budget explicitly approved by the plan; never retain old branches, result contracts, or migration shims merely to be “safe”

--- a/templates/.agents/skills/code-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/code-task/SKILL.zh-CN.md
@@ -19,6 +19,7 @@ description: >
 
 生成实现报告时，先读取 `.agents/rules/evidence-reporting.md`。成功测试记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议保留复现入口、准确位置和决定性摘录，不默认粘贴完整成功 stdout。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在实现报告记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 严格遵循最新方案产物：`plan.md` 或 `plan-r{N}.md`
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 实现前读取 `.agents/rules/compatibility-policy.md`；只实现方案明确批准的兼容预算，不以“稳妥”为由保留旧分支、旧结果契约或迁移 shim

--- a/templates/.agents/skills/code-task/reference/dual-mode.en.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.en.md
@@ -20,7 +20,7 @@ The core scans `plan.md` / `plan-r{N}.md`, `review-plan.md` / `review-plan-r{N}.
 |---|---|---:|---|
 | no code artifact, and the latest review-plan is exactly `Approved` and references the latest plan | `init` | 0 | initial implementation, output `code.md`; a missing matching approval or `Approved-with-issues` returns an error |
 | latest review-plan is exactly `Approved`, references the latest plan, and the latest code completion receipt does not bind the same plan digest | `init` | 0 | enter a new implementation round. `Approved-with-issues` remains parse-compatible for history but is not cross-stage approval; missing or invalid receipts fail closed |
-| `rev_max < code_max` | `error` | 2 | latest code round is unreviewed; run `review-code` first |
+| the latest review-code completion receipt does not bind the latest code identity/SHA | `error` | 2 | latest code is unreviewed; run `review-code`; code and review-code family rounds may advance independently |
 | latest review-code is Approved and a pending implementation input was decided after that review completed | `decision` | 0 | select the earliest `II-N` and enter decision-driven implementation; false/not-required and consumed inputs do not trigger |
 | latest review-code is Approved with 0/0/0 | `refused` | 1 | already approved; do not run `code-task` again |
 | latest review-code is Approved with major/minor findings | `fix` | 0 | optional fix mode |

--- a/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/dual-mode.zh-CN.md
@@ -20,7 +20,7 @@ agent-infra-internal task-artifact {task-id} inspect --family code
 |---|---|---:|---|
 | 无 code 产物，且最新 review-plan 精确为 `Approved` 并引用最新 plan | `init` | 0 | 初次实现，产物为 `code.md`；缺少匹配审批或为 `Approved-with-issues` 时返回 error |
 | 最新 review-plan 精确为 `Approved`，且其「审查输入」/「Review Input」字段引用最新 plan，而最新 code 的完成 receipt 未绑定相同 plan 摘要 | `init` | 0 | plan 内容在 code 输入之后获批；进入新一轮实现。`Approved-with-issues` 仅保留历史解析兼容，不构成跨阶段批准；缺失或无效 receipt 失败关闭 |
-| `rev_max < code_max` | `error` | 2 | 最新代码未审查，先运行 `review-code` |
+| 最新 review-code 的完成收据未绑定最新 code identity/SHA | `error` | 2 | 最新代码未审查，先运行 `review-code`；code 与 review-code 的 family 轮次可独立增长 |
 | 最新 review-code 为 Approved 且存在审查完成后产生的 pending 实现输入 | `decision` | 0 | 选择最早 `II-N`，进入裁决驱动实现；false/not-required 与 consumed 输入不触发 |
 | 最新 review-code 为 Approved 且 0/0/0 | `refused` | 1 | 已通过，无需再次运行 `code-task` |
 | 最新 review-code 为 Approved 但有 major/minor | `fix` | 0 | 可选修复模式 |

--- a/templates/.agents/skills/code-task/reference/report-template.en.md
+++ b/templates/.agents/skills/code-task/reference/report-template.en.md
@@ -20,6 +20,30 @@ Use this structure when creating `code.md` or `code-r{N}.md`.
 - **Decision Evidence**: `{decision-evidence or N/A}`
 - **Scope Summary**: {scope of this round's implementation input}
 
+## Qualification Audit
+
+> Use `.agents/rules/decision-qualification.md` and fill these five tables.
+
+### Constraint Dependencies
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### Candidate Qualification
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### Classification Results
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### Upstream Relations
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### Dependency Snapshot
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 ## State Check
 
 > Record the state-check command, task/artifact scope, key result, and uncovered parts; each command starts with `$ `.

--- a/templates/.agents/skills/code-task/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/code-task/reference/report-template.zh-CN.md
@@ -20,6 +20,30 @@
 - **裁决证据**：`{decision-evidence 或 N/A}`
 - **需求摘要**：{本轮实现输入的范围摘要}
 
+## 资格审计
+
+> 按 `.agents/rules/decision-qualification.md` 填写以下五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 ## 状态核对
 
 > 记录状态核对命令、任务/产物范围、关键结果和未覆盖部分；每条命令以 `$ ` 开头。

--- a/templates/.agents/skills/plan-task/SKILL.en.md
+++ b/templates/.agents/skills/plan-task/SKILL.en.md
@@ -17,6 +17,7 @@ If the entry operands contain `--orchestrated`, bind `{execution-flag}` to `--or
 
 Before generating the plan report, read `.agents/rules/evidence-reporting.md`. Record the command, target scope, status or structured result, actual result, and uncovered parts for state checks and verification; include decisive raw excerpts only for failures, blocking conditions, or disputes.
 
+- When evaluating candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md`, audit normalized task constraints/candidates, and record the five qualification-audit tables in the plan artifact; unknown or unconfirmed constraints must not automatically exclude a candidate
 - This skill only outputs a technical plan document (`plan.md` or `plan-r{N}.md`) and does not modify any business code
 - This is a **mandatory human review checkpoint**; do not automatically proceed to implementation
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body

--- a/templates/.agents/skills/plan-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/plan-task/SKILL.zh-CN.md
@@ -17,6 +17,7 @@ description: >
 
 生成方案报告时，先读取 `.agents/rules/evidence-reporting.md`。状态核对和验证记录命令、目标范围、状态/结构化结果、实际结果和未覆盖部分；失败、阻塞或争议才附决定性原文摘录。
 
+- 涉及候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，基于 task.md 规范化约束/候选完成资格审计，并在方案产物记录五张资格审计表；不得把来源不明或未确认约束自动升级为排除条件
 - 本技能仅产出技术方案文档（`plan.md` 或 `plan-r{N}.md`）—— 不修改任何业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 这是一个**强制性的人工审查检查点** —— 不要自动进入实现阶段
@@ -86,6 +87,8 @@ agent-infra-internal task-event {task-id} plan.started --agent {standard-agent-t
 - 考虑边界情况和错误场景
 
 ### 5. 设计技术方案
+
+方案必须按 `.agents/rules/decision-qualification.md` 复核规范化约束和候选，并在方案产物保留五张资格审计表及真实上游关系；来源不明或未人工确认的约束不得自动排除候选。
 
 遵循 `.agents/workflows/feature-development.yaml` 中的 `technical-design` 步骤：
 

--- a/templates/.agents/skills/review-analysis/SKILL.en.md
+++ b/templates/.agents/skills/review-analysis/SKILL.en.md
@@ -19,6 +19,7 @@ Review the latest analysis artifact and produce `review-analysis.md` or `review-
 
 Before generating the review report, read `.agents/rules/evidence-reporting.md`. Normal inspection records the command, scope, structured result, actual conclusion, and uncovered parts; findings, blocking conditions, or disputes retain reproducible locations and decisive excerpts, while identity fields remain exact.
 
+- When reviewing candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md` and check the five qualification-audit tables, digests, QCR, and upstream relations; do not treat a process label as identity authentication
 - This skill only reviews analysis artifacts and writes a report; it does not modify product code.
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body
 - After executing this skill, you **must** immediately update task.md.

--- a/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/SKILL.zh-CN.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查分析产物并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/templates/.agents/skills/review-analysis/reference/report-template.en.md
+++ b/templates/.agents/skills/review-analysis/reference/report-template.en.md
@@ -19,6 +19,30 @@ Use this template when writing `review-analysis.md` or `review-analysis-r{N}.md`
 
 ## Review Summary
 
+## Qualification Audit Review
+
+> Use `.agents/rules/decision-qualification.md` to review the five tables: constraint dependencies, candidate qualification, classification results, upstream relations, and dependency snapshot.
+
+### Constraint Dependencies
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### Candidate Qualification
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### Classification Results
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### Upstream Relations
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### Dependency Snapshot
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **Reviewer**: {reviewer-name}
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}

--- a/templates/.agents/skills/review-analysis/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-analysis/reference/report-template.zh-CN.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/templates/.agents/skills/review-code/SKILL.en.md
+++ b/templates/.agents/skills/review-code/SKILL.en.md
@@ -19,6 +19,7 @@ Review the latest code round and produce `review-code.md` or `review-code-r{N}.m
 
 Before generating the review report, read `.agents/rules/evidence-reporting.md`. Normal inspection records the command, scope, structured result, actual conclusion, and uncovered parts; findings, blocking conditions, or disputes retain reproducible locations and decisive excerpts, while identity fields remain exact.
 
+- When reviewing candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md` and check the five qualification-audit tables, digests, QCR, and upstream relations; do not treat a process label as identity authentication
 - This skill reviews code and writes a report; it does not modify product code
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body
 - After executing this skill, you **must** immediately update task.md

--- a/templates/.agents/skills/review-code/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-code/SKILL.zh-CN.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查代码并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/templates/.agents/skills/review-code/reference/report-template.en.md
+++ b/templates/.agents/skills/review-code/reference/report-template.en.md
@@ -19,6 +19,30 @@ Use this template when writing `review-code.md` or `review-code-r{N}.md`.
 
 ## Review Summary
 
+## Qualification Audit Review
+
+> Use `.agents/rules/decision-qualification.md` to review the five tables: constraint dependencies, candidate qualification, classification results, upstream relations, and dependency snapshot.
+
+### Constraint Dependencies
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### Candidate Qualification
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### Classification Results
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### Upstream Relations
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### Dependency Snapshot
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **Reviewer**: {reviewer-name}
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}

--- a/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-code/reference/report-template.zh-CN.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/templates/.agents/skills/review-plan/SKILL.en.md
+++ b/templates/.agents/skills/review-plan/SKILL.en.md
@@ -19,6 +19,7 @@ Review the latest plan artifact and produce `review-plan.md` or `review-plan-r{N
 
 Before generating the review report, read `.agents/rules/evidence-reporting.md`. Normal inspection records the command, scope, structured result, actual conclusion, and uncovered parts; findings, blocking conditions, or disputes retain reproducible locations and decisive excerpts, while identity fields remain exact.
 
+- When reviewing candidate qualification or `HD-N`, read `.agents/rules/decision-qualification.md` and check the five qualification-audit tables, digests, QCR, and upstream relations; do not treat a process label as identity authentication
 - This skill only reviews plan artifacts and writes a report; it does not modify product code.
 - Before generating task or lifecycle Markdown that will be synchronized to an Issue, read `.agents/rules/sync-content-generation.md` and apply its producer-side constraints; the sync path does not parse or rewrite the body
 - After executing this skill, you **must** immediately update task.md.

--- a/templates/.agents/skills/review-plan/SKILL.zh-CN.md
+++ b/templates/.agents/skills/review-plan/SKILL.zh-CN.md
@@ -19,6 +19,7 @@ description: >
 
 生成审查报告时，先读取 `.agents/rules/evidence-reporting.md`。正常检视记录命令、范围、结构化结果、实际结论和未覆盖部分；finding、阻塞或争议保留可复现位置与决定性摘录，身份字段必须精确保留。
 
+- 审查候选资格或 `HD-N` 判断时，先读取 `.agents/rules/decision-qualification.md`，逐项复核产物中的五张资格审计表、digest、QCR 和上游关系；不得把流程标签当作身份认证
 - 本技能只审查方案产物并写报告，不修改业务代码
 - 生成会同步到 Issue 的任务或生命周期 Markdown 前，先读取 `.agents/rules/sync-content-generation.md` 并遵循其中的生成端约束；同步端不解析或改写正文
 - 执行本技能后，你**必须**立即更新 task.md

--- a/templates/.agents/skills/review-plan/reference/report-template.en.md
+++ b/templates/.agents/skills/review-plan/reference/report-template.en.md
@@ -19,6 +19,30 @@ Use this template when writing `review-plan.md` or `review-plan-r{N}.md`.
 
 ## Review Summary
 
+## Qualification Audit Review
+
+> Use `.agents/rules/decision-qualification.md` to review the five tables: constraint dependencies, candidate qualification, classification results, upstream relations, and dependency snapshot.
+
+### Constraint Dependencies
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### Candidate Qualification
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### Classification Results
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### Upstream Relations
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### Dependency Snapshot
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **Reviewer**: {reviewer-name}
 - **Review Time**: {timestamp}
 - **Scope**: {file-count and major modules}

--- a/templates/.agents/skills/review-plan/reference/report-template.zh-CN.md
+++ b/templates/.agents/skills/review-plan/reference/report-template.zh-CN.md
@@ -19,6 +19,30 @@
 
 ## 审查摘要
 
+## 资格审计复核
+
+> 按 `.agents/rules/decision-qualification.md` 复核：约束依赖、候选资格、分类结果、上游关系和依赖快照五张表。
+
+### 约束依赖
+| constraint_id | constraint_digest | role | evidence |
+| --- | --- | --- | --- |
+
+### 候选资格
+| candidate_id | status | impact | constraint_ids | evidence |
+| --- | --- | --- | --- | --- |
+
+### 分类结果
+| decision_id | classification | evidence |
+| --- | --- | --- |
+
+### 上游关系
+| upstream_family | upstream_artifact | upstream_round | upstream_sha256 | relation |
+| --- | --- | --- | --- | --- |
+
+### 依赖快照
+| task_input_digest | non_constraint_input_digest | upstream_artifact_digest |
+| --- | --- | --- |
+
 - **审查者**：{reviewer-name}
 - **审查时间**：{timestamp}
 - **审查范围**：{file-count and major modules}

--- a/templates/.agents/templates/task.en.md
+++ b/templates/.agents/templates/task.en.md
@@ -36,9 +36,15 @@ delivery_remote_head:          # Most recent successfully delivered task branch 
 
 ### Constraints
 
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
 ### Confirmed Decisions
 
 ### Candidate and Rejected Options
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
 
 ### Acceptance Criteria
 

--- a/templates/.agents/templates/task.zh-CN.md
+++ b/templates/.agents/templates/task.zh-CN.md
@@ -36,9 +36,15 @@ delivery_remote_head:          # 最近一次成功交付到 remote 的任务分
 
 ### 约束
 
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
 ### 已确认决策
 
 ### 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
 
 ### 验收标准
 

--- a/tests/e2e/core/code-task-dual-mode.test.ts
+++ b/tests/e2e/core/code-task-dual-mode.test.ts
@@ -50,6 +50,16 @@ function seedLifecycleReceipts(taskDir: string) {
       inputSha256: sha256File(path.join(taskDir, "plan.md")), completedAt
     });
   }
+  const reviewCodeOutputs = fs.readdirSync(taskDir).filter((name) => /^review-code(?:-r[2-9]\d*)?\.md$/.test(name));
+  for (const output of reviewCodeOutputs) {
+    const content = fs.readFileSync(path.join(taskDir, output), "utf8");
+    const input = content.match(/`((?:code|code-r[2-9]\d*)\.md)`/)?.[1];
+    if (!input || !fs.existsSync(path.join(taskDir, input))) continue;
+    addReceipt(taskDir, {
+      event: "review-code.completed", output, input,
+      inputSha256: sha256File(path.join(taskDir, input)), completedAt
+    });
+  }
 }
 
 function runDetect(files: Record<string, string>) {
@@ -62,7 +72,9 @@ function runDetect(files: Record<string, string>) {
 }
 
 function zhReview(verdict: string, findings = "0 阻塞项，0 主要，0 次要 / **人工校验**：0") {
-  return `## 审查摘要
+  return `- **审查输入**：\`code.md\`
+
+## 审查摘要
 
 - **总体结论**：${verdict}
 - **发现（AI 可处理）**：${findings}
@@ -70,7 +82,9 @@ function zhReview(verdict: string, findings = "0 阻塞项，0 主要，0 次要
 }
 
 function enReview(verdict: string, findings = "0 blockers, 0 majors, 0 minors / **Manual validation**: 0") {
-  return `## Review Summary
+  return `- **Review Input**: \`code.md\`
+
+## Review Summary
 
 - **Overall Verdict**: ${verdict}
 - **Findings (AI-actionable)**: ${findings}
@@ -203,7 +217,7 @@ test("code-task dual-mode: human-supplemented review with unparsable verdict sti
   const result = runDetect({
     "code.md": "# code",
     "review-code.md": zhReview("通过"),
-    "review-code-r2.md": "## 审查摘要\n\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要\n"
+    "review-code-r2.md": "- **审查输入**：`code.md`\n\n## 审查摘要\n\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要\n"
   });
 
   assert.equal(result.status, 2);
@@ -338,7 +352,7 @@ test("code-task dual-mode: branch 7 - Rejected refuses local fix mode", () => {
 test("code-task dual-mode: parsing failure returns error", () => {
   const result = runDetect({
     "code.md": "# code",
-    "review-code.md": "## 审查摘要\n\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要\n"
+    "review-code.md": "- **审查输入**：`code.md`\n\n## 审查摘要\n\n- **发现（AI 可处理）**：0 阻塞项，0 主要，0 次要\n"
   });
 
   assert.equal(result.status, 2);

--- a/tests/integration/cli/qualify.test.ts
+++ b/tests/integration/cli/qualify.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { CLI_PATH } from '../../helpers.ts';
+import { parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qualify-cli-'));
+  spawnSync('git', ['init', '-q'], { cwd: root });
+  const dir = path.join(root, '.agents', 'workspace', 'active', TASK_ID);
+  fs.mkdirSync(dir, { recursive: true });
+  const taskPath = path.join(dir, 'task.md');
+  fs.writeFileSync(taskPath, `---
+id: ${TASK_ID}
+status: active
+updated_at: 2026-01-01 00:00:00+00:00
+agent_infra_version: v0.9.13-alpha.0
+---
+
+# Task
+
+## 约束
+
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C-1 | Keep the public writer | derived | plan | plan.md | plan.md#scope |  |  |
+
+## 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
+| A | Use the writer | pending | C-1 | Small | task.md#input |
+
+## 审查分歧账本
+
+| id | stage | round | severity | status | evidence |
+|----|-------|-------|----------|--------|----------|
+
+## 活动日志
+
+- 2026-01-01 00:00:00+00:00 — **Create Task** by codex — created
+`);
+  return { root, taskPath };
+}
+
+function digest(taskPath: string): string {
+  const parsed = parseTaskQualification(fs.readFileSync(taskPath, 'utf8'));
+  if (!parsed.ok) throw new Error(parsed.message);
+  return parsed.qualification.constraintDigest;
+}
+
+function run(root: string, args: string[]) {
+  return spawnSync(process.execPath, [CLI_PATH, 'qualify', ...args], { cwd: root, encoding: 'utf8' });
+}
+
+test('ai qualify exposes supersede and revoke transitions', () => {
+  for (const transition of ['--supersede', '--revoke'] as const) {
+    const f = fixture();
+    try {
+      const confirmed = run(f.root, ['--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath), 'Confirm constraint.']);
+      assert.equal(confirmed.status, 0, confirmed.stderr || confirmed.stdout);
+      const changed = run(f.root, ['--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath), transition, 'Change confirmation.']);
+      assert.equal(changed.status, 0, changed.stderr || changed.stdout);
+      const parsed = parseTaskQualification(fs.readFileSync(f.taskPath, 'utf8'));
+      assert.equal(parsed.ok, true);
+      if (!parsed.ok) continue;
+      assert.equal(parsed.qualification.constraints[0]?.status, transition === '--supersede' ? 'superseded' : 'open');
+      assert.equal(parsed.qualification.constraints[0]?.approvalEvidence, '');
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('ai qualify rejects conflicting transition flags', () => {
+  const f = fixture();
+  try {
+    const result = run(f.root, [
+      '--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath),
+      '--supersede', '--revoke', 'Invalid transition.'
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /cannot be combined/);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 
 import { INTERNAL_CLI_PATH, onPlatforms, sandboxControlSafeEnv } from '../../helpers.ts';
 import { applyTaskEvent } from '../../../lib/task/events.ts';
+import { parseArtifactName as parseQualificationArtifactName } from '../../../lib/task/artifact-lifecycle.ts';
 import { prepareOrchestrationDelegation } from '../../../lib/task/orchestration.ts';
 import { upsertArtifactReceipt, type ArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
 import { upsertSection } from '../../../lib/task/sections.ts';
@@ -17,14 +18,23 @@ import {
   type LocalArtifactFamily
 } from '../../../lib/task/local-artifact-finalization.ts';
 import { parseInvalidationDocument } from '../../../lib/task/invalidation.ts';
-import { buildQualificationAudit, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
+import { buildQualificationAudit, expectedQualificationRelations, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
 
 function enableQualification(taskPath: string) {
   fs.appendFileSync(taskPath, `\n## \u7ea6\u675f\n\n| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| C-1 | Keep recovery bounded | derived | task-input | task.md | task.md#\u7ea6\u675f |  |  |\n\n## \u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848\n\n| candidate_id | statement | status | constraint_ids | impact | evidence |\n| --- | --- | --- | --- | --- | --- |\n| A | Rebuild the earliest stale stage | qualified | C-1 | bounded recovery | task.md#\u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848 |\n`);
 }
 
 function writeQualifiedArtifact(taskPath: string, artifactPath: string) {
-  const built = buildQualificationAudit(fs.readFileSync(taskPath, 'utf8'));
+  const taskContent = fs.readFileSync(taskPath, 'utf8');
+  const identity = parseQualificationArtifactName(path.basename(artifactPath));
+  const expected = identity && (identity.family === 'analysis' || identity.family === 'review-analysis'
+    || identity.family === 'plan' || identity.family === 'review-plan'
+    || identity.family === 'code' || identity.family === 'review-code')
+    ? expectedQualificationRelations(taskContent, identity.family)
+    : { ok: true as const, relations: undefined };
+  assert.equal(expected.ok, true);
+  if (!expected.ok) return;
+  const built = buildQualificationAudit(taskContent, { upstreamRelations: expected.relations });
   assert.equal(built.ok, true);
   if (!built.ok) return;
   fs.writeFileSync(artifactPath, `# Current artifact\n\n## \u8d44\u683c\u5ba1\u8ba1\n\n${renderQualificationAudit(built.audit)}\n`);
@@ -1073,6 +1083,50 @@ test('source completion records resumable invalidation and downstream writers fa
   assert.equal(retried.status, 0, retried.stdout || retried.stderr);
 });
 
+test('late qualification graph fallback records upstream-replaced reason', () => {
+  const f = fixture('code');
+  enableQualification(f.file);
+  fs.writeFileSync(path.join(f.dir, 'review-analysis.md'), reviewArtifact('Analysis Review', 'analysis.md'));
+  fs.writeFileSync(path.join(f.dir, 'plan.md'), '# Plan\n');
+  fs.writeFileSync(path.join(f.dir, 'review-plan.md'), reviewArtifact('Plan Review', 'plan.md'));
+  for (const name of ['analysis.md', 'review-analysis.md', 'plan.md', 'review-plan.md', 'code.md', 'review-code.md'] as const) {
+    const built = buildQualificationAudit(fs.readFileSync(f.file, 'utf8'));
+    assert.equal(built.ok, true);
+    if (!built.ok) return;
+    fs.appendFileSync(path.join(f.dir, name), `\n## 资格审计\n\n${renderQualificationAudit(built.audit)}\n`);
+  }
+  for (const [event, output, input] of [
+    ['review-analysis.completed', 'review-analysis.md', 'analysis.md'],
+    ['review-plan.completed', 'review-plan.md', 'plan.md'],
+    ['code.completed', 'code.md', 'plan.md'],
+    ['review-code.completed', 'review-code.md', 'code.md']
+  ] as const) addReceipt(f.file, {
+    event, output, input, inputSha256: sha256File(path.join(f.dir, input)), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+
+  const started = run(f.root, [f.id, 'analyze.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stdout || started.stderr);
+  fs.writeFileSync(f.file, fs.readFileSync(f.file, 'utf8').replace('| A | Rebuild the earliest stale stage | qualified |', '| A | Rebuild the earliest stale stage | rejected |'));
+  const currentTask = fs.readFileSync(f.file, 'utf8');
+  const expected = expectedQualificationRelations(currentTask, 'analysis');
+  assert.equal(expected.ok, true);
+  if (!expected.ok) return;
+  const currentAudit = buildQualificationAudit(currentTask, { upstreamRelations: expected.relations });
+  assert.equal(currentAudit.ok, true);
+  if (!currentAudit.ok) return;
+  fs.writeFileSync(path.join(f.dir, 'analysis-r2.md'), `${localArtifact('analysis')}\n## 资格审计\n\n${renderQualificationAudit(currentAudit.audit)}\n`);
+  const completed = run(f.root, [
+    f.id, 'analyze.completed', '--agent', 'codex', '--artifact', 'analysis-r2.md',
+    ...completionDigestArgs(f.dir, 'analysis-r2.md', 'analysis')
+  ]);
+  assert.equal(completed.status, 0, completed.stdout || completed.stderr);
+  const invalidation = parseInvalidationDocument(fs.readFileSync(f.file, 'utf8'));
+  assert.equal(invalidation.ok, true);
+  if (!invalidation.ok) return;
+  assert.equal(invalidation.document.targets.length > 0, true);
+  assert.equal(invalidation.document.targets.every((target) => target.reasonCode === 'upstream-replaced'), true);
+});
+
 test('qualification recovery started events only authorize the earliest stale stage', () => {
   const f = fixture('code-review');
   for (const [name, content] of [
@@ -1194,6 +1248,7 @@ for (const scenario of reviewScenarios) {
     const startedContent = fs.readFileSync(f.file, 'utf8');
     assert.match(startedContent, /^review_input_artifact: /m);
     assert.match(startedContent, /^review_input_sha256: [a-f0-9]{64}$/m);
+    assert.match(startedContent, /^qualification_input_relations: /m);
     const completed = completeReview(f, scenario, 'approved', { blockers: 0, major: 0, minor: 0 });
     assert.equal(completed.status, 0, completed.stderr);
     const digest = sha256File(path.join(f.dir, scenario.input));

--- a/tests/integration/cli/task-event.test.ts
+++ b/tests/integration/cli/task-event.test.ts
@@ -17,6 +17,18 @@ import {
   type LocalArtifactFamily
 } from '../../../lib/task/local-artifact-finalization.ts';
 import { parseInvalidationDocument } from '../../../lib/task/invalidation.ts';
+import { buildQualificationAudit, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
+
+function enableQualification(taskPath: string) {
+  fs.appendFileSync(taskPath, `\n## \u7ea6\u675f\n\n| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| C-1 | Keep recovery bounded | derived | task-input | task.md | task.md#\u7ea6\u675f |  |  |\n\n## \u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848\n\n| candidate_id | statement | status | constraint_ids | impact | evidence |\n| --- | --- | --- | --- | --- | --- |\n| A | Rebuild the earliest stale stage | qualified | C-1 | bounded recovery | task.md#\u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848 |\n`);
+}
+
+function writeQualifiedArtifact(taskPath: string, artifactPath: string) {
+  const built = buildQualificationAudit(fs.readFileSync(taskPath, 'utf8'));
+  assert.equal(built.ok, true);
+  if (!built.ok) return;
+  fs.writeFileSync(artifactPath, `# Current artifact\n\n## \u8d44\u683c\u5ba1\u8ba1\n\n${renderQualificationAudit(built.audit)}\n`);
+}
 
 function fixture(step = 'requirement-analysis-review') {
   const explicitStep = arguments.length > 0;
@@ -1059,6 +1071,34 @@ test('source completion records resumable invalidation and downstream writers fa
   assert.equal(reconciled.status, 0, reconciled.stdout || reconciled.stderr);
   const retried = run(f.root, [f.id, 'review-analysis.started', '--agent', 'codex']);
   assert.equal(retried.status, 0, retried.stdout || retried.stderr);
+});
+
+test('qualification recovery started events only authorize the earliest stale stage', () => {
+  const f = fixture('code-review');
+  for (const [name, content] of [
+    ['review-analysis.md', reviewArtifact('Analysis Review', 'analysis.md')],
+    ['plan.md', '# Plan\n'],
+    ['review-plan.md', reviewArtifact('Plan Review', 'plan.md')]
+  ] as const) fs.writeFileSync(path.join(f.dir, name), content);
+  addReceipt(f.file, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(f.dir, 'analysis.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  enableQualification(f.file);
+  writeQualifiedArtifact(f.file, path.join(f.dir, 'plan.md'));
+
+  const skipped = run(f.root, [f.id, 'review-plan.started', '--agent', 'codex', '--dry-run']);
+  assert.equal(skipped.status, 1);
+  assert.equal(JSON.parse(skipped.stdout).error.code, 'EVENT_TRANSITION_INVALID');
+  assert.match(JSON.parse(skipped.stdout).error.message, /QUALIFICATION_STALE/);
+
+  const planned = run(f.root, [f.id, 'analyze.started', '--agent', 'codex', '--dry-run']);
+  assert.equal(planned.status, 0, planned.stdout || planned.stderr);
+  assert.equal(JSON.parse(planned.stdout).artifact, 'analysis-r2.md');
+
+  const started = run(f.root, [f.id, 'analyze.started', '--agent', 'codex']);
+  assert.equal(started.status, 0, started.stdout || started.stderr);
+  assert.equal(JSON.parse(started.stdout).artifact, 'analysis-r2.md');
 });
 
 test('analysis restart is authorized by explicit intent without current-step adjacency', () => {

--- a/tests/integration/cli/task-qualification.test.ts
+++ b/tests/integration/cli/task-qualification.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-import { CLI_PATH } from '../../helpers.ts';
+import { INTERNAL_CLI_PATH } from '../../helpers.ts';
 import { parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
@@ -55,22 +55,24 @@ function digest(taskPath: string): string {
   return parsed.qualification.constraintDigest;
 }
 
-function run(root: string, args: string[]) {
-  return spawnSync(process.execPath, [CLI_PATH, 'qualify', ...args], { cwd: root, encoding: 'utf8' });
+function run(root: string, operation: 'confirm' | 'supersede' | 'revoke', taskPath: string, rationale: string) {
+  const input = path.join(root, `${operation}.json`);
+  fs.writeFileSync(input, JSON.stringify({ constraintId: 'C-1', expectedDigest: digest(taskPath), rationale }));
+  return spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-qualification', TASK_ID, operation, '--input', input], { cwd: root, encoding: 'utf8' });
 }
 
-test('ai qualify exposes supersede and revoke transitions', () => {
-  for (const transition of ['--supersede', '--revoke'] as const) {
+test('internal task-qualification exposes supersede and revoke transitions', () => {
+  for (const transition of ['supersede', 'revoke'] as const) {
     const f = fixture();
     try {
-      const confirmed = run(f.root, ['--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath), 'Confirm constraint.']);
+      const confirmed = run(f.root, 'confirm', f.taskPath, 'Confirm constraint.');
       assert.equal(confirmed.status, 0, confirmed.stderr || confirmed.stdout);
-      const changed = run(f.root, ['--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath), transition, 'Change confirmation.']);
+      const changed = run(f.root, transition, f.taskPath, 'Change confirmation.');
       assert.equal(changed.status, 0, changed.stderr || changed.stdout);
       const parsed = parseTaskQualification(fs.readFileSync(f.taskPath, 'utf8'));
       assert.equal(parsed.ok, true);
       if (!parsed.ok) continue;
-      assert.equal(parsed.qualification.constraints[0]?.status, transition === '--supersede' ? 'superseded' : 'open');
+      assert.equal(parsed.qualification.constraints[0]?.status, transition === 'supersede' ? 'superseded' : 'open');
       assert.equal(parsed.qualification.constraints[0]?.approvalEvidence, '');
     } finally {
       fs.rmSync(f.root, { recursive: true, force: true });
@@ -78,15 +80,12 @@ test('ai qualify exposes supersede and revoke transitions', () => {
   }
 });
 
-test('ai qualify rejects conflicting transition flags', () => {
+test('internal task-qualification rejects unknown operations', () => {
   const f = fixture();
   try {
-    const result = run(f.root, [
-      '--task', TASK_ID, '--constraint', 'C-1', '--digest', digest(f.taskPath),
-      '--supersede', '--revoke', 'Invalid transition.'
-    ]);
+    const result = spawnSync(process.execPath, [INTERNAL_CLI_PATH, 'task-qualification', TASK_ID, 'unknown', '--input', f.taskPath], { cwd: f.root, encoding: 'utf8' });
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /cannot be combined/);
+    assert.equal(JSON.parse(result.stdout).error.code, 'QUALIFICATION_PROPOSAL_INVALID');
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
   }

--- a/tests/unit/cli/task-artifact-lifecycle.test.ts
+++ b/tests/unit/cli/task-artifact-lifecycle.test.ts
@@ -286,6 +286,33 @@ test('code replan routing compares plan content with the code input receipt', ()
   assert.equal(result.codeMode?.reviewArtifact, 'review-plan.md');
 });
 
+test('code fix routing trusts the review receipt when code and review family rounds differ', () => {
+  const f = fixture();
+  enableQualification(f);
+  writeQualifiedArtifact(f, 'plan.md');
+  writeQualifiedArtifact(f, 'code.md');
+  writeQualifiedArtifact(f, 'code-r2.md');
+  writeQualifiedArtifact(f, 'review-code.md');
+  fs.appendFileSync(path.join(f.taskDir, 'review-code.md'), [
+    '', '- **审查输入**：', '  - `code-r2.md`', '', '## 审查摘要', '',
+    '- **总体结论**：需要修改',
+    '- **发现（AI 可处理）**：0 阻塞项，1 主要，0 次要 / **人工校验**：0', ''
+  ].join('\n'));
+  addReceipt(f, {
+    event: 'code.completed', output: 'code-r2.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  addReceipt(f, {
+    event: 'review-code.completed', output: 'review-code.md', input: 'code-r2.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'code-r2.md')), completedAt: '2026-01-01 00:01:00+00:00'
+  });
+
+  const result = resolveArtifactContext(TASK_ID, 'code', { repoRoot: f.repoRoot });
+  assert.equal(result.status, 'ready');
+  assert.equal(result.codeMode?.mode, 'fix');
+  assert.equal(result.codeMode?.reviewArtifact, 'review-code.md');
+});
+
 test('revision context fails closed when a review points to a future input', () => {
   const f = fixture({ 'analysis.md': '# analysis', 'review-analysis.md': '**Review Input**: `analysis.md`\n' });
   const reviewPath = path.join(f.taskDir, 'review-analysis.md');

--- a/tests/unit/cli/task-artifact-lifecycle.test.ts
+++ b/tests/unit/cli/task-artifact-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../lib/task/artifact-lifecycle.ts';
 import { sha256Bytes, sha256File, upsertArtifactReceipt } from '../../../lib/task/artifact-receipts.ts';
 import { createInvalidationOperation, invalidationMutation, targetIdFor, type InvalidationTarget } from '../../../lib/task/invalidation.ts';
+import { buildQualificationAudit, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
 import { upsertSection } from '../../../lib/task/sections.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
@@ -35,6 +36,20 @@ function addReceipt(f: ReturnType<typeof fixture>, receipt: Parameters<typeof up
   const content = fs.readFileSync(taskPath, 'utf8');
   const mutation = upsertArtifactReceipt(content, receipt);
   fs.writeFileSync(taskPath, upsertSection(content, mutation).content);
+}
+
+function enableQualification(f: ReturnType<typeof fixture>) {
+  const taskPath = path.join(f.taskDir, 'task.md');
+  const content = fs.readFileSync(taskPath, 'utf8');
+  fs.writeFileSync(taskPath, `${content}\n## \u7ea6\u675f\n\n| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| C-1 | Keep lifecycle recovery possible | derived | task-input | task.md | task.md#\u7ea6\u675f |  |  |\n\n## \u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848\n\n| candidate_id | statement | status | constraint_ids | impact | evidence |\n| --- | --- | --- | --- | --- | --- |\n| A | Rebuild from the earliest stale stage | qualified | C-1 | bounded recovery | task.md#\u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848 |\n`);
+}
+
+function writeQualifiedArtifact(f: ReturnType<typeof fixture>, name: string) {
+  const taskContent = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+  const built = buildQualificationAudit(taskContent);
+  assert.equal(built.ok, true);
+  if (!built.ok) return;
+  fs.writeFileSync(path.join(f.taskDir, name), `# ${name}\n\n## \u8d44\u683c\u5ba1\u8ba1\n\n${renderQualificationAudit(built.audit)}\n`);
 }
 
 test('catalog exposes exactly the approved artifact families', () => {
@@ -168,6 +183,65 @@ test('context resolves required latest inputs and actual review references indep
   assert.equal(review.status, 'ready');
   assert.deepEqual(review.inputs.map((item) => item.name), ['plan-r2.md']);
   assert.equal(inspectTaskArtifacts(TASK_ID, 'review-plan', { repoRoot: f.repoRoot }).reviewedInput?.name, 'plan-r2.md');
+});
+
+test('qualification recovery accepts legacy optional context for analysis and plan but rejects a legacy required input', () => {
+  const f = fixture({
+    'analysis.md': '# analysis\n',
+    'review-analysis.md': '**\u5ba1\u67e5\u8f93\u5165**\uff1a`analysis.md`\n',
+    'plan.md': '# plan\n',
+    'review-plan.md': '**\u5ba1\u67e5\u8f93\u5165**\uff1a`plan.md`\n'
+  });
+  enableQualification(f);
+  addReceipt(f, {
+    event: 'review-analysis.completed', output: 'review-analysis.md', input: 'analysis.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'analysis.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+  addReceipt(f, {
+    event: 'review-plan.completed', output: 'review-plan.md', input: 'plan.md',
+    inputSha256: sha256File(path.join(f.taskDir, 'plan.md')), completedAt: '2026-01-01 00:00:00+00:00'
+  });
+
+  const recovery = resolveArtifactContext(TASK_ID, 'analysis', { repoRoot: f.repoRoot });
+  assert.equal(recovery.status, 'ready');
+  assert.deepEqual(recovery.inputs.map((item) => item.name), ['review-analysis.md']);
+
+  const required = resolveArtifactContext(TASK_ID, 'review-plan', { repoRoot: f.repoRoot });
+  assert.equal(required.status, 'failed');
+  assert.equal(required.error?.code, 'ARTIFACT_REFERENCE_INVALID');
+
+  writeQualifiedArtifact(f, 'analysis.md');
+  const planRecovery = resolveArtifactContext(TASK_ID, 'plan', { repoRoot: f.repoRoot });
+  assert.equal(planRecovery.status, 'ready');
+  assert.deepEqual(planRecovery.inputs.map((item) => item.name), ['analysis.md', 'review-plan.md']);
+});
+
+test('qualification recovery rejects legacy optional context outside analysis and plan', () => {
+  const codeFixture = fixture({ 'plan.md': '# plan\n', 'code.md': '# legacy code\n' });
+  enableQualification(codeFixture);
+  writeQualifiedArtifact(codeFixture, 'plan.md');
+  const code = resolveArtifactContext(TASK_ID, 'code', { repoRoot: codeFixture.repoRoot });
+  assert.equal(code.status, 'failed');
+  assert.equal(code.error?.code, 'ARTIFACT_REFERENCE_INVALID');
+
+  const reviewCodeFixture = fixture({
+    'code.md': '# code\n',
+    'plan.md': '# plan\n',
+    'review-plan.md': '**\u5ba1\u67e5\u8f93\u5165**\uff1a`plan.md`\n'
+  });
+  enableQualification(reviewCodeFixture);
+  writeQualifiedArtifact(reviewCodeFixture, 'code.md');
+  const reviewCode = resolveArtifactContext(TASK_ID, 'review-code', { repoRoot: reviewCodeFixture.repoRoot });
+  assert.equal(reviewCode.status, 'failed');
+  assert.equal(reviewCode.error?.code, 'ARTIFACT_REFERENCE_INVALID');
+
+  for (const family of ['manual-validation', 'validation-run'] as const) {
+    const f = fixture({ 'review-code.md': '# legacy review code\n' });
+    enableQualification(f);
+    const result = resolveArtifactContext(TASK_ID, family, { repoRoot: f.repoRoot });
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error?.code, 'ARTIFACT_REFERENCE_INVALID');
+  }
 });
 
 test('review references ignore mtime order and fail closed on content changes', () => {

--- a/tests/unit/core/task-capabilities.test.ts
+++ b/tests/unit/core/task-capabilities.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import { buildLifecycleFacts, canStart, recommendNext, type ExplicitTrigger, type LifecycleAction, type LifecycleFacts } from '../../../lib/task/capabilities.ts';
 import { invalidationMutation, createInvalidationOperation, targetIdFor, type InvalidationTarget } from '../../../lib/task/invalidation.ts';
+import { buildQualificationAudit, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
 import { upsertSection } from '../../../lib/task/sections.ts';
 
 const trigger: ExplicitTrigger = {
@@ -21,6 +22,10 @@ function facts(currentStep: string): LifecycleFacts {
     reworkIntents: [],
     unresolvedLedger: { analysis: 0, plan: 0, code: 0 }, executionBusy: false
   };
+}
+
+function qualificationTask() {
+  return `---\nid: TASK-20260101-000001\nstatus: active\ncurrent_step: requirement-analysis\n---\n\n# Task\n\n## \u7ea6\u675f\n\n| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |\n| --- | --- | --- | --- | --- | --- | --- | --- |\n| C-1 | Keep recovery bounded | derived | task-input | task.md | task.md#\u7ea6\u675f |  |  |\n\n## \u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848\n\n| candidate_id | statement | status | constraint_ids | impact | evidence |\n| --- | --- | --- | --- | --- | --- |\n| A | Rebuild the earliest stale stage | qualified | C-1 | bounded recovery | task.md#\u5019\u9009\u4e0e\u5426\u51b3\u65b9\u6848 |\n`;
 }
 
 test('explicit trigger authorization does not depend on current_step', () => {
@@ -106,6 +111,56 @@ test('recommendation is derived from lifecycle facts rather than current_step', 
     artifacts: { ...facts('code-review').artifacts, analysis: ['analysis.md'] }
   };
   assert.equal(recommendNext(withAnalysis).action, 'review-analysis');
+});
+
+test('qualification recovery routes to the earliest stale stage and only authorizes that stage', () => {
+  const stale = {
+    ...facts('code'),
+    artifacts: {
+      analysis: ['analysis.md'], 'review-analysis': ['review-analysis.md'],
+      plan: ['plan.md'], 'review-plan': ['review-plan.md'],
+      code: ['code.md'], 'review-code': []
+    },
+    qualificationStale: true,
+    qualificationStaleArtifacts: ['review-plan.md', 'analysis.md']
+  } satisfies LifecycleFacts;
+
+  const recommendation = recommendNext(stale);
+  assert.equal(recommendation.action, 'analysis');
+  assert.equal(recommendation.reasonCode, 'QUALIFICATION_RECOVERY_REQUIRED');
+
+  const recoveryFacts = { ...stale, recommendedAction: recommendation.action };
+  assert.equal(canStart('analysis', recoveryFacts, trigger).allowed, true);
+  const busy = canStart('analysis', { ...recoveryFacts, executionBusy: true }, trigger);
+  assert.equal(busy.allowed, false);
+  assert.equal(busy.reasonCode, 'EXECUTION_BUSY');
+  const skipped = canStart('review-code', recoveryFacts, { ...trigger, requestedAction: 'review-code' });
+  assert.equal(skipped.allowed, false);
+  assert.equal(skipped.reasonCode, 'QUALIFICATION_STALE');
+});
+
+test('qualification recovery only evaluates the latest active artifact in each family', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'capability-qualification-latest-'));
+  try {
+    const taskDir = path.join(root, 'task');
+    fs.mkdirSync(taskDir, { recursive: true });
+    const content = qualificationTask();
+    fs.writeFileSync(path.join(taskDir, 'task.md'), content);
+    fs.writeFileSync(path.join(taskDir, 'analysis.md'), '# legacy analysis\n');
+    const built = buildQualificationAudit(content);
+    assert.equal(built.ok, true);
+    if (!built.ok) return;
+    fs.writeFileSync(path.join(taskDir, 'analysis-r2.md'), `# Current analysis\n\n## \u8d44\u683c\u5ba1\u8ba1\n\n${renderQualificationAudit(built.audit)}\n`);
+
+    const result = buildLifecycleFacts(taskDir, content, 'active');
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.facts.qualificationStale, false);
+    assert.deepEqual(result.facts.qualificationStaleArtifacts, []);
+    assert.equal(recommendNext(result.facts).action, 'review-analysis');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('explicit source provenance requires a matching artifact hash', () => {

--- a/tests/unit/task/local-artifact-finalization.test.ts
+++ b/tests/unit/task/local-artifact-finalization.test.ts
@@ -5,6 +5,7 @@ import {
   validateLocalArtifact,
   type LocalArtifactFamily
 } from '../../../lib/task/local-artifact-finalization.ts';
+import { buildQualificationAudit, renderQualificationAudit } from '../../../lib/task/qualification-audit.ts';
 
 const PLAN_SECTIONS = [
   ['问题理解', '范围说明'],
@@ -106,4 +107,34 @@ test('code reports support the same one-line heading repair and semantic baselin
   const repaired = validateLocalArtifact(malformed.replace('## 测试结果：', '## 测试结果'), { family: 'code' });
   assert.equal(repaired.ok, true);
   assert.equal(repaired.semanticDigest, failed.semanticDigest);
+});
+
+test('code report validation binds qualification relations to the started input', () => {
+  const task = `---
+id: TASK-20260101-000001
+code_input_artifact: plan.md
+code_input_sha256: ${'a'.repeat(64)}
+---
+
+# Task
+
+## 约束
+
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C-1 | Use the approved plan | derived | task-input | task.md | task.md#约束 |  |  |
+
+## 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
+| A | Use the approved plan | pending | C-1 | bounded | task.md#候选与否决方案 |
+`;
+  const audit = buildQualificationAudit(task);
+  assert.equal(audit.ok, true);
+  if (!audit.ok) return;
+  const content = `${artifact('code')}\n## 资格审计\n\n${renderQualificationAudit(audit.audit)}\n`;
+  const result = validateLocalArtifact(content, { family: 'code', taskContent: task, artifact: 'code.md' });
+  const mismatch = diagnostic(result, 'LOCAL_QUALIFICATION_AUDIT_INVALID');
+  assert.match(mismatch.message, /QUALIFICATION_UPSTREAM_RELATION_MISMATCH/);
 });

--- a/tests/unit/task/qualification-audit.test.ts
+++ b/tests/unit/task/qualification-audit.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildQualificationAudit,
+  constraintDigest,
+  parseQualificationAudit,
+  parseTaskQualification,
+  renderQualificationAudit,
+  upstreamArtifactDigest,
+  validateQualificationAudit
+} from '../../../lib/task/qualification-audit.ts';
+
+function taskContent(): string {
+  return `# Task
+
+## 约束
+
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C-1 | Must keep the public command stable | derived | user | task input | task.md#facts |  |  |
+| C-2 | Code must use the existing writer | derived | plan | C-1 | plan.md#method | C-1 | plan.md#method |
+
+## 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
+| A | Use the existing writer | qualified | C-1,C-2 | Small change | plan.md#A |
+| B | Add a second writer | rejected | C-1 | Larger change | plan.md#B |
+`;
+}
+
+test('qualification projection is canonical and binds confirmed evidence', () => {
+  const parsed = parseTaskQualification(taskContent());
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.qualification.constraints.length, 2);
+  assert.equal(parsed.qualification.candidates[0]?.constraintIds.join(','), 'C-1,C-2');
+  assert.match(parsed.qualification.constraintDigest, /^[a-f0-9]{64}$/);
+  assert.equal(parsed.qualification.constraints[0]?.digest, constraintDigest(parsed.qualification.constraints[0]!));
+});
+
+test('qualification audit round-trips and rejects stale or unknown dependencies', () => {
+  const parsed = parseTaskQualification(taskContent());
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  const built = buildQualificationAudit(taskContent(), {
+    classifications: [{ decisionId: 'HD-1', classification: 'deterministic', evidence: 'plan.md#HD-1' }],
+    upstreamRelations: [{
+      upstreamFamily: 'review-plan', upstreamArtifact: 'review-plan.md', upstreamRound: 1,
+      upstreamSha256: 'a'.repeat(64), relation: 'reviewed-input'
+    }]
+  });
+  assert.equal(built.ok, true);
+  if (!built.ok) return;
+  const rendered = renderQualificationAudit(built.audit);
+  const audit = parseQualificationAudit(`## Qualification Audit\n\n${rendered}`);
+  assert.equal(audit.ok, true);
+  if (!audit.ok) return;
+  assert.equal(audit.audit.upstreamRelations[0]?.upstreamArtifact, 'review-plan.md');
+  assert.equal(audit.audit.snapshot?.upstreamArtifactDigest, upstreamArtifactDigest(audit.audit.upstreamRelations));
+
+  const valid = validateQualificationAudit(taskContent(), `## Qualification Audit\n\n${rendered}`, { family: 'code', artifact: 'code.md', require: true });
+  assert.equal(valid.ok, true);
+
+  const stale = rendered.replace(parsed.qualification.constraints[0]!.digest, 'b'.repeat(64));
+  const invalid = validateQualificationAudit(taskContent(), `## Qualification Audit\n\n${stale}`, { require: true });
+  assert.equal(invalid.ok, false);
+  if (!invalid.ok) assert.equal(invalid.code, 'QUALIFICATION_CONSTRAINT_DIGEST_MISMATCH');
+});
+
+test('legacy task input remains explicitly unconfigured until migrated', () => {
+  const parsed = parseTaskQualification('# Task\n\n## 约束\n\n- a legacy constraint\n');
+  assert.equal(parsed.ok, true);
+  if (parsed.ok) assert.equal(parsed.qualification.present, false);
+});

--- a/tests/unit/task/qualification-audit.test.ts
+++ b/tests/unit/task/qualification-audit.test.ts
@@ -84,10 +84,15 @@ updated_at: old
 checkpoint_commit:
 ---
 
-${taskContent()}`;
+${taskContent()}
+
+## 活动日志
+
+- old runtime entry`;
   const lifecycleUpdated = content
     .replace('updated_at: old', 'updated_at: new')
-    .replace('checkpoint_commit:', 'checkpoint_commit: abc123');
+    .replace('checkpoint_commit:', 'checkpoint_commit: abc123')
+    .replace('old runtime entry', 'new runtime entry');
   assert.equal(nonConstraintInputDigest(content), nonConstraintInputDigest(lifecycleUpdated));
 
   const taskContentUpdated = content.replace('# Task\n', '# Task\n\nA changed task description.\n');

--- a/tests/unit/task/qualification-audit.test.ts
+++ b/tests/unit/task/qualification-audit.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   buildQualificationAudit,
   constraintDigest,
+  nonConstraintInputDigest,
   parseQualificationAudit,
   parseTaskQualification,
   renderQualificationAudit,
@@ -73,4 +74,22 @@ test('legacy task input remains explicitly unconfigured until migrated', () => {
   const parsed = parseTaskQualification('# Task\n\n## 约束\n\n- a legacy constraint\n');
   assert.equal(parsed.ok, true);
   if (parsed.ok) assert.equal(parsed.qualification.present, false);
+});
+
+test('non-constraint projection ignores mutable task frontmatter', () => {
+  const content = `---
+id: TASK-20260101-000001
+status: active
+updated_at: old
+checkpoint_commit:
+---
+
+${taskContent()}`;
+  const lifecycleUpdated = content
+    .replace('updated_at: old', 'updated_at: new')
+    .replace('checkpoint_commit:', 'checkpoint_commit: abc123');
+  assert.equal(nonConstraintInputDigest(content), nonConstraintInputDigest(lifecycleUpdated));
+
+  const taskContentUpdated = content.replace('# Task\n', '# Task\n\nA changed task description.\n');
+  assert.notEqual(nonConstraintInputDigest(content), nonConstraintInputDigest(taskContentUpdated));
 });

--- a/tests/unit/task/qualification-audit.test.ts
+++ b/tests/unit/task/qualification-audit.test.ts
@@ -70,6 +70,34 @@ test('qualification audit round-trips and rejects stale or unknown dependencies'
   if (!invalid.ok) assert.equal(invalid.code, 'QUALIFICATION_CONSTRAINT_DIGEST_MISMATCH');
 });
 
+test('qualification audit rejects candidate snapshots that diverge from task input', () => {
+  const built = buildQualificationAudit(taskContent());
+  assert.equal(built.ok, true);
+  if (!built.ok) return;
+  const rendered = renderQualificationAudit(built.audit);
+  const changed = rendered.replace('| A | qualified | Small change |', '| A | rejected | Small change |');
+  const result = validateQualificationAudit(taskContent(), `## Qualification Audit\n\n${changed}`, { require: true });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, 'QUALIFICATION_CANDIDATE_MISMATCH');
+});
+
+test('qualification audit requires the exact started upstream relations', () => {
+  const expected = [{
+    upstreamFamily: 'plan' as const, upstreamArtifact: 'plan.md', upstreamRound: 1,
+    upstreamSha256: 'a'.repeat(64), relation: 'required-input' as const
+  }];
+  const built = buildQualificationAudit(taskContent());
+  assert.equal(built.ok, true);
+  if (!built.ok) return;
+  const result = validateQualificationAudit(
+    taskContent(),
+    `## Qualification Audit\n\n${renderQualificationAudit(built.audit)}`,
+    { family: 'code', artifact: 'code.md', require: true, expectedUpstreamRelations: expected }
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, 'QUALIFICATION_UPSTREAM_RELATION_MISMATCH');
+});
+
 test('legacy task input remains explicitly unconfigured until migrated', () => {
   const parsed = parseTaskQualification('# Task\n\n## 约束\n\n- a legacy constraint\n');
   assert.equal(parsed.ok, true);

--- a/tests/unit/task/qualification-intents.test.ts
+++ b/tests/unit/task/qualification-intents.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { applyQualificationProposal } from '../../../lib/task/qualification-intents.ts';
-import { applyQualificationConfirmation } from '../../../lib/qualify.ts';
+import { applyQualificationConfirmation } from '../../../lib/task/qualification-confirmation.ts';
 import {
   buildQualificationAudit,
   parseQualificationConfirmations,
@@ -139,7 +139,7 @@ test('proposal rejects confirmation authority and stale digest without changing 
   }
 });
 
-test('top-level qualification confirms the current digest and creates a core-owned QCR', () => {
+test('internal qualification confirms the current digest and creates a core-owned QCR', () => {
   const { repoRoot, taskMd } = fixture();
   try {
     const initial = parseTaskQualification(fs.readFileSync(taskMd, 'utf8'));
@@ -157,7 +157,7 @@ test('top-level qualification confirms the current digest and creates a core-own
     assert.equal(confirmations.ok, true);
     if (confirmations.ok) {
       assert.equal(confirmations.confirmations[0]?.actor, 'human-declared');
-      assert.equal(confirmations.confirmations[0]?.entrypoint, 'ai qualify');
+      assert.equal(confirmations.confirmations[0]?.entrypoint, 'task-qualification');
       const current = parseTaskQualification(content);
       assert.equal(current.ok, true);
       if (!current.ok) return;
@@ -180,7 +180,7 @@ test('top-level qualification confirms the current digest and creates a core-own
   }
 });
 
-test('top-level qualification supersedes and revokes confirmed constraints', () => {
+test('internal qualification supersedes and revokes confirmed constraints', () => {
   for (const operation of ['supersede', 'revoke'] as const) {
     const { repoRoot, taskMd } = fixture();
     try {

--- a/tests/unit/task/qualification-intents.test.ts
+++ b/tests/unit/task/qualification-intents.test.ts
@@ -6,7 +6,13 @@ import path from 'node:path';
 
 import { applyQualificationProposal } from '../../../lib/task/qualification-intents.ts';
 import { applyQualificationConfirmation } from '../../../lib/qualify.ts';
-import { parseQualificationConfirmations, parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
+import {
+  buildQualificationAudit,
+  parseQualificationConfirmations,
+  parseTaskQualification,
+  renderQualificationAudit,
+  validateQualificationAudit
+} from '../../../lib/task/qualification-audit.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
 const VERSION = 'v0.9.13-alpha.0';
@@ -152,9 +158,55 @@ test('top-level qualification confirms the current digest and creates a core-own
     if (confirmations.ok) {
       assert.equal(confirmations.confirmations[0]?.actor, 'human-declared');
       assert.equal(confirmations.confirmations[0]?.entrypoint, 'ai qualify');
-      assert.equal(confirmations.confirmations[0]?.approvedDigest, initial.qualification.constraintDigest);
+      const current = parseTaskQualification(content);
+      assert.equal(current.ok, true);
+      if (!current.ok) return;
+      assert.equal(confirmations.confirmations[0]?.approvedDigest, current.qualification.constraints[0]?.digest);
+      const audit = buildQualificationAudit(content);
+      assert.equal(audit.ok, true);
+      if (!audit.ok) return;
+      assert.equal(validateQualificationAudit(content, `## Qualification Audit\n\n${renderQualificationAudit(audit.audit)}`, { require: true }).ok, true);
+
+      const changed = content.replace('Keep the public writer', 'Keep the public writer exactly');
+      const changedAudit = buildQualificationAudit(changed);
+      assert.equal(changedAudit.ok, true);
+      if (!changedAudit.ok) return;
+      const stale = validateQualificationAudit(changed, `## Qualification Audit\n\n${renderQualificationAudit(changedAudit.audit)}`, { require: true });
+      assert.equal(stale.ok, false);
+      if (!stale.ok) assert.equal(stale.code, 'QUALIFICATION_CONFIRMATION_DIGEST_MISMATCH');
     }
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('top-level qualification supersedes and revokes confirmed constraints', () => {
+  for (const operation of ['supersede', 'revoke'] as const) {
+    const { repoRoot, taskMd } = fixture();
+    try {
+      const initial = parseTaskQualification(fs.readFileSync(taskMd, 'utf8'));
+      assert.equal(initial.ok, true);
+      if (!initial.ok) continue;
+      assert.equal(applyQualificationConfirmation({
+        taskRef: TASK_ID, constraintId: 'C-1', expectedDigest: initial.qualification.constraintDigest,
+        rationale: 'Confirm before transition.'
+      }, { repoRoot, metadataProvider: metadata }).status, 'applied');
+      const confirmed = parseTaskQualification(fs.readFileSync(taskMd, 'utf8'));
+      assert.equal(confirmed.ok, true);
+      if (!confirmed.ok) continue;
+      const request = {
+        taskRef: TASK_ID, constraintId: 'C-1', expectedDigest: confirmed.qualification.constraintDigest,
+        rationale: `${operation} obsolete confirmation.`, operation
+      };
+      assert.equal(applyQualificationConfirmation(request, { repoRoot, metadataProvider: metadata }).status, 'applied');
+      const changed = parseTaskQualification(fs.readFileSync(taskMd, 'utf8'));
+      assert.equal(changed.ok, true);
+      if (!changed.ok) continue;
+      assert.equal(changed.qualification.constraints[0]?.status, operation === 'supersede' ? 'superseded' : 'open');
+      assert.equal(changed.qualification.constraints[0]?.approvalEvidence, '');
+      assert.equal(applyQualificationConfirmation(request, { repoRoot, metadataProvider: metadata }).status, 'no-op');
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
   }
 });

--- a/tests/unit/task/qualification-intents.test.ts
+++ b/tests/unit/task/qualification-intents.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { applyQualificationProposal } from '../../../lib/task/qualification-intents.ts';
+import { applyQualificationConfirmation } from '../../../lib/qualify.ts';
+import { parseQualificationConfirmations, parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+const VERSION = 'v0.9.13-alpha.0';
+
+function taskContent(): string {
+  return `---
+id: ${TASK_ID}
+branch: agent-infra-feature-qualification
+status: active
+updated_at: 2026-01-01 00:00:00+00:00
+agent_infra_version: ${VERSION}
+---
+
+# 任务：资格审计
+
+## 任务输入
+
+### 约束
+
+| constraint_id | statement | status | authority | source | evidence | derived_from | approval_evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C-1 | Keep the public writer | derived | plan | plan.md | plan.md#scope |  |  |
+
+### 候选与否决方案
+
+| candidate_id | statement | status | constraint_ids | impact | evidence |
+| --- | --- | --- | --- | --- | --- |
+| A | Use the existing writer | pending | C-1 | Small | task.md#input |
+
+## 审查分歧账本
+
+| id | stage | round | severity | status | evidence |
+|----|-------|-------|----------|--------|----------|
+
+## 人工裁决
+
+## 实现输入
+
+| id | ledger_id | decision_evidence | stage | needs_implementation | decided_at | status | consumed_by |
+|----|-----------|-------------------|-------|----------------------|------------|--------|-------------|
+
+## 活动日志
+
+- 2026-01-01 00:00:00+00:00 — **Create Task** by codex — created
+`;
+}
+
+function fixture(): { repoRoot: string; taskMd: string } {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qualification-intents-'));
+  const taskDir = path.join(repoRoot, '.agents', 'workspace', 'active', TASK_ID);
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), taskContent());
+  return { repoRoot, taskMd: path.join(taskDir, 'task.md') };
+}
+
+function metadata() {
+  return { timestamp: '2026-01-01 01:00:00+00:00', agentInfraVersion: VERSION };
+}
+
+test('proposal writes only pending qualification data and is idempotent', () => {
+  const { repoRoot, taskMd } = fixture();
+  try {
+    const before = fs.readFileSync(taskMd, 'utf8');
+    const parsed = parseTaskQualification(before);
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    const request = {
+      taskRef: TASK_ID,
+      expectedTaskInputDigest: parsed.qualification.taskInputDigest,
+      constraints: [{
+        constraintId: 'C-2', statement: 'Use atomic writes', status: 'assumption' as const,
+        authority: 'model', source: 'analysis.md', evidence: 'analysis.md#risk', derivedFrom: [], approvalEvidence: ''
+      }],
+      candidates: [{
+        candidateId: 'B', statement: 'Add a second writer', status: 'pending' as const,
+        constraintIds: ['C-1'], impact: 'Larger change', evidence: 'analysis.md#options'
+      }]
+    };
+    const applied = applyQualificationProposal(request, { repoRoot, metadataProvider: metadata });
+    assert.equal(applied.status, 'applied');
+    const after = fs.readFileSync(taskMd, 'utf8');
+    const updated = parseTaskQualification(after);
+    assert.equal(updated.ok, true);
+    if (!updated.ok) return;
+    assert.equal(updated.qualification.constraints.some((row) => row.constraintId === 'C-2'), true);
+    assert.equal(updated.qualification.candidates.some((row) => row.candidateId === 'B'), true);
+
+    const repeated = applyQualificationProposal(request, { repoRoot, metadataProvider: metadata });
+    assert.equal(repeated.status, 'no-op');
+    assert.equal(repeated.changed, false);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('proposal rejects confirmation authority and stale digest without changing task.md', () => {
+  const { repoRoot, taskMd } = fixture();
+  try {
+    const before = fs.readFileSync(taskMd, 'utf8');
+    const rejected = applyQualificationProposal({
+      taskRef: TASK_ID,
+      expectedTaskInputDigest: 'a'.repeat(64),
+      constraints: [{
+        constraintId: 'C-2', statement: 'No', status: 'confirmed' as never,
+        authority: 'human-declared', source: 'user', evidence: 'user', derivedFrom: [], approvalEvidence: 'QCR-1'
+      }]
+    }, { repoRoot, metadataProvider: metadata });
+    assert.equal(rejected.status, 'failed');
+    assert.equal(rejected.error?.code, 'QUALIFICATION_PROPOSAL_INVALID');
+
+    const stale = applyQualificationProposal({
+      taskRef: TASK_ID,
+      expectedTaskInputDigest: 'b'.repeat(64),
+      constraints: [{
+        constraintId: 'C-2', statement: 'No', status: 'assumption' as const,
+        authority: 'model', source: 'user', evidence: 'user', derivedFrom: [], approvalEvidence: ''
+      }]
+    }, { repoRoot, metadataProvider: metadata });
+    assert.equal(stale.status, 'failed');
+    assert.equal(stale.error?.code, 'QUALIFICATION_DIGEST_CONFLICT');
+    assert.equal(fs.readFileSync(taskMd, 'utf8'), before);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('top-level qualification confirms the current digest and creates a core-owned QCR', () => {
+  const { repoRoot, taskMd } = fixture();
+  try {
+    const initial = parseTaskQualification(fs.readFileSync(taskMd, 'utf8'));
+    assert.equal(initial.ok, true);
+    if (!initial.ok) return;
+    const result = applyQualificationConfirmation({
+      taskRef: TASK_ID, constraintId: 'C-1', expectedDigest: initial.qualification.constraintDigest,
+      rationale: '人工确认该约束来源和语义。'
+    }, { repoRoot, metadataProvider: metadata });
+    assert.equal(result.status, 'applied');
+    assert.equal(result.qcrId, 'QCR-1');
+    const content = fs.readFileSync(taskMd, 'utf8');
+    assert.match(content, /\| C-1 \| Keep the public writer \| confirmed \| human-declared \| plan\.md \| plan\.md#scope \|  \| QCR-1 \|/);
+    const confirmations = parseQualificationConfirmations(content);
+    assert.equal(confirmations.ok, true);
+    if (confirmations.ok) {
+      assert.equal(confirmations.confirmations[0]?.actor, 'human-declared');
+      assert.equal(confirmations.confirmations[0]?.entrypoint, 'ai qualify');
+      assert.equal(confirmations.confirmations[0]?.approvedDigest, initial.qualification.constraintDigest);
+    }
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- establish canonical constraint, candidate, qualification audit, QCR, and invalidation contracts across analysis, planning, implementation, and review stages
- enforce current-only qualification recovery, started-input provenance, exact candidate projection, and receipt-backed artifact routing
- add controlled confirmation, supersession, and revocation through the internal `task-qualification` intent
- synchronize runtime rules, bilingual templates, lifecycle skills, and structural tests

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` — 2904 passed, 7 skipped, 0 failed

## Review

- code review round 5 approved checkpoint `fa961af8f33e99f6ee8f9b871e3610e926626508`
- 0 blockers, 0 major findings, 0 minor findings, 0 manual-validation items

Closes #968

Generated with AI assistance
