### PR TITLE
fix(sandbox): 移除沙箱终态对 workspace 目录可见性的依赖


### DIFF
--- a/.agents/skills/complete-task/SKILL.md
+++ b/.agents/skills/complete-task/SKILL.md
@@ -170,36 +170,19 @@ agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 
 `--force` 不能解除身份、并发、本地原子性或 required-PR hard gate；这些能力失败时必须停止。其余审查、人工校验和平台证据由 terminal verification 记录为 warning/pending，并通过后续重试恢复。
 
-### 6. 执行宿主 finalization 入口并验证终态
+### 6. 执行宿主 finalization 入口
 
 ```bash
 agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。`result=completed` 即表示 lifecycle 已安全完成；若还有外围 warning，返回 `result=completed_with_warnings`、warnings 和 pending steps。`result=failed` 或 `result=blocked` 仅用于硬失败或 receipt/capability 失败，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。
-
-```bash
-ls .agents/workspace/completed/{task-id}/task.md
-```
-
-仅在 finalization 返回 `status=completed` 后确认任务目录已成功移动。
+finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。`result=completed` 即表示宿主已依据结构化结果和 receipt 安全完成；若还有外围 warning，返回 `result=completed_with_warnings`、warnings 和 pending steps。`result=failed` 或 `result=blocked` 仅用于硬失败或 receipt/capability 失败，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。沙箱不得从旧挂载执行 `ls completed` 或本地终态校验来重新裁决该结果。
 
 ### 7. 处理 finalization 重试与结果
 
 场景 A 与场景 B `finalization-retry` 都从宿主执行同一个 `task-finalization` 入口。receipt 只是重入提示，不是 canonical truth：每次重入都要重新验证终态 task 评论和完成校验；只有任务已处于 `completed` 且短号 registry 已释放时，才可跳过不可逆的 lifecycle。不得拆开调用旧的 lifecycle、评论同步或完成校验命令。若 task 评论或校验因网络问题返回 `blocked`，保留 receipt 和已完成状态，修复网络后重跑 complete-task；若生命周期仍未完成，任务保持 active 并从 receipt 的待处理步骤继续。
 
-完成结果必须包含本次 finalization 的结构化输出，确认任务产物和同步状态符合规范：
-
-```bash
-agent-infra-internal task-verify {task-id} complete-task.completed --format text
-```
-
-处理结果：
-- `status=completed` / 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- `status=failed` / 退出码 1 -> 根据输出修复问题后重新运行 finalization
-- `status=blocked` / 退出码 2 -> 保留 receipt 与已完成的步骤并停止；稍后重跑 complete-task 进入 `finalization-retry`
-
-将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
+完成结果必须直接消费本次宿主 finalization 的结构化输出、receipt 和 warning projection。`completed` 或 `completed_with_warnings` 才允许继续；`failed` / `blocked` / `unknown` 必须保留 receipt 并停止，之后通过同一 finalization 入口重试。不要在沙箱旧挂载中另行运行 `ls completed` 或 `task-verify complete-task.completed`，也不要用其结果推翻宿主结果。
 
 ### accepted 后的 sandbox-control 结果恢复
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 import { VERSION } from '../lib/version.ts';
+import {
+  formatTaskViewDiagnostic,
+  guardTaskOperation,
+  TaskViewOperationError
+} from '../lib/internal/task-operation-registry.ts';
 
 // Node.js version check
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
@@ -53,6 +58,22 @@ const command = Object.hasOwn(COMMAND_ALIASES, rawCommand)
   ? COMMAND_ALIASES[rawCommand]
   : rawCommand;
 
+let taskViewGuardFailed = false;
+try {
+  const guard = guardTaskOperation('public', command ?? '', process.argv.slice(3));
+  if (guard.taskView && guard.descriptor.effect === 'diagnostic') {
+    process.stderr.write(formatTaskViewDiagnostic(guard.taskView));
+  }
+} catch (error) {
+  taskViewGuardFailed = true;
+  if (error instanceof TaskViewOperationError) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = error.exitCode;
+  } else {
+    throw error;
+  }
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -73,7 +94,7 @@ async function importCommand(importPath: string) {
   }
 }
 
-switch (command) {
+if (!taskViewGuardFailed) switch (command) {
   case 'agent-client': {
     const imported = await importCommand('../lib/agent-client.ts');
     if (!imported) break;

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,6 +5,7 @@ import {
   guardTaskOperation,
   TaskViewOperationError
 } from '../lib/internal/task-operation-registry.ts';
+import { PUBLIC_CLI_COMMAND_ALIASES } from '../lib/internal/cli-route-inventory.ts';
 
 // Node.js version check
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
@@ -48,14 +49,9 @@ Examples:
   npx @fitlab-ai/agent-infra init
 `;
 
-const COMMAND_ALIASES: Record<string, string> = {
-  s: 'sandbox',
-  t: 'task'
-};
-
 const rawCommand = process.argv[2] || '';
-const command = Object.hasOwn(COMMAND_ALIASES, rawCommand)
-  ? COMMAND_ALIASES[rawCommand]
+const command = Object.hasOwn(PUBLIC_CLI_COMMAND_ALIASES, rawCommand)
+  ? PUBLIC_CLI_COMMAND_ALIASES[rawCommand as keyof typeof PUBLIC_CLI_COMMAND_ALIASES]
   : rawCommand;
 
 let taskViewGuardFailed = false;

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -20,7 +20,7 @@ const USAGE = `agent-infra ${VERSION} - bootstrap AI collaboration infrastructur
 Usage: ai <command> [options]
 
 Commands:
-  agent-client    List, inspect, enable, disable, or configure Agent Clients
+  agent-client    List, status, enable, disable, or configure Agent Clients
   cp <ssh-alias>  Copy local clipboard image to a remote macOS clipboard or Linux sandbox over SSH
   data            Capture, verify, audit, repair, and export process data
   decide          Record a ruling; code-stage decisions require explicit implementation intent

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -5,6 +5,7 @@ import {
   guardTaskOperation,
   TaskViewOperationError
 } from '../lib/internal/task-operation-registry.ts';
+import { INTERNAL_CLI_ROUTE_SELECTORS } from '../lib/internal/cli-route-inventory.ts';
 
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
 if (major < 22 || (major === 22 && minor < 9)) {
@@ -15,6 +16,7 @@ if (major < 22 || (major === 22 && minor < 9)) {
 }
 
 const command = process.argv[2] || '';
+const internalRouteRegistered = Object.hasOwn(INTERNAL_CLI_ROUTE_SELECTORS, command);
 const taskControlCommand = command === 'task-lifecycle' || command === 'task-orchestration' || command === 'task-finalization';
 
 let taskViewGuardFailed = false;
@@ -82,7 +84,7 @@ if (!taskViewGuardFailed && taskControlCommand) {
       }
     }
   }
-} else if (!taskViewGuardFailed) switch (command) {
+} else if (!taskViewGuardFailed && internalRouteRegistered) switch (command) {
 
   case 'task-create': {
     const { taskCreate } = await import('../lib/internal/task-create.ts');

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -5,7 +5,7 @@ import {
   guardTaskOperation,
   TaskViewOperationError
 } from '../lib/internal/task-operation-registry.ts';
-import { INTERNAL_CLI_ROUTE_SELECTORS } from '../lib/internal/cli-route-inventory.ts';
+import { INTERNAL_HANDLER_ROUTE_SELECTORS } from '../lib/internal/cli-route-inventory.ts';
 
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
 if (major < 22 || (major === 22 && minor < 9)) {
@@ -16,7 +16,7 @@ if (major < 22 || (major === 22 && minor < 9)) {
 }
 
 const command = process.argv[2] || '';
-const internalRouteRegistered = Object.hasOwn(INTERNAL_CLI_ROUTE_SELECTORS, command);
+const internalRouteRegistered = Object.hasOwn(INTERNAL_HANDLER_ROUTE_SELECTORS, command);
 const taskControlCommand = command === 'task-lifecycle' || command === 'task-orchestration' || command === 'task-finalization';
 
 let taskViewGuardFailed = false;

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+import {
+  formatTaskViewDiagnostic,
+  guardTaskOperation,
+  TaskViewOperationError
+} from '../lib/internal/task-operation-registry.ts';
+
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
 if (major < 22 || (major === 22 && minor < 9)) {
   process.stderr.write(
@@ -11,6 +17,22 @@ if (major < 22 || (major === 22 && minor < 9)) {
 const command = process.argv[2] || '';
 const taskControlCommand = command === 'task-lifecycle' || command === 'task-orchestration' || command === 'task-finalization';
 
+let taskViewGuardFailed = false;
+try {
+  const guard = guardTaskOperation('internal', command, process.argv.slice(3));
+  if (guard.taskView && guard.descriptor.effect === 'diagnostic') {
+    process.stderr.write(formatTaskViewDiagnostic(guard.taskView));
+  }
+} catch (error) {
+  taskViewGuardFailed = true;
+  if (error instanceof TaskViewOperationError) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = error.exitCode;
+  } else {
+    throw error;
+  }
+}
+
 function taskControlTransportFailure(message: string): never {
   process.stdout.write(`${JSON.stringify({
     status: 'failed', changed: false,
@@ -19,7 +41,7 @@ function taskControlTransportFailure(message: string): never {
   process.exit(1);
 }
 
-if (taskControlCommand) {
+if (!taskViewGuardFailed && taskControlCommand) {
   const env = process.env;
   const executorMarked = Boolean(env.AGENT_INFRA_EXECUTOR_MANIFEST);
   const controlKeys = [
@@ -60,7 +82,7 @@ if (taskControlCommand) {
       }
     }
   }
-} else switch (command) {
+} else if (!taskViewGuardFailed) switch (command) {
 
   case 'task-create': {
     const { taskCreate } = await import('../lib/internal/task-create.ts');

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -158,7 +158,7 @@ If in-place recovery fails, the command stops before entering the container or s
 
 Tmpfs runtime data is deliberately ephemeral. Codex databases, logs, sessions, and other non-seeded files under `/home/devuser/.codex` cannot be recovered after tmpfs loss. Declared seed entries such as `config.toml` and `model-catalogs` are reconstructable from their read-only staging mounts; bind-mounted worktrees, credentials, shell configuration, and share directories remain host-persistent.
 
-`ai sandbox ls` keeps a compact view: it lists only the Containers table for the current project (the `#` row number, the `SHORT` task short id, names, status, workspace identity, full task ID, and branch). It no longer prints the worktree list or each tool's state paths. To inspect those details for one sandbox, use `ai sandbox show <branch | TASK-id | N>`: it prints the label-derived workspace identity, that branch's worktree path, and the per-tool state paths (Claude Code, Codex, Antigravity CLI, OpenCode). The argument follows the same contract as `ai sandbox exec` and `ai sandbox start`, so `ai sandbox show 11` resolves the active task short id via `.agents/workspace/active/.short-ids.json`.
+`ai sandbox ls` keeps a compact view: it lists the current project's Containers table (the `#` row number, the `SHORT` task short id, names, status, workspace identity, full task ID, and branch), followed by one health/task-view summary per container. To inspect full details for one sandbox, use `ai sandbox show <branch | TASK-id | N>`: it prints the label-derived workspace identity, that branch's worktree path, per-tool state paths (Claude Code, Codex, Antigravity CLI, OpenCode), broker health, and task-view details. The argument follows the same contract as `ai sandbox exec` and `ai sandbox start`, so `ai sandbox show 11` resolves the active task short id via `.agents/workspace/active/.short-ids.json`.
 
 Breaking migration for the next major version: task short ids now use bare digits only. Replace `#NN` with `NN`; quoted `#NN` input is rejected.
 
@@ -344,6 +344,25 @@ processing evidence and reservation remain for a later same-ID recovery. If a
 graceful shutdown observes a settled result, it attempts this same terminal
 publication before terminating the broker; an unsettled child keeps the
 accepted request in the unknown/retained-evidence path.
+
+### Health and task-view state
+
+`public/status.json` is version 3 and carries two independent dimensions:
+`state` describes broker health (`starting`, `healthy`, `busy`, or `parked`),
+while `taskView.state` describes task evidence (`not-applicable`, `current`,
+`finalized-stale`, or `unknown`). A healthy broker may therefore expose a
+`finalized-stale` task view. The task view is a validated projection of the
+canonical task source and finalization receipt, not a second completion
+authority. A completed view is read-only; a stale or unknown view allows
+diagnostics, explicit cleanup, and only matching original-request recovery,
+but rejects new task progress, artifact writes, terminal verdicts, and remote
+writes before task resolution or locking.
+
+Ordinary broker restart or `ai sandbox enter` does not clear stale state. A
+completed re-entry becomes `current` only after the canonical completed source,
+receipt identity, task ID, and container identity all match. `ai sandbox ls` and
+`ai sandbox show` print both health and task-view values so broker availability
+is not mistaken for task write authorization.
 
 ### Capacity and retention (HD-3/A)
 

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -150,7 +150,7 @@ v0.9.7 的父挂载加子挂载拓扑属于 legacy，与当前 per-state 拓扑�
 
 tmpfs runtime 数据本来就是临时数据。tmpfs 丢失后，`/home/devuser/.codex` 下的 Codex 数据库、日志、session 与其他未列入 seed 的文件无法恢复；`config.toml`、`model-catalogs` 等声明式 seed 可以从只读 staging mount 重建；bind mount 的 worktree、凭据、shell 配置与 share 目录继续由宿主持久化。
 
-`ai sandbox ls` 保持精简：只列出当前项目的 Containers 容器表（`#` 行号、`SHORT` 任务短号，以及名称、状态、workspace identity、完整 task ID 和分支），不再打印 worktree 列表和各工具的 state 路径。要查看某个沙箱的这些详情，使用 `ai sandbox show <branch | TASK-id | N>`：它会打印基于标签的 workspace identity、该分支的 worktree 路径和各工具（Claude Code、Codex、Antigravity CLI、OpenCode）的 state 路径。入参契约与 `ai sandbox exec`、`ai sandbox start` 一致，因此 `ai sandbox show 11` 会通过 `.agents/workspace/active/.short-ids.json` 解析当前任务短号。
+`ai sandbox ls` 保持精简：列出当前项目的 Containers 容器表（`#` 行号、`SHORT` 任务短号，以及名称、状态、workspace identity、完整 task ID 和分支），并在表后为每个容器显示 health/task-view 摘要。要查看某个沙箱的完整详情，使用 `ai sandbox show <branch | TASK-id | N>`：它会打印基于标签的 workspace identity、该分支的 worktree 路径、各工具（Claude Code、Codex、Antigravity CLI、OpenCode）的 state 路径、broker health 和 task-view。入参契约与 `ai sandbox exec`、`ai sandbox start` 一致，因此 `ai sandbox show 11` 会通过 `.agents/workspace/active/.short-ids.json` 解析当前任务短号。
 
 下一个大版本的破坏性迁移：任务短号仅使用裸数字。请把 `#NN` 改为 `NN`；引用后的 `#NN` 输入也会被拒绝。
 
@@ -292,6 +292,21 @@ family 有有效 result 时可以生成 output-unavailable terminal；finalizati
 缺失或绑定冲突时，不能落入 generic success terminal，processing evidence 和 reservation
 会保留，等待后续同 ID 恢复。graceful shutdown 如果观察到已 settled 的 result，会先按同一
 authority 尝试发布 terminal 再停止 broker；尚未 settled 的 child 则保留 accepted 和未知结果证据。
+
+### health 与 task-view 状态
+
+`public/status.json` 使用 version 3，并携带两个相互独立的维度：`state` 表示 broker health
+（`starting`、`healthy`、`busy` 或 `parked`），`taskView.state` 表示任务证据
+（`not-applicable`、`current`、`finalized-stale` 或 `unknown`）。因此 healthy broker
+可以同时拥有 `finalized-stale` task view。task view 是对 canonical task source 和
+finalization receipt 的经过验证的投影，不是第二个完成事实源。completed view 只读；stale
+或 unknown 允许诊断、显式清理以及仅匹配原 request 的 recovery，但会在解析任务或加锁前
+拒绝新的任务推进、artifact 写入、终态裁决和远端写入。
+
+普通 broker 重启或 `ai sandbox enter` 不会清除 stale。completed re-entry 只有在 canonical
+completed source、receipt identity、task ID 和 container identity 全部匹配后才会变成
+`current`。`ai sandbox ls` 与 `ai sandbox show` 会同时显示 health 和 task-view，避免把
+broker 可用性误认为任务写入授权。
 
 ### 容量与保留（HD-3/A）
 

--- a/lib/agent-client.ts
+++ b/lib/agent-client.ts
@@ -11,6 +11,9 @@ import { AGENT_CLIENT_IDS, isAgentClientId } from './agent-clients/types.ts';
 import type { AgentClientState } from './agent-clients/types.ts';
 import { closePrompt, multiSelect } from './prompt.ts';
 import { resolveTemplateDir } from './paths.ts';
+import { PUBLIC_CLI_ROUTE_SELECTORS } from './internal/cli-route-inventory.ts';
+
+const AGENT_CLIENT_OPERATIONS = PUBLIC_CLI_ROUTE_SELECTORS['agent-client'];
 
 const USAGE = `Usage: ai agent-client <operation>
 
@@ -106,6 +109,12 @@ async function cmdAgentClient(args: string[]): Promise<number> {
   if (!operation || operation === '--help' || operation === '-h' || operation === 'help') {
     process.stdout.write(USAGE);
     return 0;
+  }
+  if (!AGENT_CLIENT_OPERATIONS.includes(operation as typeof AGENT_CLIENT_OPERATIONS[number])) {
+    throw new AgentClientCommandError(
+      'AGENT_CLIENT_OPERATION_INVALID',
+      `Unknown operation '${operation}'`
+    );
   }
 
   if (operation === 'list') {

--- a/lib/internal/agent-client.ts
+++ b/lib/internal/agent-client.ts
@@ -9,7 +9,7 @@ import { normalizeCustomTUIs } from '../agent-clients/custom-tuis.ts';
 import { renderNextStepCommands } from '../agent-clients/next-steps.ts';
 import { getAgentClientModelSelection } from '../agent-clients/registry.ts';
 import { isAgentClientId } from '../agent-clients/types.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal agent-client <next-steps|model-selection> [options]\n';
 
@@ -36,7 +36,7 @@ function parseArgs(args: string[]): ParsedArgs | null {
     process.stdout.write(USAGE);
     return null;
   }
-  if (args[0] !== 'next-steps') {
+  if (!internalHandlerRoute('agent-client', 'next-steps', args[0] ?? '')) {
     failure('AGENT_CLIENT_PAYLOAD_INVALID', "operation must be 'next-steps'");
     return null;
   }
@@ -86,7 +86,7 @@ function parseArgs(args: string[]): ParsedArgs | null {
 
 function agentClient(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('agent-client', args)) return;
-  if (args[0] === 'model-selection') {
+  if (internalHandlerRoute('agent-client', 'model-selection', args[0] ?? '')) {
     const values: Record<string, string> = {};
     const seen = new Set<string>();
     for (let index = 1; index < args.length; index += 1) {

--- a/lib/internal/agent-client.ts
+++ b/lib/internal/agent-client.ts
@@ -9,6 +9,7 @@ import { normalizeCustomTUIs } from '../agent-clients/custom-tuis.ts';
 import { renderNextStepCommands } from '../agent-clients/next-steps.ts';
 import { getAgentClientModelSelection } from '../agent-clients/registry.ts';
 import { isAgentClientId } from '../agent-clients/types.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal agent-client <next-steps|model-selection> [options]\n';
 
@@ -84,6 +85,7 @@ function parseArgs(args: string[]): ParsedArgs | null {
 }
 
 function agentClient(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('agent-client', args)) return;
   if (args[0] === 'model-selection') {
     const values: Record<string, string> = {};
     const seen = new Set<string>();

--- a/lib/internal/cli-route-inventory.ts
+++ b/lib/internal/cli-route-inventory.ts
@@ -1,0 +1,63 @@
+export const PUBLIC_CLI_COMMAND_ALIASES = Object.freeze({
+  '': 'help',
+  s: 'sandbox',
+  t: 'task',
+  '--version': 'version',
+  '-v': 'version'
+} as const);
+
+export const PUBLIC_CLI_SELECTOR_ALIASES = Object.freeze({
+  task: Object.freeze({ d: 'decisions' })
+} as const);
+
+export const PUBLIC_CLI_ROUTE_SELECTORS = Object.freeze({
+  'agent-client': ['list', 'status', 'enable', 'disable', 'configure'],
+  cp: ['cp'],
+  data: ['capture', 'verify', 'audit', 'repair', 'export'],
+  decide: ['decide'],
+  help: ['help'],
+  init: ['init'],
+  merge: ['merge'],
+  run: ['create-task', 'task-skill', 'recreate'],
+  sandbox: ['create', 'exec', 'ls', 'show', 'prune', 'rebuild', 'refresh', 'rm', 'start', 'vm'],
+  server: ['start', 'stop', 'status', 'logs', '__daemon'],
+  task: ['cat', 'decisions', 'files', 'grep', 'issue-body', 'log', 'ls', 'show', 'status'],
+  sync: ['sync'],
+  update: ['update'],
+  version: ['version']
+} as const);
+
+export const INTERNAL_CLI_ROUTE_SELECTORS = Object.freeze({
+  'task-create': ['input'],
+  'sandbox-control': ['serve', 'execute', 'recover', 'client'],
+  'agent-client': ['next-steps', 'model-selection'],
+  'codex-lifecycle': ['preflight', 'capability-arm', 'hook-event', 'resolve-start', 'resolve-stop', 'consume'],
+  'codex-sandbox-controller': ['verify-context', 'run'],
+  'git-workflow': ['inspect', 'preview-tree', 'snapshot', 'compare-trees', 'commit', 'push-rebased'],
+  'task-delivery': ['deliver'],
+  'release-workflow': ['inspect', 'prepare', 'publish', 'post-prepare', 'post-publish'],
+  'platform-release-notes': ['context', 'stage', 'publish'],
+  'platform-context': ['resolve'],
+  'platform-comment': ['list', 'owner', 'backfill', 'sync'],
+  'platform-issue': ['inspect', 'create', 'bind', 'sync'],
+  'platform-pr': ['inspect', 'summary-context', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'change-report', 'summary-sync', 'sync-in-labels'],
+  'platform-pr-review': ['inspect', 'list', 'publish-pr', 'publish-task'],
+  'pr-review-grade': ['decide', 'resolve-host', 'verify-artifact'],
+  'platform-checks': ['inspect', 'watch', 'resolve-run', 'logs'],
+  'task-context': ['resolve'],
+  'task-ledger': ['decision-next-id', 'stage-status', 'finding-upsert', 'finding-respond', 'finding-review', 'decision-upsert', 'rework-intent-upsert'],
+  'task-warning': ['list', 'add', 'set-status'],
+  'task-activity': ['pr-review-inspect', 'pr-review-start', 'pr-review-complete', 'pr-review-terminate'],
+  'task-artifact': ['inspect', 'finalize-local'],
+  'task-orchestration': ['status', 'progress'],
+  'task-review': ['finalize-summary'],
+  'task-event': ['event'],
+  'task-invalidation': ['reconcile'],
+  'task-override': ['diagnose', 'issue', 'consume'],
+  'task-lifecycle': ['intent'],
+  'task-finalization': ['complete'],
+  'task-short-id': ['list', 'list-verify', 'alloc', 'release', 'resolve'],
+  'task-snapshot': ['snapshot'],
+  'task-verify': ['event'],
+  'task-validate': ['snapshot', 'inplace']
+} as const);

--- a/lib/internal/cli-route-inventory.ts
+++ b/lib/internal/cli-route-inventory.ts
@@ -112,6 +112,17 @@ export function isInternalHandlerRoute(command: string, args: readonly string[])
   return Boolean(selector && selectors?.some((candidate) => candidate === selector));
 }
 
+/**
+ * Marks a selector at the handler's actual dispatch branch.
+ *
+ * The call is intentionally side-effect free so the top-level task-view guard
+ * can still run before a handler module is imported. Route coverage tests read
+ * these branch markers independently from the pre-import inventory.
+ */
+export function internalHandlerRoute(command: string, selector: string, actualSelector: string): boolean {
+  return command.length > 0 && selector === actualSelector;
+}
+
 export function ensureInternalHandlerRoute(command: string, args: readonly string[]): boolean {
   if (isInternalHandlerRoute(command, args)) return true;
   const selector = internalRouteSelector(command, args);

--- a/lib/internal/cli-route-inventory.ts
+++ b/lib/internal/cli-route-inventory.ts
@@ -34,6 +34,7 @@ export const PUBLIC_CLI_ROUTE_SELECTORS = Object.freeze({
  */
 export const INTERNAL_HANDLER_ROUTE_SELECTORS = Object.freeze({
   'task-create': ['input'],
+  'task-qualification': ['proposal', 'confirm', 'supersede', 'revoke'],
   'sandbox-control': ['serve', 'execute', 'recover', 'client'],
   'agent-client': ['next-steps', 'model-selection'],
   'codex-lifecycle': ['preflight', 'capability-arm', 'hook-event', 'resolve-start', 'resolve-stop', 'consume'],
@@ -42,6 +43,8 @@ export const INTERNAL_HANDLER_ROUTE_SELECTORS = Object.freeze({
   'task-delivery': ['deliver'],
   'release-workflow': ['inspect', 'prepare', 'publish', 'post-prepare', 'post-publish'],
   'platform-release-notes': ['context', 'stage', 'publish'],
+  'platform-security': ['read', 'dismiss'],
+  'platform-metadata': ['init-labels', 'init-milestones'],
   'platform-context': ['resolve'],
   'platform-comment': ['list', 'owner', 'backfill', 'sync'],
   'platform-issue': ['inspect', 'create', 'bind', 'sync'],
@@ -83,6 +86,7 @@ function optionValue(args: readonly string[], name: string): string | undefined 
 export function internalRouteSelector(command: string, args: readonly string[]): string {
   if (command === 'sandbox-control') return first(args);
   if (command === 'task-create') return 'input';
+  if (command === 'task-qualification') return args[1] ?? '';
   if (command === 'task-lifecycle') return args[1] ? 'intent' : '';
   if (command === 'task-finalization') return args[1] === 'complete' ? 'complete' : '';
   if (command === 'task-event') return args[1] ? 'event' : '';

--- a/lib/internal/cli-route-inventory.ts
+++ b/lib/internal/cli-route-inventory.ts
@@ -27,7 +27,12 @@ export const PUBLIC_CLI_ROUTE_SELECTORS = Object.freeze({
   version: ['version']
 } as const);
 
-export const INTERNAL_CLI_ROUTE_SELECTORS = Object.freeze({
+/**
+ * The selector definitions consumed by every internal handler. Keep this
+ * module free of handler imports so the pre-import task-view guard remains
+ * effective.
+ */
+export const INTERNAL_HANDLER_ROUTE_SELECTORS = Object.freeze({
   'task-create': ['input'],
   'sandbox-control': ['serve', 'execute', 'recover', 'client'],
   'agent-client': ['next-steps', 'model-selection'],
@@ -61,3 +66,60 @@ export const INTERNAL_CLI_ROUTE_SELECTORS = Object.freeze({
   'task-verify': ['event'],
   'task-validate': ['snapshot', 'inplace']
 } as const);
+
+export const INTERNAL_CLI_ROUTE_SELECTORS = INTERNAL_HANDLER_ROUTE_SELECTORS;
+
+function first(args: readonly string[]): string {
+  return args[0] ?? '';
+}
+
+function optionValue(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${name}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+export function internalRouteSelector(command: string, args: readonly string[]): string {
+  if (command === 'sandbox-control') return first(args);
+  if (command === 'task-create') return 'input';
+  if (command === 'task-lifecycle') return args[1] ? 'intent' : '';
+  if (command === 'task-finalization') return args[1] === 'complete' ? 'complete' : '';
+  if (command === 'task-event') return args[1] ? 'event' : '';
+  if (command === 'task-verify') return args[0] && args[1] ? 'event' : '';
+  if (command === 'task-snapshot') return 'snapshot';
+  if (command === 'task-validate') return optionValue(args, '--scope') ?? 'snapshot';
+  if (command === 'task-short-id') return first(args) === 'list' && args.includes('--verify') ? 'list-verify' : first(args);
+  if (command === 'task-orchestration') return args[1] === 'status' ? 'status' : args[1] ? 'progress' : '';
+  if (command === 'task-review') return args[1] ?? '';
+  if (command === 'task-invalidation') return args[1] ?? '';
+  if (command === 'task-override') return args[1] ?? '';
+  if (command === 'task-artifact') return args[1] ?? '';
+  if (command === 'platform-pr-review' && first(args) === 'publish') {
+    const scope = optionValue(args, '--scope') ?? '';
+    return /^TASK-\d{8}-\d{6}$/u.test(scope) ? 'publish-task' : /^pr\d+$/u.test(scope) ? 'publish-pr' : '';
+  }
+  if (['task-ledger', 'task-warning', 'task-activity'].includes(command)) return args[1] ?? '';
+  if (command === 'task-delivery') return args[1] ?? '';
+  if (command === 'task-context') return first(args);
+  return first(args);
+}
+
+export function isInternalHandlerRoute(command: string, args: readonly string[]): boolean {
+  if (args[0] === '--help' || args[0] === '-h') return true;
+  const selector = internalRouteSelector(command, args);
+  const selectors = INTERNAL_HANDLER_ROUTE_SELECTORS[command as keyof typeof INTERNAL_HANDLER_ROUTE_SELECTORS];
+  return Boolean(selector && selectors?.some((candidate) => candidate === selector));
+}
+
+export function ensureInternalHandlerRoute(command: string, args: readonly string[]): boolean {
+  if (isInternalHandlerRoute(command, args)) return true;
+  const selector = internalRouteSelector(command, args);
+  process.stdout.write(`${JSON.stringify({
+    status: 'failed',
+    changed: false,
+    error: { code: 'INTERNAL_ROUTE_UNREGISTERED', message: `operation '${command} ${selector || first(args)}' is not registered` }
+  })}\n`);
+  process.exitCode = 1;
+  return false;
+}

--- a/lib/internal/codex-lifecycle.ts
+++ b/lib/internal/codex-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   sealCodexOrchestrationDelegation,
   sealCodexParentDelegation
 } from '../task/codex-orchestration.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal codex-lifecycle <capability-arm|hook-event|resolve-start|resolve-stop|preflight|consume> [options]\n';
 const MANAGED_AGENT = /^agent-infra-lifecycle-(executor|reviewer)$/;
@@ -162,6 +163,7 @@ function payloadText(payload: unknown, key: string): string {
 }
 
 async function codexLifecycle(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('codex-lifecycle', args)) return;
   const parsed = parse(args);
   if (!parsed || process.exitCode) return;
   try {

--- a/lib/internal/codex-lifecycle.ts
+++ b/lib/internal/codex-lifecycle.ts
@@ -22,7 +22,7 @@ import {
   sealCodexOrchestrationDelegation,
   sealCodexParentDelegation
 } from '../task/codex-orchestration.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal codex-lifecycle <capability-arm|hook-event|resolve-start|resolve-stop|preflight|consume> [options]\n';
 const MANAGED_AGENT = /^agent-infra-lifecycle-(executor|reviewer)$/;
@@ -167,7 +167,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
   const parsed = parse(args);
   if (!parsed || process.exitCode) return;
   try {
-    if (parsed.operation === 'preflight') {
+    if (internalHandlerRoute('codex-lifecycle', 'preflight', parsed.operation)) {
       const format = parsed.values['--format'] ?? 'json';
       if (!['text', 'json'].includes(format)) throw new Error("format must be 'text' or 'json'");
       const runtimeFields = [
@@ -190,7 +190,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
       return;
     }
 
-    if (parsed.operation === 'capability-arm') {
+    if (internalHandlerRoute('codex-lifecycle', 'capability-arm', parsed.operation)) {
       const taskId = parsed.values['--task-id'];
       if (!taskId) throw new Error('capability-arm requires --task-id');
       const resolved = resolveTaskRef(taskId, { repoRoot: process.cwd() });
@@ -213,7 +213,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
     }
 
     const store = createCodexLifecycleStore({ cliVersion: cliVersion() });
-    if (parsed.operation === 'hook-event') {
+    if (internalHandlerRoute('codex-lifecycle', 'hook-event', parsed.operation)) {
       const phase = parsed.values['--event'];
       if (!phase || !['pre-tool', 'subagent-start', 'post-tool', 'subagent-stop'].includes(phase)) {
         throw new Error('hook-event requires a known --event');
@@ -350,7 +350,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
 
     const childThreadId = parsed.values['--child-id'];
     if (!childThreadId) throw new Error(`operation '${parsed.operation}' requires --child-id`);
-    if (parsed.operation === 'resolve-start') {
+    if (internalHandlerRoute('codex-lifecycle', 'resolve-start', parsed.operation)) {
       if (store.read(childThreadId).state.spawn?.hookDefinitionHash !== hookDefinitionHash()) {
         throw new Error('Codex lifecycle hook definition hash is stale');
       }
@@ -362,7 +362,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
       if (latest.state.status !== 'start-ready') process.exitCode = 1;
       return;
     }
-    if (parsed.operation === 'resolve-stop') {
+    if (internalHandlerRoute('codex-lifecycle', 'resolve-stop', parsed.operation)) {
       const stopTurnId = store.read(childThreadId).state.stop?.turnId;
       if (!stopTurnId) throw new Error('Codex lifecycle stop hook is not available');
       const terminal = await resolveCodexTerminal(childThreadId, stopTurnId);
@@ -373,7 +373,7 @@ async function codexLifecycle(args: string[] = []): Promise<void> {
       output({ status: latest.state.status, changed: true, evidence: latest.state.stopEvidence, diagnostics: [], error: latest.state.error });
       return;
     }
-    if (parsed.operation === 'consume') {
+    if (internalHandlerRoute('codex-lifecycle', 'consume', parsed.operation)) {
       const consumer = parsed.values['--consumer'];
       if (!consumer) throw new Error('consume requires --consumer');
       const consumed = store.consume(childThreadId, consumer, hookDefinitionHash());

--- a/lib/internal/codex-sandbox-controller.ts
+++ b/lib/internal/codex-sandbox-controller.ts
@@ -2,7 +2,7 @@ import {
   runCodexSandboxController,
   verifyCodexSandboxControllerContextWithWarnings
 } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal codex-sandbox-controller <run|verify-context> [options]\n';
 
@@ -21,7 +21,10 @@ function parse(args: string[]): Readonly<{ operation: string; values: Readonly<R
     return null;
   }
   const operation = args[0];
-  if (!operation || !['run', 'verify-context'].includes(operation)) {
+  if (!operation || ![
+    internalHandlerRoute('codex-sandbox-controller', 'run', operation),
+    internalHandlerRoute('codex-sandbox-controller', 'verify-context', operation)
+  ].some(Boolean)) {
     process.stderr.write(USAGE);
     fail('CODEX_SANDBOX_CONTROLLER_PAYLOAD_INVALID', 'operation must be run or verify-context', 2);
     return null;
@@ -56,7 +59,7 @@ async function codexSandboxController(args: string[] = []): Promise<void> {
   const parsed = parse(args);
   if (!parsed || process.exitCode) return;
   try {
-    if (parsed.operation === 'verify-context') {
+    if (internalHandlerRoute('codex-sandbox-controller', 'verify-context', parsed.operation)) {
       const contextPath = parsed.values['--context']
         ?? process.env.AGENT_INFRA_CODEX_CONTROLLER_CONTEXT;
       if (!contextPath) throw new Error('CODEX_SANDBOX_CONTROLLER_CONTEXT_MISSING');

--- a/lib/internal/codex-sandbox-controller.ts
+++ b/lib/internal/codex-sandbox-controller.ts
@@ -2,6 +2,7 @@ import {
   runCodexSandboxController,
   verifyCodexSandboxControllerContextWithWarnings
 } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal codex-sandbox-controller <run|verify-context> [options]\n';
 
@@ -51,6 +52,7 @@ function parse(args: string[]): Readonly<{ operation: string; values: Readonly<R
 }
 
 async function codexSandboxController(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('codex-sandbox-controller', args)) return;
   const parsed = parse(args);
   if (!parsed || process.exitCode) return;
   try {

--- a/lib/internal/git-workflow.ts
+++ b/lib/internal/git-workflow.ts
@@ -3,10 +3,12 @@ import { inspectGitWorkflow, previewCommitTree, pushRebasedBranch } from '../git
 import { compareReviewTrees, snapshotReview } from '../git/review-snapshot.ts';
 import { resolvePostReviewGlobs } from '../task/review-fingerprint.ts';
 import { executeCommitOperation } from '../task/commit-operation.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 function output(value: unknown): void { process.stdout.write(`${JSON.stringify(value)}\n`); }
 
 function gitWorkflow(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('git-workflow', args)) return;
   const [action, ...rest] = args;
   const cwdIndex = rest.indexOf('--cwd');
   const cwd = cwdIndex >= 0 ? rest[cwdIndex + 1] : process.cwd();

--- a/lib/internal/git-workflow.ts
+++ b/lib/internal/git-workflow.ts
@@ -3,7 +3,7 @@ import { inspectGitWorkflow, previewCommitTree, pushRebasedBranch } from '../git
 import { compareReviewTrees, snapshotReview } from '../git/review-snapshot.ts';
 import { resolvePostReviewGlobs } from '../task/review-fingerprint.ts';
 import { executeCommitOperation } from '../task/commit-operation.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 function output(value: unknown): void { process.stdout.write(`${JSON.stringify(value)}\n`); }
 
@@ -13,32 +13,33 @@ function gitWorkflow(args: string[] = []): void {
   const cwdIndex = rest.indexOf('--cwd');
   const cwd = cwdIndex >= 0 ? rest[cwdIndex + 1] : process.cwd();
   let result;
-  if (action === 'inspect') {
+  if (internalHandlerRoute('git-workflow', 'inspect', action ?? '')) {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) as { remote?: string; refs?: string[] } : null;
     result = inspectGitWorkflow(cwd ?? process.cwd(), undefined, input?.remote && input.refs ? { remote: input.remote, refs: input.refs } : undefined);
   }
-  else if (action === 'commit') {
+  else if (internalHandlerRoute('git-workflow', 'commit', action ?? '')) {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
     result = input
       ? executeCommitOperation({ cwd: cwd ?? process.cwd(), ...input })
       : { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
-  } else if (action === 'push-rebased') {
+  } else if (internalHandlerRoute('git-workflow', 'push-rebased', action ?? '')) {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
     result = input ? pushRebasedBranch({ cwd: cwd ?? process.cwd(), ...input }) : { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
-  } else if (action === 'preview-tree') {
+  } else if (internalHandlerRoute('git-workflow', 'preview-tree', action ?? '')) {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
     result = input
       ? previewCommitTree({ cwd: cwd ?? process.cwd(), paths: input.paths, expectedHead: input.expectedHead })
       : { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
-  } else if (action === 'snapshot' || action === 'compare-trees') {
+  } else if (internalHandlerRoute('git-workflow', 'snapshot', action ?? '')
+    || internalHandlerRoute('git-workflow', 'compare-trees', action ?? '')) {
     const inputIndex = rest.indexOf('--input');
     const input = inputIndex >= 0 && rest[inputIndex + 1] ? JSON.parse(fs.readFileSync(rest[inputIndex + 1]!, 'utf8')) : null;
     if (!input) result = { status: 'failed', changed: false, error: { code: 'GIT_INPUT_REQUIRED', message: '--input JSON file is required' } };
-    else if (action === 'snapshot') result = { status: 'no-op', changed: false, snapshot: snapshotReview({ cwd: cwd ?? process.cwd(), mode: input.mode, baseline: input.baseline, diffBase: input.diffBase, globs: input.globs ?? resolvePostReviewGlobs({}, {}) }), error: null };
+    else if (internalHandlerRoute('git-workflow', 'snapshot', action ?? '')) result = { status: 'no-op', changed: false, snapshot: snapshotReview({ cwd: cwd ?? process.cwd(), mode: input.mode, baseline: input.baseline, diffBase: input.diffBase, globs: input.globs ?? resolvePostReviewGlobs({}, {}) }), error: null };
     else result = { status: 'no-op', changed: false, comparison: compareReviewTrees({ cwd: cwd ?? process.cwd(), expected: input.expected, actual: input.actual }), error: null };
   } else result = { status: 'failed', changed: false, error: { code: 'GIT_ACTION_INVALID', message: `Unknown git-workflow action '${action ?? ''}'` } };
   output(result);

--- a/lib/internal/platform-checks.ts
+++ b/lib/internal/platform-checks.ts
@@ -7,6 +7,7 @@ import {
   watchPullRequestReadiness
 } from '../platform/pr-checks.ts';
 import type { ChecksResult } from '../platform/pr-checks.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-checks inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-checks watch <task-ref> --interval-seconds <N> --deadline-seconds <N> [--cwd <path>]
@@ -53,6 +54,7 @@ function positive(value: string | undefined): number | null {
 }
 
 async function platformChecks(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-checks', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['inspect', 'watch', 'resolve-run', 'logs'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/platform-checks.ts
+++ b/lib/internal/platform-checks.ts
@@ -7,7 +7,7 @@ import {
   watchPullRequestReadiness
 } from '../platform/pr-checks.ts';
 import type { ChecksResult } from '../platform/pr-checks.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-checks inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-checks watch <task-ref> --interval-seconds <N> --deadline-seconds <N> [--cwd <path>]
@@ -57,7 +57,12 @@ async function platformChecks(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-checks', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'watch', 'resolve-run', 'logs'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || ![
+    internalHandlerRoute('platform-checks', 'inspect', operation),
+    internalHandlerRoute('platform-checks', 'watch', operation),
+    internalHandlerRoute('platform-checks', 'resolve-run', operation),
+    internalHandlerRoute('platform-checks', 'logs', operation)
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
   const taskRef = args[1];
   if (!taskRef || taskRef.startsWith('--')) { fail(`${operation} requires a task ref`); return; }
   const parsed = parse(args, 2);
@@ -72,19 +77,20 @@ async function platformChecks(args: string[] = []): Promise<void> {
   };
   const unexpected = Object.keys(values).find((name) => !allowed[operation]!.includes(name));
   if (unexpected) { fail(`${operation} does not accept --${unexpected}`); return; }
-  if (operation === 'inspect') { finish(await inspectPullRequestReadiness(taskRef, { cwd })); return; }
-  if (operation === 'resolve-run') {
+  if (internalHandlerRoute('platform-checks', 'inspect', operation)) { finish(await inspectPullRequestReadiness(taskRef, { cwd })); return; }
+  if (internalHandlerRoute('platform-checks', 'resolve-run', operation)) {
     if (!values.checkName) { fail('resolve-run requires --check-name'); return; }
     finish(await resolvePlatformCheckRun(taskRef, { cwd, checkName: values.checkName, detailsUrl: values.detailsUrl }));
     return;
   }
-  if (operation === 'logs') {
+  if (internalHandlerRoute('platform-checks', 'logs', operation)) {
     const run = positive(values.run);
     const job = values.job === undefined ? undefined : positive(values.job);
     if (!run || values.job !== undefined && !job) { fail('logs requires a positive --run and optional positive --job'); return; }
     finish(await fetchPlatformCheckLogs(taskRef, { cwd, run, job: job || undefined }));
     return;
   }
+  if (!internalHandlerRoute('platform-checks', 'watch', operation)) { fail('operation is not registered'); return; }
   const intervalSeconds = positive(values.intervalSeconds);
   const deadlineSeconds = positive(values.deadlineSeconds);
   if (!intervalSeconds || !deadlineSeconds) { fail('watch requires positive --interval-seconds and --deadline-seconds'); return; }

--- a/lib/internal/platform-comment.ts
+++ b/lib/internal/platform-comment.ts
@@ -10,6 +10,7 @@ import {
 import type { CommentKind } from '../platform/issue-comments.ts';
 import type { PlatformResult } from '../platform/types.ts';
 import { backfillCompletionComments } from '../platform/completion-backfill.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-comment list --issue <token> [--cwd <path>]
        agent-infra-internal platform-comment owner <task-ref> [--cwd <path>]
@@ -53,6 +54,7 @@ function readBodyFile(value: string, cwd: string): string {
 }
 
 async function platformComment(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-comment', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['list', 'owner', 'backfill', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/platform-comment.ts
+++ b/lib/internal/platform-comment.ts
@@ -10,7 +10,7 @@ import {
 import type { CommentKind } from '../platform/issue-comments.ts';
 import type { PlatformResult } from '../platform/types.ts';
 import { backfillCompletionComments } from '../platform/completion-backfill.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-comment list --issue <token> [--cwd <path>]
        agent-infra-internal platform-comment owner <task-ref> [--cwd <path>]
@@ -57,14 +57,19 @@ async function platformComment(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-comment', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['list', 'owner', 'backfill', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || ![
+    internalHandlerRoute('platform-comment', 'list', operation),
+    internalHandlerRoute('platform-comment', 'owner', operation),
+    internalHandlerRoute('platform-comment', 'backfill', operation),
+    internalHandlerRoute('platform-comment', 'sync', operation)
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
   const hasTaskRef = operation !== 'list';
   const taskRef = hasTaskRef ? args[1] : undefined;
   if (hasTaskRef && (!taskRef || taskRef.startsWith('--'))) { fail(`${operation} requires a task ref`); return; }
   const parsed = parseFlags(args, hasTaskRef ? 2 : 1);
   if (parsed.error) { fail(parsed.error); return; }
   const cwd = path.resolve(typeof parsed.values.cwd === 'string' ? parsed.values.cwd : process.cwd());
-  if (operation === 'list') {
+  if (internalHandlerRoute('platform-comment', 'list', operation)) {
     const issue = parsed.values.issue;
     if (typeof issue !== 'string' || !issue) { fail('list requires --issue <token>'); return; }
     const unexpected = Object.keys(parsed.values).find((key) => !['issue', 'cwd'].includes(key));
@@ -72,13 +77,13 @@ async function platformComment(args: string[] = []): Promise<void> {
     finish(await listPlatformComments(issue, cwd));
     return;
   }
-  if (operation === 'owner') {
+  if (internalHandlerRoute('platform-comment', 'owner', operation)) {
     const unexpected = Object.keys(parsed.values).find((key) => key !== 'cwd');
     if (unexpected) { fail(`owner does not accept '--${unexpected}'`); return; }
     finish(await checkPlatformCommentOwner(taskRef!, { cwd }));
     return;
   }
-  if (operation === 'backfill') {
+  if (internalHandlerRoute('platform-comment', 'backfill', operation)) {
     const unexpected = Object.keys(parsed.values).find((key) => !['cwd', 'agent'].includes(key));
     if (unexpected) { fail(`backfill does not accept '--${unexpected}'`); return; }
     const agent = parsed.values.agent;
@@ -88,6 +93,7 @@ async function platformComment(args: string[] = []): Promise<void> {
     finish(await backfillCompletionComments(taskRef!, { cwd, agent: normalizedAgent }));
     return;
   }
+  if (!internalHandlerRoute('platform-comment', 'sync', operation)) { fail('operation is not registered'); return; }
   const kind = parsed.values.kind;
   const agent = parsed.values.agent;
   if (!['task', 'artifact', 'summary', 'cancel'].includes(String(kind))) { fail('sync requires a valid --kind'); return; }

--- a/lib/internal/platform-context.ts
+++ b/lib/internal/platform-context.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import { resolvePlatformContext } from '../platform/context.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal platform-context resolve [--cwd <path>]\n';
 
@@ -14,7 +14,7 @@ function fail(message: string): void {
 async function platformContext(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-context', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
-  if (args[0] !== 'resolve') { fail("operation must be 'resolve'"); return; }
+  if (!internalHandlerRoute('platform-context', 'resolve', args[0] ?? '')) { fail("operation must be 'resolve'"); return; }
   let cwd = process.cwd();
   const seen = new Set<string>();
   for (let index = 1; index < args.length; index += 1) {

--- a/lib/internal/platform-context.ts
+++ b/lib/internal/platform-context.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { resolvePlatformContext } from '../platform/context.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal platform-context resolve [--cwd <path>]\n';
 
@@ -11,6 +12,7 @@ function fail(message: string): void {
 }
 
 async function platformContext(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-context', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args[0] !== 'resolve') { fail("operation must be 'resolve'"); return; }
   let cwd = process.cwd();

--- a/lib/internal/platform-issue.ts
+++ b/lib/internal/platform-issue.ts
@@ -8,7 +8,7 @@ import {
   syncPlatformIssue
 } from '../platform/issues.ts';
 import type { IssueResult } from '../platform/issues.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-issue inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-issue create <task-ref> --agent <agent> [--dry-run] [--cwd <path>]
@@ -64,7 +64,12 @@ async function platformIssue(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-issue', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'create', 'bind', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || ![
+    internalHandlerRoute('platform-issue', 'inspect', operation),
+    internalHandlerRoute('platform-issue', 'create', operation),
+    internalHandlerRoute('platform-issue', 'bind', operation),
+    internalHandlerRoute('platform-issue', 'sync', operation)
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
   const taskRef = args[1];
   if (!taskRef || taskRef.startsWith('--')) { fail(`${operation} requires a task ref`); return; }
   const parsed = parse(args, 2);
@@ -77,15 +82,15 @@ async function platformIssue(args: string[] = []): Promise<void> {
   };
   const unexpected = Object.keys(values).find((name) => !allowed[operation]!.includes(name));
   if (unexpected) { fail(`${operation} does not accept --${unexpected}`); return; }
-  if (operation === 'inspect') { finish(await inspectPlatformIssue(taskRef, { cwd })); return; }
+  if (internalHandlerRoute('platform-issue', 'inspect', operation)) { finish(await inspectPlatformIssue(taskRef, { cwd })); return; }
   if (typeof values.agent !== 'string' || !values.agent) { fail(`${operation} requires --agent`); return; }
   const agent = normalizeAgentToken(values.agent);
   if (!agent) { fail(`invalid --agent '${values.agent}': ${AGENT_USAGE_HINT}`); return; }
   values.agent = agent;
-  if (operation === 'create') {
+  if (internalHandlerRoute('platform-issue', 'create', operation)) {
     finish(await createPlatformIssue(taskRef, { cwd, agent: values.agent, dryRun: values.dryRun === true })); return;
   }
-  if (operation === 'bind') {
+  if (internalHandlerRoute('platform-issue', 'bind', operation)) {
     if (typeof values.issue !== 'string' || !values.issue) { fail('bind requires --issue <token>'); return; }
     finish(await bindPlatformIssue(taskRef, { cwd, agent: values.agent, issue: values.issue, dryRun: values.dryRun === true })); return;
   }

--- a/lib/internal/platform-issue.ts
+++ b/lib/internal/platform-issue.ts
@@ -8,6 +8,7 @@ import {
   syncPlatformIssue
 } from '../platform/issues.ts';
 import type { IssueResult } from '../platform/issues.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-issue inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-issue create <task-ref> --agent <agent> [--dry-run] [--cwd <path>]
@@ -60,6 +61,7 @@ function oneOf(values: Record<string, string | boolean>, name: string, allowed: 
 }
 
 async function platformIssue(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-issue', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['inspect', 'create', 'bind', 'sync'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/platform-metadata.ts
+++ b/lib/internal/platform-metadata.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { initializeLabels, initializeMilestones } from '../platform/repository-metadata.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-metadata init-labels [--cleanup-stale-in] [--cwd <path>]
        agent-infra-internal platform-metadata init-milestones [--history] [--cwd <path>]
@@ -46,8 +47,14 @@ function parseOptions(args: string[]): { cwd: string; cleanup: boolean; history:
 }
 
 async function platformMetadata(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-metadata', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const action = args[0];
+  if (!internalHandlerRoute('platform-metadata', 'init-labels', action ?? '')
+    && !internalHandlerRoute('platform-metadata', 'init-milestones', action ?? '')) {
+    fail('a valid operation is required');
+    return;
+  }
   if (action !== 'init-labels' && action !== 'init-milestones') { fail('a valid operation is required'); return; }
   const parsed = parseOptions(args.slice(1));
   if (!parsed) { fail('invalid metadata options'); return; }

--- a/lib/internal/platform-pr-review.ts
+++ b/lib/internal/platform-pr-review.ts
@@ -5,6 +5,7 @@ import { inspectPlatformPullRequestByNumber } from '../platform/pull-requests.ts
 import { listPrReviews, publishPrReview } from '../platform/pr-review.ts';
 import type { PrReviewEvent } from '../platform/pr-review.ts';
 import type { PlatformResult } from '../platform/types.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-pr-review inspect --pr <token> [--cwd <path>]
        agent-infra-internal platform-pr-review list --pr <token> [--cwd <path>]
@@ -51,6 +52,7 @@ function readBodyFile(value: string, cwd: string): string {
 }
 
 async function platformPrReview(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-pr-review', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['inspect', 'list', 'publish'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/platform-pr-review.ts
+++ b/lib/internal/platform-pr-review.ts
@@ -5,7 +5,7 @@ import { inspectPlatformPullRequestByNumber } from '../platform/pull-requests.ts
 import { listPrReviews, publishPrReview } from '../platform/pr-review.ts';
 import type { PrReviewEvent } from '../platform/pr-review.ts';
 import type { PlatformResult } from '../platform/types.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-pr-review inspect --pr <token> [--cwd <path>]
        agent-infra-internal platform-pr-review list --pr <token> [--cwd <path>]
@@ -55,7 +55,11 @@ async function platformPrReview(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-pr-review', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'list', 'publish'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || ![
+    internalHandlerRoute('platform-pr-review', 'inspect', operation),
+    internalHandlerRoute('platform-pr-review', 'list', operation),
+    operation === 'publish'
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
   const parsed = parse(args, 1);
   if (parsed.error) { fail(parsed.error); return; }
   const values = parsed.values;
@@ -69,19 +73,24 @@ async function platformPrReview(args: string[] = []): Promise<void> {
   if (unexpected) { fail(`${operation} does not accept --${unexpected}`); return; }
   const pr = values.pr;
   if (typeof pr !== 'string' || !pr) { fail(`${operation} requires --pr <token>`); return; }
-  if (operation === 'inspect') {
+  if (internalHandlerRoute('platform-pr-review', 'inspect', operation)) {
     finish(await inspectPlatformPullRequestByNumber(pr, { cwd }));
     return;
   }
-  if (operation === 'list') {
+  if (internalHandlerRoute('platform-pr-review', 'list', operation)) {
     finish(await listPrReviews(pr, { cwd }));
     return;
   }
   const scope = typeof values.scope === 'string' ? values.scope : '';
+  const publishSelector = /^TASK-\d{8}-\d{6}$/u.test(scope) ? 'publish-task' : /^pr\d+$/u.test(scope) ? 'publish-pr' : '';
   const round = Number(values.round);
   const commit = typeof values.commit === 'string' ? values.commit : '';
   const event = values.event as string;
   if (!scope || !/^(?:pr\d+|TASK-\d{8}-\d{6})$/.test(scope)) { fail('publish requires --scope <taskId|pr{N}>'); return; }
+  if (!internalHandlerRoute('platform-pr-review', 'publish-task', publishSelector)
+    && !internalHandlerRoute('platform-pr-review', 'publish-pr', publishSelector)) {
+    fail('publish scope is not registered'); return;
+  }
   if (!Number.isInteger(round) || round <= 0) { fail('publish requires a positive --round'); return; }
   if (!/^[0-9a-f]{7,40}$/i.test(commit)) { fail('publish requires --commit <sha>'); return; }
   if (!['COMMENT', 'APPROVE', 'REQUEST_CHANGES'].includes(event)) { fail('publish requires --event <COMMENT|APPROVE|REQUEST_CHANGES>'); return; }

--- a/lib/internal/platform-pr.ts
+++ b/lib/internal/platform-pr.ts
@@ -14,6 +14,7 @@ import {
 import type { PullRequestResult } from '../platform/pull-requests.ts';
 import { reportWrite, summaryContext, syncPullRequestSummary } from '../platform/pr-summary.ts';
 import type { PlatformResult } from '../platform/types.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-pr inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-pr resolve-external <task-ref> --agent <agent> [--pr <token>] [--dry-run] [--cwd <path>]
@@ -67,6 +68,7 @@ function readFile(value: string, cwd: string): string {
 }
 
 async function platformPr(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-pr', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'sync-in-labels', 'summary-context', 'change-report', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/platform-pr.ts
+++ b/lib/internal/platform-pr.ts
@@ -14,7 +14,7 @@ import {
 import type { PullRequestResult } from '../platform/pull-requests.ts';
 import { reportWrite, summaryContext, syncPullRequestSummary } from '../platform/pr-summary.ts';
 import type { PlatformResult } from '../platform/types.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-pr inspect <task-ref> [--cwd <path>]
        agent-infra-internal platform-pr resolve-external <task-ref> --agent <agent> [--pr <token>] [--dry-run] [--cwd <path>]
@@ -71,8 +71,19 @@ async function platformPr(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-pr', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['inspect', 'resolve-external', 'create', 'bind', 'skip', 'sync', 'sync-in-labels', 'summary-context', 'change-report', 'summary-sync'].includes(operation)) { fail('a valid operation is required'); return; }
-  if (operation === 'sync-in-labels') {
+  if (!operation || ![
+    internalHandlerRoute('platform-pr', 'inspect', operation),
+    internalHandlerRoute('platform-pr', 'resolve-external', operation),
+    internalHandlerRoute('platform-pr', 'create', operation),
+    internalHandlerRoute('platform-pr', 'bind', operation),
+    internalHandlerRoute('platform-pr', 'skip', operation),
+    internalHandlerRoute('platform-pr', 'sync', operation),
+    internalHandlerRoute('platform-pr', 'sync-in-labels', operation),
+    internalHandlerRoute('platform-pr', 'summary-context', operation),
+    internalHandlerRoute('platform-pr', 'change-report', operation),
+    internalHandlerRoute('platform-pr', 'summary-sync', operation)
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
+  if (internalHandlerRoute('platform-pr', 'sync-in-labels', operation)) {
     const parsed = parse(args, 1);
     if (parsed.error) { fail(parsed.error); return; }
     const values = parsed.values;
@@ -104,20 +115,20 @@ async function platformPr(args: string[] = []): Promise<void> {
   };
   const unexpected = Object.keys(values).find((name) => !allowed[operation]!.includes(name));
   if (unexpected) { fail(`${operation} does not accept --${unexpected}`); return; }
-  if (operation === 'inspect') { finish(await inspectPlatformPullRequest(taskRef, { cwd })); return; }
-  if (operation === 'summary-context') { finish(await summaryContext(taskRef, { cwd })); return; }
+  if (internalHandlerRoute('platform-pr', 'inspect', operation)) { finish(await inspectPlatformPullRequest(taskRef, { cwd })); return; }
+  if (internalHandlerRoute('platform-pr', 'summary-context', operation)) { finish(await summaryContext(taskRef, { cwd })); return; }
   if (typeof values.agent !== 'string' || !values.agent) { fail(`${operation} requires --agent`); return; }
   const agent = normalizeAgentToken(values.agent);
   if (!agent) { fail(`invalid --agent '${values.agent}': ${AGENT_USAGE_HINT}`); return; }
   values.agent = agent;
-  if (operation === 'change-report') {
+  if (internalHandlerRoute('platform-pr', 'change-report', operation)) {
     if (typeof values.mechanicalFile !== 'string' || typeof values.precheckFile !== 'string') { fail('change-report requires --mechanical-file and --precheck-file'); return; }
     finish(await reportWrite(taskRef, {
       cwd, agent: values.agent, mechanicalFile: values.mechanicalFile, precheckFile: values.precheckFile, dryRun: values.dryRun === true
     }));
     return;
   }
-  if (operation === 'skip') {
+  if (internalHandlerRoute('platform-pr', 'skip', operation)) {
     finish(await skipPlatformPullRequestFact(taskRef, { cwd, agent, dryRun: values.dryRun === true }));
     return;
   }
@@ -126,25 +137,25 @@ async function platformPr(args: string[] = []): Promise<void> {
     fail('--result must be pr_created, pr_reused, or no_op');
     return;
   }
-  if (operation === 'resolve-external') {
+  if (internalHandlerRoute('platform-pr', 'resolve-external', operation)) {
     const pr = values.pr === undefined ? undefined : values.pr;
     if (pr !== undefined && (typeof pr !== 'string' || !pr)) { fail('resolve-external requires --pr <token>'); return; }
     finish(await resolveExternalPullRequest(taskRef, { cwd, agent: values.agent, pr, dryRun: values.dryRun === true }));
     return;
   }
-  if (operation === 'bind') {
+  if (internalHandlerRoute('platform-pr', 'bind', operation)) {
     const pr = values.pr;
     if (typeof pr !== 'string' || !pr) { fail('bind requires --pr <token>'); return; }
     finish(await bindPlatformPullRequest(taskRef, { cwd, agent: values.agent, pr, dryRun: values.dryRun === true }));
     return;
   }
-  if (operation === 'sync') {
+  if (internalHandlerRoute('platform-pr', 'sync', operation)) {
     if (values.metadata !== true && values.closingIssue !== true) { fail('sync requires --metadata or --closing-issue'); return; }
     if (!primaryResult) { fail('sync requires --result pr_created, pr_reused, or no_op'); return; }
     finish(await syncPlatformPullRequest(taskRef, { cwd, agent: values.agent, metadata: values.metadata === true, closingIssue: values.closingIssue === true, primaryResult: primaryResult as 'pr_created' | 'pr_reused' | 'no_op', dryRun: values.dryRun === true }));
     return;
   }
-  if (operation === 'summary-sync') {
+  if (internalHandlerRoute('platform-pr', 'summary-sync', operation)) {
     if (typeof values.bodyFile !== 'string') { fail('summary-sync requires --body-file'); return; }
     if (typeof values.changeReportFile !== 'string') { fail('summary-sync requires --change-report-file'); return; }
     if (!primaryResult) { fail('summary-sync requires --result pr_created, pr_reused, or no_op'); return; }

--- a/lib/internal/platform-release-notes.ts
+++ b/lib/internal/platform-release-notes.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { publishReleaseNotes, releaseNoteContext, stageReleaseNotes } from '../platform/release-notes.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 type ParsedOptions = Readonly<{ values: ReadonlyMap<string, string>; switches: ReadonlySet<string> }>;
 
@@ -40,7 +40,7 @@ function finish(result: { status: string; [key: string]: unknown }): void {
 async function platformReleaseNotes(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('platform-release-notes', args)) return;
   const [action, ...rest] = args;
-  if (action === 'context') {
+  if (internalHandlerRoute('platform-release-notes', 'context', action ?? '')) {
     const parsed = parseOptions(rest, ['--cwd', '--history-limit', '--from-tag', '--to-tag', '--branch']);
     if (!parsed) return finish(invalidInput('invalid context options'));
     const cwd = path.resolve(parsed.values.get('--cwd') || process.cwd());
@@ -53,7 +53,7 @@ async function platformReleaseNotes(args: string[] = []): Promise<void> {
     }, { cwd }));
     return;
   }
-  if (action === 'stage') {
+  if (internalHandlerRoute('platform-release-notes', 'stage', action ?? '')) {
     const parsed = parseOptions(rest, ['--cwd', '--notes-file']);
     if (!parsed) return finish(invalidInput('invalid stage options'));
     const notesFile = parsed.values.get('--notes-file');
@@ -64,7 +64,7 @@ async function platformReleaseNotes(args: string[] = []): Promise<void> {
     ));
     return;
   }
-  if (action === 'publish') {
+  if (internalHandlerRoute('platform-release-notes', 'publish', action ?? '')) {
     const parsed = parseOptions(
       rest,
       ['--cwd', '--notes-file', '--tag', '--title', '--expected-sha256'],

--- a/lib/internal/platform-release-notes.ts
+++ b/lib/internal/platform-release-notes.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { publishReleaseNotes, releaseNoteContext, stageReleaseNotes } from '../platform/release-notes.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 type ParsedOptions = Readonly<{ values: ReadonlyMap<string, string>; switches: ReadonlySet<string> }>;
 
@@ -37,6 +38,7 @@ function finish(result: { status: string; [key: string]: unknown }): void {
 }
 
 async function platformReleaseNotes(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-release-notes', args)) return;
   const [action, ...rest] = args;
   if (action === 'context') {
     const parsed = parseOptions(rest, ['--cwd', '--history-limit', '--from-tag', '--to-tag', '--branch']);

--- a/lib/internal/platform-security.ts
+++ b/lib/internal/platform-security.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { dismissSecurityAlert, readCommentFile, readSecurityAlert } from '../platform/security-alerts.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal platform-security read --kind <dependabot|code-scanning> --number <number> [--cwd <path>]
        agent-infra-internal platform-security dismiss --kind <dependabot|code-scanning> --number <number> --reason <reason> --comment-file <path> [--cwd <path>]
@@ -38,8 +39,14 @@ function required(values: Map<string, string>, flag: string): string | null {
 }
 
 async function platformSecurity(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('platform-security', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const action = args[0];
+  if (!internalHandlerRoute('platform-security', 'read', action ?? '')
+    && !internalHandlerRoute('platform-security', 'dismiss', action ?? '')) {
+    fail('a valid operation is required');
+    return;
+  }
   if (action !== 'read' && action !== 'dismiss') { fail('a valid operation is required'); return; }
   const parsed = parseOptions(args.slice(1));
   if (!parsed) { fail('invalid security alert options'); return; }

--- a/lib/internal/pr-review-grade.ts
+++ b/lib/internal/pr-review-grade.ts
@@ -11,7 +11,7 @@ import {
 import type { DecisionRecord, HostResolution } from '../pr-review/evidence-grading.ts';
 import { inspectPlatformPullRequestByNumber } from '../platform/pull-requests.ts';
 import { verifyInProcess } from '../task/verification-engine.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal pr-review-grade decide --input-file <path|-> [--cwd <path>]
        agent-infra-internal pr-review-grade resolve-host --pr <token> [--cwd <path>]
@@ -54,7 +54,11 @@ async function prReviewGrade(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('pr-review-grade', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['decide', 'resolve-host', 'verify-artifact'].includes(operation)) { fail('a valid operation is required'); return; }
+  if (!operation || ![
+    internalHandlerRoute('pr-review-grade', 'decide', operation),
+    internalHandlerRoute('pr-review-grade', 'resolve-host', operation),
+    internalHandlerRoute('pr-review-grade', 'verify-artifact', operation)
+  ].some(Boolean)) { fail('a valid operation is required'); return; }
   const parsed = parseFlags(args, 1);
   if (parsed.error) { fail(parsed.error); return; }
   const values = parsed.values;
@@ -67,7 +71,7 @@ async function prReviewGrade(args: string[] = []): Promise<void> {
   const unexpected = Object.keys(values).find((key) => !allowed[operation]!.includes(key));
   if (unexpected) { fail(`${operation} does not accept '--${unexpected}'`); return; }
 
-  if (operation === 'decide') {
+  if (internalHandlerRoute('pr-review-grade', 'decide', operation)) {
     if (typeof values.inputFile !== 'string') { fail('decide requires --input-file'); return; }
     let input: unknown;
     try {
@@ -86,7 +90,7 @@ async function prReviewGrade(args: string[] = []): Promise<void> {
     return;
   }
 
-  if (operation === 'resolve-host') {
+  if (internalHandlerRoute('pr-review-grade', 'resolve-host', operation)) {
     const pr = typeof values.pr === 'string' ? values.pr : '';
     if (!pr) { fail('resolve-host requires --pr <token>'); return; }
     const inspected = await inspectPlatformPullRequestByNumber(pr, { cwd });
@@ -111,6 +115,7 @@ async function prReviewGrade(args: string[] = []): Promise<void> {
     return;
   }
 
+  if (!internalHandlerRoute('pr-review-grade', 'verify-artifact', operation)) { fail('operation is not registered'); return; }
   if (typeof values.artifactFile !== 'string') { fail('verify-artifact requires --artifact-file'); return; }
   const artifactPath = path.resolve(cwd, values.artifactFile);
   let result: Record<string, unknown>;

--- a/lib/internal/pr-review-grade.ts
+++ b/lib/internal/pr-review-grade.ts
@@ -11,6 +11,7 @@ import {
 import type { DecisionRecord, HostResolution } from '../pr-review/evidence-grading.ts';
 import { inspectPlatformPullRequestByNumber } from '../platform/pull-requests.ts';
 import { verifyInProcess } from '../task/verification-engine.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal pr-review-grade decide --input-file <path|-> [--cwd <path>]
        agent-infra-internal pr-review-grade resolve-host --pr <token> [--cwd <path>]
@@ -50,6 +51,7 @@ function readInput(value: string, cwd: string): string {
 }
 
 async function prReviewGrade(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('pr-review-grade', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['decide', 'resolve-host', 'verify-artifact'].includes(operation)) { fail('a valid operation is required'); return; }

--- a/lib/internal/release-workflow.ts
+++ b/lib/internal/release-workflow.ts
@@ -9,7 +9,7 @@ import { inspectPlatformRelease, reconcileReleaseMilestones } from '../platform/
 import { inspectHomebrewChannel, inspectNpmChannel } from '../release/channels.ts';
 import { releaseSnapshot } from '../release/workflow.ts';
 import type { PostReleaseFacts, ReleaseFacts } from '../release/workflow.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 function command(cwd: string, executable: string, args: string[]) {
   return spawnSync(executable, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
@@ -313,18 +313,24 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
   const version = String(rawVersion || '').replace(/^v/, '');
   const cwdIndex = rest.indexOf('--cwd');
   const cwd = path.resolve(cwdIndex >= 0 && rest[cwdIndex + 1] ? rest[cwdIndex + 1]! : process.cwd());
-  if (!['inspect', 'prepare', 'publish', 'post-prepare', 'post-publish'].includes(action || '') || !semver.valid(version)) {
+  if (![
+    internalHandlerRoute('release-workflow', 'inspect', action || ''),
+    internalHandlerRoute('release-workflow', 'prepare', action || ''),
+    internalHandlerRoute('release-workflow', 'publish', action || ''),
+    internalHandlerRoute('release-workflow', 'post-prepare', action || ''),
+    internalHandlerRoute('release-workflow', 'post-publish', action || '')
+  ].some(Boolean) || !semver.valid(version)) {
     process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'RELEASE_INPUT_INVALID', message: 'Usage: release-workflow inspect|prepare|publish|post-prepare|post-publish <version>' } })}\n`);
     process.exitCode = 1; return;
   }
   if (!ensureInternalHandlerRoute('release-workflow', args)) return;
   const before = releaseSnapshot(version, await inspectFacts(cwd, version));
-  if (action === 'inspect') { process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`); return; }
+  if (internalHandlerRoute('release-workflow', 'inspect', action || '')) { process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`); return; }
   if (before.facts.localTagConflict) {
     process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'GIT_TAG_CONFLICT', message: `Tag v${version} is not reachable from HEAD` } })}\n`);
     process.exitCode = 1; return;
   }
-  if (action === 'prepare') {
+  if (internalHandlerRoute('release-workflow', 'prepare', action || '')) {
     if (before.phase !== 'unprepared') {
       const milestones = await reconcileReleaseMilestones(version, { cwd });
       process.stdout.write(`${JSON.stringify({ ...milestones, snapshot: before })}\n`);
@@ -354,14 +360,14 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
     process.stdout.write(`${JSON.stringify({ status, changed: true, snapshot, operations: milestones?.operations ?? [], error: tagged.status !== 0 ? { code: 'GIT_TAG_FAILED', message: String(tagged.stderr) } : milestones?.error ?? null })}\n`);
     process.exitCode = failed ? 1 : blocked ? 2 : 0; return;
   }
-  if (action === 'publish') {
+  if (internalHandlerRoute('release-workflow', 'publish', action || '')) {
     if (!before.facts.localTag || !['prepared', 'partially-published'].includes(before.phase)) { process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'RELEASE_PHASE_INVALID', message: `Cannot publish from ${before.phase}` } })}\n`); process.exitCode = 1; return; }
     const branch = git(cwd, ['branch', '--show-current']) || '';
     const refs = [...(!before.facts.remoteBranch ? [branch] : []), ...(!before.facts.remoteTag ? [`refs/tags/v${version}`] : [])];
     const result = pushGitRefs({ cwd, remote: 'origin', refs });
     process.stdout.write(`${JSON.stringify({ ...result, snapshot: releaseSnapshot(version, await inspectFacts(cwd, version)) })}\n`); process.exitCode = result.status === 'failed' ? 1 : result.status === 'degraded' ? 2 : 0; return;
   }
-  if (action === 'post-publish') {
+  if (internalHandlerRoute('release-workflow', 'post-publish', action || '')) {
     const expectedValues = optionValues(rest, '--expected-sha256');
     if (expectedValues.length !== 1 || !/^sha256:[0-9a-f]{64}$/.test(expectedValues[0]!)) {
       process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'RELEASE_INPUT_INVALID', message: 'post-publish requires one --expected-sha256 sha256:<64 hex>' } })}\n`);
@@ -396,6 +402,10 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
     process.exitCode = blocked ? 2 : 1; return;
   }
 
+  if (!internalHandlerRoute('release-workflow', 'post-prepare', action || '')) {
+    process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, snapshot: before, error: { code: 'RELEASE_INPUT_INVALID', message: 'release-workflow action is not registered' } })}\n`);
+    process.exitCode = 1; return;
+  }
   if (before.phase === 'complete') {
     process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`);
     return;

--- a/lib/internal/release-workflow.ts
+++ b/lib/internal/release-workflow.ts
@@ -9,6 +9,7 @@ import { inspectPlatformRelease, reconcileReleaseMilestones } from '../platform/
 import { inspectHomebrewChannel, inspectNpmChannel } from '../release/channels.ts';
 import { releaseSnapshot } from '../release/workflow.ts';
 import type { PostReleaseFacts, ReleaseFacts } from '../release/workflow.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 function command(cwd: string, executable: string, args: string[]) {
   return spawnSync(executable, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
@@ -316,6 +317,7 @@ async function releaseWorkflow(args: string[] = []): Promise<void> {
     process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'RELEASE_INPUT_INVALID', message: 'Usage: release-workflow inspect|prepare|publish|post-prepare|post-publish <version>' } })}\n`);
     process.exitCode = 1; return;
   }
+  if (!ensureInternalHandlerRoute('release-workflow', args)) return;
   const before = releaseSnapshot(version, await inspectFacts(cwd, version));
   if (action === 'inspect') { process.stdout.write(`${JSON.stringify({ status: 'no-op', changed: false, snapshot: before, error: null })}\n`); return; }
   if (before.facts.localTagConflict) {

--- a/lib/internal/sandbox-control.ts
+++ b/lib/internal/sandbox-control.ts
@@ -12,7 +12,7 @@ import {
   controllerProofFromContext,
   verifyCodexSandboxControllerContextWithWarnings
 } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 function isCanonicalCodexPrepare(args: readonly string[]): boolean {
   if (args[1] !== 'prepare') return false;
@@ -90,7 +90,7 @@ function sandboxFinalizationClient(args: string[]): void {
 async function sandboxControl(args: string[]): Promise<void> {
   if (!ensureInternalHandlerRoute('sandbox-control', args)) return;
   const [operation, ...rest] = args;
-  if (operation === 'serve') {
+  if (internalHandlerRoute('sandbox-control', 'serve', operation ?? '')) {
     const manifestIndex = rest.indexOf('--manifest');
     const manifest = manifestIndex >= 0 ? rest[manifestIndex + 1] : undefined;
     if (!manifest) throw new Error('sandbox-control serve requires --manifest');
@@ -106,7 +106,7 @@ async function sandboxControl(args: string[]): Promise<void> {
     }
     return;
   }
-  if (operation === 'execute') {
+  if (internalHandlerRoute('sandbox-control', 'execute', operation ?? '')) {
     const requestIndex = rest.indexOf('--request');
     const nonceIndex = rest.indexOf('--nonce');
     const request = requestIndex >= 0 ? rest[requestIndex + 1] : undefined;
@@ -115,7 +115,7 @@ async function sandboxControl(args: string[]): Promise<void> {
     await runSandboxControlExecutor(request, nonce);
     return;
   }
-  if (operation === 'recover') {
+  if (internalHandlerRoute('sandbox-control', 'recover', operation ?? '')) {
     if (rest.length !== 1 || !rest[0]) throw new Error('sandbox-control recover requires <request-id>');
     let response;
     try {
@@ -133,7 +133,7 @@ async function sandboxControl(args: string[]): Promise<void> {
       : response.exitCode ?? 1;
     return;
   }
-  if (operation === 'client') {
+  if (internalHandlerRoute('sandbox-control', 'client', operation ?? '')) {
     const [family = '', ...commandArgs] = rest;
     if (family === 'task-finalization') {
       sandboxFinalizationClient(commandArgs);

--- a/lib/internal/sandbox-control.ts
+++ b/lib/internal/sandbox-control.ts
@@ -12,6 +12,7 @@ import {
   controllerProofFromContext,
   verifyCodexSandboxControllerContextWithWarnings
 } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 function isCanonicalCodexPrepare(args: readonly string[]): boolean {
   if (args[1] !== 'prepare') return false;
@@ -87,6 +88,7 @@ function sandboxFinalizationClient(args: string[]): void {
 }
 
 async function sandboxControl(args: string[]): Promise<void> {
+  if (!ensureInternalHandlerRoute('sandbox-control', args)) return;
   const [operation, ...rest] = args;
   if (operation === 'serve') {
     const manifestIndex = rest.indexOf('--manifest');

--- a/lib/internal/task-activity.ts
+++ b/lib/internal/task-activity.ts
@@ -9,7 +9,7 @@ import type {
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-activity <task-ref> pr-review-inspect
        agent-infra-internal task-activity <task-ref> pr-review-start --agent <agent> --artifact <canonical.md> --head <40hex> [--dry-run]
@@ -48,7 +48,13 @@ async function taskActivity(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-activity', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
-  if (!taskRef || taskRef.startsWith('--') || !kind || !OPERATIONS.has(kind)) {
+  if (!taskRef || taskRef.startsWith('--') || !kind || !OPERATIONS.has(kind)
+    || ![
+      internalHandlerRoute('task-activity', 'pr-review-inspect', kind),
+      internalHandlerRoute('task-activity', 'pr-review-start', kind),
+      internalHandlerRoute('task-activity', 'pr-review-complete', kind),
+      internalHandlerRoute('task-activity', 'pr-review-terminate', kind)
+    ].some(Boolean)) {
     usageFailure('task ref and a supported PR review intent are required');
     return;
   }
@@ -74,7 +80,7 @@ async function taskActivity(args: string[] = []): Promise<void> {
   const allowed = ALLOWED[kind]!;
   const unexpected = Object.keys(values).find((key) => !allowed.has(key));
   if (unexpected) { usageFailure(`${kind} does not accept '${unexpected}'`); return; }
-  if (kind === 'pr-review-inspect') {
+  if (internalHandlerRoute('task-activity', 'pr-review-inspect', kind)) {
     const result = inspectPrReviewActivity(values as PrReviewInspectIntent);
     process.stdout.write(`${JSON.stringify(result)}\n`);
     if (result.status === 'failed') process.exitCode = 1;
@@ -83,9 +89,9 @@ async function taskActivity(args: string[] = []): Promise<void> {
   for (const key of COMMON) {
     if (values[key] === undefined) { usageFailure(`${kind} requires '${key}'`); return; }
   }
-  const operationRequired = kind === 'pr-review-complete'
+  const operationRequired = internalHandlerRoute('task-activity', 'pr-review-complete', kind)
     ? ['verdict', 'blockers', 'major', 'minor']
-    : kind === 'pr-review-terminate' ? ['outcome', 'reason'] : [];
+    : internalHandlerRoute('task-activity', 'pr-review-terminate', kind) ? ['outcome', 'reason'] : [];
   for (const key of operationRequired) {
     if (values[key] === undefined) { usageFailure(`${kind} requires '${key}'`); return; }
   }

--- a/lib/internal/task-activity.ts
+++ b/lib/internal/task-activity.ts
@@ -9,6 +9,7 @@ import type {
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-activity <task-ref> pr-review-inspect
        agent-infra-internal task-activity <task-ref> pr-review-start --agent <agent> --artifact <canonical.md> --head <40hex> [--dry-run]
@@ -44,6 +45,7 @@ function usageFailure(message: string): void {
 }
 
 async function taskActivity(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-activity', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
   if (!taskRef || taskRef.startsWith('--') || !kind || !OPERATIONS.has(kind)) {

--- a/lib/internal/task-artifact.ts
+++ b/lib/internal/task-artifact.ts
@@ -3,7 +3,7 @@ import { finalizeLocalArtifact } from '../task/local-artifact-finalization.ts';
 import type { LocalArtifactFamily } from '../task/local-artifact-finalization.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { loadVerificationConfig } from '../task/verification-config.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan|code> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan/code artifact without changing task state.\n`;
 
@@ -18,7 +18,8 @@ function taskArtifact(args: string[] = []): void {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args.length < 2) { failUsage('task ref and operation are required'); return; }
   const operation = args[1];
-  if (operation !== 'inspect' && operation !== 'finalize-local') { failUsage(`unknown operation '${operation}'`); return; }
+  if (!internalHandlerRoute('task-artifact', 'inspect', operation ?? '')
+    && !internalHandlerRoute('task-artifact', 'finalize-local', operation ?? '')) { failUsage(`unknown operation '${operation}'`); return; }
   let family = '';
   let artifact = '';
   const seen = new Set<string>();
@@ -33,7 +34,7 @@ function taskArtifact(args: string[] = []): void {
     else artifact = value;
   }
   if (!family) { failUsage("option '--family' is required"); return; }
-  if (operation === 'inspect') {
+  if (internalHandlerRoute('task-artifact', 'inspect', operation ?? '')) {
     if (artifact) { failUsage("option '--artifact' is only valid for finalize-local"); return; }
     const result = resolveArtifactContext(args[0]!, family);
     const output = family === 'code' && result.codeMode ? {

--- a/lib/internal/task-artifact.ts
+++ b/lib/internal/task-artifact.ts
@@ -3,6 +3,7 @@ import { finalizeLocalArtifact } from '../task/local-artifact-finalization.ts';
 import type { LocalArtifactFamily } from '../task/local-artifact-finalization.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { loadVerificationConfig } from '../task/verification-config.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-artifact <N | TASK-id> inspect --family <family>\n       agent-infra-internal task-artifact <N | TASK-id> finalize-local --family <analysis|plan|code> --artifact <artifact>\n\nInspect workflow artifact context or finalize a local analysis/plan/code artifact without changing task state.\n`;
 
@@ -13,6 +14,7 @@ function failUsage(message: string): void {
 }
 
 function taskArtifact(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-artifact', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args.length < 2) { failUsage('task ref and operation are required'); return; }
   const operation = args[1];

--- a/lib/internal/task-context.ts
+++ b/lib/internal/task-context.ts
@@ -1,6 +1,6 @@
 import { parseTaskScope } from '../task/command-options.ts';
 import { resolveTaskContext } from '../task/resolve-ref.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-context resolve [<task-ref> | --task <task-ref> | -t <task-ref>]\n`;
 
@@ -13,7 +13,7 @@ function fail(code: string, message: string, usage = false): void {
 function taskContext(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('task-context', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
-  if (args[0] !== 'resolve') { fail('TASK_CONTEXT_PAYLOAD_INVALID', "operation 'resolve' is required", true); return; }
+  if (!internalHandlerRoute('task-context', 'resolve', args[0] ?? '')) { fail('TASK_CONTEXT_PAYLOAD_INVALID', "operation 'resolve' is required", true); return; }
   let scope;
   try {
     scope = parseTaskScope(args.slice(1));

--- a/lib/internal/task-context.ts
+++ b/lib/internal/task-context.ts
@@ -1,5 +1,6 @@
 import { parseTaskScope } from '../task/command-options.ts';
 import { resolveTaskContext } from '../task/resolve-ref.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-context resolve [<task-ref> | --task <task-ref> | -t <task-ref>]\n`;
 
@@ -10,6 +11,7 @@ function fail(code: string, message: string, usage = false): void {
 }
 
 function taskContext(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-context', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args[0] !== 'resolve') { fail('TASK_CONTEXT_PAYLOAD_INVALID', "operation 'resolve' is required", true); return; }
   let scope;

--- a/lib/internal/task-create.ts
+++ b/lib/internal/task-create.ts
@@ -5,6 +5,7 @@ import { requestSandboxTaskCreate, SandboxControlClientError } from '../sandbox/
 import { SANDBOX_CONTROL_MAX_BYTES } from '../sandbox/control/protocol.ts';
 import { validateTaskCreateCandidate } from '../task/create.ts';
 import { createTask, type TaskCreateResult } from '../task/create-service.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 function failed(code: string, message: string, retryable = false): TaskCreateResult {
   return {
@@ -19,6 +20,7 @@ function output(result: TaskCreateResult): void {
 }
 
 async function taskCreate(args: string[]): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-create', args)) return;
   const inputIndex = args.indexOf('--input');
   const input = inputIndex >= 0 ? args[inputIndex + 1] : undefined;
   if (!input || args.length !== 2 || inputIndex !== 0) {

--- a/lib/internal/task-create.ts
+++ b/lib/internal/task-create.ts
@@ -5,7 +5,7 @@ import { requestSandboxTaskCreate, SandboxControlClientError } from '../sandbox/
 import { SANDBOX_CONTROL_MAX_BYTES } from '../sandbox/control/protocol.ts';
 import { validateTaskCreateCandidate } from '../task/create.ts';
 import { createTask, type TaskCreateResult } from '../task/create-service.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 function failed(code: string, message: string, retryable = false): TaskCreateResult {
   return {
@@ -21,7 +21,8 @@ function output(result: TaskCreateResult): void {
 
 async function taskCreate(args: string[]): Promise<void> {
   if (!ensureInternalHandlerRoute('task-create', args)) return;
-  const inputIndex = args.indexOf('--input');
+  const inputSelector = args.includes('--input') ? 'input' : '';
+  const inputIndex = internalHandlerRoute('task-create', 'input', inputSelector) ? args.indexOf('--input') : -1;
   const input = inputIndex >= 0 ? args[inputIndex + 1] : undefined;
   if (!input || args.length !== 2 || inputIndex !== 0) {
     output(failed('TASK_CREATE_PAYLOAD_INVALID', 'Usage: agent-infra-internal task-create --input <candidate.json>'));

--- a/lib/internal/task-delivery.ts
+++ b/lib/internal/task-delivery.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { normalizeAgentToken, AGENT_USAGE_HINT } from '../agent-clients/tokens.ts';
 import { deliverTaskBranch } from '../task/delivery.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-delivery <task-ref> deliver --agent <agent> [--remote <name>] [--base <branch>] [--dry-run] [--cwd <path>]\n`;
 
@@ -10,7 +10,7 @@ function taskDelivery(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('task-delivery', args)) return;
   const taskRef = args[0];
   const operation = args[1];
-  if (!taskRef || operation !== 'deliver') {
+  if (!taskRef || !internalHandlerRoute('task-delivery', 'deliver', operation ?? '')) {
     process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'DELIVERY_PAYLOAD_INVALID', message: 'task ref and deliver operation are required' } })}\n`);
     process.stderr.write(USAGE);
     process.exitCode = 1;

--- a/lib/internal/task-delivery.ts
+++ b/lib/internal/task-delivery.ts
@@ -2,10 +2,12 @@ import path from 'node:path';
 
 import { normalizeAgentToken, AGENT_USAGE_HINT } from '../agent-clients/tokens.ts';
 import { deliverTaskBranch } from '../task/delivery.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-delivery <task-ref> deliver --agent <agent> [--remote <name>] [--base <branch>] [--dry-run] [--cwd <path>]\n`;
 
 function taskDelivery(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-delivery', args)) return;
   const taskRef = args[0];
   const operation = args[1];
   if (!taskRef || operation !== 'deliver') {

--- a/lib/internal/task-event.ts
+++ b/lib/internal/task-event.ts
@@ -4,6 +4,7 @@ import type { TaskEventRequest, Verdict } from '../task/events.ts';
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-event <N | TASK-id> <event> --agent <agent> [event options] [--orchestrated] [--dry-run]
 
@@ -31,6 +32,7 @@ function usageFailure(message: string): void {
 }
 
 async function taskEvent(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-event', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (args.length < 2) { usageFailure('task ref and event are required'); return; }
   const request: TaskEventRequest = { taskRef: args[0]!, event: args[1]!, agent: '' };

--- a/lib/internal/task-event.ts
+++ b/lib/internal/task-event.ts
@@ -4,7 +4,7 @@ import type { TaskEventRequest, Verdict } from '../task/events.ts';
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-event <N | TASK-id> <event> --agent <agent> [event options] [--orchestrated] [--dry-run]
 
@@ -34,7 +34,7 @@ function usageFailure(message: string): void {
 async function taskEvent(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-event', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
-  if (args.length < 2) { usageFailure('task ref and event are required'); return; }
+  if (args.length < 2 || !internalHandlerRoute('task-event', 'event', args[1] ? 'event' : '')) { usageFailure('task ref and event are required'); return; }
   const request: TaskEventRequest = { taskRef: args[0]!, event: args[1]!, agent: '' };
   const seen = new Set<string>();
   for (let index = 2; index < args.length; index += 1) {

--- a/lib/internal/task-finalization.ts
+++ b/lib/internal/task-finalization.ts
@@ -5,7 +5,7 @@ import {
 } from '../task/control-authority.ts';
 import { applyTaskFinalization } from '../task/finalization.ts';
 import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-finalization <N | TASK-id> complete --agent <agent>\n';
 
@@ -48,7 +48,7 @@ async function taskFinalization(args: string[] = []): Promise<void> {
     fail(parseFailure(error));
     return;
   }
-  if (operation.family !== 'task-finalization') {
+  if (operation.family !== 'task-finalization' || !internalHandlerRoute('task-finalization', 'complete', args[1] ?? '')) {
     fail('finalization operation is invalid');
     return;
   }

--- a/lib/internal/task-finalization.ts
+++ b/lib/internal/task-finalization.ts
@@ -5,6 +5,7 @@ import {
 } from '../task/control-authority.ts';
 import { applyTaskFinalization } from '../task/finalization.ts';
 import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-finalization <N | TASK-id> complete --agent <agent>\n';
 
@@ -37,6 +38,7 @@ function parseFailure(error: unknown): string {
 }
 
 async function taskFinalization(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-finalization', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
 
   let operation;

--- a/lib/internal/task-invalidation.ts
+++ b/lib/internal/task-invalidation.ts
@@ -1,7 +1,7 @@
 import { reconcileTaskInvalidation } from '../task/invalidation-command.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-invalidation <task-ref> reconcile [--max-targets <n>] [--dry-run]\n';
 
@@ -9,7 +9,7 @@ function taskInvalidation(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('task-invalidation', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const taskRef = args[0];
-  if (!taskRef || args[1] !== 'reconcile') {
+  if (!taskRef || !internalHandlerRoute('task-invalidation', 'reconcile', args[1] ?? '')) {
     process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'INVALIDATION_PAYLOAD_INVALID', message: 'task ref and reconcile are required' } })}\n`);
     process.stderr.write(USAGE);
     process.exitCode = 1;

--- a/lib/internal/task-invalidation.ts
+++ b/lib/internal/task-invalidation.ts
@@ -1,10 +1,12 @@
 import { reconcileTaskInvalidation } from '../task/invalidation-command.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-invalidation <task-ref> reconcile [--max-targets <n>] [--dry-run]\n';
 
 function taskInvalidation(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-invalidation', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const taskRef = args[0];
   if (!taskRef || args[1] !== 'reconcile') {

--- a/lib/internal/task-ledger.ts
+++ b/lib/internal/task-ledger.ts
@@ -6,7 +6,7 @@ import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task
 import { LEDGER_SECTION_MISSING_CODE, LEDGER_SECTION_MISSING_MESSAGE, isReviewStage, parseLedgerDocument, summarizeLedgerStage, validateLedgerRows } from '../task/ledger.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-ledger <task-ref> <intent> [intent flags] [--dry-run]\n\nIntents: finding-upsert, finding-respond, finding-review, decision-next-id, decision-upsert, rework-intent-upsert, stage-status\n`;
 const FLAGS: Record<string, string> = {
@@ -31,7 +31,15 @@ async function taskLedger(args: string[] = []): Promise<void> {
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
   if (!taskRef || !kind) { usageFailure('task ref and intent are required'); return; }
-  if (!['finding-upsert', 'finding-respond', 'finding-review', 'decision-next-id', 'decision-upsert', 'rework-intent-upsert', 'stage-status'].includes(kind)) {
+  if (![
+    internalHandlerRoute('task-ledger', 'finding-upsert', kind),
+    internalHandlerRoute('task-ledger', 'finding-respond', kind),
+    internalHandlerRoute('task-ledger', 'finding-review', kind),
+    internalHandlerRoute('task-ledger', 'decision-next-id', kind),
+    internalHandlerRoute('task-ledger', 'decision-upsert', kind),
+    internalHandlerRoute('task-ledger', 'rework-intent-upsert', kind),
+    internalHandlerRoute('task-ledger', 'stage-status', kind)
+  ].some(Boolean)) {
     usageFailure(`unknown ledger intent '${kind}'`); return;
   }
   const values: Record<string, unknown> = { kind, taskRef };

--- a/lib/internal/task-ledger.ts
+++ b/lib/internal/task-ledger.ts
@@ -6,6 +6,7 @@ import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task
 import { LEDGER_SECTION_MISSING_CODE, LEDGER_SECTION_MISSING_MESSAGE, isReviewStage, parseLedgerDocument, summarizeLedgerStage, validateLedgerRows } from '../task/ledger.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-ledger <task-ref> <intent> [intent flags] [--dry-run]\n\nIntents: finding-upsert, finding-respond, finding-review, decision-next-id, decision-upsert, rework-intent-upsert, stage-status\n`;
 const FLAGS: Record<string, string> = {
@@ -26,6 +27,7 @@ function usageFailure(message: string): void {
 }
 
 async function taskLedger(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-ledger', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
   if (!taskRef || !kind) { usageFailure('task ref and intent are required'); return; }

--- a/lib/internal/task-lifecycle.ts
+++ b/lib/internal/task-lifecycle.ts
@@ -7,7 +7,7 @@ import {
 import { lifecycleIntentCatalog } from '../task/lifecycle.ts';
 import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
 import type { TaskLifecycleResult } from '../task/lifecycle.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-lifecycle <N | TASK-id> <intent> --agent <agent> [intent flags] [--dry-run]\n\nIntents: ${lifecycleIntentCatalog.join(', ')}\nOverride: --override-ticket <ticket> --override-target <target> --override-scope <scope>\n`;
 
@@ -33,7 +33,7 @@ async function taskLifecycle(args: string[] = []): Promise<void> {
     usageFailure(parseFailure(error));
     return;
   }
-  if (operation.family !== 'task-lifecycle') {
+  if (operation.family !== 'task-lifecycle' || !internalHandlerRoute('task-lifecycle', 'intent', args[1] ? 'intent' : '')) {
     usageFailure('lifecycle operation is invalid');
     return;
   }

--- a/lib/internal/task-lifecycle.ts
+++ b/lib/internal/task-lifecycle.ts
@@ -7,6 +7,7 @@ import {
 import { lifecycleIntentCatalog } from '../task/lifecycle.ts';
 import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
 import type { TaskLifecycleResult } from '../task/lifecycle.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-lifecycle <N | TASK-id> <intent> --agent <agent> [intent flags] [--dry-run]\n\nIntents: ${lifecycleIntentCatalog.join(', ')}\nOverride: --override-ticket <ticket> --override-target <target> --override-scope <scope>\n`;
 
@@ -22,6 +23,7 @@ function parseFailure(error: unknown): string {
 }
 
 async function taskLifecycle(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-lifecycle', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
 
   let operation;

--- a/lib/internal/task-operation-registry.ts
+++ b/lib/internal/task-operation-registry.ts
@@ -10,7 +10,8 @@ import {
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import {
   PUBLIC_CLI_COMMAND_ALIASES,
-  PUBLIC_CLI_SELECTOR_ALIASES
+  PUBLIC_CLI_SELECTOR_ALIASES,
+  internalRouteSelector
 } from './cli-route-inventory.ts';
 
 export type TaskOperationDispatcher = 'public' | 'internal';
@@ -218,31 +219,6 @@ function optionValue(args: readonly string[], name: string): string | undefined 
   return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
 }
 
-function internalSelector(command: string, args: readonly string[]): string {
-  if (command === 'sandbox-control') return first(args);
-  if (command === 'task-create') return 'input';
-  if (command === 'task-lifecycle') return args[1] ? 'intent' : '';
-  if (command === 'task-finalization') return args[1] === 'complete' ? 'complete' : '';
-  if (command === 'task-event') return args[1] ? 'event' : '';
-  if (command === 'task-verify') return args[0] && args[1] ? 'event' : '';
-  if (command === 'task-snapshot') return 'snapshot';
-  if (command === 'task-validate') return optionValue(args, '--scope') ?? 'snapshot';
-  if (command === 'task-short-id') return first(args) === 'list' && args.includes('--verify') ? 'list-verify' : first(args);
-  if (command === 'task-orchestration') return args[1] === 'status' ? 'status' : args[1] ? 'progress' : '';
-  if (command === 'task-review') return args[1] ?? '';
-  if (command === 'task-invalidation') return args[1] ?? '';
-  if (command === 'task-override') return args[1] ?? '';
-  if (command === 'task-artifact') return args[1] ?? '';
-  if (command === 'platform-pr-review' && first(args) === 'publish') {
-    const scope = optionValue(args, '--scope') ?? '';
-    return /^TASK-\d{8}-\d{6}$/u.test(scope) ? 'publish-task' : /^pr\d+$/u.test(scope) ? 'publish-pr' : '';
-  }
-  if (['task-ledger', 'task-warning', 'task-activity'].includes(command)) return args[1] ?? '';
-  if (command === 'task-delivery') return args[1] ?? '';
-  if (command === 'task-context') return first(args);
-  return first(args);
-}
-
 function publicSelector(command: string, args: readonly string[]): string {
   if (command === 'agent-client' || command === 'data' || command === 'server' || command === 'sandbox' || command === 'task') {
     const selector = first(args);
@@ -272,7 +248,7 @@ export function resolveTaskOperation(
   const normalizedCommand = dispatcher === 'public'
     ? PUBLIC_CLI_COMMAND_ALIASES[command as keyof typeof PUBLIC_CLI_COMMAND_ALIASES] ?? command
     : command;
-  const selector = dispatcher === 'internal' ? internalSelector(normalizedCommand, args) : publicSelector(normalizedCommand, args);
+  const selector = dispatcher === 'internal' ? internalRouteSelector(normalizedCommand, args) : publicSelector(normalizedCommand, args);
   if (!selector) return null;
   return descriptorsFor(dispatcher).find((item) => item.command === normalizedCommand && item.selector === selector) ?? null;
 }

--- a/lib/internal/task-operation-registry.ts
+++ b/lib/internal/task-operation-registry.ts
@@ -8,11 +8,15 @@ import {
   type TaskViewAccessEffect
 } from '../sandbox/control/task-view.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
+import {
+  PUBLIC_CLI_COMMAND_ALIASES,
+  PUBLIC_CLI_SELECTOR_ALIASES
+} from './cli-route-inventory.ts';
 
 export type TaskOperationDispatcher = 'public' | 'internal';
 export type TaskOperationScope = 'task-bound' | 'non-task' | 'conditional';
 export type TaskOperationEffect = TaskViewAccessEffect;
-export type TaskRefSource = 'argv' | 'environment' | 'none' | 'delegated';
+export type TaskRefSource = 'argv' | 'environment' | 'none' | 'delegated' | 'input';
 
 export type TaskOperationDescriptor = Readonly<{
   dispatcher: TaskOperationDispatcher;
@@ -54,7 +58,7 @@ function internalTaskRoutes(): TaskOperationDescriptor[] {
     descriptor('internal', 'git-workflow', 'preview-tree', 'conditional', 'diagnostic'),
     descriptor('internal', 'git-workflow', 'snapshot', 'conditional', 'diagnostic'),
     descriptor('internal', 'git-workflow', 'compare-trees', 'conditional', 'diagnostic'),
-    descriptor('internal', 'git-workflow', 'commit', 'task-bound', 'progress'),
+    descriptor('internal', 'git-workflow', 'commit', 'task-bound', 'progress', 'input'),
     descriptor('internal', 'git-workflow', 'push-rebased', 'task-bound', 'remote-write'),
     descriptor('internal', 'task-delivery', 'deliver', 'task-bound', 'remote-write'),
     descriptor('internal', 'release-workflow', 'inspect', 'non-task', 'diagnostic', 'none'),
@@ -241,8 +245,11 @@ function internalSelector(command: string, args: readonly string[]): string {
 
 function publicSelector(command: string, args: readonly string[]): string {
   if (command === 'agent-client' || command === 'data' || command === 'server' || command === 'sandbox' || command === 'task') {
-    if (command === 'task' && first(args) === 'd') return 'decisions';
-    return first(args);
+    const selector = first(args);
+    if (command === 'task') {
+      return PUBLIC_CLI_SELECTOR_ALIASES.task[selector as keyof typeof PUBLIC_CLI_SELECTOR_ALIASES.task] ?? selector;
+    }
+    return selector;
   }
   if (command === 'run') {
     const skill = optionValue(args, '--skill');
@@ -262,8 +269,8 @@ export function resolveTaskOperation(
   command: string,
   args: readonly string[] = []
 ): TaskOperationDescriptor | null {
-  const normalizedCommand = dispatcher === 'public' && (command === '--version' || command === '-v')
-    ? 'version'
+  const normalizedCommand = dispatcher === 'public'
+    ? PUBLIC_CLI_COMMAND_ALIASES[command as keyof typeof PUBLIC_CLI_COMMAND_ALIASES] ?? command
     : command;
   const selector = dispatcher === 'internal' ? internalSelector(normalizedCommand, args) : publicSelector(normalizedCommand, args);
   if (!selector) return null;
@@ -284,18 +291,24 @@ const TASK_MARKER_KEYS = [
   'AGENT_INFRA_CONTROL_STATUS_DIR',
   'AGENT_INFRA_RUNTIME_DIR'
 ] as const;
-const TASK_CONTROL_MARKER_KEYS = TASK_MARKER_KEYS.slice(1, -1);
+const TASK_CONTROL_MARKER_KEYS = [
+  'AGENT_INFRA_CONTROL_TOKEN',
+  'AGENT_INFRA_CONTROL_GENERATION',
+  'AGENT_INFRA_CONTROL_DIR',
+  'AGENT_INFRA_CONTROL_STATUS_DIR'
+] as const;
 
 type TaskMarkerState = 'none' | 'branch-only' | 'task-bound' | 'incomplete';
 
 function taskMarkerState(env: NodeJS.ProcessEnv): TaskMarkerState {
   const present = (key: typeof TASK_MARKER_KEYS[number]) => Boolean(env[key]);
   const taskId = present('AGENT_INFRA_TASK_ID');
-  const controls = TASK_MARKER_KEYS.slice(1).every(present);
+  const controls = TASK_CONTROL_MARKER_KEYS.every(present);
+  const runtime = present('AGENT_INFRA_RUNTIME_DIR');
   const any = TASK_MARKER_KEYS.some(present);
   if (!any) return 'none';
-  if (taskId && controls) return 'task-bound';
-  if (!taskId && controls) return 'branch-only';
+  if (taskId && controls && runtime) return 'task-bound';
+  if (!taskId && controls && !runtime) return 'branch-only';
   return 'incomplete';
 }
 
@@ -310,6 +323,7 @@ function explicitTaskRefForOperation(
   selected: TaskOperationDescriptor
 ): string | null {
   if (selected.taskRefSource === 'none' || selected.taskRefSource === 'environment') return null;
+  if (selected.taskRefSource === 'input') return inputTaskRefForOperation(args);
   if (command === 'sandbox-control' && args[0] === 'client') {
     return explicitTaskRefForOperation('internal', args[1] ?? '', args.slice(2), selected);
   }
@@ -342,6 +356,21 @@ function explicitTaskRefForOperation(
   if (command === 'task-create' || command === 'task-short-id' && first(args) === 'list') return null;
   if (command === 'task-short-id') return args[1] ?? null;
   return first(args) || null;
+}
+
+function inputTaskRefForOperation(args: readonly string[]): string | null {
+  const inputPath = optionValue(args, '--input');
+  if (!inputPath) return null;
+  try {
+    const input = JSON.parse(fs.readFileSync(inputPath, 'utf8')) as { taskRef?: unknown };
+    return typeof input.taskRef === 'string' && input.taskRef.trim() ? input.taskRef.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function isTaskInputRef(taskRef: string): boolean {
+  return /^TASK-\d{8}-\d{6}$/u.test(taskRef) || /^\d+$/u.test(taskRef);
 }
 
 function taskRefMatchesEnvironment(taskRef: string, taskId: string): boolean {
@@ -440,19 +469,25 @@ export function guardTaskOperation(
   }
   if (selected.scope === 'non-task' || markerState !== 'task-bound') return { descriptor: selected, taskView: null };
   const taskId = env.AGENT_INFRA_TASK_ID!;
-  const taskRef = explicitTaskRefForOperation(dispatcher, command, args, selected);
-  if (taskRef && !taskRefMatchesEnvironment(taskRef, taskId)) {
-    throw new TaskViewOperationError(
-      'SANDBOX_TASK_REF_MISMATCH',
-      `task-bound operation targets '${taskRef}', but the sandbox is bound to '${taskId}'`
-    );
-  }
   const taskView = options.taskView ?? viewFromEnvironment(env);
   if (taskView.state === 'not-applicable' && selected.effect !== 'cleanup') {
     throw new TaskViewOperationError('SANDBOX_TASK_VIEW_INVALID', 'task-bound operation has no applicable task view');
   }
   const access = accessSandboxTaskView(taskView, selected.effect);
   if (!access.allowed) throw new TaskViewOperationError(access.reasonCode ?? 'SANDBOX_TASK_VIEW_DENIED', access.message ?? 'task view denied');
+  const taskRef = explicitTaskRefForOperation(dispatcher, command, args, selected);
+  if (selected.taskRefSource === 'input' && (!taskRef || !isTaskInputRef(taskRef))) {
+    throw new TaskViewOperationError(
+      'SANDBOX_TASK_REF_INVALID',
+      'task-bound input must contain a valid taskRef'
+    );
+  }
+  if (taskRef && !taskRefMatchesEnvironment(taskRef, taskId)) {
+    throw new TaskViewOperationError(
+      'SANDBOX_TASK_REF_MISMATCH',
+      `task-bound operation targets '${taskRef}', but the sandbox is bound to '${taskId}'`
+    );
+  }
   return { descriptor: selected, taskView };
 }
 

--- a/lib/internal/task-operation-registry.ts
+++ b/lib/internal/task-operation-registry.ts
@@ -41,6 +41,10 @@ const descriptor = (
 function internalTaskRoutes(): TaskOperationDescriptor[] {
   return [
     descriptor('internal', 'task-create', 'input', 'conditional', 'progress'),
+    descriptor('internal', 'task-qualification', 'proposal', 'task-bound', 'progress'),
+    descriptor('internal', 'task-qualification', 'confirm', 'task-bound', 'progress'),
+    descriptor('internal', 'task-qualification', 'supersede', 'task-bound', 'progress'),
+    descriptor('internal', 'task-qualification', 'revoke', 'task-bound', 'progress'),
     descriptor('internal', 'sandbox-control', 'serve', 'non-task', 'progress', 'none'),
     descriptor('internal', 'sandbox-control', 'execute', 'non-task', 'progress', 'none'),
     descriptor('internal', 'sandbox-control', 'recover', 'conditional', 'recovery', 'delegated'),
@@ -70,6 +74,10 @@ function internalTaskRoutes(): TaskOperationDescriptor[] {
     descriptor('internal', 'platform-release-notes', 'context', 'non-task', 'diagnostic', 'none'),
     descriptor('internal', 'platform-release-notes', 'stage', 'non-task', 'artifact-write', 'none'),
     descriptor('internal', 'platform-release-notes', 'publish', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-security', 'read', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-security', 'dismiss', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-metadata', 'init-labels', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-metadata', 'init-milestones', 'non-task', 'remote-write', 'none'),
     descriptor('internal', 'platform-context', 'resolve', 'non-task', 'diagnostic', 'none'),
     descriptor('internal', 'platform-comment', 'list', 'non-task', 'diagnostic', 'none'),
     descriptor('internal', 'platform-comment', 'owner', 'task-bound', 'diagnostic'),
@@ -197,8 +205,8 @@ export const TASK_OPERATION_DESCRIPTORS = Object.freeze([
 ]);
 
 export const INTERNAL_DISPATCHER_ROUTES = Object.freeze([
-  'task-create', 'sandbox-control', 'agent-client', 'codex-lifecycle', 'codex-sandbox-controller',
-  'git-workflow', 'task-delivery', 'release-workflow', 'platform-release-notes', 'platform-context',
+  'task-create', 'task-qualification', 'sandbox-control', 'agent-client', 'codex-lifecycle', 'codex-sandbox-controller',
+  'git-workflow', 'task-delivery', 'release-workflow', 'platform-release-notes', 'platform-security', 'platform-metadata', 'platform-context',
   'platform-comment', 'platform-issue', 'platform-pr', 'platform-pr-review', 'pr-review-grade',
   'platform-checks', 'task-context', 'task-ledger', 'task-warning', 'task-activity', 'task-artifact',
   'task-orchestration', 'task-review', 'task-event', 'task-invalidation', 'task-lifecycle',

--- a/lib/internal/task-operation-registry.ts
+++ b/lib/internal/task-operation-registry.ts
@@ -1,0 +1,357 @@
+import fs from 'node:fs';
+
+import {
+  accessSandboxTaskView,
+  parseSandboxTaskView,
+  taskViewFromStatus,
+  type SandboxTaskView,
+  type TaskViewAccessEffect
+} from '../sandbox/control/task-view.ts';
+
+export type TaskOperationDispatcher = 'public' | 'internal';
+export type TaskOperationScope = 'task-bound' | 'non-task' | 'conditional';
+export type TaskOperationEffect = TaskViewAccessEffect;
+export type TaskRefSource = 'argv' | 'environment' | 'none' | 'delegated';
+
+export type TaskOperationDescriptor = Readonly<{
+  dispatcher: TaskOperationDispatcher;
+  command: string;
+  selector: string;
+  scope: TaskOperationScope;
+  effect: TaskOperationEffect;
+  taskRefSource: TaskRefSource;
+  guardBeforeImport: true;
+}>;
+
+const descriptor = (
+  dispatcher: TaskOperationDispatcher,
+  command: string,
+  selector: string,
+  scope: TaskOperationScope,
+  effect: TaskOperationEffect,
+  taskRefSource: TaskRefSource = scope === 'non-task' ? 'none' : 'argv'
+): TaskOperationDescriptor => ({ dispatcher, command, selector, scope, effect, taskRefSource, guardBeforeImport: true });
+
+function internalTaskRoutes(): TaskOperationDescriptor[] {
+  return [
+    descriptor('internal', 'task-create', 'input', 'conditional', 'progress'),
+    descriptor('internal', 'sandbox-control', 'serve', 'non-task', 'progress', 'none'),
+    descriptor('internal', 'sandbox-control', 'execute', 'non-task', 'progress', 'none'),
+    descriptor('internal', 'sandbox-control', 'recover', 'conditional', 'recovery', 'delegated'),
+    descriptor('internal', 'sandbox-control', 'client', 'conditional', 'progress', 'delegated'),
+    descriptor('internal', 'agent-client', 'next-steps', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'agent-client', 'model-selection', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'codex-lifecycle', 'preflight', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'codex-lifecycle', 'capability-arm', 'conditional', 'progress'),
+    descriptor('internal', 'codex-lifecycle', 'hook-event', 'conditional', 'progress'),
+    descriptor('internal', 'codex-lifecycle', 'resolve-start', 'conditional', 'progress'),
+    descriptor('internal', 'codex-lifecycle', 'resolve-stop', 'conditional', 'progress'),
+    descriptor('internal', 'codex-lifecycle', 'consume', 'conditional', 'progress'),
+    descriptor('internal', 'codex-sandbox-controller', 'verify-context', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'codex-sandbox-controller', 'run', 'task-bound', 'progress'),
+    descriptor('internal', 'git-workflow', 'inspect', 'conditional', 'diagnostic'),
+    descriptor('internal', 'git-workflow', 'preview-tree', 'conditional', 'diagnostic'),
+    descriptor('internal', 'git-workflow', 'snapshot', 'conditional', 'diagnostic'),
+    descriptor('internal', 'git-workflow', 'compare-trees', 'conditional', 'diagnostic'),
+    descriptor('internal', 'git-workflow', 'commit', 'task-bound', 'progress'),
+    descriptor('internal', 'git-workflow', 'push-rebased', 'task-bound', 'remote-write'),
+    descriptor('internal', 'task-delivery', 'deliver', 'task-bound', 'remote-write'),
+    descriptor('internal', 'release-workflow', 'inspect', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'release-workflow', 'prepare', 'non-task', 'progress', 'none'),
+    descriptor('internal', 'release-workflow', 'publish', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'release-workflow', 'post-prepare', 'non-task', 'progress', 'none'),
+    descriptor('internal', 'release-workflow', 'post-publish', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-release-notes', 'context', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-release-notes', 'stage', 'non-task', 'artifact-write', 'none'),
+    descriptor('internal', 'platform-release-notes', 'publish', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-context', 'resolve', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-comment', 'list', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-comment', 'owner', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'platform-comment', 'backfill', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-comment', 'sync', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-issue', 'inspect', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'platform-issue', 'create', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-issue', 'bind', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-issue', 'sync', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'inspect', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'platform-pr', 'summary-context', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'platform-pr', 'resolve-external', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'create', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'bind', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'skip', 'task-bound', 'progress'),
+    descriptor('internal', 'platform-pr', 'sync', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'change-report', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'summary-sync', 'task-bound', 'remote-write'),
+    descriptor('internal', 'platform-pr', 'sync-in-labels', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-pr-review', 'inspect', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-pr-review', 'list', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-pr-review', 'publish-pr', 'non-task', 'remote-write', 'none'),
+    descriptor('internal', 'platform-pr-review', 'publish-task', 'task-bound', 'remote-write'),
+    descriptor('internal', 'pr-review-grade', 'decide', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'pr-review-grade', 'resolve-host', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'pr-review-grade', 'verify-artifact', 'non-task', 'diagnostic', 'none'),
+    descriptor('internal', 'platform-checks', 'inspect', 'conditional', 'diagnostic'),
+    descriptor('internal', 'platform-checks', 'watch', 'conditional', 'diagnostic'),
+    descriptor('internal', 'platform-checks', 'resolve-run', 'conditional', 'diagnostic'),
+    descriptor('internal', 'platform-checks', 'logs', 'conditional', 'diagnostic'),
+    descriptor('internal', 'task-context', 'resolve', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-ledger', 'decision-next-id', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-ledger', 'stage-status', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-ledger', 'finding-upsert', 'task-bound', 'progress'),
+    descriptor('internal', 'task-ledger', 'finding-respond', 'task-bound', 'progress'),
+    descriptor('internal', 'task-ledger', 'finding-review', 'task-bound', 'progress'),
+    descriptor('internal', 'task-ledger', 'decision-upsert', 'task-bound', 'progress'),
+    descriptor('internal', 'task-ledger', 'rework-intent-upsert', 'task-bound', 'progress'),
+    descriptor('internal', 'task-warning', 'list', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-warning', 'add', 'task-bound', 'progress'),
+    descriptor('internal', 'task-warning', 'set-status', 'task-bound', 'progress'),
+    descriptor('internal', 'task-activity', 'pr-review-inspect', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-activity', 'pr-review-start', 'task-bound', 'progress'),
+    descriptor('internal', 'task-activity', 'pr-review-complete', 'task-bound', 'progress'),
+    descriptor('internal', 'task-activity', 'pr-review-terminate', 'task-bound', 'progress'),
+    descriptor('internal', 'task-artifact', 'inspect', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-artifact', 'finalize-local', 'task-bound', 'artifact-write'),
+    descriptor('internal', 'task-orchestration', 'status', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-orchestration', 'progress', 'task-bound', 'progress'),
+    descriptor('internal', 'task-review', 'finalize-summary', 'task-bound', 'progress'),
+    descriptor('internal', 'task-event', 'event', 'task-bound', 'progress'),
+    descriptor('internal', 'task-invalidation', 'reconcile', 'task-bound', 'progress'),
+    descriptor('internal', 'task-override', 'diagnose', 'task-bound', 'diagnostic'),
+    descriptor('internal', 'task-override', 'issue', 'task-bound', 'progress'),
+    descriptor('internal', 'task-override', 'consume', 'task-bound', 'progress'),
+    descriptor('internal', 'task-lifecycle', 'intent', 'task-bound', 'progress'),
+    descriptor('internal', 'task-finalization', 'complete', 'task-bound', 'progress'),
+    descriptor('internal', 'task-short-id', 'list', 'conditional', 'diagnostic'),
+    descriptor('internal', 'task-short-id', 'list-verify', 'conditional', 'diagnostic'),
+    descriptor('internal', 'task-short-id', 'alloc', 'task-bound', 'progress'),
+    descriptor('internal', 'task-short-id', 'release', 'task-bound', 'progress'),
+    descriptor('internal', 'task-short-id', 'resolve', 'task-bound', 'progress'),
+    descriptor('internal', 'task-snapshot', 'snapshot', 'conditional', 'diagnostic'),
+    descriptor('internal', 'task-verify', 'event', 'task-bound', 'terminal-verdict'),
+    descriptor('internal', 'task-validate', 'snapshot', 'conditional', 'diagnostic'),
+    descriptor('internal', 'task-validate', 'inplace', 'task-bound', 'progress')
+  ];
+}
+
+function publicTaskRoutes(): TaskOperationDescriptor[] {
+  return [
+    descriptor('public', 'agent-client', 'list', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'agent-client', 'inspect', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'agent-client', 'enable', 'non-task', 'progress', 'none'),
+    descriptor('public', 'agent-client', 'disable', 'non-task', 'progress', 'none'),
+    descriptor('public', 'agent-client', 'configure', 'non-task', 'progress', 'none'),
+    descriptor('public', 'cp', 'cp', 'non-task', 'remote-write', 'none'),
+    descriptor('public', 'data', 'capture', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'data', 'verify', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'data', 'audit', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'data', 'repair', 'non-task', 'progress', 'none'),
+    descriptor('public', 'data', 'export', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'decide', 'decide', 'task-bound', 'progress'),
+    descriptor('public', 'help', 'help', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'version', 'version', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'init', 'init', 'non-task', 'progress', 'none'),
+    descriptor('public', 'merge', 'merge', 'conditional', 'progress'),
+    descriptor('public', 'run', 'create-task', 'conditional', 'progress'),
+    descriptor('public', 'run', 'task-skill', 'task-bound', 'progress'),
+    descriptor('public', 'run', 'recreate', 'task-bound', 'recovery'),
+    descriptor('public', 'sandbox', 'ls', 'conditional', 'diagnostic'),
+    descriptor('public', 'sandbox', 'show', 'conditional', 'diagnostic'),
+    descriptor('public', 'sandbox', 'create', 'conditional', 'recovery'),
+    descriptor('public', 'sandbox', 'exec', 'conditional', 'recovery'),
+    descriptor('public', 'sandbox', 'enter', 'conditional', 'recovery'),
+    descriptor('public', 'sandbox', 'start', 'conditional', 'recovery'),
+    descriptor('public', 'sandbox', 'rm', 'conditional', 'cleanup'),
+    descriptor('public', 'sandbox', 'prune', 'non-task', 'cleanup', 'none'),
+    descriptor('public', 'sandbox', 'rebuild', 'non-task', 'progress', 'none'),
+    descriptor('public', 'sandbox', 'refresh', 'non-task', 'progress', 'none'),
+    descriptor('public', 'sandbox', 'vm', 'non-task', 'progress', 'none'),
+    descriptor('public', 'server', 'start', 'non-task', 'progress', 'none'),
+    descriptor('public', 'server', 'stop', 'non-task', 'progress', 'none'),
+    descriptor('public', 'server', 'status', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'server', 'logs', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'task', 'cat', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'decisions', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'files', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'grep', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'issue-body', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'log', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'ls', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'show', 'task-bound', 'diagnostic'),
+    descriptor('public', 'task', 'status', 'task-bound', 'diagnostic'),
+    descriptor('public', 'sync', 'sync', 'non-task', 'progress', 'none'),
+    descriptor('public', 'update', 'update', 'non-task', 'progress', 'none')
+  ];
+}
+
+export const INTERNAL_OPERATION_DESCRIPTORS = Object.freeze(internalTaskRoutes());
+export const PUBLIC_OPERATION_DESCRIPTORS = Object.freeze(publicTaskRoutes());
+export const TASK_OPERATION_DESCRIPTORS = Object.freeze([
+  ...INTERNAL_OPERATION_DESCRIPTORS,
+  ...PUBLIC_OPERATION_DESCRIPTORS
+]);
+
+export const INTERNAL_DISPATCHER_ROUTES = Object.freeze([
+  'task-create', 'sandbox-control', 'agent-client', 'codex-lifecycle', 'codex-sandbox-controller',
+  'git-workflow', 'task-delivery', 'release-workflow', 'platform-release-notes', 'platform-context',
+  'platform-comment', 'platform-issue', 'platform-pr', 'platform-pr-review', 'pr-review-grade',
+  'platform-checks', 'task-context', 'task-ledger', 'task-warning', 'task-activity', 'task-artifact',
+  'task-orchestration', 'task-review', 'task-event', 'task-invalidation', 'task-lifecycle',
+  'task-finalization', 'task-override', 'task-short-id', 'task-snapshot', 'task-verify', 'task-validate'
+]);
+export const PUBLIC_DISPATCHER_ROUTES = Object.freeze([
+  'agent-client', 'cp', 'data', 'decide', 'help', 'init', 'merge', 'run', 'sandbox', 'server', 'task', 'sync', 'update', 'version'
+]);
+
+function first(args: readonly string[]): string {
+  return args[0] ?? '';
+}
+
+function optionValue(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${name}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function internalSelector(command: string, args: readonly string[]): string {
+  if (command === 'sandbox-control') return first(args);
+  if (command === 'task-create') return 'input';
+  if (command === 'task-lifecycle') return args[1] ? 'intent' : '';
+  if (command === 'task-finalization') return args[1] === 'complete' ? 'complete' : '';
+  if (command === 'task-event') return args[1] ? 'event' : '';
+  if (command === 'task-verify') return args[0] && args[1] ? 'event' : '';
+  if (command === 'task-snapshot') return 'snapshot';
+  if (command === 'task-validate') return optionValue(args, '--scope') ?? 'snapshot';
+  if (command === 'task-short-id') return first(args) === 'list' && args.includes('--verify') ? 'list-verify' : first(args);
+  if (command === 'task-orchestration') return args[1] === 'status' ? 'status' : args[1] ? 'progress' : '';
+  if (command === 'task-review') return args[1] ?? '';
+  if (command === 'task-invalidation') return args[1] ?? '';
+  if (command === 'task-override') return args[1] ?? '';
+  if (command === 'task-artifact') return args[1] ?? '';
+  if (command === 'platform-pr-review' && first(args) === 'publish') {
+    const scope = optionValue(args, '--scope') ?? '';
+    return /^TASK-\d{8}-\d{6}$/u.test(scope) ? 'publish-task' : /^pr\d+$/u.test(scope) ? 'publish-pr' : '';
+  }
+  if (['task-ledger', 'task-warning', 'task-activity'].includes(command)) return args[1] ?? '';
+  if (command === 'task-delivery') return args[1] ?? '';
+  if (command === 'task-context') return first(args);
+  return first(args);
+}
+
+function publicSelector(command: string, args: readonly string[]): string {
+  if (command === 'agent-client' || command === 'data' || command === 'server' || command === 'sandbox' || command === 'task') {
+    if (command === 'task' && first(args) === 'd') return 'decisions';
+    return first(args);
+  }
+  if (command === 'run') {
+    const skill = optionValue(args, '--skill');
+    if (skill === 'create-task') return 'create-task';
+    if (args.includes('--recreate')) return 'recreate';
+    return skill ? 'task-skill' : '';
+  }
+  return command;
+}
+
+function descriptorsFor(dispatcher: TaskOperationDispatcher): readonly TaskOperationDescriptor[] {
+  return dispatcher === 'internal' ? INTERNAL_OPERATION_DESCRIPTORS : PUBLIC_OPERATION_DESCRIPTORS;
+}
+
+export function resolveTaskOperation(
+  dispatcher: TaskOperationDispatcher,
+  command: string,
+  args: readonly string[] = []
+): TaskOperationDescriptor | null {
+  const normalizedCommand = dispatcher === 'public' && (command === '--version' || command === '-v')
+    ? 'version'
+    : command;
+  const selector = dispatcher === 'internal' ? internalSelector(normalizedCommand, args) : publicSelector(normalizedCommand, args);
+  if (!selector) return null;
+  return descriptorsFor(dispatcher).find((item) => item.command === normalizedCommand && item.selector === selector) ?? null;
+}
+
+export function resolveDelegatedTaskOperation(args: readonly string[]): TaskOperationDescriptor | null {
+  const [operation, ...rest] = args;
+  if (operation !== 'client' || !rest[0]) return null;
+  return resolveTaskOperation('internal', rest[0], rest.slice(1));
+}
+
+export function hasTaskBoundMarker(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.AGENT_INFRA_TASK_ID)
+    && Boolean(env.AGENT_INFRA_CONTROL_TOKEN || env.AGENT_INFRA_CONTROL_GENERATION
+      || env.AGENT_INFRA_CONTROL_STATUS_DIR || env.AGENT_INFRA_RUNTIME_DIR || env.AGENT_INFRA_CONTROL_DIR);
+}
+
+function viewFromEnvironment(env: NodeJS.ProcessEnv): SandboxTaskView {
+  const statusDir = env.AGENT_INFRA_CONTROL_STATUS_DIR;
+  if (!statusDir) {
+    return { state: 'unknown', taskId: env.AGENT_INFRA_TASK_ID ?? null, observedSource: 'unknown', receipt: null, reasonCode: 'SANDBOX_TASK_VIEW_STATUS_MISSING' };
+  }
+  try {
+    const view = taskViewFromStatus(JSON.parse(fs.readFileSync(`${statusDir}/status.json`, 'utf8')));
+    if (view.taskId !== env.AGENT_INFRA_TASK_ID) {
+      return {
+        state: 'unknown', taskId: env.AGENT_INFRA_TASK_ID ?? null, observedSource: 'unknown', receipt: null,
+        reasonCode: 'SANDBOX_TASK_VIEW_TASK_ID_MISMATCH'
+      };
+    }
+    return view;
+  } catch {
+    return { state: 'unknown', taskId: env.AGENT_INFRA_TASK_ID ?? null, observedSource: 'unknown', receipt: null, reasonCode: 'SANDBOX_TASK_VIEW_STATUS_INVALID' };
+  }
+}
+
+export function formatTaskViewDiagnostic(view: SandboxTaskView): string {
+  const task = view.taskId ?? '-';
+  const source = view.observedSource ?? '-';
+  const reason = view.reasonCode ? ` reason=${view.reasonCode}` : '';
+  return `Task view: ${view.state} task=${task} source=${source}${reason}\n`;
+}
+
+export class TaskViewOperationError extends Error {
+  readonly code: string;
+  readonly exitCode: number;
+  constructor(code: string, message: string, exitCode = 1) {
+    super(`${code}: ${message}`);
+    this.name = 'TaskViewOperationError';
+    this.code = code;
+    this.exitCode = exitCode;
+  }
+}
+
+export function guardTaskOperation(
+  dispatcher: TaskOperationDispatcher,
+  command: string,
+  args: readonly string[] = [],
+  options: Readonly<{ env?: NodeJS.ProcessEnv; taskView?: SandboxTaskView }> = {}
+): Readonly<{ descriptor: TaskOperationDescriptor; taskView: SandboxTaskView | null }> {
+  if (args.some((arg) => arg === '--help' || arg === '-h' || arg === 'help')) {
+    return {
+      descriptor: resolveTaskOperation(dispatcher, command, args)
+        ?? descriptor(dispatcher, command, 'help', 'non-task', 'diagnostic', 'none'),
+      taskView: null
+    };
+  }
+  const selected = command === 'sandbox-control'
+    ? first(args) === 'client'
+      ? resolveDelegatedTaskOperation(args)
+      : resolveTaskOperation(dispatcher, command, args)
+    : resolveTaskOperation(dispatcher, command, args);
+  if (!selected) {
+    if (hasTaskBoundMarker(options.env)) {
+      throw new TaskViewOperationError('TASK_VIEW_OPERATION_UNREGISTERED', `operation '${command} ${first(args)}' is not registered for a task-bound workspace`);
+    }
+    return { descriptor: descriptor(dispatcher, command, 'unregistered', 'non-task', 'diagnostic', 'none'), taskView: null };
+  }
+  if (selected.scope === 'non-task' || !hasTaskBoundMarker(options.env)) return { descriptor: selected, taskView: null };
+  const taskView = options.taskView ?? viewFromEnvironment(options.env ?? process.env);
+  if (taskView.state === 'not-applicable' && selected.effect !== 'cleanup') {
+    throw new TaskViewOperationError('SANDBOX_TASK_VIEW_INVALID', 'task-bound operation has no applicable task view');
+  }
+  const access = accessSandboxTaskView(taskView, selected.effect);
+  if (!access.allowed) throw new TaskViewOperationError(access.reasonCode ?? 'SANDBOX_TASK_VIEW_DENIED', access.message ?? 'task view denied');
+  return { descriptor: selected, taskView };
+}
+
+export function assertTaskViewStatus(value: unknown): SandboxTaskView {
+  return parseSandboxTaskView(value);
+}

--- a/lib/internal/task-operation-registry.ts
+++ b/lib/internal/task-operation-registry.ts
@@ -7,6 +7,7 @@ import {
   type SandboxTaskView,
   type TaskViewAccessEffect
 } from '../sandbox/control/task-view.ts';
+import { resolveTaskRef } from '../task/resolve-ref.ts';
 
 export type TaskOperationDispatcher = 'public' | 'internal';
 export type TaskOperationScope = 'task-bound' | 'non-task' | 'conditional';
@@ -136,7 +137,7 @@ function internalTaskRoutes(): TaskOperationDescriptor[] {
 function publicTaskRoutes(): TaskOperationDescriptor[] {
   return [
     descriptor('public', 'agent-client', 'list', 'non-task', 'diagnostic', 'none'),
-    descriptor('public', 'agent-client', 'inspect', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'agent-client', 'status', 'non-task', 'diagnostic', 'none'),
     descriptor('public', 'agent-client', 'enable', 'non-task', 'progress', 'none'),
     descriptor('public', 'agent-client', 'disable', 'non-task', 'progress', 'none'),
     descriptor('public', 'agent-client', 'configure', 'non-task', 'progress', 'none'),
@@ -158,7 +159,6 @@ function publicTaskRoutes(): TaskOperationDescriptor[] {
     descriptor('public', 'sandbox', 'show', 'conditional', 'diagnostic'),
     descriptor('public', 'sandbox', 'create', 'conditional', 'recovery'),
     descriptor('public', 'sandbox', 'exec', 'conditional', 'recovery'),
-    descriptor('public', 'sandbox', 'enter', 'conditional', 'recovery'),
     descriptor('public', 'sandbox', 'start', 'conditional', 'recovery'),
     descriptor('public', 'sandbox', 'rm', 'conditional', 'cleanup'),
     descriptor('public', 'sandbox', 'prune', 'non-task', 'cleanup', 'none'),
@@ -169,6 +169,7 @@ function publicTaskRoutes(): TaskOperationDescriptor[] {
     descriptor('public', 'server', 'stop', 'non-task', 'progress', 'none'),
     descriptor('public', 'server', 'status', 'non-task', 'diagnostic', 'none'),
     descriptor('public', 'server', 'logs', 'non-task', 'diagnostic', 'none'),
+    descriptor('public', 'server', '__daemon', 'non-task', 'progress', 'none'),
     descriptor('public', 'task', 'cat', 'task-bound', 'diagnostic'),
     descriptor('public', 'task', 'decisions', 'task-bound', 'diagnostic'),
     descriptor('public', 'task', 'files', 'task-bound', 'diagnostic'),
@@ -275,10 +276,97 @@ export function resolveDelegatedTaskOperation(args: readonly string[]): TaskOper
   return resolveTaskOperation('internal', rest[0], rest.slice(1));
 }
 
+const TASK_MARKER_KEYS = [
+  'AGENT_INFRA_TASK_ID',
+  'AGENT_INFRA_CONTROL_TOKEN',
+  'AGENT_INFRA_CONTROL_GENERATION',
+  'AGENT_INFRA_CONTROL_DIR',
+  'AGENT_INFRA_CONTROL_STATUS_DIR',
+  'AGENT_INFRA_RUNTIME_DIR'
+] as const;
+const TASK_CONTROL_MARKER_KEYS = TASK_MARKER_KEYS.slice(1, -1);
+
+type TaskMarkerState = 'none' | 'branch-only' | 'task-bound' | 'incomplete';
+
+function taskMarkerState(env: NodeJS.ProcessEnv): TaskMarkerState {
+  const present = (key: typeof TASK_MARKER_KEYS[number]) => Boolean(env[key]);
+  const taskId = present('AGENT_INFRA_TASK_ID');
+  const controls = TASK_MARKER_KEYS.slice(1).every(present);
+  const any = TASK_MARKER_KEYS.some(present);
+  if (!any) return 'none';
+  if (taskId && controls) return 'task-bound';
+  if (!taskId && controls) return 'branch-only';
+  return 'incomplete';
+}
+
 export function hasTaskBoundMarker(env: NodeJS.ProcessEnv = process.env): boolean {
-  return Boolean(env.AGENT_INFRA_TASK_ID)
-    && Boolean(env.AGENT_INFRA_CONTROL_TOKEN || env.AGENT_INFRA_CONTROL_GENERATION
-      || env.AGENT_INFRA_CONTROL_STATUS_DIR || env.AGENT_INFRA_RUNTIME_DIR || env.AGENT_INFRA_CONTROL_DIR);
+  return taskMarkerState(env) === 'task-bound';
+}
+
+function explicitTaskRefForOperation(
+  dispatcher: TaskOperationDispatcher,
+  command: string,
+  args: readonly string[],
+  selected: TaskOperationDescriptor
+): string | null {
+  if (selected.taskRefSource === 'none' || selected.taskRefSource === 'environment') return null;
+  if (command === 'sandbox-control' && args[0] === 'client') {
+    return explicitTaskRefForOperation('internal', args[1] ?? '', args.slice(2), selected);
+  }
+  if (dispatcher === 'public') {
+    if (command === 'decide' || command === 'run' || command === 'task') {
+      return optionValue(args, '--task') ?? optionValue(args, '-t') ?? null;
+    }
+    if (command === 'sandbox') {
+      const subcommand = first(args);
+      if (!['create', 'exec', 'show', 'rm', 'start'].includes(subcommand)) return null;
+      const targetIndex = (subcommand === 'exec' || subcommand === 'start') && args[1] === '--recreate' ? 2 : 1;
+      return args[targetIndex] ?? null;
+    }
+    return command === 'merge' ? null : first(args) || null;
+  }
+  if (command === 'codex-lifecycle') return optionValue(args, '--task-id') ?? null;
+  if (command === 'platform-comment' || command === 'platform-issue') {
+    return first(args) === 'list' ? null : args[1] ?? null;
+  }
+  if (command === 'platform-pr') return first(args) === 'sync-in-labels' ? null : args[1] ?? null;
+  if (command === 'platform-pr-review') return optionValue(args, '--scope') ?? null;
+  if (command === 'platform-checks') return args[1] ?? null;
+  if (command === 'task-context') {
+    const taskArgs = args.slice(1);
+    return optionValue(taskArgs, '--task')
+      ?? optionValue(taskArgs, '-t')
+      ?? taskArgs.find((arg) => !arg.startsWith('--'))
+      ?? null;
+  }
+  if (command === 'task-create' || command === 'task-short-id' && first(args) === 'list') return null;
+  if (command === 'task-short-id') return args[1] ?? null;
+  return first(args) || null;
+}
+
+function taskRefMatchesEnvironment(taskRef: string, taskId: string): boolean {
+  if (/^TASK-\d{8}-\d{6}$/u.test(taskRef)) return taskRef === taskId;
+  if (!/^\d+$/u.test(taskRef)) return true;
+  try {
+    const resolved = resolveTaskRef(taskRef);
+    return resolved.ok && resolved.taskId === taskId;
+  } catch {
+    return false;
+  }
+}
+
+function isSandboxExecutorRoute(
+  dispatcher: TaskOperationDispatcher,
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv
+): boolean {
+  return dispatcher === 'internal'
+    && command === 'sandbox-control'
+    && first(args) === 'execute'
+    && Boolean(env.AGENT_INFRA_EXECUTOR_MANIFEST)
+    && Boolean(env.AGENT_INFRA_RUNTIME_DIR)
+    && !TASK_CONTROL_MARKER_KEYS.some((key) => Boolean(env[key]));
 }
 
 function viewFromEnvironment(env: NodeJS.ProcessEnv): SandboxTaskView {
@@ -324,12 +412,20 @@ export function guardTaskOperation(
   args: readonly string[] = [],
   options: Readonly<{ env?: NodeJS.ProcessEnv; taskView?: SandboxTaskView }> = {}
 ): Readonly<{ descriptor: TaskOperationDescriptor; taskView: SandboxTaskView | null }> {
-  if (args.some((arg) => arg === '--help' || arg === '-h' || arg === 'help')) {
+  const env = options.env ?? process.env;
+  if (args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
     return {
       descriptor: resolveTaskOperation(dispatcher, command, args)
         ?? descriptor(dispatcher, command, 'help', 'non-task', 'diagnostic', 'none'),
       taskView: null
     };
+  }
+  const markerState = taskMarkerState(env);
+  if (markerState === 'incomplete' && !isSandboxExecutorRoute(dispatcher, command, args, env)) {
+    throw new TaskViewOperationError(
+      'SANDBOX_TASK_VIEW_MARKER_INVALID',
+      'sandbox task markers are incomplete; refusing to infer host-direct authority'
+    );
   }
   const selected = command === 'sandbox-control'
     ? first(args) === 'client'
@@ -337,13 +433,21 @@ export function guardTaskOperation(
       : resolveTaskOperation(dispatcher, command, args)
     : resolveTaskOperation(dispatcher, command, args);
   if (!selected) {
-    if (hasTaskBoundMarker(options.env)) {
+    if (markerState === 'task-bound') {
       throw new TaskViewOperationError('TASK_VIEW_OPERATION_UNREGISTERED', `operation '${command} ${first(args)}' is not registered for a task-bound workspace`);
     }
     return { descriptor: descriptor(dispatcher, command, 'unregistered', 'non-task', 'diagnostic', 'none'), taskView: null };
   }
-  if (selected.scope === 'non-task' || !hasTaskBoundMarker(options.env)) return { descriptor: selected, taskView: null };
-  const taskView = options.taskView ?? viewFromEnvironment(options.env ?? process.env);
+  if (selected.scope === 'non-task' || markerState !== 'task-bound') return { descriptor: selected, taskView: null };
+  const taskId = env.AGENT_INFRA_TASK_ID!;
+  const taskRef = explicitTaskRefForOperation(dispatcher, command, args, selected);
+  if (taskRef && !taskRefMatchesEnvironment(taskRef, taskId)) {
+    throw new TaskViewOperationError(
+      'SANDBOX_TASK_REF_MISMATCH',
+      `task-bound operation targets '${taskRef}', but the sandbox is bound to '${taskId}'`
+    );
+  }
+  const taskView = options.taskView ?? viewFromEnvironment(env);
   if (taskView.state === 'not-applicable' && selected.effect !== 'cleanup') {
     throw new TaskViewOperationError('SANDBOX_TASK_VIEW_INVALID', 'task-bound operation has no applicable task view');
   }

--- a/lib/internal/task-orchestration.ts
+++ b/lib/internal/task-orchestration.ts
@@ -1,6 +1,7 @@
 import { createDirectHostExecutionContext, dispatchTaskControlOperation, parseTaskControlOperation } from '../task/control-authority.ts';
 import { OrchestrationStateError } from '../task/orchestration.ts';
 import { detectRepoRoot } from '../task/resolve-ref.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|dispatch|await-activation|recover-prepared|hook-start|hook-stop|advance|pause|status> [options]\n';
 
@@ -19,6 +20,7 @@ function parseFailure(error: unknown): string {
 }
 
 async function taskOrchestration(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-orchestration', args)) return;
   if (args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(USAGE);
     return;

--- a/lib/internal/task-orchestration.ts
+++ b/lib/internal/task-orchestration.ts
@@ -1,7 +1,7 @@
 import { createDirectHostExecutionContext, dispatchTaskControlOperation, parseTaskControlOperation } from '../task/control-authority.ts';
 import { OrchestrationStateError } from '../task/orchestration.ts';
 import { detectRepoRoot } from '../task/resolve-ref.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-orchestration <task-ref|auto> <begin-or-resume|route|prepare|dispatch|await-activation|recover-prepared|hook-start|hook-stop|advance|pause|status> [options]\n';
 
@@ -23,6 +23,16 @@ async function taskOrchestration(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-orchestration', args)) return;
   if (args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(USAGE);
+    return;
+  }
+
+  const route = internalHandlerRoute('task-orchestration', 'status', args[1] ?? '')
+    ? 'status'
+    : internalHandlerRoute('task-orchestration', 'progress', args[1] ? 'progress' : '')
+      ? 'progress'
+      : '';
+  if (!route) {
+    usageFailure('orchestration operation is required');
     return;
   }
 

--- a/lib/internal/task-override.ts
+++ b/lib/internal/task-override.ts
@@ -6,7 +6,7 @@ import {
 import type { ConsumeHumanOverrideRequest, HumanOverrideRequest } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-override <task-ref> <diagnose|issue|consume> [options]
 
@@ -42,7 +42,11 @@ async function taskOverride(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-override', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, operation] = args;
-  if (!taskRef || !operation || !['diagnose', 'issue', 'consume'].includes(operation)) {
+  if (!taskRef || !operation || ![
+    internalHandlerRoute('task-override', 'diagnose', operation ?? ''),
+    internalHandlerRoute('task-override', 'issue', operation ?? ''),
+    internalHandlerRoute('task-override', 'consume', operation ?? '')
+  ].some(Boolean)) {
     usageFailure('task ref and a valid operation are required');
     return;
   }
@@ -77,13 +81,13 @@ async function taskOverride(args: string[] = []): Promise<void> {
 
   let result;
   try {
-    if (operation === 'diagnose') {
+    if (internalHandlerRoute('task-override', 'diagnose', operation)) {
       result = await diagnoseHumanOverrideForTask(
         taskRef,
         values.failureId ? String(values.failureId) : undefined,
         values.target ? String(values.target) : undefined
       );
-    } else if (operation === 'issue') {
+    } else if (internalHandlerRoute('task-override', 'issue', operation)) {
       result = await withTaskExecutionLock(
         resolved.repoRoot,
         resolved.taskId,

--- a/lib/internal/task-override.ts
+++ b/lib/internal/task-override.ts
@@ -6,6 +6,7 @@ import {
 import type { ConsumeHumanOverrideRequest, HumanOverrideRequest } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-override <task-ref> <diagnose|issue|consume> [options]
 
@@ -38,6 +39,7 @@ function usageFailure(message: string): void {
 }
 
 async function taskOverride(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-override', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, operation] = args;
   if (!taskRef || !operation || !['diagnose', 'issue', 'consume'].includes(operation)) {

--- a/lib/internal/task-qualification.ts
+++ b/lib/internal/task-qualification.ts
@@ -6,6 +6,7 @@ import { applyQualificationProposal } from '../task/qualification-intents.ts';
 import type { QualificationProposalRequest } from '../task/qualification-intents.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-qualification <task-ref> <proposal|confirm|supersede|revoke> --input <json-file> [--dry-run]\n`;
 
@@ -17,6 +18,17 @@ function fail(message: string, code = 'QUALIFICATION_PROPOSAL_INVALID'): void {
 
 async function taskQualification(args: string[] = []): Promise<void> {
   const [taskRef, operation] = args;
+  const registered = [
+    internalHandlerRoute('task-qualification', 'proposal', operation ?? ''),
+    internalHandlerRoute('task-qualification', 'confirm', operation ?? ''),
+    internalHandlerRoute('task-qualification', 'supersede', operation ?? ''),
+    internalHandlerRoute('task-qualification', 'revoke', operation ?? '')
+  ].some(Boolean);
+  if (!registered) {
+    fail('task ref and a valid qualification operation are required');
+    return;
+  }
+  if (!ensureInternalHandlerRoute('task-qualification', args)) return;
   if (!taskRef || !['proposal', 'confirm', 'supersede', 'revoke'].includes(operation ?? '')) { fail('task ref and a valid qualification operation are required'); return; }
   let inputPath = '';
   let dryRun = false;

--- a/lib/internal/task-review.ts
+++ b/lib/internal/task-review.ts
@@ -2,6 +2,7 @@ import { finalizeReviewSummary } from '../task/review-finalization.ts';
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-review <task-ref> finalize-summary --stage <analysis|plan|code> --artifact <review-*.md> [--orchestrated] [--dry-run] [--override-ticket <ticket> --override-target <target> --override-scope <scope>]\n';
 
@@ -17,6 +18,7 @@ function failUsage(message: string): void {
 }
 
 async function taskReview(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-review', args)) return;
   if (args[0] === '--help' || args[0] === '-h') {
     process.stdout.write(USAGE);
     return;

--- a/lib/internal/task-review.ts
+++ b/lib/internal/task-review.ts
@@ -2,7 +2,7 @@ import { finalizeReviewSummary } from '../task/review-finalization.ts';
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-review <task-ref> finalize-summary --stage <analysis|plan|code> --artifact <review-*.md> [--orchestrated] [--dry-run] [--override-ticket <ticket> --override-target <target> --override-scope <scope>]\n';
 
@@ -27,7 +27,7 @@ async function taskReview(args: string[] = []): Promise<void> {
     failUsage('task ref and intent are required');
     return;
   }
-  if (args[1] !== 'finalize-summary') {
+  if (!internalHandlerRoute('task-review', 'finalize-summary', args[1] ?? '')) {
     failUsage(`unknown intent '${args[1]}'`);
     return;
   }

--- a/lib/internal/task-short-id.ts
+++ b/lib/internal/task-short-id.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { detectRepoRoot } from '../task/resolve-ref.ts';
 import { configuredShortIdLength, executeShortIdCommand } from '../task/short-id.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-short-id <alloc|release|resolve|list> [argument] [--active-dir <path>] [--short-id-length <N>] [--verify]\n`;
 
@@ -16,7 +16,14 @@ function taskShortId(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('task-short-id', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
-  if (!operation || !['alloc', 'release', 'resolve', 'list'].includes(operation)) { failure('a valid short-id operation is required'); return; }
+  const route = operation === 'list' && args.includes('--verify') ? 'list-verify' : operation ?? '';
+  if (!operation || ![
+    internalHandlerRoute('task-short-id', 'alloc', route),
+    internalHandlerRoute('task-short-id', 'release', route),
+    internalHandlerRoute('task-short-id', 'resolve', route),
+    internalHandlerRoute('task-short-id', 'list', route),
+    internalHandlerRoute('task-short-id', 'list-verify', route)
+  ].some(Boolean)) { failure('a valid short-id operation is required'); return; }
   const positional: string[] = [];
   let activeDir: string | null = null;
   let shortIdLength: number | null = null;

--- a/lib/internal/task-short-id.ts
+++ b/lib/internal/task-short-id.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { detectRepoRoot } from '../task/resolve-ref.ts';
 import { configuredShortIdLength, executeShortIdCommand } from '../task/short-id.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-short-id <alloc|release|resolve|list> [argument] [--active-dir <path>] [--short-id-length <N>] [--verify]\n`;
 
@@ -12,6 +13,7 @@ function failure(message: string): void {
 }
 
 function taskShortId(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-short-id', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const operation = args[0];
   if (!operation || !['alloc', 'release', 'resolve', 'list'].includes(operation)) { failure('a valid short-id operation is required'); return; }

--- a/lib/internal/task-snapshot.ts
+++ b/lib/internal/task-snapshot.ts
@@ -1,5 +1,5 @@
 import { collectTaskSnapshot } from '../task/snapshot.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-snapshot <N | TASK-id> [--format json|text]\n';
 
@@ -12,7 +12,7 @@ function fail(message: string): void {
 function taskSnapshot(args: string[] = []): void {
   if (!ensureInternalHandlerRoute('task-snapshot', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
-  if (!args[0] || args[0].startsWith('--')) { fail('task ref is required'); return; }
+  if (!args[0] || args[0].startsWith('--') || !internalHandlerRoute('task-snapshot', 'snapshot', 'snapshot')) { fail('task ref is required'); return; }
   let format: 'json' | 'text' = 'json';
   let seenFormat = false;
   for (let index = 1; index < args.length; index += 1) {

--- a/lib/internal/task-snapshot.ts
+++ b/lib/internal/task-snapshot.ts
@@ -1,4 +1,5 @@
 import { collectTaskSnapshot } from '../task/snapshot.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-snapshot <N | TASK-id> [--format json|text]\n';
 
@@ -9,6 +10,7 @@ function fail(message: string): void {
 }
 
 function taskSnapshot(args: string[] = []): void {
+  if (!ensureInternalHandlerRoute('task-snapshot', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (!args[0] || args[0].startsWith('--')) { fail('task ref is required'); return; }
   let format: 'json' | 'text' = 'json';

--- a/lib/internal/task-validate.ts
+++ b/lib/internal/task-validate.ts
@@ -24,7 +24,7 @@ import {
 } from '../sandbox/control/protocol.ts';
 import { getProcessStartTime } from '../server/process-state.ts';
 import { assertGitWorktreeBinding } from '../git/worktree-identity.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-validate <branch | TASK-id | N> [--scope snapshot|inplace] [--timeout <ms>] [--format text|json] -- <command> [args...]`;
 const MAX_TIMEOUT_MS = 60 * 60 * 1000;
@@ -289,9 +289,11 @@ function taskValidate(args: string[]): void {
     const target = resolveSandboxTarget(options.target, config.repoRoot);
     const commit = git(config.repoRoot, ['rev-parse', target.branch]);
     const startedAt = new Date().toISOString();
-    const result = options.scope === 'snapshot'
+    const result = internalHandlerRoute('task-validate', 'snapshot', options.scope)
       ? snapshotValidation(config.repoRoot, commit, options)
-      : inplaceValidation(config, target, options);
+      : internalHandlerRoute('task-validate', 'inplace', options.scope)
+        ? inplaceValidation(config, target, options)
+        : (() => { throw new Error('TASK_VALIDATE_SCOPE_UNREGISTERED'); })();
     const evidence = {
       version: 1,
       taskId: target.workspace.mode === 'task-bound' ? target.workspace.taskId : null,

--- a/lib/internal/task-validate.ts
+++ b/lib/internal/task-validate.ts
@@ -24,6 +24,7 @@ import {
 } from '../sandbox/control/protocol.ts';
 import { getProcessStartTime } from '../server/process-state.ts';
 import { assertGitWorktreeBinding } from '../git/worktree-identity.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-validate <branch | TASK-id | N> [--scope snapshot|inplace] [--timeout <ms>] [--format text|json] -- <command> [args...]`;
 const MAX_TIMEOUT_MS = 60 * 60 * 1000;
@@ -271,6 +272,7 @@ function sniffFormat(args: string[]): 'text' | 'json' {
 }
 
 function taskValidate(args: string[]): void {
+  if (!ensureInternalHandlerRoute('task-validate', args)) return;
   let options: ValidateOptions;
   try {
     options = parseValidateArgs(args);

--- a/lib/internal/task-verify.ts
+++ b/lib/internal/task-verify.ts
@@ -2,7 +2,7 @@ import { renderTaskVerification, verifyTaskEvent } from '../task/verification.ts
 import { consumeHumanOverride, failureId } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-verify <N | TASK-id> <verification-event> [--artifact <canonical.md>] [--format json|text] [--override-ticket <ticket> --override-target <target> --override-scope <scope>]\n';
 
@@ -15,7 +15,8 @@ function fail(message: string): void {
 async function taskVerify(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-verify', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
-  if (!args[0] || !args[1] || args[0].startsWith('--') || args[1].startsWith('--')) { fail('task ref and verification event are required'); return; }
+  if (!args[0] || !args[1] || args[0].startsWith('--') || args[1].startsWith('--')
+    || !internalHandlerRoute('task-verify', 'event', args[1] ? 'event' : '')) { fail('task ref and verification event are required'); return; }
   const taskRef = args[0];
   const event = args[1];
   let artifact: string | undefined;

--- a/lib/internal/task-verify.ts
+++ b/lib/internal/task-verify.ts
@@ -2,6 +2,7 @@ import { renderTaskVerification, verifyTaskEvent } from '../task/verification.ts
 import { consumeHumanOverride, failureId } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = 'Usage: agent-infra-internal task-verify <N | TASK-id> <verification-event> [--artifact <canonical.md>] [--format json|text] [--override-ticket <ticket> --override-target <target> --override-scope <scope>]\n';
 
@@ -12,6 +13,7 @@ function fail(message: string): void {
 }
 
 async function taskVerify(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-verify', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   if (!args[0] || !args[1] || args[0].startsWith('--') || args[1].startsWith('--')) { fail('task ref and verification event are required'); return; }
   const taskRef = args[0];

--- a/lib/internal/task-warning.ts
+++ b/lib/internal/task-warning.ts
@@ -3,6 +3,7 @@ import type { WorkflowWarningIntent } from '../task/workflow-warning-intents.ts'
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
+import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-warning <task-ref> <add|set-status|list> [intent flags] [--dry-run]\n`;
 const FLAGS: Record<string, string> = {
@@ -18,6 +19,7 @@ function usageFailure(message: string): void {
 }
 
 async function taskWarning(args: string[] = []): Promise<void> {
+  if (!ensureInternalHandlerRoute('task-warning', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
   if (!taskRef || !kind || !['add', 'set-status', 'list'].includes(kind)) { usageFailure('task ref and a valid intent are required'); return; }

--- a/lib/internal/task-warning.ts
+++ b/lib/internal/task-warning.ts
@@ -3,7 +3,7 @@ import type { WorkflowWarningIntent } from '../task/workflow-warning-intents.ts'
 import { consumeHumanOverride, failureId, overrideDryRunConflict } from '../task/human-override.ts';
 import { resolveTaskRef } from '../task/resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from '../task/task-execution-lock.ts';
-import { ensureInternalHandlerRoute } from './cli-route-inventory.ts';
+import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
 const USAGE = `Usage: agent-infra-internal task-warning <task-ref> <add|set-status|list> [intent flags] [--dry-run]\n`;
 const FLAGS: Record<string, string> = {
@@ -22,7 +22,11 @@ async function taskWarning(args: string[] = []): Promise<void> {
   if (!ensureInternalHandlerRoute('task-warning', args)) return;
   if (args[0] === '--help' || args[0] === '-h') { process.stdout.write(USAGE); return; }
   const [taskRef, kind] = args;
-  if (!taskRef || !kind || !['add', 'set-status', 'list'].includes(kind)) { usageFailure('task ref and a valid intent are required'); return; }
+  if (!taskRef || !kind || ![
+    internalHandlerRoute('task-warning', 'add', kind ?? ''),
+    internalHandlerRoute('task-warning', 'set-status', kind ?? ''),
+    internalHandlerRoute('task-warning', 'list', kind ?? '')
+  ].some(Boolean)) { usageFailure('task ref and a valid intent are required'); return; }
   const values: Record<string, unknown> = { kind, taskRef };
   const seen = new Set<string>();
   for (let index = 2; index < args.length; index += 1) {

--- a/lib/process-data/index.ts
+++ b/lib/process-data/index.ts
@@ -10,6 +10,7 @@ import { readAppliedOverlays, repairSnapshot } from './repair.ts';
 import { collectGitHubBoundary, resolveGitHubRepository } from './sources.ts';
 import { canonicalJsonBytes, createObjectStore, findSnapshot, publishSnapshotV2, verifySnapshot } from './store.ts';
 import { createGitHubClient } from '../platform/github-client.ts';
+import { PUBLIC_CLI_ROUTE_SELECTORS } from '../internal/cli-route-inventory.ts';
 
 import type { NormalizedRecord } from './types.ts';
 
@@ -22,6 +23,7 @@ Commands:
   repair <snapshot-id> [--root <dir>] [--apply]
   export <snapshot-id> [--root <dir>] [--repairs none|applied] [--as-of <ISO>] [--output <file|->]
 `;
+const DATA_OPERATIONS = PUBLIC_CLI_ROUTE_SELECTORS.data;
 
 type ParsedArgs = { positionals: string[]; options: Map<string, string | true> };
 
@@ -256,6 +258,11 @@ async function cmdData(args: string[]): Promise<number> {
     return command ? 0 : 1;
   }
   try {
+    if (!DATA_OPERATIONS.includes(command as typeof DATA_OPERATIONS[number])) {
+      process.stderr.write(`Unknown data command: ${command}\n`);
+      process.stdout.write(USAGE);
+      return 1;
+    }
     switch (command) {
       case 'capture': return capture(rest);
       case 'verify': return verify(rest);

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -7,6 +7,7 @@ import { loadShortIdByTaskId, normalizeShortIdInput } from '../task/short-id.ts'
 import { buildTuiCommand, renderPrompt, selectTui } from './tui.ts';
 import { getSkillRunSpec } from './skills.ts';
 import { runHostCommand, type RunProcessResult } from './host.ts';
+import { PUBLIC_CLI_ROUTE_SELECTORS } from '../internal/cli-route-inventory.ts';
 
 export type ParsedRunArgs = {
   skill: string;
@@ -107,6 +108,10 @@ export function parseRunArgs(args: string[]): ParsedRunArgs {
   if (!skill) throw new Error("option '--skill' is required");
   const spec = getSkillRunSpec(skill);
   if (!spec) throw new Error(`Unknown skill '${skill}'`);
+  const routeSelector = spec.kind === 'create' ? 'create-task' : recreate ? 'recreate' : 'task-skill';
+  if (!PUBLIC_CLI_ROUTE_SELECTORS.run.includes(routeSelector as typeof PUBLIC_CLI_ROUTE_SELECTORS.run[number])) {
+    throw new Error(`Unsupported run route '${routeSelector}'`);
+  }
   if (spec.kind === 'create') {
     if (taskRef !== null) throw new Error("create-task does not accept '--task'");
     if (recreate) throw new Error('--recreate is only valid for sandbox task runs');

--- a/lib/sandbox/commands/control-status.ts
+++ b/lib/sandbox/commands/control-status.ts
@@ -1,0 +1,26 @@
+import type { SandboxConfig } from '../config.ts';
+import { readSandboxControlStatus } from '../control/state.ts';
+import type { SandboxControlStatus } from '../control/protocol.ts';
+import { sandboxControlPaths } from '../workspace-view.ts';
+import type { SandboxRow } from './list-running.ts';
+
+export function readSandboxControlStatusForRow(
+  config: SandboxConfig,
+  row: Pick<SandboxRow, 'name' | 'workspaceMode' | 'taskId'>
+): SandboxControlStatus | null {
+  if (!row.workspaceMode || row.workspaceMode === 'legacy-invalid') return null;
+  const identity = row.workspaceMode === 'task-bound' && row.taskId
+    ? { mode: 'task-bound' as const, taskId: row.taskId }
+    : { mode: 'branch-only' as const };
+  const control = sandboxControlPaths({
+    base: config.controlBase,
+    project: config.project,
+    container: row.name,
+    identity
+  });
+  try {
+    return readSandboxControlStatus(control.statusDir);
+  } catch {
+    return null;
+  }
+}

--- a/lib/sandbox/commands/ls.ts
+++ b/lib/sandbox/commands/ls.ts
@@ -11,6 +11,7 @@ import { detectEngine } from '../engine.ts';
 import { formatTable } from '../../table.ts';
 import { loadShortIdByTaskId } from '../../task/short-id.ts';
 import { fetchSandboxRows } from './list-running.ts';
+import { readSandboxControlStatusForRow } from './control-status.ts';
 
 export { containerListFormat, parseLabels } from './list-running.ts';
 
@@ -88,6 +89,12 @@ export function ls(args: string[] = []): void {
       process.stdout.write(`  ${line}\n`);
     }
     process.stdout.write(`  Total: ${ordered.length} containers\n`);
+    for (const row of ordered) {
+      const controlStatus = readSandboxControlStatusForRow(config, row);
+      process.stdout.write(
+        `  ${row.name}: health=${controlStatus?.state ?? 'unavailable'} task-view=${controlStatus?.taskView.state ?? 'unavailable'}\n`
+      );
+    }
     if (tableRows.some((r) => r.shortId === '-')) {
       process.stdout.write(
         `  SHORT '-' = no active task bound; that sandbox is free to remove with 'ai sandbox rm <branch>'.\n`

--- a/lib/sandbox/commands/show.ts
+++ b/lib/sandbox/commands/show.ts
@@ -16,6 +16,7 @@ import { fetchSandboxRows, selectSandboxContainer } from './list-running.ts';
 import { resolveTools, toolConfigDirCandidates } from '../tools.ts';
 import { detectEngine } from '../engine.ts';
 import { resolveSandboxTarget } from '../workspace-identity.ts';
+import { readSandboxControlStatusForRow } from './control-status.ts';
 
 const USAGE = `Usage: ai sandbox show <branch | TASK-id | N>
 
@@ -92,6 +93,21 @@ export function show(args: string[] = []): void {
   p.log.step('Workspace identity');
   process.stdout.write(`  Mode: ${container?.workspaceMode ?? 'legacy-invalid'}\n`);
   process.stdout.write(`  Task: ${container?.taskId ?? '-'}\n`);
+
+  p.log.step('Control status');
+  const controlStatus = container
+    ? readSandboxControlStatusForRow(config, container)
+    : null;
+  if (!controlStatus) {
+    p.log.warn('  Control status unavailable');
+  } else {
+    process.stdout.write(`  Health: ${controlStatus.state}\n`);
+    process.stdout.write(`  Task view: ${controlStatus.taskView.state}\n`);
+    process.stdout.write(`  Task source: ${controlStatus.taskView.observedSource ?? '-'}\n`);
+    if (controlStatus.taskView.reasonCode) {
+      process.stdout.write(`  Task view reason: ${controlStatus.taskView.reasonCode}\n`);
+    }
+  }
 
   for (const tool of detail.toolStates) {
     p.log.step(`${tool.name} state`);

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -22,6 +22,7 @@ import type { ProcessIdentity } from '../../server/process-state.ts';
 import { normalizeAgentToken } from '../../agent-clients/tokens.ts';
 import { readSandboxControlPayload, readSandboxControlStatus } from './state.ts';
 import type { TaskCreateCandidateV1 } from '../../task/create.ts';
+import { accessSandboxTaskView, taskViewFromStatus, type TaskViewAccessEffect } from './task-view.ts';
 
 const SANDBOX_CONTROL_RESPONSE_SETTLE_MS = 250;
 
@@ -52,7 +53,19 @@ function clientError(
   throw new SandboxControlClientError({ code, message: `${code}: ${message}`, retryable }, accepted, requestId);
 }
 
-function preflight(statusDir: string, generation: string, now = Date.now()): void {
+function hasTaskBoundMarker(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.AGENT_INFRA_TASK_ID)
+    && Boolean(env.AGENT_INFRA_CONTROL_TOKEN || env.AGENT_INFRA_CONTROL_GENERATION
+      || env.AGENT_INFRA_CONTROL_STATUS_DIR || env.AGENT_INFRA_RUNTIME_DIR || env.AGENT_INFRA_CONTROL_DIR);
+}
+
+function preflight(
+  statusDir: string,
+  generation: string,
+  taskViewEffect: TaskViewAccessEffect | null = null,
+  now = Date.now(),
+  env: NodeJS.ProcessEnv = process.env
+): void {
   let status;
   try {
     status = readSandboxControlStatus(statusDir);
@@ -71,6 +84,26 @@ function preflight(statusDir: string, generation: string, now = Date.now()): voi
     clientError(code, 'broker is parked until the host restores a valid binding', true);
   }
   if (status.state !== 'healthy') clientError('SANDBOX_CONTROL_BROKER_UNAVAILABLE', 'broker is not ready', true);
+  if (taskViewEffect && hasTaskBoundMarker(env)) {
+    const view = taskViewFromStatus(status);
+    if (view.taskId !== env.AGENT_INFRA_TASK_ID) {
+      clientError('SANDBOX_TASK_VIEW_TASK_ID_MISMATCH', 'task view task id does not match the sandbox task marker', false);
+    }
+    const access = accessSandboxTaskView(view, taskViewEffect);
+    if (!access.allowed) {
+      clientError(
+        access.reasonCode ?? 'SANDBOX_TASK_VIEW_DENIED',
+        access.message ?? 'task view denied',
+        false
+      );
+    }
+  }
+}
+
+function taskViewEffectForRequest(request: SandboxControlRequest): TaskViewAccessEffect | null {
+  if (request.family === 'task-lifecycle' || request.family === 'task-finalization') return 'progress';
+  if (request.family === 'task-orchestration') return request.args[1] === 'status' ? 'diagnostic' : 'progress';
+  return null;
 }
 
 function parseResponse(raw: string, id: string): SandboxControlResponse {
@@ -122,7 +155,8 @@ function exchangeSandboxControl(request: SandboxControlRequest, params: Readonly
 }>): SandboxControlResponse {
   const channelDir = params.channelDir ?? process.env.AGENT_INFRA_CONTROL_DIR ?? '/run/agent-infra/control';
   const statusDir = params.statusDir ?? process.env.AGENT_INFRA_CONTROL_STATUS_DIR ?? '/run/agent-infra/control-status';
-  preflight(statusDir, request.generation);
+  const taskViewEffect = taskViewEffectForRequest(request);
+  preflight(statusDir, request.generation, taskViewEffect);
   const encoded = `${JSON.stringify(request)}\n`;
   if (Buffer.byteLength(encoded, 'utf8') > SANDBOX_CONTROL_MAX_BYTES) {
     clientError('SANDBOX_CONTROL_REQUEST_TOO_LARGE', 'request exceeds the control limit', false, false, request.id);
@@ -176,7 +210,7 @@ function exchangeSandboxControl(request: SandboxControlRequest, params: Readonly
     }
     if (!accepted) {
       try {
-        preflight(statusDir, request.generation);
+        preflight(statusDir, request.generation, taskViewEffect);
       } catch (error) {
         if (cancelPendingRequest(requestPath)) throw error;
         clientError(

--- a/lib/sandbox/control/completed-reentry.ts
+++ b/lib/sandbox/control/completed-reentry.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveTaskWorkspace } from '../task-resolver.ts';
+import { assertGitWorktreeBinding } from '../../git/worktree-identity.ts';
+import { parseTypedTaskFrontmatter } from '../../task/frontmatter.ts';
+import { readTaskFinalizationReceipt } from '../../task/finalization.ts';
+import { inspectSandboxControlContainer } from './container-identity.ts';
+import type { SandboxControlManifest } from './protocol.ts';
+import { atomicWriteJson, readSandboxControlStatus } from './state.ts';
+import { taskViewForManifest, type SandboxTaskView } from './task-view.ts';
+
+type ReentryEvidence = Readonly<{
+  taskId: string;
+  generation: string;
+  containerId: string;
+  branch: string;
+  worktreeRoot: string;
+  source: string;
+  sourceDevice: string;
+  sourceInode: string;
+  receipt: NonNullable<SandboxTaskView['receipt']>;
+}>;
+
+function evidencePath(manifest: SandboxControlManifest): string {
+  return path.join(path.dirname(manifest.processingDir), 'completed-reentry.json');
+}
+
+function invalid(): Error {
+  return new Error('SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID');
+}
+
+export async function prepareCompletedReentry(
+  manifest: SandboxControlManifest,
+  inspect: typeof inspectSandboxControlContainer = inspectSandboxControlContainer
+): Promise<ReentryEvidence> {
+  if (manifest.mode !== 'task-bound' || !manifest.taskId) throw invalid();
+  assertGitWorktreeBinding(manifest.repoRoot, manifest.worktreeRoot, manifest.branch);
+  const container = await inspect(manifest);
+  if (container.state !== 'found' || container.id !== manifest.containerIdentity.id) throw invalid();
+  const task = resolveTaskWorkspace(manifest.taskId, manifest.repoRoot);
+  const metadata = parseTypedTaskFrontmatter(fs.readFileSync(task.taskMd, 'utf8'));
+  if (task.state !== 'completed' || task.branch !== manifest.branch
+    || metadata.id !== manifest.taskId || metadata.status !== 'completed') throw invalid();
+  const receipt = readTaskFinalizationReceipt(manifest.repoRoot, manifest.taskId);
+  if (!receipt || receipt.taskId !== manifest.taskId) throw invalid();
+  const view = taskViewForManifest({ ...manifest, receipt });
+  if (view.state !== 'current' || view.observedSource !== 'completed' || !view.receipt) throw invalid();
+  const status = readSandboxControlStatus(manifest.publicStatusDir);
+  const previous = status.taskView;
+  if (status.generation !== manifest.generation || status.activeRequestId !== null
+    || previous.taskId !== manifest.taskId || !previous.receipt
+    || previous.receipt.receiptId !== view.receipt.receiptId
+    || previous.receipt.generation !== view.receipt.generation
+    || previous.receipt.requestId !== view.receipt.requestId
+    || previous.receipt.revision > view.receipt.revision) throw invalid();
+  const completedRoot = fs.realpathSync.native(path.join(manifest.repoRoot, '.agents', 'workspace', 'completed'));
+  const source = fs.realpathSync.native(path.join(completedRoot, manifest.taskId));
+  if (source !== path.join(completedRoot, manifest.taskId)) throw invalid();
+  const stat = fs.statSync(source, { bigint: true });
+  return {
+    taskId: manifest.taskId, generation: manifest.generation,
+    containerId: container.id, branch: manifest.branch,
+    worktreeRoot: fs.realpathSync.native(manifest.worktreeRoot),
+    source, sourceDevice: String(stat.dev), sourceInode: String(stat.ino), receipt: view.receipt
+  };
+}
+
+export function publishCompletedReentry(manifest: SandboxControlManifest, evidence: ReentryEvidence): void {
+  atomicWriteJson(evidencePath(manifest), evidence);
+}
+
+export async function completedReentryView(
+  manifest: SandboxControlManifest,
+  inspect: typeof inspectSandboxControlContainer = inspectSandboxControlContainer
+): Promise<SandboxTaskView | null> {
+  const file = evidencePath(manifest);
+  if (!fs.existsSync(file)) return null;
+  const evidence: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const current = await prepareCompletedReentry(manifest, inspect);
+  if (JSON.stringify(evidence) !== JSON.stringify(current)) throw invalid();
+  return {
+    state: 'current', taskId: current.taskId, observedSource: 'completed',
+    receipt: current.receipt, reasonCode: null
+  };
+}
+
+export async function waitForCompletedReentry(manifest: SandboxControlManifest, evidence: ReentryEvidence): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const status = readSandboxControlStatus(manifest.publicStatusDir);
+    if (status.generation !== evidence.generation) throw invalid();
+    if (status.taskView.state === 'current' && status.taskView.observedSource === 'completed'
+      && status.taskView.taskId === evidence.taskId
+      && JSON.stringify(status.taskView.receipt) === JSON.stringify(evidence.receipt)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('SANDBOX_COMPLETED_REENTRY_STATUS_TIMEOUT');
+}

--- a/lib/sandbox/control/protocol.ts
+++ b/lib/sandbox/control/protocol.ts
@@ -4,6 +4,7 @@ import { normalizeAgentToken } from '../../agent-clients/tokens.ts';
 import type { ProcessIdentity } from '../../server/process-state.ts';
 import type { CodexControllerLeaseProofV1 } from './controller-registration.ts';
 import type { SandboxAuthorityEvidenceV1 } from '../engines/authority.ts';
+import type { SandboxTaskView } from './task-view.ts';
 
 export const SANDBOX_CONTROL_MAX_BYTES = 64 * 1024;
 export const SANDBOX_CONTROL_MAX_LOGICAL_RECORDS = 1024;
@@ -109,9 +110,9 @@ export type SandboxControlResponse = Readonly<{
   payload?: SandboxControlPayloadReference | null;
 }>;
 export type SandboxControlStatus = Readonly<{
-  version: 2; generation: string; broker: ProcessIdentity & { brokerId: string };
+  version: 3; generation: string; broker: ProcessIdentity & { brokerId: string };
   state: 'starting' | 'healthy' | 'busy' | 'parked'; reasonCode: string | null;
-  activeRequestId: string | null; updatedAt: number;
+  activeRequestId: string | null; updatedAt: number; taskView: SandboxTaskView;
 }>;
 export type SandboxControlLease = Readonly<{
   version: 2; generation: string; nonce: string; owner: ProcessIdentity;

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -703,6 +703,17 @@ export async function serveSandboxControl(
   let bindingBackoffMs: number = timing.parkedBindingInitialMs;
   try {
     if (!brokerOwns()) return;
+    if (taskView.state === 'current' && taskView.observedSource === 'completed') {
+      // Recheck durable re-entry evidence before publishing a trusted startup view.
+      const unverified = { ...taskView, state: 'unknown' as const,
+        reasonCode: 'SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID' };
+      try {
+        taskView = await completedReentryView(manifest, inspectContainer) ?? unverified;
+      } catch {
+        taskView = unverified;
+      }
+      if (!brokerOwns()) return;
+    }
     writeSandboxControlStatus(manifest, broker, 'starting', null, null, Date.now(), taskView);
     if (!brokerOwns()) return;
     appendBrokerAudit(manifest, 'broker-start', {

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -721,7 +721,7 @@ export async function serveSandboxControl(
       processingDir: manifest.processingDir,
       internalCliPath: options.internalCliPath ?? process.argv[1] ?? null
     });
-    if (!recoverProcessing(manifest, brokerOwns)) return;
+    if (!recoverProcessing(manifest, broker, brokerOwns)) return;
     try {
       const published = readSandboxControlStatus(manifest.publicStatusDir);
       if (published.generation === manifest.generation) taskView = published.taskView;

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -34,7 +34,8 @@ import {
   writeSandboxControlReservation,
   writeSandboxControlResultEvidence,
   terminateSandboxControlExecution,
-  writeSandboxControlStatus
+  writeSandboxControlStatus,
+  readSandboxControlStatus
 } from './state.ts';
 import { validateSandboxControlRequest } from './protocol.ts';
 import { inspectSandboxControlContainer, type ContainerObservation } from './container-identity.ts';
@@ -48,6 +49,12 @@ import type { BrokerOwner } from './lifecycle.ts';
 import { nextSandboxControlBackoff } from './timing.ts';
 import { readTaskFinalizationReceipt } from '../../task/finalization.ts';
 import { resolveTaskRef } from '../../task/resolve-ref.ts';
+import {
+  mergeSandboxTaskView,
+  taskViewAfterFinalization,
+  taskViewForManifest,
+  type SandboxTaskView
+} from './task-view.ts';
 
 type ActiveExecution = {
   request: SandboxControlRequest;
@@ -232,6 +239,36 @@ function finalizationRecoveryResponse(
   };
 }
 
+function publishFinalizationTaskView(
+  manifest: SandboxControlManifest,
+  broker: BrokerOwner,
+  requestId: string,
+  state: 'starting' | 'healthy' | 'busy' | 'parked',
+  reasonCode: string | null,
+  activeRequestId: string | null
+): SandboxTaskView {
+  let view: SandboxTaskView;
+  try {
+    const resolved = resolveTaskRef(manifest.taskId ?? '', { repoRoot: manifest.repoRoot });
+    const receipt = readTaskFinalizationReceipt(manifest.repoRoot, manifest.taskId ?? '');
+    view = resolved.ok && resolved.state === 'completed'
+      ? taskViewAfterFinalization({
+          taskId: manifest.taskId ?? '', generation: manifest.generation, requestId, receipt
+        })
+      : {
+          state: 'unknown', taskId: manifest.taskId, observedSource: 'unknown', receipt: null,
+          reasonCode: 'SANDBOX_TASK_VIEW_SOURCE_UNCONFIRMED'
+        };
+  } catch {
+    view = {
+      state: 'unknown', taskId: manifest.taskId, observedSource: 'unknown', receipt: null,
+      reasonCode: 'SANDBOX_TASK_VIEW_RECEIPT_INVALID'
+    };
+  }
+  writeSandboxControlStatus(manifest, broker, state, reasonCode, activeRequestId, Date.now(), view);
+  return view;
+}
+
 function payloadReference(payload: ReturnType<typeof createSandboxControlPayload>) {
   return {
     version: payload.version,
@@ -343,6 +380,7 @@ function publishExecutionResult(
   manifest: SandboxControlManifest,
   request: SandboxControlRequest,
   result: SandboxControlExecutionResult,
+  broker: BrokerOwner,
   brokerOwns: () => boolean
 ): boolean {
   const normalized = sanitizeSandboxControlResult(manifest, result);
@@ -387,6 +425,10 @@ function publishExecutionResult(
     }
   }
   if (!brokerOwns()) return false;
+  if (request.family === 'task-finalization' && normalized.exitCode === 0) {
+    const view = publishFinalizationTaskView(manifest, broker, request.id, 'healthy', null, null);
+    if (view.state === 'unknown') return false;
+  }
   return writeSandboxControlResponse(manifest, terminal);
 }
 
@@ -452,7 +494,7 @@ function bindingReason(manifest: SandboxControlManifest): string | null {
   }
 }
 
-function recoverProcessing(manifest: SandboxControlManifest, brokerOwns: () => boolean): boolean {
+function recoverProcessing(manifest: SandboxControlManifest, broker: BrokerOwner, brokerOwns: () => boolean): boolean {
   for (const entry of fs.readdirSync(manifest.processingDir, { withFileTypes: true })) {
     if (!entry.isDirectory() || !/^[a-f0-9-]{16,64}$/.test(entry.name)) continue;
     if (!brokerOwns()) return false;
@@ -534,12 +576,20 @@ function recoverProcessing(manifest: SandboxControlManifest, brokerOwns: () => b
         const reconciliation = terminalMatchesEvidence(manifest, request, existingTerminalResponse!, resultEvidence, payload, payloadInvalid);
         if (!reconciliation.valid) continue;
         payloadReferenced = reconciliation.payloadReferenced;
+        if (request.family === 'task-finalization' && resultEvidence.exitCode === 0) {
+          const view = publishFinalizationTaskView(manifest, broker, request.id, 'starting', null, null);
+          if (view.state === 'unknown') continue;
+        }
       }
       if (!terminal) {
         if (!brokerOwns()) return false;
         if (!resultEvidence || !request || payloadInvalid) continue;
         const recovered = recoveryResponse(manifest, request, resultEvidence, payload);
         if (!recovered) continue;
+        if (request.family === 'task-finalization' && resultEvidence.exitCode === 0) {
+          const view = publishFinalizationTaskView(manifest, broker, request.id, 'starting', null, null);
+          if (view.state === 'unknown') continue;
+        }
         writeSandboxControlResponse(manifest, recovered);
         payloadReferenced = Boolean(payload) && request.family !== 'task-finalization';
       }
@@ -623,6 +673,25 @@ export async function serveSandboxControl(
     releaseStartup();
   }
   let active: ActiveExecution | null = null;
+  let startupReceipt: unknown = null;
+  if (manifest.taskId) {
+    try {
+      startupReceipt = readTaskFinalizationReceipt(manifest.repoRoot, manifest.taskId);
+    } catch {
+      // Preserve malformed receipt evidence as unknown rather than treating it as no receipt.
+      startupReceipt = {};
+    }
+  }
+  let taskView = taskViewForManifest({
+    ...manifest,
+    receipt: startupReceipt
+  });
+  try {
+    const previous = readSandboxControlStatus(manifest.publicStatusDir);
+    if (previous.generation === manifest.generation) taskView = mergeSandboxTaskView(taskView, previous.taskView);
+  } catch {
+    // A fresh control root has no previous task-view projection.
+  }
   let lastState = '';
   let lastStatusAt = 0;
   let nextBindingCheckAt = 0;
@@ -633,7 +702,7 @@ export async function serveSandboxControl(
   let bindingBackoffMs: number = timing.parkedBindingInitialMs;
   try {
     if (!brokerOwns()) return;
-    writeSandboxControlStatus(manifest, broker, 'starting', null, null);
+    writeSandboxControlStatus(manifest, broker, 'starting', null, null, Date.now(), taskView);
     if (!brokerOwns()) return;
     appendBrokerAudit(manifest, 'broker-start', {
       pid: broker.pid,
@@ -653,6 +722,12 @@ export async function serveSandboxControl(
       internalCliPath: options.internalCliPath ?? process.argv[1] ?? null
     });
     if (!recoverProcessing(manifest, brokerOwns)) return;
+    try {
+      const published = readSandboxControlStatus(manifest.publicStatusDir);
+      if (published.generation === manifest.generation) taskView = published.taskView;
+    } catch {
+      // The regular heartbeat will publish an invalid or missing projection as unknown.
+    }
     while (!signal.aborted) {
       let settledExecution: ActiveExecution | null = null;
       if (!brokerOwns()) break;
@@ -747,7 +822,7 @@ export async function serveSandboxControl(
       const state = reasonCode ? 'parked' : active ? 'busy' : 'healthy';
       const stateKey = `${state}:${reasonCode ?? ''}:${active?.request.id ?? ''}`;
       if (brokerOwns() && (stateKey !== lastState || now - lastStatusAt >= timing.controlTickMs)) {
-        writeSandboxControlStatus(manifest, broker, state, reasonCode, active?.request.id ?? null, now);
+        writeSandboxControlStatus(manifest, broker, state, reasonCode, active?.request.id ?? null, now, taskView);
         lastStatusAt = now;
       }
       if (brokerOwns() && stateKey !== lastState) {
@@ -758,7 +833,15 @@ export async function serveSandboxControl(
         if (!brokerOwns()) break;
         let terminalCommitted = false;
         if (settledExecution.result && settledExecution.resultEvidenceWritten) {
-          terminalCommitted = publishExecutionResult(manifest, settledExecution.request, settledExecution.result, brokerOwns);
+          terminalCommitted = publishExecutionResult(manifest, settledExecution.request, settledExecution.result, broker, brokerOwns);
+          if (terminalCommitted && settledExecution.request.family === 'task-finalization') {
+            try {
+              const published = readSandboxControlStatus(manifest.publicStatusDir);
+              if (published.generation === manifest.generation) taskView = published.taskView;
+            } catch {
+              taskView = { state: 'unknown', taskId: manifest.taskId, observedSource: 'unknown', receipt: null, reasonCode: 'SANDBOX_TASK_VIEW_STATUS_INVALID' };
+            }
+          }
         } else {
           terminalCommitted = writeSandboxControlResponse(manifest, unknown(settledExecution.request.id));
         }
@@ -988,7 +1071,7 @@ export async function serveSandboxControl(
         }
       }
       if (owned && active.result && active.resultEvidenceWritten) {
-        if (publishExecutionResult(manifest, active.request, active.result, brokerOwns)) {
+        if (publishExecutionResult(manifest, active.request, active.result, broker, brokerOwns)) {
           if (brokerOwns()) {
             removeAcceptedResponse(manifest, active.request.id);
             fs.rmSync(path.join(manifest.processingDir, active.request.id), { recursive: true, force: true });
@@ -1000,7 +1083,11 @@ export async function serveSandboxControl(
         const terminationConfirmed = active.prepared.terminate(owned);
         if (owned && brokerOwns() && active.request.family === 'task-finalization') {
           const recovered = finalizationRecoveryResponse(manifest, active.request.id, 0);
-          if (recovered.status === 'matched' && recovered.response && writeSandboxControlResponse(manifest, recovered.response)) {
+          const view = recovered.status === 'matched'
+            ? publishFinalizationTaskView(manifest, broker, active.request.id, 'healthy', null, null)
+            : null;
+          if (view?.state !== 'unknown' && recovered.status === 'matched' && recovered.response
+            && writeSandboxControlResponse(manifest, recovered.response)) {
             if (terminationConfirmed && brokerOwns()) {
               removeAcceptedResponse(manifest, active.request.id);
               fs.rmSync(path.join(manifest.processingDir, active.request.id), { recursive: true, force: true });

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -1,3 +1,4 @@
+import { completedReentryView } from './completed-reentry.ts';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
@@ -819,6 +820,16 @@ export async function serveSandboxControl(
       }
       reasonCode ??= containerReasonCode;
       reasonCode ??= bindingReasonCode;
+      if (!reasonCode && !active && taskView.state !== 'current') {
+        try {
+          const reentered = await completedReentryView(manifest, inspectContainer);
+          if (reentered && brokerOwns() && !readActiveLease(manifest) && !bindingCheck(manifest)) {
+            taskView = reentered;
+          }
+        } catch {
+          // Invalid or changed re-entry evidence never clears the existing task view.
+        }
+      }
       const state = reasonCode ? 'parked' : active ? 'busy' : 'healthy';
       const stateKey = `${state}:${reasonCode ?? ''}:${active?.request.id ?? ''}`;
       if (brokerOwns() && (stateKey !== lastState || now - lastStatusAt >= timing.controlTickMs)) {

--- a/lib/sandbox/control/state.ts
+++ b/lib/sandbox/control/state.ts
@@ -23,6 +23,7 @@ import {
   SANDBOX_CONTROL_MAX_TERMINAL_RECORD_BYTES,
   SANDBOX_CONTROL_RESERVATION_BYTES
 } from './protocol.ts';
+import { parseSandboxTaskView, taskViewForManifest, type SandboxTaskView } from './task-view.ts';
 
 export const SANDBOX_CONTROL_AUDIT_MAX_BYTES = 1024 * 1024;
 export const SANDBOX_CONTROL_EXECUTION_STOP_MS = 2_000;
@@ -296,10 +297,11 @@ export function writeSandboxControlStatus(
   state: SandboxControlStatus['state'],
   reasonCode: string | null,
   activeRequestId: string | null,
-  now = Date.now()
+  now = Date.now(),
+  taskView: SandboxTaskView = taskViewForManifest(manifest)
 ): SandboxControlStatus {
   const status: SandboxControlStatus = {
-    version: 2, generation: manifest.generation, broker, state, reasonCode, activeRequestId, updatedAt: now
+    version: 3, generation: manifest.generation, broker, state, reasonCode, activeRequestId, updatedAt: now, taskView
   };
   atomicWriteJson(statusPath(manifest), status, 0o600, false);
   return status;
@@ -307,7 +309,7 @@ export function writeSandboxControlStatus(
 
 export function parseSandboxControlStatus(value: unknown): SandboxControlStatus {
   const status = value as Partial<SandboxControlStatus> | null;
-  if (!status || status.version !== 2 || typeof status.generation !== 'string'
+  if (!status || status.version !== 3 || typeof status.generation !== 'string'
     || !status.broker || !Number.isSafeInteger(status.broker.pid) || typeof status.broker.startTime !== 'number'
     || !Number.isSafeInteger(status.broker.startTime) || typeof status.broker.brokerId !== 'string'
     || status.broker.brokerId.length === 0
@@ -315,6 +317,7 @@ export function parseSandboxControlStatus(value: unknown): SandboxControlStatus 
     || (status.reasonCode !== null && typeof status.reasonCode !== 'string')
     || (status.activeRequestId !== null && typeof status.activeRequestId !== 'string')
     || !Number.isSafeInteger(status.updatedAt)) throw new Error('SANDBOX_CONTROL_STATUS_INVALID');
+  parseSandboxTaskView(status.taskView);
   return status as SandboxControlStatus;
 }
 

--- a/lib/sandbox/control/task-view.ts
+++ b/lib/sandbox/control/task-view.ts
@@ -203,9 +203,6 @@ export function mergeSandboxTaskView(
   previous: SandboxTaskView
 ): SandboxTaskView {
   if (previous.state !== 'finalized-stale' && previous.state !== 'unknown') return canonical;
-  if (canonical.state === 'current' && canonical.observedSource === 'completed' && canonical.receipt !== null) {
-    return canonical;
-  }
   return previous;
 }
 

--- a/lib/sandbox/control/task-view.ts
+++ b/lib/sandbox/control/task-view.ts
@@ -1,0 +1,243 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const SANDBOX_TASK_VIEW_STATES = ['not-applicable', 'current', 'finalized-stale', 'unknown'] as const;
+export const SANDBOX_TASK_VIEW_SOURCES = ['active', 'completed', 'unknown'] as const;
+
+export type SandboxTaskViewState = typeof SANDBOX_TASK_VIEW_STATES[number];
+export type SandboxTaskViewSource = typeof SANDBOX_TASK_VIEW_SOURCES[number];
+export type SandboxTaskViewReceipt = Readonly<{
+  receiptId: string;
+  revision: number;
+  generation: string;
+  requestId: string;
+}>;
+export type SandboxTaskView = Readonly<{
+  state: SandboxTaskViewState;
+  taskId: string | null;
+  observedSource: SandboxTaskViewSource | null;
+  receipt: SandboxTaskViewReceipt | null;
+  reasonCode: string | null;
+}>;
+
+export type TaskViewProjectionInput = Readonly<{
+  mode: 'task-bound' | 'branch-only';
+  taskId: string | null;
+  generation: string;
+  source: SandboxTaskViewSource;
+  sourceMatches: boolean;
+  receipt?: unknown;
+  requestId?: string;
+}>;
+
+export type TaskViewAccessEffect =
+  | 'diagnostic'
+  | 'progress'
+  | 'artifact-write'
+  | 'terminal-verdict'
+  | 'recovery'
+  | 'cleanup'
+  | 'remote-write';
+
+export type TaskViewAccess = Readonly<{
+  allowed: boolean;
+  state: SandboxTaskViewState;
+  reasonCode: string | null;
+  message: string | null;
+}>;
+
+function invalidView(message: string): Error {
+  return new Error(`SANDBOX_TASK_VIEW_INVALID: ${message}`);
+}
+
+function receiptIdentity(value: unknown, generation: string, requestId?: string): SandboxTaskViewReceipt | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const receipt = value as Record<string, unknown>;
+  const binding = receipt.controlBinding;
+  if (!binding || typeof binding !== 'object' || Array.isArray(binding)) return null;
+  const controlBinding = binding as Record<string, unknown>;
+  if (receipt.version !== 2 || typeof receipt.receiptId !== 'string' || receipt.receiptId.length === 0
+    || !Number.isSafeInteger(receipt.revision) || (receipt.revision as number) < 0
+    || receipt.lifecycle !== 'done'
+    || controlBinding.generation !== generation
+    || typeof controlBinding.requestId !== 'string'
+    || !/^[a-f0-9-]{16,64}$/u.test(controlBinding.requestId)
+    || (requestId !== undefined && controlBinding.requestId !== requestId)) return null;
+  return {
+    receiptId: receipt.receiptId,
+    revision: receipt.revision as number,
+    generation,
+    requestId: controlBinding.requestId
+  };
+}
+
+export function parseSandboxTaskView(value: unknown): SandboxTaskView {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw invalidView('taskView must be an object');
+  const view = value as Record<string, unknown>;
+  const receipt = view.receipt === null ? null : parseSandboxTaskViewReceipt(view.receipt);
+  if (!SANDBOX_TASK_VIEW_STATES.includes(view.state as SandboxTaskViewState)
+    || (view.taskId !== null && typeof view.taskId !== 'string')
+    || (view.observedSource !== null && !SANDBOX_TASK_VIEW_SOURCES.includes(view.observedSource as SandboxTaskViewSource))
+    || (view.reasonCode !== null && typeof view.reasonCode !== 'string')
+    || (view.receipt !== null && receipt === null)) {
+    throw invalidView('taskView schema is invalid');
+  }
+  if (view.state === 'not-applicable' && (view.taskId !== null || view.observedSource !== null || view.receipt !== null)) {
+    throw invalidView('not-applicable taskView cannot carry task evidence');
+  }
+  if (view.state === 'current' && (view.taskId === null || view.observedSource === null)) {
+    throw invalidView('current taskView requires taskId and observedSource');
+  }
+  if (view.state === 'current' && view.observedSource === 'completed' && view.receipt === null) {
+    throw invalidView('completed current taskView requires receipt');
+  }
+  if (view.state === 'finalized-stale' && (view.taskId === null || view.receipt === null)) {
+    throw invalidView('finalized-stale taskView requires taskId and receipt');
+  }
+  return view as SandboxTaskView;
+}
+
+function parseSandboxTaskViewReceipt(value: unknown): SandboxTaskViewReceipt | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const receipt = value as Record<string, unknown>;
+  if (Object.keys(receipt).sort().join(',') !== 'generation,receiptId,requestId,revision'
+    || typeof receipt.receiptId !== 'string' || receipt.receiptId.length === 0
+    || !Number.isSafeInteger(receipt.revision) || (receipt.revision as number) < 0
+    || typeof receipt.generation !== 'string' || receipt.generation.length === 0
+    || typeof receipt.requestId !== 'string' || !/^[a-f0-9-]{16,64}$/u.test(receipt.requestId)) return null;
+  return receipt as SandboxTaskViewReceipt;
+}
+
+export function taskViewForManifest(params: Readonly<{
+  repoRoot: string;
+  mode: 'task-bound' | 'branch-only';
+  taskId: string | null;
+  generation: string;
+  receipt?: unknown;
+}>): SandboxTaskView {
+  if (params.mode !== 'task-bound' || !params.taskId) {
+    return { state: 'not-applicable', taskId: null, observedSource: null, receipt: null, reasonCode: null };
+  }
+  const active = path.join(params.repoRoot, '.agents', 'workspace', 'active', params.taskId, 'task.md');
+  const completed = path.join(params.repoRoot, '.agents', 'workspace', 'completed', params.taskId, 'task.md');
+  const activeExists = fs.existsSync(active);
+  const completedExists = fs.existsSync(completed);
+  if (activeExists === completedExists) {
+    return {
+      state: 'unknown', taskId: params.taskId,
+      observedSource: activeExists ? 'unknown' : null,
+      receipt: null, reasonCode: activeExists ? 'SANDBOX_TASK_VIEW_SOURCE_CONFLICT' : 'SANDBOX_TASK_VIEW_SOURCE_MISSING'
+    };
+  }
+  const source = completedExists ? 'completed' : 'active';
+  const receipt = receiptIdentity(params.receipt, params.generation);
+  const receiptProvided = params.receipt !== undefined && params.receipt !== null;
+  if (source === 'completed' && receipt) {
+    return { state: 'current', taskId: params.taskId, observedSource: source, receipt, reasonCode: null };
+  }
+  if (source === 'active' && receipt) {
+    return {
+      state: 'finalized-stale', taskId: params.taskId, observedSource: source, receipt,
+      reasonCode: 'SANDBOX_TASK_VIEW_SOURCE_STALE'
+    };
+  }
+  if (receiptProvided) {
+    return {
+      state: 'unknown', taskId: params.taskId, observedSource: source, receipt: null,
+      reasonCode: 'SANDBOX_TASK_VIEW_RECEIPT_INVALID'
+    };
+  }
+  if (source === 'active') {
+    return { state: 'current', taskId: params.taskId, observedSource: source, receipt: null, reasonCode: null };
+  }
+  return {
+    state: 'unknown', taskId: params.taskId, observedSource: source, receipt: null,
+    reasonCode: 'SANDBOX_TASK_VIEW_EVIDENCE_UNAVAILABLE'
+  };
+}
+
+export function projectSandboxTaskView(input: TaskViewProjectionInput): SandboxTaskView {
+  if (input.mode !== 'task-bound' || !input.taskId) {
+    return { state: 'not-applicable', taskId: null, observedSource: null, receipt: null, reasonCode: null };
+  }
+  const receipt = receiptIdentity(input.receipt, input.generation, input.requestId);
+  if (input.source === 'completed' && receipt && input.sourceMatches) {
+    return { state: 'current', taskId: input.taskId, observedSource: 'completed', receipt, reasonCode: null };
+  }
+  if (receipt && input.source === 'active' && !input.sourceMatches) {
+    return { state: 'finalized-stale', taskId: input.taskId, observedSource: 'active', receipt, reasonCode: 'SANDBOX_TASK_VIEW_SOURCE_STALE' };
+  }
+  if (!receipt && input.source === 'active' && input.sourceMatches) {
+    return { state: 'current', taskId: input.taskId, observedSource: 'active', receipt: null, reasonCode: null };
+  }
+  return {
+    state: 'unknown',
+    taskId: input.taskId,
+    observedSource: input.source,
+    receipt,
+    reasonCode: receipt ? 'SANDBOX_TASK_VIEW_SOURCE_UNCONFIRMED' : 'SANDBOX_TASK_VIEW_EVIDENCE_UNAVAILABLE'
+  };
+}
+
+export function taskViewAfterFinalization(params: Readonly<{
+  taskId: string;
+  generation: string;
+  requestId: string;
+  receipt: unknown;
+}>): SandboxTaskView {
+  const receipt = receiptIdentity(params.receipt, params.generation, params.requestId);
+  if (!receipt) {
+    return {
+      state: 'unknown', taskId: params.taskId, observedSource: 'unknown', receipt: null,
+      reasonCode: 'SANDBOX_TASK_VIEW_RECEIPT_INVALID'
+    };
+  }
+  return {
+    state: 'finalized-stale', taskId: params.taskId, observedSource: 'active', receipt,
+    reasonCode: 'SANDBOX_TASK_VIEW_FINALIZED'
+  };
+}
+
+export function mergeSandboxTaskView(
+  canonical: SandboxTaskView,
+  previous: SandboxTaskView
+): SandboxTaskView {
+  if (previous.state !== 'finalized-stale' && previous.state !== 'unknown') return canonical;
+  if (canonical.state === 'current' && canonical.observedSource === 'completed' && canonical.receipt !== null) {
+    return canonical;
+  }
+  return previous;
+}
+
+export function accessSandboxTaskView(view: SandboxTaskView, effect: TaskViewAccessEffect): TaskViewAccess {
+  if (effect === 'diagnostic' || effect === 'cleanup' || effect === 'recovery') {
+    return { allowed: true, state: view.state, reasonCode: view.reasonCode, message: null };
+  }
+  if (view.state === 'current' && view.observedSource === 'active') {
+    return { allowed: true, state: view.state, reasonCode: null, message: null };
+  }
+  const reasonCode = view.state === 'current'
+    ? 'SANDBOX_TASK_VIEW_COMPLETED_READ_ONLY'
+    : view.reasonCode ?? `SANDBOX_TASK_VIEW_${view.state.toUpperCase().replaceAll('-', '_')}`;
+  return {
+    allowed: false,
+    state: view.state,
+    reasonCode,
+    message: view.state === 'unknown'
+      ? 'task view cannot be confirmed; inspect status, recover the original request, or explicitly clean up the sandbox'
+      : view.state === 'finalized-stale'
+        ? 'task view is finalized/stale; exit or clean up the sandbox, or use a validated re-entry'
+        : 'completed task views are read-only'
+  };
+}
+
+export function taskViewFromStatus(value: unknown): SandboxTaskView {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw invalidView('status must be an object');
+  const status = value as Record<string, unknown>;
+  if (status.version !== 3) throw invalidView('status version is unsupported');
+  const taskView = parseSandboxTaskView(status.taskView);
+  if (taskView.receipt && taskView.receipt.generation !== status.generation) {
+    throw invalidView('taskView receipt generation does not match status generation');
+  }
+  return taskView;
+}

--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -1,3 +1,5 @@
+import { PUBLIC_CLI_ROUTE_SELECTORS } from '../internal/cli-route-inventory.ts';
+
 const USAGE = `Usage: ai sandbox <command> [options]
 
 Commands:
@@ -26,6 +28,7 @@ Commands:
   vm status|start|stop         Manage the sandbox VM (macOS) or check the backend (Windows)
 
 Run 'ai sandbox <command> --help' for details.`;
+const SANDBOX_OPERATIONS = PUBLIC_CLI_ROUTE_SELECTORS.sandbox;
 
 export async function runSandbox(args: string[]): Promise<void> {
   const [subcommand, ...rest] = args;
@@ -39,6 +42,10 @@ export async function runSandbox(args: string[]): Promise<void> {
   if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
     process.stdout.write(`${USAGE}\n`);
     return;
+  }
+
+  if (!SANDBOX_OPERATIONS.includes(subcommand as typeof SANDBOX_OPERATIONS[number])) {
+    throw new Error(`Unknown sandbox command: ${subcommand}`);
   }
 
   switch (subcommand) {

--- a/lib/sandbox/recovery.ts
+++ b/lib/sandbox/recovery.ts
@@ -1,3 +1,4 @@
+import { prepareCompletedReentry, publishCompletedReentry, waitForCompletedReentry } from './control/completed-reentry.ts';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -653,7 +654,7 @@ function recoveryTaskSources(repoRoot: string, taskId: string): {
   return { mountPaths, accessiblePaths: [completedSource] };
 }
 
-function startCompletedSandboxContainer(params: {
+export function startCompletedSandboxContainer(params: {
   config: SandboxConfig;
   engine: string;
   container: string;
@@ -1250,7 +1251,17 @@ export async function ensureSandboxReady(params: EnsureSandboxReadyParams): Prom
       throw new Error('Explicit container recreation requested.');
     }
     if (!params.row.running) {
+      let completedReentry: { manifest: SandboxControlManifest; evidence: Awaited<ReturnType<typeof prepareCompletedReentry>> } | null = null;
       if (params.reentry === 'completed' && params.workspace?.mode === 'task-bound') {
+        const control = sandboxControlPaths({
+          base: params.config.controlBase, project: params.config.project,
+          container: params.row.name, identity: params.workspace
+        });
+        const manifest = readSandboxControlManifest(control.manifestPath);
+        if (manifest.taskId !== params.workspace.taskId || manifest.branch !== params.branch) {
+          throw new Error('SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID');
+        }
+        completedReentry = { manifest, evidence: await prepareCompletedReentry(manifest) };
         startCompletedSandboxContainer({
           config: params.config,
           engine: params.engine,
@@ -1314,6 +1325,15 @@ export async function ensureSandboxReady(params: EnsureSandboxReadyParams): Prom
       }
       if (final.findings.length > 0) {
         throw new Error(describeFindings(final.findings));
+      }
+      if (completedReentry) {
+        const { manifest, evidence } = completedReentry;
+        const current = await prepareCompletedReentry(manifest);
+        if (JSON.stringify(current) !== JSON.stringify(evidence)) {
+          throw new Error('SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID');
+        }
+        publishCompletedReentry(manifest, evidence);
+        await waitForCompletedReentry(manifest, evidence);
       }
       return { container: params.row.name, path: 'recovered', warnings };
     }

--- a/lib/server/index.ts
+++ b/lib/server/index.ts
@@ -1,5 +1,8 @@
 import { runDaemon } from './daemon.ts';
 import { start, stop, status, logs } from './process-control.ts';
+import { PUBLIC_CLI_ROUTE_SELECTORS } from '../internal/cli-route-inventory.ts';
+
+const SERVER_OPERATIONS = PUBLIC_CLI_ROUTE_SELECTORS.server;
 
 const USAGE = `Usage: ai server <command> [options]
 
@@ -22,6 +25,13 @@ export async function runServer(args: string[]): Promise<void> {
   }
   if (subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
     process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  if (!SERVER_OPERATIONS.includes(subcommand as typeof SERVER_OPERATIONS[number])) {
+    process.stderr.write(`Unknown server command: ${subcommand}\n`);
+    process.stdout.write(`${USAGE}\n`);
+    process.exitCode = 1;
     return;
   }
 

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -1,3 +1,8 @@
+import {
+  PUBLIC_CLI_ROUTE_SELECTORS,
+  PUBLIC_CLI_SELECTOR_ALIASES
+} from '../internal/cli-route-inventory.ts';
+
 const USAGE = `Usage: ai task <command> [options]
 
 Commands:
@@ -30,6 +35,7 @@ Examples:
   ai task status --task 11
 
 Run 'ai task <command> --help' for details.`;
+const TASK_OPERATIONS = PUBLIC_CLI_ROUTE_SELECTORS.task;
 
 export async function runTask(args: string[]): Promise<void> {
   const [subcommand, ...rest] = args;
@@ -45,14 +51,21 @@ export async function runTask(args: string[]): Promise<void> {
     return;
   }
 
-  switch (subcommand) {
+  const routeSelector: string = PUBLIC_CLI_SELECTOR_ALIASES.task[subcommand as keyof typeof PUBLIC_CLI_SELECTOR_ALIASES.task] ?? subcommand;
+  if (!TASK_OPERATIONS.includes(routeSelector as typeof TASK_OPERATIONS[number])) {
+    process.stderr.write(`Unknown task command: ${subcommand}\n\n`);
+    process.stdout.write(`${USAGE}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  switch (routeSelector) {
     case 'cat': {
       const { cat } = await import('./commands/cat.ts');
       cat(rest);
       break;
     }
-    case 'decisions':
-    case 'd': {
+    case 'decisions': {
       const { decisions } = await import('./commands/decisions.ts');
       decisions(rest);
       break;

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -9,7 +9,9 @@ const env = Object.fromEntries(
   Object.entries(process.env).filter(([key]) => {
     const normalized = key.toUpperCase();
     return normalized !== 'NODE_TEST_CONTEXT'
-      && !normalized.startsWith('AGENT_INFRA_CONTROL_');
+      && !normalized.startsWith('AGENT_INFRA_CONTROL_')
+      && normalized !== 'AGENT_INFRA_TASK_ID'
+      && normalized !== 'AGENT_INFRA_RUNTIME_DIR';
   })
 );
 const args = process.argv.slice(2);

--- a/templates/.agents/skills/complete-task/SKILL.en.md
+++ b/templates/.agents/skills/complete-task/SKILL.en.md
@@ -171,36 +171,19 @@ If a summary must mirror a human-decided `post-review-commit` exemption, make a 
 
 `--force` cannot lift identity, concurrency, local atomicity, or required-PR hard gates; failures there must stop. Other review, manual-validation, and platform evidence is recorded by terminal verification as warning/pending and can be repaired by retrying.
 
-### 6. Run the Host Finalization Entry Point and Verify the Terminal State
+### 6. Run the Host Finalization Entry Point
 
 ```bash
 agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-Finalization runs lifecycle -> the terminal task comment -> the `complete-task.completed` gate in a fixed order and records each step in the host receipt. `result=completed` means lifecycle completed safely; if peripheral warnings remain, return `result=completed_with_warnings`, warnings, and pending steps. Use `result=failed` or `result=blocked` only for hard or receipt/capability failures, then fix the cause and retry through the same entry point; do not claim completion or hand-repair partial state.
-
-```bash
-ls .agents/workspace/completed/{task-id}/task.md
-```
-
-Check the task directory only after finalization returns `status=completed`.
+Finalization runs lifecycle -> the terminal task comment -> the `complete-task.completed` gate in a fixed order and records each step in the host receipt. `result=completed` means the host safely completed the task from structured results and the receipt; if peripheral warnings remain, return `result=completed_with_warnings`, warnings, and pending steps. Use `result=failed` or `result=blocked` only for hard or receipt/capability failures, then fix the cause and retry through the same entry point; do not claim completion or hand-repair partial state. A sandbox must not run `ls completed` or a local terminal verification against its historical mount to re-decide this result.
 
 ### 7. Handle Finalization Retries and Results
 
 Both Scenario A and Scenario B `finalization-retry` run the same `task-finalization` entry point from the host. The receipt is only a re-entry hint, not canonical truth: every re-entry revalidates the terminal task comment and completion gate; only an already `completed` task with its short-id registry entry released may skip the irreversible lifecycle. Do not split the operation into the former lifecycle, comment-sync, or completion-gate commands. If the task comment or gate is blocked by the network, preserve the receipt and completed steps, fix the network, and rerun complete-task. If lifecycle has not completed, keep the task active and resume the pending steps from the receipt.
 
-The result must include the structured output from this finalization run, confirming that the task artifact and sync state are valid:
-
-```bash
-agent-infra-internal task-verify {task-id} complete-task.completed --format text
-```
-
-Handle the result as follows:
-- `status=completed` / exit code 0 (all checks passed) -> continue to the "Inform User" step
-- `status=failed` / exit code 1 -> fix the reported issues and run finalization again
-- `status=blocked` / exit code 2 -> preserve the receipt and completed steps and stop; rerun complete-task later to enter `finalization-retry`
-
-Keep the gate output in your reply as fresh evidence. Do not claim completion without output from this run.
+Consume the structured finalization result, receipt, and warning projection directly. Continue only for `completed` or `completed_with_warnings`; preserve the receipt and stop for `failed`, `blocked`, or `unknown`, then retry through the same finalization entry point. Do not run `ls completed` or `task-verify complete-task.completed` from a stale sandbox mount, and do not let that local result overrule the host result.
 
 ### Accepted sandbox-control result recovery
 

--- a/templates/.agents/skills/complete-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/complete-task/SKILL.zh-CN.md
@@ -170,36 +170,19 @@ agent-infra-internal task-verify {task-id} complete-task.preflight --format text
 
 `--force` 不能解除身份、并发、本地原子性或 required-PR hard gate；这些能力失败时必须停止。其余审查、人工校验和平台证据由 terminal verification 记录为 warning/pending，并通过后续重试恢复。
 
-### 6. 执行宿主 finalization 入口并验证终态
+### 6. 执行宿主 finalization 入口
 
 ```bash
 agent-infra-internal task-finalization {task-id} complete --agent {standard-agent-token}
 ```
 
-finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。`result=completed` 即表示 lifecycle 已安全完成；若还有外围 warning，返回 `result=completed_with_warnings`、warnings 和 pending steps。`result=failed` 或 `result=blocked` 仅用于硬失败或 receipt/capability 失败，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。
-
-```bash
-ls .agents/workspace/completed/{task-id}/task.md
-```
-
-仅在 finalization 返回 `status=completed` 后确认任务目录已成功移动。
+finalization 按 lifecycle → task 评论 → `complete-task.completed` 校验的固定顺序执行，并将每一步的状态写入宿主 receipt。`result=completed` 即表示宿主已依据结构化结果和 receipt 安全完成；若还有外围 warning，返回 `result=completed_with_warnings`、warnings 和 pending steps。`result=failed` 或 `result=blocked` 仅用于硬失败或 receipt/capability 失败，修复原因后以同一入口重试，不得宣称完成或手工补写局部状态。沙箱不得从旧挂载执行 `ls completed` 或本地终态校验来重新裁决该结果。
 
 ### 7. 处理 finalization 重试与结果
 
 场景 A 与场景 B `finalization-retry` 都从宿主执行同一个 `task-finalization` 入口。receipt 只是重入提示，不是 canonical truth：每次重入都要重新验证终态 task 评论和完成校验；只有任务已处于 `completed` 且短号 registry 已释放时，才可跳过不可逆的 lifecycle。不得拆开调用旧的 lifecycle、评论同步或完成校验命令。若 task 评论或校验因网络问题返回 `blocked`，保留 receipt 和已完成状态，修复网络后重跑 complete-task；若生命周期仍未完成，任务保持 active 并从 receipt 的待处理步骤继续。
 
-完成结果必须包含本次 finalization 的结构化输出，确认任务产物和同步状态符合规范：
-
-```bash
-agent-infra-internal task-verify {task-id} complete-task.completed --format text
-```
-
-处理结果：
-- `status=completed` / 退出码 0（全部通过）-> 继续到「告知用户」步骤
-- `status=failed` / 退出码 1 -> 根据输出修复问题后重新运行 finalization
-- `status=blocked` / 退出码 2 -> 保留 receipt 与已完成的步骤并停止；稍后重跑 complete-task 进入 `finalization-retry`
-
-将校验输出保留在回复中作为当次验证输出。没有当次校验输出，不得声明完成。
+完成结果必须直接消费本次宿主 finalization 的结构化输出、receipt 和 warning projection。`completed` 或 `completed_with_warnings` 才允许继续；`failed` / `blocked` / `unknown` 必须保留 receipt 并停止，之后通过同一 finalization 入口重试。不要在沙箱旧挂载中另行运行 `ls completed` 或 `task-verify complete-task.completed`，也不要用其结果推翻宿主结果。
 
 ### accepted 后的 sandbox-control 结果恢复
 

--- a/tests/integration/cli/sandbox-completed-reentry.test.ts
+++ b/tests/integration/cli/sandbox-completed-reentry.test.ts
@@ -1,0 +1,83 @@
+import test, { type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { completedReentryView, prepareCompletedReentry, publishCompletedReentry } from '../../../lib/sandbox/control/completed-reentry.ts';
+import { mergeSandboxTaskView, taskViewAfterFinalization } from '../../../lib/sandbox/control/task-view.ts';
+import type { SandboxControlManifest } from '../../../lib/sandbox/control/protocol.ts';
+
+function fixture(t: TestContext) {
+  const root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'completed-reentry-')));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  execFileSync('git', ['init', '-q', '-b', 'scratch'], { cwd: root });
+  execFileSync('git', ['-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '--allow-empty', '-qm', 'Fixture'], { cwd: root });
+  const taskId = 'TASK-20260906-010203';
+  const source = path.join(root, '.agents', 'workspace', 'completed', taskId);
+  fs.mkdirSync(source, { recursive: true });
+  fs.writeFileSync(path.join(source, 'task.md'), `---\nid: ${taskId}\nbranch: scratch\nstatus: completed\n---\n`);
+  const control = path.join(root, 'control');
+  fs.mkdirSync(path.join(control, 'public'), { recursive: true });
+  const generation = 'fixture-generation';
+  const requestId = 'a'.repeat(32);
+  const receipt = { version: 2, taskId, intent: 'complete', receiptId: 'fixture-receipt', revision: 3,
+    lifecycle: 'done', taskComment: 'skipped', verification: 'done', warningProjection: 'done', warnings: [],
+    controlBinding: { generation, requestId }, updatedAt: new Date().toISOString(), lastError: null };
+  const receiptPath = path.join(root, '.agents', 'workspace', '.task-finalization', taskId + '.json');
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  fs.writeFileSync(receiptPath, JSON.stringify(receipt));
+  const stale = taskViewAfterFinalization({ taskId, generation, requestId, receipt });
+  fs.writeFileSync(path.join(control, 'public', 'status.json'), JSON.stringify({ version: 3, generation,
+    broker: { pid: process.pid, startTime: 1, brokerId: 'fixture-broker' }, state: 'healthy', reasonCode: null,
+    activeRequestId: null, updatedAt: Date.now(), taskView: stale }));
+  const manifest = { repoRoot: root, worktreeRoot: root, project: 'fixture', container: 'fixture-container',
+    containerIdentity: { id: 'fixture-container-id', labels: {} }, branch: 'scratch', mode: 'task-bound', taskId,
+    generation, token: 'fixture-token', engine: 'native', channelDir: path.join(control, 'channel'),
+    publicStatusDir: path.join(control, 'public'), processingDir: path.join(control, 'processing'), runtimeDir: path.join(control, 'runtime')
+  } as SandboxControlManifest;
+  const inspect = async () => ({ state: 'found' as const, id: manifest.containerIdentity.id, labels: {}, running: true });
+  return { root, source, manifest, inspect, receipt, receiptPath, stale };
+}
+
+test('only a verified completed re-entry clears the stale projection', async (t) => {
+  const f = fixture(t);
+  assert.equal(await completedReentryView(f.manifest, f.inspect), null);
+  const evidence = await prepareCompletedReentry(f.manifest, f.inspect);
+  publishCompletedReentry(f.manifest, evidence);
+  const current = await completedReentryView(f.manifest, f.inspect);
+  assert.equal(current?.state, 'current');
+  assert.equal(current?.observedSource, 'completed');
+  assert.deepEqual(current?.receipt, f.stale.receipt);
+  assert.deepEqual(mergeSandboxTaskView(current!, f.stale), f.stale);
+});
+
+for (const field of ['taskId', 'generation', 'containerId', 'branch', 'worktreeRoot', 'source', 'sourceDevice', 'sourceInode', 'receipt'] as const) {
+  test(`completed re-entry rejects changed ${field} evidence`, async (t) => {
+    const f = fixture(t);
+    const evidence = await prepareCompletedReentry(f.manifest, f.inspect);
+    const changed = { ...evidence, [field]: field === 'receipt' ? { ...evidence.receipt, requestId: 'b'.repeat(32) } : 'mismatch' };
+    publishCompletedReentry(f.manifest, changed as typeof evidence);
+    await assert.rejects(completedReentryView(f.manifest, f.inspect), /SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID/);
+  });
+}
+
+test('completed re-entry rechecks canonical receipt and container identity', async (t) => {
+  const f = fixture(t);
+  const evidence = await prepareCompletedReentry(f.manifest, f.inspect);
+  publishCompletedReentry(f.manifest, evidence);
+  await assert.rejects(completedReentryView(f.manifest, async () => ({ state: 'absent', id: f.manifest.containerIdentity.id })), /SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID/);
+  fs.writeFileSync(f.receiptPath, JSON.stringify({ ...f.receipt, controlBinding: { ...f.receipt.controlBinding, requestId: 'b'.repeat(32) } }));
+  await assert.rejects(completedReentryView(f.manifest, f.inspect), /SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID/);
+});
+
+for (const field of ['id', 'status'] as const) {
+  test(`completed re-entry rejects changed canonical task ${field}`, async (t) => {
+    const f = fixture(t);
+    const evidence = await prepareCompletedReentry(f.manifest, f.inspect);
+    publishCompletedReentry(f.manifest, evidence);
+    const file = path.join(f.source, 'task.md');
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace(new RegExp(`^${field}:.*$`, 'm'), `${field}: changed`));
+    await assert.rejects(completedReentryView(f.manifest, f.inspect), /SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID/);
+  });
+}

--- a/tests/integration/cli/sandbox-completed-reentry.test.ts
+++ b/tests/integration/cli/sandbox-completed-reentry.test.ts
@@ -81,3 +81,57 @@ for (const field of ['id', 'status'] as const) {
     await assert.rejects(completedReentryView(f.manifest, f.inspect), /SANDBOX_COMPLETED_REENTRY_EVIDENCE_INVALID/);
   });
 }
+
+for (const scenario of ['valid', 'task-id', 'source', 'missing-evidence', 'stale'] as const) {
+  test(`broker restart revalidates completed identity: ${scenario}`, async (t) => {
+    const f = fixture(t);
+    const { captureSandboxAuthority } = await import('../../../lib/sandbox/engines/authority.ts');
+    const { serveSandboxControl } = await import('../../../lib/sandbox/control/server.ts');
+    const evidence = await prepareCompletedReentry(f.manifest, f.inspect);
+    if (scenario !== 'stale') publishCompletedReentry(f.manifest, evidence);
+    const statusPath = path.join(f.manifest.publicStatusDir, 'status.json');
+    const previous = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
+    if (scenario !== 'stale') {
+      previous.taskView = await completedReentryView(f.manifest, f.inspect);
+      fs.writeFileSync(statusPath, JSON.stringify(previous));
+    }
+    if (scenario === 'task-id') {
+      const file = path.join(f.source, 'task.md');
+      fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace(/^id:.*$/m, 'id: TASK-20990101-010101'));
+    } else if (scenario === 'source') {
+      fs.renameSync(f.source, f.source + '-old');
+      fs.mkdirSync(f.source);
+      fs.copyFileSync(path.join(f.source + '-old', 'task.md'), path.join(f.source, 'task.md'));
+      fs.rmSync(f.source + '-old', { recursive: true });
+    } else if (scenario === 'missing-evidence') {
+      fs.unlinkSync(path.join(path.dirname(f.manifest.processingDir), 'completed-reentry.json'));
+    }
+    const authorityEvidence = captureSandboxAuthority('native', {
+      env: { DOCKER_CONTEXT: 'default' }, lockDomain: 'a'.repeat(64),
+      probe: (_cmd, args) => ({ status: 0, signal: null,
+        stdout: JSON.stringify(args.at(-1) === '{{json .ID}}' ? 'fixture-daemon-id' : { ApiVersion: '1.50' }),
+        stderr: '', pid: 1, output: [] })
+    });
+    const manifestPath = path.join(path.dirname(f.manifest.processingDir), 'manifest.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({ ...f.manifest, authorityEvidence }));
+    const abort = new AbortController();
+    const running = serveSandboxControl(manifestPath, abort.signal, { inspectContainer: f.inspect });
+    try {
+      let observed = previous;
+      for (let i = 0; i < 100; i++) {
+        await new Promise(resolve => setTimeout(resolve, 25));
+        observed = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
+        if (observed.broker.brokerId === 'fixture-broker') continue;
+        if (scenario !== 'valid') assert.notEqual(observed.taskView.state, 'current');
+        if (observed.state === 'healthy') break;
+      }
+      assert.notEqual(observed.broker.brokerId, 'fixture-broker');
+      assert.equal(observed.state, 'healthy');
+      assert.equal(observed.taskView.state, scenario === 'valid' ? 'current' : scenario === 'stale' ? 'finalized-stale' : 'unknown');
+      if (scenario === 'valid') assert.equal(observed.taskView.observedSource, 'completed');
+    } finally {
+      abort.abort();
+      await running;
+    }
+  });
+}

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -1189,7 +1189,7 @@ test('task-finalization client exposes accepted result loss as a structured unkn
       AGENT_INFRA_CONTROL_DIR: channelDir,
       AGENT_INFRA_CONTROL_STATUS_DIR: statusDir,
       AGENT_INFRA_TASK_ID: undefined,
-      AGENT_INFRA_RUNTIME_DIR: undefined
+      AGENT_INFRA_RUNTIME_DIR: path.join(root, 'runtime')
     },
     stdio: ['ignore', 'pipe', 'pipe']
   }));
@@ -1330,6 +1330,7 @@ test('task-bound finalization rejects a new request after accepted response loss
     assert.equal(firstClient.exitCode, 1);
     assert.equal((firstClient.payload.error as { code?: string }).code, 'SANDBOX_CONTROL_RESULT_UNKNOWN');
     assert.equal(firstClient.payload.accepted, true);
+    assert.ok(firstExecution.stdout, firstExecution.stderr);
     assert.equal(JSON.parse(firstExecution.stdout).status, 'completed');
     assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'completed', taskId, 'task.md')), true);
 

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -286,6 +286,12 @@ function fixtureAuthorityEvidence() {
   });
 }
 
+function statusTaskView(taskId: string | null = 'TASK-20260809-010203') {
+  return taskId
+    ? { state: 'unknown', taskId, observedSource: 'unknown', receipt: null, reasonCode: 'SANDBOX_TASK_VIEW_EVIDENCE_UNAVAILABLE' }
+    : { state: 'not-applicable', taskId: null, observedSource: null, receipt: null, reasonCode: null };
+}
+
 function writeControlManifest(root: string, branch: string, generation = 'lifecycle-generation'): string {
   const manifestPath = path.join(root, 'manifest.json');
   const channelDir = path.join(root, 'channel');
@@ -587,9 +593,9 @@ for (const removalFails of [false, true]) {
         token: 'lifecycle-secret', generation: 'remove-stages-generation'
       })}\n`);
       fs.writeFileSync(path.join(root, 'public', 'status.json'), `${JSON.stringify({
-        version: 2, generation: 'remove-stages-generation',
+        version: 3, generation: 'remove-stages-generation',
         broker: { pid: brokerProcess.pid, startTime: brokerStartTime, brokerId: 'stubborn-broker' },
-        state: 'busy', reasonCode: null, activeRequestId: 'stubborn-request', updatedAt: Date.now()
+        state: 'busy', reasonCode: null, activeRequestId: 'stubborn-request', updatedAt: Date.now(), taskView: statusTaskView()
       })}\n`);
       const executionDir = path.join(root, 'processing', 'stubborn-request');
       fs.mkdirSync(executionDir);
@@ -687,9 +693,9 @@ test('sandbox control lifecycle excludes a concurrent broker recovery after quie
       token: 'lifecycle-secret', generation: 'recovery-quiesce-generation'
     })}\n`);
     fs.writeFileSync(path.join(root, 'public', 'status.json'), `${JSON.stringify({
-      version: 2, generation: 'recovery-quiesce-generation',
+      version: 3, generation: 'recovery-quiesce-generation',
       broker: { pid: 999_999_999, startTime: 0, brokerId: 'stale-broker' }, state: 'healthy',
-      reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+      reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView()
     })}\n`);
 
     const startup = startSandboxControlBroker(root, manifestPath).then(
@@ -760,8 +766,8 @@ test('sandbox control lifecycle terminates execution trees before forcing an unr
       token: 'lifecycle-secret', generation: 'forced-generation'
     })}\n`);
     fs.writeFileSync(path.join(root, 'public', 'status.json'), `${JSON.stringify({
-      version: 2, generation: 'forced-generation', broker: { pid: broker.pid, startTime: brokerStartTime, brokerId: 'test-broker' },
-      state: 'healthy', reasonCode: null, activeRequestId: 'forced-request', updatedAt: Date.now()
+      version: 3, generation: 'forced-generation', broker: { pid: broker.pid, startTime: brokerStartTime, brokerId: 'test-broker' },
+      state: 'healthy', reasonCode: null, activeRequestId: 'forced-request', updatedAt: Date.now(), taskView: statusTaskView()
     })}\n`);
     const executionDir = path.join(root, 'processing', 'forced-request');
     fs.mkdirSync(executionDir);
@@ -1059,13 +1065,13 @@ test('sandbox control client tolerates a transient torn response but rejects sta
   const responseBrokerStartTime = getProcessStartTime(process.pid);
   assert.ok(responseBrokerStartTime);
   fs.writeFileSync(statusPath, `${JSON.stringify({
-    version: 2,
+    version: 3,
     generation: 'response-generation',
     broker: { pid: process.pid, startTime: responseBrokerStartTime, brokerId: 'test-broker' },
     state: 'healthy',
     reasonCode: null,
     activeRequestId: null,
-    updatedAt: Date.now()
+    updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const clientModule = path.resolve('lib/sandbox/control/client.ts');
   const runClient = (): CollectedChild => {
@@ -1163,13 +1169,13 @@ test('task-finalization client exposes accepted result loss as a structured unkn
   assert.ok(startTime);
   const generation = 'finalization-generation';
   fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
-    version: 2,
+    version: 3,
     generation,
     broker: { pid: process.pid, startTime, brokerId: 'finalization-broker' },
     state: 'healthy',
     reasonCode: null,
     activeRequestId: null,
-    updatedAt: Date.now()
+    updatedAt: Date.now(), taskView: statusTaskView()
   })}\n`);
   const client = collectChild(spawn(process.execPath, [
     '--experimental-strip-types', '--no-warnings', path.resolve('bin/internal-cli.ts'),
@@ -1181,7 +1187,9 @@ test('task-finalization client exposes accepted result loss as a structured unkn
       AGENT_INFRA_CONTROL_TOKEN: 'finalization-secret',
       AGENT_INFRA_CONTROL_GENERATION: generation,
       AGENT_INFRA_CONTROL_DIR: channelDir,
-      AGENT_INFRA_CONTROL_STATUS_DIR: statusDir
+      AGENT_INFRA_CONTROL_STATUS_DIR: statusDir,
+      AGENT_INFRA_TASK_ID: undefined,
+      AGENT_INFRA_RUNTIME_DIR: undefined
     },
     stdio: ['ignore', 'pipe', 'pipe']
   }));
@@ -1256,13 +1264,16 @@ test('task-bound finalization rejects a new request after accepted response loss
     const startTime = getProcessStartTime(process.pid);
     assert.ok(startTime);
     fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
-      version: 2,
+      version: 3,
       generation,
       broker: { pid: process.pid, startTime, brokerId: 'finalization-compensation-broker' },
       state: 'healthy',
       reasonCode: null,
       activeRequestId: null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      taskView: {
+        state: 'current', taskId, observedSource: 'active', receipt: null, reasonCode: null
+      }
     })}\n`);
     fs.writeFileSync(path.join(root, 'broker.json'), `${JSON.stringify({
       version: 3,

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -1188,8 +1188,7 @@ test('task-finalization client exposes accepted result loss as a structured unkn
       AGENT_INFRA_CONTROL_GENERATION: generation,
       AGENT_INFRA_CONTROL_DIR: channelDir,
       AGENT_INFRA_CONTROL_STATUS_DIR: statusDir,
-      AGENT_INFRA_TASK_ID: undefined,
-      AGENT_INFRA_RUNTIME_DIR: path.join(root, 'runtime')
+      AGENT_INFRA_TASK_ID: undefined
     },
     stdio: ['ignore', 'pipe', 'pipe']
   }));

--- a/tests/integration/cli/sandbox-core.test.ts
+++ b/tests/integration/cli/sandbox-core.test.ts
@@ -162,6 +162,13 @@ async function quiesceSandboxControlRootForCleanup(root: string): Promise<void> 
 
 function withInternalCliOnPath<T>(binDir: string, action: () => T): T {
   writeNodeCommandShim(path.join(binDir, "agent-infra-internal"), INTERNAL_CLI_PATH);
+  const previousEnv = process.env;
+  const hostDirectEnv = { ...process.env };
+  delete hostDirectEnv.AGENT_INFRA_TASK_ID;
+  for (const key of Object.keys(hostDirectEnv)) {
+    if (key.startsWith("AGENT_INFRA_CONTROL_") || key === "AGENT_INFRA_RUNTIME_DIR") delete hostDirectEnv[key];
+  }
+  process.env = hostDirectEnv;
   const originalPath = process.env.PATH;
   process.env.PATH = envWithPrependedPath(process.env, binDir).PATH;
   try {
@@ -169,6 +176,7 @@ function withInternalCliOnPath<T>(binDir: string, action: () => T): T {
   } finally {
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
+    process.env = previousEnv;
   }
 }
 
@@ -369,13 +377,20 @@ function writeTaskBoundControlEvidence(
     runtimeDir: path.join(controlRoot, "runtime")
   })}\n`, "utf8");
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2,
+    version: 3,
     generation: `${taskId}-generation`,
     broker: { pid: 999_999_999, startTime: 0, brokerId: `${taskId}-broker` },
     state: "healthy",
     reasonCode: null,
     activeRequestId: null,
-    updatedAt: Date.now()
+    updatedAt: Date.now(),
+    taskView: {
+      state: "unknown",
+      taskId,
+      observedSource: "unknown",
+      receipt: null,
+      reasonCode: "SANDBOX_TASK_VIEW_EVIDENCE_UNAVAILABLE"
+    }
   })}\n`, "utf8");
   return controlRoot;
 }

--- a/tests/integration/cli/sandbox-show.test.ts
+++ b/tests/integration/cli/sandbox-show.test.ts
@@ -142,10 +142,20 @@ function mkCliFixture(): { repoRoot: string; activeDir: string; scriptPath: stri
   return { repoRoot, activeDir, scriptPath, binDir };
 }
 
+function hostDirectEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = gitSafeEnv(extra);
+  delete env.AGENT_INFRA_TASK_ID;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('AGENT_INFRA_CONTROL_') || key === 'AGENT_INFRA_RUNTIME_DIR') delete env[key];
+  }
+  return env;
+}
+
 function runShow(args: string[], repoRoot: string, binDir: string) {
+  const env = envWithPrependedPath(hostDirectEnv({ HOME: repoRoot, USERPROFILE: repoRoot }), binDir);
   return spawnSync('node', cliArgs('sandbox', 'show', ...args), {
     cwd: repoRoot,
-    env: envWithPrependedPath(gitSafeEnv({ HOME: repoRoot, USERPROFILE: repoRoot }), binDir),
+    env,
     encoding: 'utf8'
   });
 }
@@ -183,7 +193,7 @@ test('ai sandbox show <bare-numeric> resolves the branch via the short-id regist
   );
   const alloc = spawnSync('node', [scriptPath, 'alloc', taskId], {
     cwd: repoRoot,
-    env: envWithPrependedPath(gitSafeEnv(), binDir),
+    env: envWithPrependedPath(hostDirectEnv(), binDir),
     encoding: 'utf8'
   });
   assert.equal(alloc.status, 0, alloc.stderr);

--- a/tests/integration/cli/sandbox-tmpfs.test.ts
+++ b/tests/integration/cli/sandbox-tmpfs.test.ts
@@ -17,6 +17,7 @@ import {
   classifySandboxRecovery,
   collectSandboxRecoverySnapshot,
   ensureSandboxReady,
+  startCompletedSandboxContainer,
   prepareTmpfsMounts,
   worktreeProbeForEngine,
   type SandboxRecoverySnapshot
@@ -648,56 +649,45 @@ test("healthy completed re-entry rejects an explicit recreate request", async ()
   }
 });
 
-test("stopped completed re-entry restores the historical task source only while starting", async () => {
+test("completed container start restores the historical source only while starting", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-completed-stopped-source-"));
   const config = recoveryFixtureConfig(tmpDir);
   const taskId = "TASK-20260814-223557";
-  const fixture = taskBoundRecoveryFixture(config, taskId);
+  taskBoundRecoveryFixture(config, taskId);
   moveTaskToCompleted(config, taskId);
   const activePath = path.join(config.repoRoot, ".agents", "workspace", "active", taskId);
   const completedPath = path.join(config.repoRoot, ".agents", "workspace", "completed", taskId);
   let startedWithSource = false;
-
   try {
-    const result = await ensureSandboxReady({
-      config,
-      engine: "native",
-      branch: "feature/demo",
-      workspace: { mode: "task-bound", taskId },
-      reentry: "completed",
-      row: {
-        name: "demo-dev-feature..demo",
-        status: "Exited",
-        branch: "feature/demo",
-        running: false,
-        index: 1
-      },
-      deps: {
-        ensureControlBroker: async () => {},
-        start: () => {
-          startedWithSource = fs.lstatSync(activePath).isSymbolicLink()
-            && fs.realpathSync.native(activePath) === fs.realpathSync.native(completedPath);
-        },
-        run: () => JSON.stringify([{
-          Id: "fixture-container-id",
-          Config: { Labels: fixture.labels },
-          Mounts: fixture.mounts
-        }]),
-        runOk: (_engine, _cmd, args) => {
-          const script = args[6] ?? "";
-          const target = args.at(-1);
-          if (script === 'test -r "$1"' && target?.endsWith("/task.md")) {
-            return startedWithSource;
-          }
-          return true;
-        },
-        runVerbose: () => {}
+    startCompletedSandboxContainer({
+      config, engine: "native", container: "demo-dev-feature..demo", taskId,
+      start: () => {
+        startedWithSource = fs.lstatSync(activePath).isSymbolicLink()
+          && fs.realpathSync.native(activePath) === fs.realpathSync.native(completedPath);
       }
     });
-
-    assert.equal(result.path, "recovered");
     assert.equal(startedWithSource, true);
     assert.equal(fs.existsSync(activePath), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("completed re-entry refuses missing control evidence before starting", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-infra-completed-missing-evidence-"));
+  const config = recoveryFixtureConfig(tmpDir);
+  const taskId = "TASK-20260814-223557";
+  taskBoundRecoveryFixture(config, taskId);
+  moveTaskToCompleted(config, taskId);
+  let started = false;
+  try {
+    await assert.rejects(ensureSandboxReady({
+      config, engine: "native", branch: "feature/demo",
+      workspace: { mode: "task-bound", taskId }, reentry: "completed",
+      row: { name: "demo-dev-feature..demo", status: "Exited", branch: "feature/demo", running: false, index: 1 },
+      deps: { ensureControlBroker: async () => {}, start: () => { started = true; } }
+    }), /SANDBOX_COMPLETED_REENTRY_FAILED/);
+    assert.equal(started, false);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/integration/cli/sandbox-worktree-safety.test.ts
+++ b/tests/integration/cli/sandbox-worktree-safety.test.ts
@@ -1032,9 +1032,9 @@ test("sandbox rm preserves a replacement after a share cleanup phase crash", onP
       channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-      version: 2, generation: "share-phase-generation",
+      version: 3, generation: "share-phase-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
     })}\n`);
 
     fs.writeFileSync = ((targetPath, data, options) => {
@@ -1122,9 +1122,9 @@ test("sandbox rm preserves a same-head branch replacement after a branch phase c
     channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
   })}\n`);
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2, generation: "branch-phase-generation",
+    version: 3, generation: "branch-phase-generation",
     broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const target = {
     branch,
@@ -1218,9 +1218,9 @@ test("sandbox rm preserves a replacement worktree after a workspace phase crash"
     channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
   })}\n`);
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2, generation: "worktree-phase-generation",
+    version: 3, generation: "worktree-phase-generation",
     broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const target = {
     branch,
@@ -1312,9 +1312,9 @@ test("sandbox rm recovers a worktree after a prune-phase crash", onPlatforms("li
     channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
   })}\n`);
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2, generation: "worktree-prune-generation",
+    version: 3, generation: "worktree-prune-generation",
     broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const target = {
     branch,
@@ -1403,9 +1403,9 @@ test("sandbox rm preserves an unowned tombstone when the source is absent", onPl
     channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
   })}\n`);
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2, generation: "unowned-tombstone-generation",
+    version: 3, generation: "unowned-tombstone-generation",
     broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const target = {
     branch,
@@ -1485,9 +1485,9 @@ test("sandbox rm retains an unexpected moved share payload for diagnosis", onPla
       processingDir: path.join(controlRoot, "processing"), runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(controlRoot, "public", "status.json"), `${JSON.stringify({
-      version: 2, generation: "share-replacement-generation",
+      version: 3, generation: "share-replacement-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
     })}\n`);
 
     fs.writeFileSync = ((targetPath, data, options) => {
@@ -1574,9 +1574,9 @@ test("sandbox rm preserves foreign tombstone payload on interrupted retry", onPl
       processingDir: path.join(controlRoot, "processing"), runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(controlRoot, "public", "status.json"), `${JSON.stringify({
-      version: 2, generation: "share-replacement-crash-generation",
+      version: 3, generation: "share-replacement-crash-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+      state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
     })}\n`);
 
     fs.renameSync = ((source, destination) => {
@@ -1660,9 +1660,9 @@ test("sandbox rm preserves untouched targets after a partial workspace phase cra
     channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, "runtime")
   })}\n`);
   fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-    version: 2, generation: "multi-target-phase-generation",
+    version: 3, generation: "multi-target-phase-generation",
     broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
-    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now()
+    state: "healthy", reasonCode: null, activeRequestId: null, updatedAt: Date.now(), taskView: statusTaskView(null)
   })}\n`);
   const target = {
     branch,

--- a/tests/integration/cli/sandbox-worktree-safety.test.ts
+++ b/tests/integration/cli/sandbox-worktree-safety.test.ts
@@ -38,6 +38,12 @@ function fixtureAuthorityEvidence() {
   });
 }
 
+function statusTaskView(taskId: string | null) {
+  return taskId
+    ? { state: "unknown", taskId, observedSource: "unknown", receipt: null, reasonCode: "SANDBOX_TASK_VIEW_EVIDENCE_UNAVAILABLE" }
+    : { state: "not-applicable", taskId: null, observedSource: null, receipt: null, reasonCode: null };
+}
+
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, {
     cwd,
@@ -249,13 +255,14 @@ test("sandbox rm retries control and workspace cleanup after the container is al
       runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(controlRoot, "public", "status.json"), `${JSON.stringify({
-      version: 2,
+      version: 3,
       generation: "partial-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
       state: "healthy",
       reasonCode: null,
       activeRequestId: null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      taskView: statusTaskView(null)
     })}\n`);
     const rm = await loadFreshEsm<RmModule>("lib/sandbox/commands/rm.js");
 
@@ -321,13 +328,14 @@ test("sandbox rm removes an empty control container parent after control cleanup
       runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(controlRoot, "public", "status.json"), `${JSON.stringify({
-      version: 2,
+      version: 3,
       generation: "empty-parent-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
       state: "healthy",
       reasonCode: null,
       activeRequestId: null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      taskView: statusTaskView(null)
     })}\n`);
     const previousPath = process.env.PATH;
     const previousDockerLog = process.env.DOCKER_LOG_PATH;
@@ -849,13 +857,14 @@ test("sandbox rm rejects a control manifest whose container does not match its c
       runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-      version: 2,
+      version: 3,
       generation: "manifest-mismatch-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
       state: "healthy",
       reasonCode: null,
       activeRequestId: null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      taskView: statusTaskView(taskId)
     })}\n`);
 
     const previousNotFound = process.env.DOCKER_INSPECT_NOT_FOUND;
@@ -938,13 +947,14 @@ test("sandbox rm cleans a completed task-bound sandbox only with matching contro
       runtimeDir: path.join(controlRoot, "runtime")
     })}\n`);
     fs.writeFileSync(path.join(publicStatusDir, "status.json"), `${JSON.stringify({
-      version: 2,
+      version: 3,
       generation: "completed-task-generation",
       broker: { pid: 999_999_999, startTime: 0, brokerId: "stale-broker" },
       state: "healthy",
       reasonCode: null,
       activeRequestId: null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      taskView: statusTaskView(taskId)
     })}\n`);
     const shellConfig = path.join(config.shellConfigBase, branch.replaceAll("/", ".."));
     fs.mkdirSync(shellConfig, { recursive: true });

--- a/tests/integration/cli/task-control-dual-mode.test.ts
+++ b/tests/integration/cli/task-control-dual-mode.test.ts
@@ -72,10 +72,12 @@ test('task control without sandbox markers uses the direct-host entry', () => {
 
 test('complete sandbox markers use the client entry without executing local authority', () => {
   const result = run('task-orchestration', ['TASK-20260809-010203', 'status'], cleanEnv({
+    AGENT_INFRA_TASK_ID: TASK_ID,
     AGENT_INFRA_CONTROL_TOKEN: 'token',
     AGENT_INFRA_CONTROL_GENERATION: 'generation',
     AGENT_INFRA_CONTROL_DIR: '/missing/control',
-    AGENT_INFRA_CONTROL_STATUS_DIR: '/missing/status'
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/missing/status',
+    AGENT_INFRA_RUNTIME_DIR: '/missing/runtime'
   }));
   assert.equal(result.status, 75);
   assert.match(result.stderr, /SANDBOX_CONTROL_BROKER_UNAVAILABLE/);
@@ -187,17 +189,22 @@ function runSandboxClient(
     cwd: fixture.root,
     env: {
       ...cleanEnv(),
+      AGENT_INFRA_TASK_ID: TASK_ID,
       AGENT_INFRA_CONTROL_DIR: fixture.channelDir,
       AGENT_INFRA_CONTROL_STATUS_DIR: fixture.statusDir,
       AGENT_INFRA_CONTROL_TOKEN: fixture.token,
-      AGENT_INFRA_CONTROL_GENERATION: fixture.generation
+      AGENT_INFRA_CONTROL_GENERATION: fixture.generation,
+      AGENT_INFRA_RUNTIME_DIR: path.join(fixture.controlRoot, 'runtime')
     },
     encoding: 'utf8'
   });
+  const stdout = result.stdout?.toString() ?? '';
+  const stderr = result.stderr?.toString() ?? '';
+  if (!stdout) throw new Error(`sandbox client produced no JSON (status=${result.status}, stderr=${stderr})`);
   return {
     status: result.status,
-    payload: JSON.parse(result.stdout?.toString() ?? '') as Record<string, unknown>,
-    stderr: result.stderr?.toString() ?? ''
+    payload: JSON.parse(stdout) as Record<string, unknown>,
+    stderr
   };
 }
 

--- a/tests/integration/cli/task-control-dual-mode.test.ts
+++ b/tests/integration/cli/task-control-dual-mode.test.ts
@@ -6,7 +6,7 @@ import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { pathToFileURL } from 'node:url';
 
-import { INTERNAL_CLI_PATH, sandboxControlSafeEnv } from '../../helpers.ts';
+import { CLI_PATH, INTERNAL_CLI_PATH, sandboxControlSafeEnv } from '../../helpers.ts';
 import {
   createDirectHostExecutionContext,
   createSandboxExecutorExecutionContext,
@@ -28,6 +28,19 @@ function cleanEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 
 function run(command: string, args: string[], env: NodeJS.ProcessEnv): { status: number | null; stdout: string; stderr: string } {
   const result = spawnSync(process.execPath, [INTERNAL_CLI_PATH, command, ...args], {
+    cwd: os.tmpdir(),
+    env,
+    encoding: 'utf8'
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? ''
+  };
+}
+
+function runPublic(args: string[], env: NodeJS.ProcessEnv): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     cwd: os.tmpdir(),
     env,
     encoding: 'utf8'
@@ -68,6 +81,34 @@ test('task control without sandbox markers uses the direct-host entry', () => {
   const result = run('task-lifecycle', ['--help'], cleanEnv());
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Usage: agent-infra-internal task-lifecycle/);
+});
+
+test('branch-only control markers keep non-task public commands on the host entry', () => {
+  const result = runPublic(['version'], cleanEnv({
+    AGENT_INFRA_CONTROL_TOKEN: 'token',
+    AGENT_INFRA_CONTROL_GENERATION: 'generation',
+    AGENT_INFRA_CONTROL_DIR: '/missing/control',
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/missing/status'
+  }));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /agent-infra v/);
+  assert.equal(result.stderr, '');
+});
+
+test('top-level usage and version aliases remain available in task-bound environments', () => {
+  const env = cleanEnv({
+    AGENT_INFRA_TASK_ID: TASK_ID,
+    AGENT_INFRA_CONTROL_TOKEN: 'token',
+    AGENT_INFRA_CONTROL_GENERATION: 'generation',
+    AGENT_INFRA_CONTROL_DIR: '/missing/control',
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/missing/status',
+    AGENT_INFRA_RUNTIME_DIR: '/missing/runtime'
+  });
+  for (const args of [[], ['help'], ['--version'], ['-v']]) {
+    const result = runPublic(args, env);
+    assert.equal(result.status, 0, `${args.join(' ')}: ${result.stderr}`);
+    assert.notEqual(result.stdout, '');
+  }
 });
 
 test('complete sandbox markers use the client entry without executing local authority', () => {

--- a/tests/integration/cli/task-validate.test.ts
+++ b/tests/integration/cli/task-validate.test.ts
@@ -180,8 +180,9 @@ function inplaceFixture({ includeContainer = true }: { includeContainer?: boolea
   const statusPath = path.join(control.statusDir, 'status.json');
   const writeStatus = (overrides: Record<string, unknown>) => {
     fs.writeFileSync(statusPath, `${JSON.stringify({
-      version: 2, generation, broker: { pid: 999999, startTime: 123456789, brokerId: 'fixture-broker' },
+      version: 3, generation, broker: { pid: 999999, startTime: 123456789, brokerId: 'fixture-broker' },
       state: 'healthy', reasonCode: null, activeRequestId: null, updatedAt: Date.now(),
+      taskView: { state: 'current', taskId, observedSource: 'active', receipt: null, reasonCode: null },
       ...overrides
     })}\n`);
   };

--- a/tests/integration/scripts/run-tests.test.ts
+++ b/tests/integration/scripts/run-tests.test.ts
@@ -120,6 +120,8 @@ test('test runner strips inherited sandbox control authority before loading test
     "    key.toUpperCase().startsWith('AGENT_INFRA_CONTROL_')",
     "  ), false);",
     "  assert.equal(process.env.AGENT_INFRA_TEST_SENTINEL, 'preserved');",
+    "  assert.equal(process.env.AGENT_INFRA_TASK_ID, undefined);",
+    "  assert.equal(process.env.AGENT_INFRA_RUNTIME_DIR, undefined);",
     "  assert.notEqual(process.env.NODE_TEST_CONTEXT, 'inherited-context');",
     '});',
     ''
@@ -133,6 +135,8 @@ test('test runner strips inherited sandbox control authority before loading test
         agent_infra_control_token: 'live-token',
         Agent_Infra_Control_Dir: path.join(root, 'live-channel'),
         aGeNt_InFrA_cOnTrOl_FuTuRe: 'future-authority',
+        AGENT_INFRA_TASK_ID: 'TASK-20260904-002344',
+        AGENT_INFRA_RUNTIME_DIR: path.join(root, 'runtime'),
         Node_Test_Context: 'inherited-context',
         AGENT_INFRA_TEST_SENTINEL: 'preserved'
       }

--- a/tests/unit/cli/sandbox-task-view.test.ts
+++ b/tests/unit/cli/sandbox-task-view.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  accessSandboxTaskView,
+  mergeSandboxTaskView,
+  parseSandboxTaskView,
+  projectSandboxTaskView,
+  taskViewAfterFinalization,
+  taskViewFromStatus
+} from '../../../lib/sandbox/control/task-view.ts';
+
+const taskId = 'TASK-20260904-002344';
+const requestId = '0123456789abcdef0123456789abcdef';
+const generation = 'generation-1';
+const receipt = {
+  version: 2,
+  receiptId: 'receipt-1',
+  revision: 4,
+  lifecycle: 'done',
+  controlBinding: { generation, requestId }
+};
+
+test('task-view projection distinguishes active current from completed current', () => {
+  assert.deepEqual(projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'active', sourceMatches: true
+  }), {
+    state: 'current', taskId, observedSource: 'active', receipt: null, reasonCode: null
+  });
+  const completed = projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'completed', sourceMatches: true,
+    receipt, requestId
+  });
+  assert.equal(completed.state, 'current');
+  assert.equal(completed.observedSource, 'completed');
+  assert.equal(completed.receipt?.requestId, requestId);
+});
+
+test('receipt-backed historical active source becomes finalized-stale', () => {
+  const view = taskViewAfterFinalization({ taskId, generation, requestId, receipt });
+  assert.equal(view.state, 'finalized-stale');
+  assert.equal(view.observedSource, 'active');
+  assert.equal(view.receipt?.revision, 4);
+  assert.equal(accessSandboxTaskView(view, 'diagnostic').allowed, true);
+  assert.equal(accessSandboxTaskView(view, 'cleanup').allowed, true);
+  assert.equal(accessSandboxTaskView(view, 'progress').allowed, false);
+});
+
+test('active source with a valid completion receipt remains finalized-stale after broker restart', () => {
+  const view = projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'active', sourceMatches: false,
+    receipt, requestId
+  });
+  assert.equal(view.state, 'finalized-stale');
+  assert.equal(accessSandboxTaskView(view, 'progress').allowed, false);
+});
+
+test('broker restart preserves stale or unknown evidence unless completed source is revalidated', () => {
+  const stale = taskViewAfterFinalization({ taskId, generation, requestId, receipt });
+  const active = projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'active', sourceMatches: true
+  });
+  assert.equal(mergeSandboxTaskView(active, stale).state, 'finalized-stale');
+  assert.equal(mergeSandboxTaskView(active, {
+    state: 'unknown', taskId, observedSource: 'unknown', receipt: null,
+    reasonCode: 'SANDBOX_TASK_VIEW_STATUS_INVALID'
+  }).state, 'unknown');
+  const completed = projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'completed', sourceMatches: true,
+    receipt, requestId
+  });
+  assert.equal(mergeSandboxTaskView(completed, stale).state, 'current');
+});
+
+test('receipt and source conflicts fail closed as unknown', () => {
+  const view = projectSandboxTaskView({
+    mode: 'task-bound', taskId, generation, source: 'unknown', sourceMatches: false,
+    receipt: { ...receipt, controlBinding: { generation: 'other', requestId } }, requestId
+  });
+  assert.equal(view.state, 'unknown');
+  assert.equal(accessSandboxTaskView(view, 'terminal-verdict').allowed, false);
+});
+
+test('status schema is v3-only and keeps health separate from task view', () => {
+  const view = parseSandboxTaskView({
+    state: 'finalized-stale', taskId, observedSource: 'active', receipt: {
+      receiptId: 'receipt-1', revision: 4, generation, requestId
+    }, reasonCode: 'SANDBOX_TASK_VIEW_FINALIZED'
+  });
+  assert.equal(view.state, 'finalized-stale');
+  assert.equal(taskViewFromStatus({ version: 3, generation, taskView: view }).state, 'finalized-stale');
+  assert.throws(() => taskViewFromStatus({ version: 2, taskView: view }), /SANDBOX_TASK_VIEW_INVALID/);
+  assert.throws(() => taskViewFromStatus({
+    version: 3,
+    generation: 'other-generation',
+    taskView: view
+  }), /SANDBOX_TASK_VIEW_INVALID/);
+});

--- a/tests/unit/cli/sandbox-task-view.test.ts
+++ b/tests/unit/cli/sandbox-task-view.test.ts
@@ -55,7 +55,7 @@ test('active source with a valid completion receipt remains finalized-stale afte
   assert.equal(accessSandboxTaskView(view, 'progress').allowed, false);
 });
 
-test('broker restart preserves stale or unknown evidence unless completed source is revalidated', () => {
+test('broker restart preserves stale or unknown evidence until a new re-entry projection', () => {
   const stale = taskViewAfterFinalization({ taskId, generation, requestId, receipt });
   const active = projectSandboxTaskView({
     mode: 'task-bound', taskId, generation, source: 'active', sourceMatches: true
@@ -69,7 +69,7 @@ test('broker restart preserves stale or unknown evidence unless completed source
     mode: 'task-bound', taskId, generation, source: 'completed', sourceMatches: true,
     receipt, requestId
   });
-  assert.equal(mergeSandboxTaskView(completed, stale).state, 'current');
+  assert.equal(mergeSandboxTaskView(completed, stale).state, 'finalized-stale');
 });
 
 test('receipt and source conflicts fail closed as unknown', () => {

--- a/tests/unit/cli/task-operation-registry.test.ts
+++ b/tests/unit/cli/task-operation-registry.test.ts
@@ -15,7 +15,10 @@ import {
   type TaskOperationDescriptor
 } from '../../../lib/internal/task-operation-registry.ts';
 import {
+  INTERNAL_HANDLER_ROUTE_SELECTORS,
   INTERNAL_CLI_ROUTE_SELECTORS,
+  ensureInternalHandlerRoute,
+  isInternalHandlerRoute,
   PUBLIC_CLI_ROUTE_SELECTORS
 } from '../../../lib/internal/cli-route-inventory.ts';
 import type { SandboxTaskView } from '../../../lib/sandbox/control/task-view.ts';
@@ -79,6 +82,36 @@ test('internal descriptor selectors match the shared dispatcher inventory', () =
     ])),
     Object.fromEntries(Object.entries(INTERNAL_CLI_ROUTE_SELECTORS).map(([route, selectors]) => [route, [...selectors].sort()]))
   );
+});
+
+test('internal handler route definitions are the registry input and reject selector drift', () => {
+  assert.strictEqual(INTERNAL_CLI_ROUTE_SELECTORS, INTERNAL_HANDLER_ROUTE_SELECTORS);
+  for (const [command, selectors] of Object.entries(INTERNAL_HANDLER_ROUTE_SELECTORS)) {
+    for (const selector of selectors) {
+      const args = command === 'task-create'
+        ? ['--input', 'candidate.json']
+        : command === 'task-short-id' && selector === 'list-verify'
+          ? ['list', '--verify']
+          : command === 'task-snapshot'
+            ? ['TASK-20260904-002344']
+          : command === 'task-delivery' || command === 'task-ledger' || command === 'task-warning' || command === 'task-activity'
+            || command === 'task-artifact' || command === 'task-review' || command === 'task-invalidation' || command === 'task-override'
+          ? ['TASK-20260904-002344', selector]
+          : command === 'task-context'
+            ? [selector]
+            : command === 'task-validate'
+              ? ['TASK-20260904-002344', '--scope', selector]
+              : command === 'platform-pr-review'
+                ? [selector === 'publish-pr' || selector === 'publish-task' ? 'publish' : selector, '--scope', selector === 'publish-task' ? 'TASK-20260904-002344' : 'pr123']
+                : command === 'task-lifecycle' || command === 'task-finalization' || command === 'task-orchestration'
+                  ? ['TASK-20260904-002344', selector]
+                  : command === 'task-event' || command === 'task-verify'
+                    ? ['TASK-20260904-002344', selector]
+                    : [selector];
+      assert.equal(ensureInternalHandlerRoute(command, args), true, `${command} ${selector}`);
+    }
+  }
+  assert.equal(isInternalHandlerRoute('git-workflow', ['unregistered']), false);
 });
 
 test('non-prefix task mutation routes resolve to task-bound descriptors', () => {

--- a/tests/unit/cli/task-operation-registry.test.ts
+++ b/tests/unit/cli/task-operation-registry.test.ts
@@ -28,6 +28,23 @@ function commands(descriptors: readonly TaskOperationDescriptor[], command: stri
   return descriptors.filter((item) => item.command === command);
 }
 
+const actualPublicSelectors: Readonly<Record<string, readonly string[]>> = {
+  'agent-client': ['list', 'status', 'enable', 'disable', 'configure'],
+  cp: ['cp'],
+  data: ['capture', 'verify', 'audit', 'repair', 'export'],
+  decide: ['decide'],
+  help: ['help'],
+  init: ['init'],
+  merge: ['merge'],
+  run: ['create-task', 'task-skill', 'recreate'],
+  sandbox: ['create', 'exec', 'ls', 'show', 'prune', 'rebuild', 'refresh', 'rm', 'start', 'vm'],
+  server: ['start', 'stop', 'status', 'logs', '__daemon'],
+  task: ['cat', 'decisions', 'files', 'grep', 'issue-body', 'log', 'ls', 'show', 'status'],
+  sync: ['sync'],
+  update: ['update'],
+  version: ['version']
+};
+
 test('dispatcher route inventories have explicit descriptors in both directions', () => {
   for (const [routes, descriptors] of [
     [INTERNAL_DISPATCHER_ROUTES, INTERNAL_OPERATION_DESCRIPTORS],
@@ -45,6 +62,20 @@ test('dispatcher route inventories have explicit descriptors in both directions'
     keys.add(key);
     assert.equal(item.guardBeforeImport, true);
   }
+});
+
+test('public descriptor selectors match the actual command dispatchers', () => {
+  assert.deepEqual(
+    Object.fromEntries(PUBLIC_DISPATCHER_ROUTES.map((route) => [
+      route,
+      commands(PUBLIC_OPERATION_DESCRIPTORS, route).map((item) => item.selector).sort()
+    ])),
+    Object.fromEntries(Object.entries(actualPublicSelectors).map(([route, selectors]) => [route, [...selectors].sort()]))
+  );
+  assert.equal(resolveTaskOperation('public', 'agent-client', ['status'])?.selector, 'status');
+  assert.equal(resolveTaskOperation('public', 'agent-client', ['inspect']), null);
+  assert.equal(resolveTaskOperation('public', 'sandbox', ['enter']), null);
+  assert.equal(resolveTaskOperation('public', 'server', ['__daemon'])?.selector, '__daemon');
 });
 
 test('non-prefix task mutation routes resolve to task-bound descriptors', () => {
@@ -70,12 +101,17 @@ test('delegated control selectors reuse the same internal descriptors', () => {
 });
 
 test('task-view guard refuses stale progress before a route can import its module', () => {
+  const taskEnv = {
+    AGENT_INFRA_TASK_ID: staleView.taskId!,
+    AGENT_INFRA_CONTROL_TOKEN: 'token',
+    AGENT_INFRA_CONTROL_GENERATION: 'generation-1',
+    AGENT_INFRA_CONTROL_DIR: '/control',
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/status',
+    AGENT_INFRA_RUNTIME_DIR: '/runtime'
+  };
   assert.throws(
     () => guardTaskOperation('internal', 'git-workflow', ['commit'], {
-      env: {
-        AGENT_INFRA_TASK_ID: staleView.taskId!,
-        AGENT_INFRA_CONTROL_STATUS_DIR: '/unused'
-      },
+      env: taskEnv,
       taskView: staleView
     }),
     (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_VIEW_FINALIZED:')
@@ -83,12 +119,51 @@ test('task-view guard refuses stale progress before a route can import its modul
   assert.doesNotThrow(() => guardTaskOperation('internal', 'task-warning', [
     staleView.taskId!, 'list'
   ], {
+    env: taskEnv,
+    taskView: staleView
+  }));
+  for (const help of ['help', '-h', '--help']) {
+    assert.throws(
+      () => guardTaskOperation('internal', 'git-workflow', ['commit', help], { env: taskEnv, taskView: staleView }),
+      (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_VIEW_FINALIZED:')
+    );
+  }
+});
+
+test('task-bound guard rejects incomplete markers and cross-task references', () => {
+  assert.throws(
+    () => guardTaskOperation('internal', 'git-workflow', ['commit'], {
+      env: { AGENT_INFRA_TASK_ID: staleView.taskId!, AGENT_INFRA_CONTROL_STATUS_DIR: '/status' },
+      taskView: staleView
+    }),
+    (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_VIEW_MARKER_INVALID:')
+  );
+  assert.doesNotThrow(() => guardTaskOperation('internal', 'git-workflow', ['commit'], {
     env: {
-      AGENT_INFRA_TASK_ID: staleView.taskId!,
-      AGENT_INFRA_CONTROL_STATUS_DIR: '/unused'
+      AGENT_INFRA_CONTROL_TOKEN: 'token',
+      AGENT_INFRA_CONTROL_GENERATION: 'generation-1',
+      AGENT_INFRA_CONTROL_DIR: '/control',
+      AGENT_INFRA_CONTROL_STATUS_DIR: '/status',
+      AGENT_INFRA_RUNTIME_DIR: '/runtime'
     },
     taskView: staleView
   }));
+  assert.throws(
+    () => guardTaskOperation('internal', 'task-event', [
+      'TASK-20990101-010101', 'started'
+    ], {
+      env: {
+        AGENT_INFRA_TASK_ID: staleView.taskId!,
+        AGENT_INFRA_CONTROL_TOKEN: 'token',
+        AGENT_INFRA_CONTROL_GENERATION: 'generation-1',
+        AGENT_INFRA_CONTROL_DIR: '/control',
+        AGENT_INFRA_CONTROL_STATUS_DIR: '/status',
+        AGENT_INFRA_RUNTIME_DIR: '/runtime'
+      },
+      taskView: { ...staleView, state: 'current', observedSource: 'active', reasonCode: null }
+    }),
+    (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_REF_MISMATCH:')
+  );
 });
 
 test('host-direct routes remain unchanged without task-bound markers', () => {

--- a/tests/unit/cli/task-operation-registry.test.ts
+++ b/tests/unit/cli/task-operation-registry.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  INTERNAL_DISPATCHER_ROUTES,
+  INTERNAL_OPERATION_DESCRIPTORS,
+  PUBLIC_DISPATCHER_ROUTES,
+  PUBLIC_OPERATION_DESCRIPTORS,
+  guardTaskOperation,
+  resolveDelegatedTaskOperation,
+  resolveTaskOperation,
+  type TaskOperationDescriptor
+} from '../../../lib/internal/task-operation-registry.ts';
+import type { SandboxTaskView } from '../../../lib/sandbox/control/task-view.ts';
+
+const staleView: SandboxTaskView = {
+  state: 'finalized-stale',
+  taskId: 'TASK-20260904-002344',
+  observedSource: 'active',
+  receipt: {
+    receiptId: 'receipt-1', revision: 3, generation: 'generation-1',
+    requestId: '0123456789abcdef0123456789abcdef'
+  },
+  reasonCode: 'SANDBOX_TASK_VIEW_FINALIZED'
+};
+
+function commands(descriptors: readonly TaskOperationDescriptor[], command: string): TaskOperationDescriptor[] {
+  return descriptors.filter((item) => item.command === command);
+}
+
+test('dispatcher route inventories have explicit descriptors in both directions', () => {
+  for (const [routes, descriptors] of [
+    [INTERNAL_DISPATCHER_ROUTES, INTERNAL_OPERATION_DESCRIPTORS],
+    [PUBLIC_DISPATCHER_ROUTES, PUBLIC_OPERATION_DESCRIPTORS]
+  ] as const) {
+    for (const route of routes) assert.ok(commands(descriptors, route).length > 0, `missing descriptor for ${route}`);
+    for (const command of new Set(descriptors.map((item) => item.command))) {
+      assert.ok((routes as readonly string[]).includes(command), `descriptor has no dispatcher route: ${command}`);
+    }
+  }
+  const keys = new Set<string>();
+  for (const item of [...INTERNAL_OPERATION_DESCRIPTORS, ...PUBLIC_OPERATION_DESCRIPTORS]) {
+    const key = `${item.dispatcher}:${item.command}:${item.selector}`;
+    assert.equal(keys.has(key), false, `duplicate descriptor ${key}`);
+    keys.add(key);
+    assert.equal(item.guardBeforeImport, true);
+  }
+});
+
+test('non-prefix task mutation routes resolve to task-bound descriptors', () => {
+  assert.equal(resolveTaskOperation('internal', 'task-short-id', ['resolve'])?.effect, 'progress');
+  assert.equal(resolveTaskOperation('internal', 'git-workflow', ['commit'])?.effect, 'progress');
+  assert.equal(resolveTaskOperation('internal', 'platform-comment', ['sync', 'TASK-20260904-002344'])?.effect, 'remote-write');
+  assert.equal(resolveTaskOperation('internal', 'platform-pr-review', [
+    'publish', '--scope', 'TASK-20260904-002344'
+  ])?.selector, 'publish-task');
+  assert.equal(resolveTaskOperation('internal', 'platform-pr-review', [
+    'publish', '--scope', 'pr123'
+  ])?.selector, 'publish-pr');
+  assert.equal(resolveTaskOperation('internal', 'task-validate', [
+    'feature', '--scope', 'inplace', '--', 'true'
+  ])?.effect, 'progress');
+  assert.equal(resolveTaskOperation('public', 'decide', ['--task', '11'])?.scope, 'task-bound');
+  assert.equal(resolveTaskOperation('public', 'task', ['d', '--task', '11'])?.selector, 'decisions');
+});
+
+test('delegated control selectors reuse the same internal descriptors', () => {
+  assert.equal(resolveDelegatedTaskOperation(['client', 'task-lifecycle', 'TASK-20260904-002344', 'complete'])?.command, 'task-lifecycle');
+  assert.equal(resolveDelegatedTaskOperation(['client', 'task-orchestration', 'TASK-20260904-002344', 'status'])?.effect, 'diagnostic');
+});
+
+test('task-view guard refuses stale progress before a route can import its module', () => {
+  assert.throws(
+    () => guardTaskOperation('internal', 'git-workflow', ['commit'], {
+      env: {
+        AGENT_INFRA_TASK_ID: staleView.taskId!,
+        AGENT_INFRA_CONTROL_STATUS_DIR: '/unused'
+      },
+      taskView: staleView
+    }),
+    (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_VIEW_FINALIZED:')
+  );
+  assert.doesNotThrow(() => guardTaskOperation('internal', 'task-warning', [
+    staleView.taskId!, 'list'
+  ], {
+    env: {
+      AGENT_INFRA_TASK_ID: staleView.taskId!,
+      AGENT_INFRA_CONTROL_STATUS_DIR: '/unused'
+    },
+    taskView: staleView
+  }));
+});
+
+test('host-direct routes remain unchanged without task-bound markers', () => {
+  assert.doesNotThrow(() => guardTaskOperation('internal', 'git-workflow', ['commit'], { env: {} }));
+  assert.doesNotThrow(() => guardTaskOperation('public', 'decide', ['--task', '11'], { env: {} }));
+});

--- a/tests/unit/cli/task-operation-registry.test.ts
+++ b/tests/unit/cli/task-operation-registry.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
@@ -11,6 +14,10 @@ import {
   resolveTaskOperation,
   type TaskOperationDescriptor
 } from '../../../lib/internal/task-operation-registry.ts';
+import {
+  INTERNAL_CLI_ROUTE_SELECTORS,
+  PUBLIC_CLI_ROUTE_SELECTORS
+} from '../../../lib/internal/cli-route-inventory.ts';
 import type { SandboxTaskView } from '../../../lib/sandbox/control/task-view.ts';
 
 const staleView: SandboxTaskView = {
@@ -27,23 +34,6 @@ const staleView: SandboxTaskView = {
 function commands(descriptors: readonly TaskOperationDescriptor[], command: string): TaskOperationDescriptor[] {
   return descriptors.filter((item) => item.command === command);
 }
-
-const actualPublicSelectors: Readonly<Record<string, readonly string[]>> = {
-  'agent-client': ['list', 'status', 'enable', 'disable', 'configure'],
-  cp: ['cp'],
-  data: ['capture', 'verify', 'audit', 'repair', 'export'],
-  decide: ['decide'],
-  help: ['help'],
-  init: ['init'],
-  merge: ['merge'],
-  run: ['create-task', 'task-skill', 'recreate'],
-  sandbox: ['create', 'exec', 'ls', 'show', 'prune', 'rebuild', 'refresh', 'rm', 'start', 'vm'],
-  server: ['start', 'stop', 'status', 'logs', '__daemon'],
-  task: ['cat', 'decisions', 'files', 'grep', 'issue-body', 'log', 'ls', 'show', 'status'],
-  sync: ['sync'],
-  update: ['update'],
-  version: ['version']
-};
 
 test('dispatcher route inventories have explicit descriptors in both directions', () => {
   for (const [routes, descriptors] of [
@@ -66,16 +56,29 @@ test('dispatcher route inventories have explicit descriptors in both directions'
 
 test('public descriptor selectors match the actual command dispatchers', () => {
   assert.deepEqual(
-    Object.fromEntries(PUBLIC_DISPATCHER_ROUTES.map((route) => [
+    Object.fromEntries(Object.keys(PUBLIC_CLI_ROUTE_SELECTORS).map((route) => [
       route,
       commands(PUBLIC_OPERATION_DESCRIPTORS, route).map((item) => item.selector).sort()
     ])),
-    Object.fromEntries(Object.entries(actualPublicSelectors).map(([route, selectors]) => [route, [...selectors].sort()]))
+    Object.fromEntries(Object.entries(PUBLIC_CLI_ROUTE_SELECTORS).map(([route, selectors]) => [route, [...selectors].sort()]))
   );
   assert.equal(resolveTaskOperation('public', 'agent-client', ['status'])?.selector, 'status');
   assert.equal(resolveTaskOperation('public', 'agent-client', ['inspect']), null);
   assert.equal(resolveTaskOperation('public', 'sandbox', ['enter']), null);
   assert.equal(resolveTaskOperation('public', 'server', ['__daemon'])?.selector, '__daemon');
+  assert.equal(resolveTaskOperation('public', '', [])?.selector, 'help');
+  assert.equal(resolveTaskOperation('public', '--version', [])?.selector, 'version');
+  assert.equal(resolveTaskOperation('public', '-v', [])?.selector, 'version');
+});
+
+test('internal descriptor selectors match the shared dispatcher inventory', () => {
+  assert.deepEqual(
+    Object.fromEntries(Object.keys(INTERNAL_CLI_ROUTE_SELECTORS).map((route) => [
+      route,
+      commands(INTERNAL_OPERATION_DESCRIPTORS, route).map((item) => item.selector).sort()
+    ])),
+    Object.fromEntries(Object.entries(INTERNAL_CLI_ROUTE_SELECTORS).map(([route, selectors]) => [route, [...selectors].sort()]))
+  );
 });
 
 test('non-prefix task mutation routes resolve to task-bound descriptors', () => {
@@ -144,7 +147,7 @@ test('task-bound guard rejects incomplete markers and cross-task references', ()
       AGENT_INFRA_CONTROL_GENERATION: 'generation-1',
       AGENT_INFRA_CONTROL_DIR: '/control',
       AGENT_INFRA_CONTROL_STATUS_DIR: '/status',
-      AGENT_INFRA_RUNTIME_DIR: '/runtime'
+      AGENT_INFRA_RUNTIME_DIR: undefined
     },
     taskView: staleView
   }));
@@ -164,6 +167,43 @@ test('task-bound guard rejects incomplete markers and cross-task references', ()
     }),
     (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_REF_MISMATCH:')
   );
+});
+
+test('task-bound git input identity is checked before the commit module can load', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-operation-input-'));
+  const inputPath = path.join(root, 'commit.json');
+  const taskEnv = {
+    AGENT_INFRA_TASK_ID: staleView.taskId!,
+    AGENT_INFRA_CONTROL_TOKEN: 'token',
+    AGENT_INFRA_CONTROL_GENERATION: 'generation-1',
+    AGENT_INFRA_CONTROL_DIR: '/control',
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/status',
+    AGENT_INFRA_RUNTIME_DIR: '/runtime'
+  };
+  try {
+    fs.writeFileSync(inputPath, JSON.stringify({ taskRef: 'TASK-20990101-010101' }));
+    assert.throws(
+      () => guardTaskOperation('internal', 'git-workflow', ['commit', '--input', inputPath], { env: taskEnv, taskView: { ...staleView, state: 'current', observedSource: 'active', reasonCode: null } }),
+      (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_REF_MISMATCH:')
+    );
+    fs.writeFileSync(inputPath, JSON.stringify({ taskRef: staleView.taskId }));
+    assert.throws(
+      () => guardTaskOperation('internal', 'git-workflow', ['commit', '--input', inputPath], { env: taskEnv, taskView: staleView }),
+      (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_VIEW_FINALIZED:')
+    );
+    fs.writeFileSync(inputPath, JSON.stringify({ taskRef: 'feature/other-task' }));
+    assert.throws(
+      () => guardTaskOperation('internal', 'git-workflow', ['commit', '--input', inputPath], { env: taskEnv, taskView: { ...staleView, state: 'current', observedSource: 'active', reasonCode: null } }),
+      (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_REF_INVALID:')
+    );
+    fs.writeFileSync(inputPath, JSON.stringify({}));
+    assert.throws(
+      () => guardTaskOperation('internal', 'git-workflow', ['commit', '--input', inputPath], { env: taskEnv, taskView: { ...staleView, state: 'current', observedSource: 'active', reasonCode: null } }),
+      (error: unknown) => error instanceof Error && error.message.startsWith('SANDBOX_TASK_REF_INVALID:')
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('host-direct routes remain unchanged without task-bound markers', () => {

--- a/tests/unit/cli/task-operation-registry.test.ts
+++ b/tests/unit/cli/task-operation-registry.test.ts
@@ -17,7 +17,6 @@ import {
 import {
   INTERNAL_HANDLER_ROUTE_SELECTORS,
   INTERNAL_CLI_ROUTE_SELECTORS,
-  ensureInternalHandlerRoute,
   isInternalHandlerRoute,
   PUBLIC_CLI_ROUTE_SELECTORS
 } from '../../../lib/internal/cli-route-inventory.ts';
@@ -36,6 +35,31 @@ const staleView: SandboxTaskView = {
 
 function commands(descriptors: readonly TaskOperationDescriptor[], command: string): TaskOperationDescriptor[] {
   return descriptors.filter((item) => item.command === command);
+}
+
+function routeKey(command: string, selector: string): string {
+  return `${command}:${selector}`;
+}
+
+function routeKeysFromHandlerBranches(): Set<string> {
+  const internalDir = path.resolve(process.cwd(), 'lib/internal');
+  const marker = /internalHandlerRoute\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]/gu;
+  const keys = new Set<string>();
+  for (const name of fs.readdirSync(internalDir).filter((entry) => entry.endsWith('.ts'))) {
+    if (name === 'cli-route-inventory.ts') continue;
+    const source = fs.readFileSync(path.join(internalDir, name), 'utf8');
+    for (const match of source.matchAll(marker)) keys.add(routeKey(match[1]!, match[2]!));
+  }
+  return keys;
+}
+
+function routeKeysFromInventory(): Set<string> {
+  return new Set(Object.entries(INTERNAL_HANDLER_ROUTE_SELECTORS)
+    .flatMap(([command, selectors]) => selectors.map((selector) => routeKey(command, selector))));
+}
+
+function routeKeysFromDescriptors(): Set<string> {
+  return new Set(INTERNAL_OPERATION_DESCRIPTORS.map((item) => routeKey(item.command, item.selector)));
 }
 
 test('dispatcher route inventories have explicit descriptors in both directions', () => {
@@ -84,34 +108,22 @@ test('internal descriptor selectors match the shared dispatcher inventory', () =
   );
 });
 
-test('internal handler route definitions are the registry input and reject selector drift', () => {
+test('actual handler branches and registry descriptors have bidirectional coverage', () => {
+  const actual = routeKeysFromHandlerBranches();
+  const inventory = routeKeysFromInventory();
+  const descriptors = routeKeysFromDescriptors();
+  assert.deepEqual([...actual].sort(), [...inventory].sort());
+  assert.deepEqual([...actual].sort(), [...descriptors].sort());
   assert.strictEqual(INTERNAL_CLI_ROUTE_SELECTORS, INTERNAL_HANDLER_ROUTE_SELECTORS);
-  for (const [command, selectors] of Object.entries(INTERNAL_HANDLER_ROUTE_SELECTORS)) {
-    for (const selector of selectors) {
-      const args = command === 'task-create'
-        ? ['--input', 'candidate.json']
-        : command === 'task-short-id' && selector === 'list-verify'
-          ? ['list', '--verify']
-          : command === 'task-snapshot'
-            ? ['TASK-20260904-002344']
-          : command === 'task-delivery' || command === 'task-ledger' || command === 'task-warning' || command === 'task-activity'
-            || command === 'task-artifact' || command === 'task-review' || command === 'task-invalidation' || command === 'task-override'
-          ? ['TASK-20260904-002344', selector]
-          : command === 'task-context'
-            ? [selector]
-            : command === 'task-validate'
-              ? ['TASK-20260904-002344', '--scope', selector]
-              : command === 'platform-pr-review'
-                ? [selector === 'publish-pr' || selector === 'publish-task' ? 'publish' : selector, '--scope', selector === 'publish-task' ? 'TASK-20260904-002344' : 'pr123']
-                : command === 'task-lifecycle' || command === 'task-finalization' || command === 'task-orchestration'
-                  ? ['TASK-20260904-002344', selector]
-                  : command === 'task-event' || command === 'task-verify'
-                    ? ['TASK-20260904-002344', selector]
-                    : [selector];
-      assert.equal(ensureInternalHandlerRoute(command, args), true, `${command} ${selector}`);
-    }
-  }
   assert.equal(isInternalHandlerRoute('git-workflow', ['unregistered']), false);
+
+  const removed = [...actual][0]!;
+  const simulatedDeletion = new Set([...actual].filter((key) => key !== removed));
+  assert.deepEqual([...descriptors].filter((key) => !simulatedDeletion.has(key)), [removed]);
+
+  const [command, selector] = removed.split(':');
+  const simulatedRename = new Set([...actual].map((key) => key === removed ? routeKey(command!, `${selector}-renamed`) : key));
+  assert.deepEqual([...descriptors].filter((key) => !simulatedRename.has(key)), [removed]);
 });
 
 test('non-prefix task mutation routes resolve to task-bound descriptors', () => {

--- a/tests/unit/templates/skills.test.ts
+++ b/tests/unit/templates/skills.test.ts
@@ -586,7 +586,7 @@ test("workflow verification consumers declare their business verification events
     "block-task": ["block-task.completed"],
     "cancel-task": ["cancel-task.completed"],
     "commit": ["commit.completed"],
-    "complete-task": ["complete-task.preflight", "complete-task.completed"],
+    "complete-task": ["complete-task.preflight"],
     "create-pr": ["create-pr.completed"],
     "create-task": ["create-task.completed"],
     "import-codescan": ["import-codescan.completed"],


### PR DESCRIPTION
## 摘要

修复沙箱在宿主完成任务终态迁移后仍依赖旧 workspace bind mount，导致终态判断错误的问题。

## 变更

- 以宿主 finalization 结果和 receipt 作为终态事实源，维护 finalized/stale task view，并在 stale/unknown 状态下对任务写入 fail-closed。
- 保持 task-view guard 位于 internal handler 动态 import 之前，补齐所有 internal route 的统一分类与访问边界。
- 将实际 handler 分支纳入 route inventory 与 operation descriptor 的双向漂移检测，覆盖删除/改名场景。

## 验证

- `npm run build`
- `npm run typecheck`
- `npm test`：2909 tests，2902 pass，0 fail，7 skipped
- `review-code-r5.md`：Approved；0 blocker、0 major、0 minor

## 未覆盖验证

真实 Docker bind mount、broker restart、container inspect、进程竞态及合法 completed re-entry 仍需宿主机人工验证。

Closes #961

Generated with AI assistance
