### PR TITLE
fix(sandbox): 修复受控任务创建恢复状态


### DIFF
--- a/.agents/skills/create-task/SKILL.md
+++ b/.agents/skills/create-task/SKILL.md
@@ -125,6 +125,13 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 - `blocked`：保留 candidate 文件，修复暂态问题后用同一文件重试。
 - `failed`：报告稳定错误码；幂等冲突时不得改写原 key 或原 candidate 后重试。
 
+受控调用可能在结果中返回 `control` 请求证据：`accepted: true` 且
+`recovery: none` 表示可以消费当前结果；`accepted: false` 且
+`recovery: new-request-id` 表示请求尚未受理，暂态问题恢复后才能用同一份
+candidate 和新的 outer request ID 重试；`recovery: same-request-id` 或
+`recovery: inspect-domain-state` 表示请求已经受理，不得创建新的 candidate 或
+自动重放，必须先使用原 request 检查结果或宿主任务状态。
+
 ### 4. 平台失败兼容说明
 
 平台级联由宿主服务完成。兼容的人工恢复命令仍由宿主 warning 指引，不在沙箱内执行：

--- a/bin/internal-cli.ts
+++ b/bin/internal-cli.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
+import { classifySandboxControlEnvironment } from '../lib/sandbox/control/client.ts';
 import {
   formatTaskViewDiagnostic,
   guardTaskOperation,
   TaskViewOperationError
 } from '../lib/internal/task-operation-registry.ts';
 import { INTERNAL_HANDLER_ROUTE_SELECTORS } from '../lib/internal/cli-route-inventory.ts';
-
 const [major = 0, minor = 0] = process.versions.node.split('.').map((part) => parseInt(part, 10));
 if (major < 22 || (major === 22 && minor < 9)) {
   process.stderr.write(
@@ -44,25 +44,11 @@ function taskControlTransportFailure(message: string): never {
 }
 
 if (!taskViewGuardFailed && taskControlCommand) {
-  const env = process.env;
-  const executorMarked = Boolean(env.AGENT_INFRA_EXECUTOR_MANIFEST);
-  const controlKeys = [
-    'AGENT_INFRA_CONTROL_TOKEN', 'AGENT_INFRA_CONTROL_GENERATION',
-    'AGENT_INFRA_CONTROL_DIR', 'AGENT_INFRA_CONTROL_STATUS_DIR'
-  ];
-  const hasControlMarker = controlKeys.some((key) => Boolean(env[key]))
-    || Boolean(env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING);
-  const taskBindingMarker = hasControlMarker && Boolean(env.AGENT_INFRA_TASK_ID);
-  const hasCompleteClientConfig = controlKeys.every((key) => Boolean(env[key]))
-    && !env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING
-    && (!taskBindingMarker || Boolean(env.AGENT_INFRA_RUNTIME_DIR));
-  if (executorMarked) {
-    taskControlTransportFailure('executor context is only valid for sandbox-control execute');
+  const environment = classifySandboxControlEnvironment();
+  if (environment.kind === 'invalid') {
+    taskControlTransportFailure(environment.message ?? 'sandbox client control configuration is invalid');
   }
-  if ((hasControlMarker || taskBindingMarker) && !hasCompleteClientConfig) {
-    taskControlTransportFailure('sandbox client control configuration is incomplete or conflicting');
-  }
-  if (hasCompleteClientConfig) {
+  if (environment.kind === 'controlled') {
     const { sandboxControl } = await import('../lib/internal/sandbox-control.ts');
     await sandboxControl(['client', command, ...process.argv.slice(3)]);
   } else {

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -142,6 +142,15 @@ Both identities may create a new task through the dedicated typed `task-create` 
 
 Creation retries have two identities. Reusing an outer request id is rejected even after a broker restart. After a timeout, the caller uses a new outer id but reuses the original immutable candidate file and business idempotency key; semantically identical JSON returns the original task as `no-op`, while changed field values fail closed. Platform failures retain the local task and short id and return a structured warning.
 
+Controlled `task-create` results also carry request evidence: `accepted: true` with
+`recovery: none` means the result is complete, `accepted: false` with
+`recovery: new-request-id` permits retrying the same candidate after a transient
+pre-acceptance failure, and `recovery: same-request-id` requires recovery using
+the accepted request. If broker recovery cannot retain the output payload, it
+returns a failed `SANDBOX_CONTROL_OUTPUT_UNAVAILABLE` task result with
+`recovery: inspect-domain-state`; inspect the host task state before deciding
+whether a later retry is safe.
+
 Task lifecycle, finalization, and orchestration use one typed Task Control Authority with separate transport entries. Direct-host commands call the local authority adapter and do not create a broker, control channel, manifest, or sandbox authority root. A sandbox client only creates a control request; the broker-spawned executor becomes the authority caller only after the gate, current manifest, request, owner, lease, and controller checks pass. Branch-only containers, mismatched IDs, unknown command families, and stale shared-workspace containers fail closed. `ai sandbox ls` exposes `WORKSPACE` and `TASK` columns, while `ai sandbox show` reports the same label-derived identity.
 
 The parent-plus-child bind topology from v0.9.7 is legacy and intentionally incompatible with the current per-state topology. On upgrade, or when old code encounters a newer per-state container during rollback, the check fails closed; run `ai sandbox start --recreate <task-ref-or-branch>` once. Container-local processes, tmux sessions, the writable layer, ordinary `/tmp`, and RAM state may be lost, while the worktree, local branch, and host-managed task/tool data are preserved.

--- a/docs/zh-CN/sandbox.md
+++ b/docs/zh-CN/sandbox.md
@@ -134,6 +134,14 @@ ai sandbox create feature/proxy --inherit-proxy
 
 创建重试包含两层身份：重复 outer request ID 即使在 broker 重启后也会被拒绝；超时后调用方使用新的 outer ID，但必须复用原不可变 candidate 文件和业务幂等 key。语义相同的 JSON 返回原任务 `no-op`，任一字段值变化均 fail closed。平台失败时保留本地任务和短号，并返回结构化 warning。
 
+受控 `task-create` 结果还会携带请求证据：`accepted: true` 且
+`recovery: none` 表示结果完整；`accepted: false` 且
+`recovery: new-request-id` 表示请求尚未受理，暂态失败恢复后可以复用同一份
+candidate 并使用新的 outer ID；`recovery: same-request-id` 则必须使用已受理的
+request 做恢复。如果 broker 恢复时无法保留输出 payload，会返回失败的
+`SANDBOX_CONTROL_OUTPUT_UNAVAILABLE` task 结果并标记
+`recovery: inspect-domain-state`；应先检查宿主任务状态，再判断后续重试是否安全。
+
 任务生命周期、完成收尾和编排统一使用一个 typed Task Control Authority，但入口承载分开。direct-host 命令通过本地 authority adapter 执行，不创建 broker、control channel、manifest 或沙箱 authority 根目录。沙箱 client 只负责创建 control request；只有 broker 启动的 executor 依次通过 gate、current manifest、request、owner、lease 和 controller 校验后，才能成为 authority caller。branch-only 容器、identity 不匹配、未知命令族和旧共享 workspace 容器都会 fail closed。`ai sandbox ls` 通过 `WORKSPACE` 与 `TASK` 列展示身份，`ai sandbox show` 展示同一份基于标签的事实。
 
 v0.9.7 的父挂载加子挂载拓扑属于 legacy，与当前 per-state 拓扑有意不兼容。升级时，或回滚时旧代码访问较新的 per-state 容器，检查都会 fail closed；请执行一次 `ai sandbox start --recreate <task-ref-or-branch>`。容器内进程、tmux 会话、writable layer、普通 `/tmp` 和 RAM 状态可能丢失，但 worktree、本地分支以及宿主管理的任务/工具数据会保留。

--- a/lib/internal/sandbox-control.ts
+++ b/lib/internal/sandbox-control.ts
@@ -13,6 +13,7 @@ import {
   verifyCodexSandboxControllerContextWithWarnings
 } from '../agent-clients/adapters/codex-lifecycle/sandbox-controller.ts';
 import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
+import { parseTaskCreateResult, taskCreateExitCode } from '../task/create-service.ts';
 
 function isCanonicalCodexPrepare(args: readonly string[]): boolean {
   if (args[1] !== 'prepare') return false;
@@ -44,6 +45,17 @@ function finalizationErrorStatus(error: { retryable: boolean; code: string }): F
 function writeClientError(error: SandboxControlClientError): void {
   process.stderr.write(`${error.detail.message}\n`);
   if (error.requestId) process.stderr.write(`SANDBOX_CONTROL_REQUEST_ID: ${error.requestId}\n`);
+}
+
+function recoveredExitCode(response: Awaited<ReturnType<typeof recoverSandboxControl>>): number {
+  if (response.phase !== 'completed') return response.exitCode ?? 1;
+  try {
+    const result = parseTaskCreateResult(JSON.parse(response.stdout));
+    if (result.control?.requestId === response.id) return taskCreateExitCode(result);
+  } catch {
+    // Other control families use their own result envelopes.
+  }
+  return response.exitCode ?? 1;
 }
 
 function sandboxFinalizationClient(args: string[]): void {
@@ -130,7 +142,7 @@ async function sandboxControl(args: string[]): Promise<void> {
     process.stderr.write(response.stderr);
     process.exitCode = response.phase === 'rejected'
       ? response.error?.retryable ? 75 : 1
-      : response.exitCode ?? 1;
+      : recoveredExitCode(response);
     return;
   }
   if (internalHandlerRoute('sandbox-control', 'client', operation ?? '')) {

--- a/lib/internal/task-create.ts
+++ b/lib/internal/task-create.ts
@@ -1,22 +1,71 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { requestSandboxTaskCreate, SandboxControlClientError } from '../sandbox/control/client.ts';
+import {
+  classifySandboxControlEnvironment,
+  requestSandboxTaskCreate,
+  SandboxControlClientError
+} from '../sandbox/control/client.ts';
 import { SANDBOX_CONTROL_MAX_BYTES } from '../sandbox/control/protocol.ts';
 import { validateTaskCreateCandidate } from '../task/create.ts';
-import { createTask, type TaskCreateResult } from '../task/create-service.ts';
+import {
+  createTask,
+  parseTaskCreateResult,
+  projectTaskCreateResult,
+  taskCreateExitCode,
+  taskCreateFailure,
+  type TaskCreateControl,
+  type TaskCreateResult
+} from '../task/create-service.ts';
 import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
-function failed(code: string, message: string, retryable = false): TaskCreateResult {
-  return {
-    status: retryable ? 'blocked' : 'failed', changed: false, task: { id: null, shortId: null }, issue: null,
-    operations: [], warnings: [], error: { code, message, retryable }
-  };
+function failed(code: string, message: string, retryable = false, control?: TaskCreateControl): TaskCreateResult {
+  return taskCreateFailure({ code, message, retryable }, control);
 }
 
 function output(result: TaskCreateResult): void {
   process.stdout.write(`${JSON.stringify(result)}\n`);
-  process.exitCode = result.status === 'blocked' ? 2 : result.status === 'failed' ? 1 : 0;
+  process.exitCode = taskCreateExitCode(result);
+}
+
+function clientErrorControl(error: SandboxControlClientError): TaskCreateControl {
+  return {
+    requestId: error.requestId,
+    accepted: error.accepted,
+    recovery: error.accepted ? 'same-request-id' : error.detail.retryable ? 'new-request-id' : 'none'
+  };
+}
+
+function parseControlledResult(response: ReturnType<typeof requestSandboxTaskCreate>): TaskCreateResult {
+  if (response.phase !== 'completed' || response.error !== null) {
+    return failed(
+      'SANDBOX_CONTROL_RESPONSE_INVALID',
+      'SANDBOX_CONTROL_RESPONSE_INVALID: completed task-create response is invalid',
+      false,
+      { requestId: response.id, accepted: true, recovery: 'same-request-id' }
+    );
+  }
+  let result: TaskCreateResult;
+  try {
+    result = parseTaskCreateResult(JSON.parse(response.stdout));
+  } catch {
+    return failed(
+      'TASK_CREATE_RESULT_INVALID',
+      'TASK_CREATE_RESULT_INVALID: task-create result payload is invalid',
+      false,
+      { requestId: response.id, accepted: true, recovery: 'same-request-id' }
+    );
+  }
+  if (!result.control || result.control.requestId !== response.id || result.control.accepted !== true) {
+    return failed(
+      'TASK_CREATE_RESULT_INVALID',
+      'TASK_CREATE_RESULT_INVALID: controlled task-create result is missing request evidence',
+      false,
+      { requestId: response.id, accepted: true, recovery: 'same-request-id' }
+    );
+  }
+  process.stderr.write(response.stderr);
+  return result;
 }
 
 async function taskCreate(args: string[]): Promise<void> {
@@ -34,25 +83,33 @@ async function taskCreate(args: string[]): Promise<void> {
     if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('TASK_CREATE_INPUT_INVALID: input must be a regular file');
     if (stat.size > SANDBOX_CONTROL_MAX_BYTES) throw new Error('TASK_CREATE_INPUT_TOO_LARGE: input exceeds the control limit');
     const candidate = validateTaskCreateCandidate(JSON.parse(fs.readFileSync(inputPath, 'utf8')));
-    if (process.env.AGENT_INFRA_CONTROL_TOKEN) {
+    const environment = classifySandboxControlEnvironment();
+    if (environment.kind === 'invalid') {
+      output(failed(environment.code ?? 'TASK_CONTROL_TRANSPORT_INVALID', environment.message ?? 'sandbox client control configuration is invalid'));
+      return;
+    }
+    if (environment.kind === 'controlled') {
       const response = requestSandboxTaskCreate({ candidate });
       if (response.phase === 'rejected') {
         output(failed(
           response.error?.code ?? 'SANDBOX_CONTROL_REJECTED',
           response.error?.message ?? response.stderr,
-          response.error?.retryable ?? false
+          response.error?.retryable ?? false,
+          {
+            requestId: response.id,
+            accepted: false,
+            recovery: response.error?.retryable ? 'new-request-id' : 'none'
+          }
         ));
         return;
       }
-      process.stdout.write(response.stdout);
-      process.stderr.write(response.stderr);
-      process.exitCode = response.exitCode;
+      output(parseControlledResult(response));
       return;
     }
     output(await createTask(candidate, { repoRoot: process.cwd() }));
   } catch (error) {
     if (error instanceof SandboxControlClientError) {
-      output(failed(error.detail.code, error.detail.message, error.detail.retryable));
+      output(failed(error.detail.code, error.detail.message, error.detail.retryable, clientErrorControl(error)));
       return;
     }
     const message = error instanceof Error ? error.message : String(error);

--- a/lib/internal/task-create.ts
+++ b/lib/internal/task-create.ts
@@ -91,14 +91,15 @@ async function taskCreate(args: string[]): Promise<void> {
     if (environment.kind === 'controlled') {
       const response = requestSandboxTaskCreate({ candidate });
       if (response.phase === 'rejected') {
+        const accepted = response.error?.code === 'SANDBOX_CONTROL_RESULT_UNKNOWN';
         output(failed(
           response.error?.code ?? 'SANDBOX_CONTROL_REJECTED',
           response.error?.message ?? response.stderr,
           response.error?.retryable ?? false,
           {
             requestId: response.id,
-            accepted: false,
-            recovery: response.error?.retryable ? 'new-request-id' : 'none'
+            accepted,
+            recovery: accepted ? 'same-request-id' : response.error?.retryable ? 'new-request-id' : 'none'
           }
         ));
         return;

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -244,6 +244,8 @@ function exchangeSandboxControl(request: SandboxControlRequest, params: Readonly
       }
       let response: SandboxControlResponse;
       try {
+        // The request-specific terminal proves the broker claimed the request; preserve recovery evidence if marker cleanup won the race.
+        accepted = true;
         response = readPublishedResponse(raw, request.id, channelDir, accepted);
         malformedResponseRaw = null;
       } catch (error) {
@@ -326,6 +328,8 @@ export function recoverSandboxControl(requestId: string, params: Readonly<{
       }
       let response: SandboxControlResponse;
       try {
+        // The request-specific terminal proves the broker claimed the request; preserve recovery evidence if marker cleanup won the race.
+        accepted = true;
         response = readPublishedResponse(raw, requestId, channelDir, accepted);
         malformedResponseRaw = null;
       } catch (error) {

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -162,7 +162,7 @@ function taskViewEffectForRequest(request: SandboxControlRequest): TaskViewAcces
   return null;
 }
 
-function parseResponse(raw: string, id: string): SandboxControlResponse {
+function parseResponse(raw: string, id: string, accepted = false): SandboxControlResponse {
   const response = JSON.parse(raw) as SandboxControlResponse;
   if (response.version !== 2 || response.id !== id
     || !['completed', 'rejected'].includes(response.phase)
@@ -170,13 +170,13 @@ function parseResponse(raw: string, id: string): SandboxControlResponse {
     || (response.outputState !== undefined && response.outputState !== 'available' && response.outputState !== 'unavailable')
     || (response.outputState === 'available' && !response.payload)
     || (response.outputState === 'unavailable' && response.payload !== null && response.payload !== undefined)) {
-    clientError('SANDBOX_CONTROL_RESPONSE_INVALID', 'broker response is invalid', false, false, id);
+    clientError('SANDBOX_CONTROL_RESPONSE_INVALID', 'broker response is invalid', false, accepted, id);
   }
   return response;
 }
 
-function readPublishedResponse(raw: string, id: string, channelDir: string): SandboxControlResponse {
-  const response = parseResponse(raw, id);
+function readPublishedResponse(raw: string, id: string, channelDir: string, accepted = false): SandboxControlResponse {
+  const response = parseResponse(raw, id, accepted);
   if (response.outputState !== 'available') return response;
   const filePath = path.join(channelDir, 'responses', `${id}.payload.json`);
   let payload;
@@ -244,7 +244,7 @@ function exchangeSandboxControl(request: SandboxControlRequest, params: Readonly
       }
       let response: SandboxControlResponse;
       try {
-        response = readPublishedResponse(raw, request.id, channelDir);
+        response = readPublishedResponse(raw, request.id, channelDir, accepted);
         malformedResponseRaw = null;
       } catch (error) {
         if (!(error instanceof SyntaxError)) throw error;
@@ -326,7 +326,7 @@ export function recoverSandboxControl(requestId: string, params: Readonly<{
       }
       let response: SandboxControlResponse;
       try {
-        response = readPublishedResponse(raw, requestId, channelDir);
+        response = readPublishedResponse(raw, requestId, channelDir, accepted);
         malformedResponseRaw = null;
       } catch (error) {
         if (!(error instanceof SyntaxError)) throw error;

--- a/lib/sandbox/control/client.ts
+++ b/lib/sandbox/control/client.ts
@@ -26,6 +26,62 @@ import { accessSandboxTaskView, taskViewFromStatus, type TaskViewAccessEffect } 
 
 const SANDBOX_CONTROL_RESPONSE_SETTLE_MS = 250;
 
+type SandboxControlEnvironmentClassification = Readonly<{
+  kind: 'direct' | 'controlled' | 'invalid';
+  mode?: 'task-bound' | 'branch-only';
+  code?: 'TASK_CONTROL_TRANSPORT_INVALID';
+  message?: string;
+}>;
+
+export function classifySandboxControlEnvironment(
+  env: NodeJS.ProcessEnv = process.env
+): SandboxControlEnvironmentClassification {
+  const controlKeys = [
+    'AGENT_INFRA_CONTROL_TOKEN',
+    'AGENT_INFRA_CONTROL_GENERATION',
+    'AGENT_INFRA_CONTROL_DIR',
+    'AGENT_INFRA_CONTROL_STATUS_DIR'
+  ] as const;
+  const hasControlMarker = controlKeys.some((key) => Boolean(env[key]));
+  const hasTaskIdentity = Boolean(env.AGENT_INFRA_TASK_ID);
+  const hasRuntime = Boolean(env.AGENT_INFRA_RUNTIME_DIR);
+  const hasExecutorMarker = Boolean(env.AGENT_INFRA_EXECUTOR_MANIFEST);
+  const hasControllerBinding = Boolean(env.AGENT_INFRA_CONTROL_CONTROLLER_BINDING);
+  const hasAnyMarker = hasControlMarker || hasTaskIdentity || hasRuntime || hasExecutorMarker || hasControllerBinding;
+  const hasCompleteControl = controlKeys.every((key) => Boolean(env[key]));
+
+  if (!hasAnyMarker) return { kind: 'direct' };
+  if (hasExecutorMarker) {
+    return {
+      kind: 'invalid',
+      code: 'TASK_CONTROL_TRANSPORT_INVALID',
+      message: 'executor context is only valid for sandbox-control execute'
+    };
+  }
+  if (hasControllerBinding) {
+    return {
+      kind: 'invalid',
+      code: 'TASK_CONTROL_TRANSPORT_INVALID',
+      message: 'sandbox client control configuration is incomplete or conflicting'
+    };
+  }
+  if (!hasCompleteControl) {
+    return {
+      kind: 'invalid',
+      code: 'TASK_CONTROL_TRANSPORT_INVALID',
+      message: 'sandbox client control configuration is incomplete or conflicting'
+    };
+  }
+  if (hasTaskIdentity !== hasRuntime) {
+    return {
+      kind: 'invalid',
+      code: 'TASK_CONTROL_TRANSPORT_INVALID',
+      message: 'sandbox task identity and runtime binding must be provided together'
+    };
+  }
+  return { kind: 'controlled', mode: hasTaskIdentity ? 'task-bound' : 'branch-only' };
+}
+
 export class SandboxControlClientError extends Error {
   readonly detail: SandboxControlError;
   readonly accepted: boolean;

--- a/lib/sandbox/control/executor.ts
+++ b/lib/sandbox/control/executor.ts
@@ -3,7 +3,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { getProcessStartTime } from '../../server/process-state.ts';
-import { createTask } from '../../task/create-service.ts';
+import {
+  createTask,
+  projectTaskCreateResult,
+  taskCreateExitCode,
+  taskCreateFailure,
+  type TaskCreateResult
+} from '../../task/create-service.ts';
 import { applyTaskFinalization } from '../../task/finalization.ts';
 import { bindSandboxControlTask, validateSandboxControlRequest, type SandboxControlExecution, type SandboxControlManifest, type SandboxControlRequest } from './protocol.ts';
 import {
@@ -286,6 +292,22 @@ function lifecycleFailure(code: string, message: string): SandboxControlExecutio
   };
 }
 
+function taskCreateExecutionResult(result: TaskCreateResult): SandboxControlExecutionResult {
+  return {
+    exitCode: taskCreateExitCode(result),
+    stdout: `${JSON.stringify(result)}\n`,
+    stderr: ''
+  };
+}
+
+function taskCreateExecutionFailure(requestId: string, code: string, message: string): SandboxControlExecutionResult {
+  return taskCreateExecutionResult(taskCreateFailure({ code, message, retryable: false }, {
+    requestId,
+    accepted: true,
+    recovery: 'inspect-domain-state'
+  }));
+}
+
 function finalizationResult(result: Awaited<ReturnType<typeof applyTaskFinalization>>): SandboxControlExecutionResult {
   const payload = {
     version: 1,
@@ -314,12 +336,18 @@ async function executeRequestInner(
   options: ExecuteRequestOptions = {}
 ): Promise<SandboxControlExecutionResult> {
   if (request.family === 'task-create') {
-    const result = await createTask(request.candidate, { repoRoot: manifest.repoRoot });
-    return {
-      exitCode: result.status === 'blocked' ? 2 : result.status === 'failed' ? 1 : 0,
-      stdout: `${JSON.stringify(result)}\n`,
-      stderr: ''
-    };
+    try {
+      const result = await createTask(request.candidate, { repoRoot: manifest.repoRoot });
+      return taskCreateExecutionResult(projectTaskCreateResult(result, {
+        requestId: request.id,
+        accepted: true,
+        recovery: 'none'
+      }));
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const code = /^([A-Z][A-Z0-9_]+)/u.exec(detail)?.[1] ?? 'TASK_CREATE_EXECUTION_FAILED';
+      return taskCreateExecutionFailure(request.id, code, detail);
+    }
   }
   if (request.family === 'codex-controller') {
     try {
@@ -557,7 +585,9 @@ export async function runSandboxControlExecutor(requestPath: string, nonce: stri
         })}\n`,
         stderr: ''
       }
-      : request.family === 'task-lifecycle'
+      : request.family === 'task-create'
+        ? taskCreateExecutionFailure(request.id, code, detail)
+        : request.family === 'task-lifecycle'
         ? lifecycleFailure(code, detail)
         : orchestrationFailure(code, detail);
   }

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -50,12 +50,7 @@ import type { BrokerOwner } from './lifecycle.ts';
 import { nextSandboxControlBackoff } from './timing.ts';
 import { readTaskFinalizationReceipt } from '../../task/finalization.ts';
 import { resolveTaskRef } from '../../task/resolve-ref.ts';
-import {
-  mergeSandboxTaskView,
-  taskViewAfterFinalization,
-  taskViewForManifest,
-  type SandboxTaskView
-} from './task-view.ts';
+import { taskCreateOutputUnavailableResult } from '../../task/create-service.ts';
 
 type ActiveExecution = {
   request: SandboxControlRequest;
@@ -300,16 +295,17 @@ function outputMatchesEvidence(output: string, bytes: number, sha256: string): b
 }
 
 function genericRecoveryResponse(
-  requestId: string,
-  evidence: ReturnType<typeof readSandboxControlResultEvidence>,
+  request: SandboxControlRequest,
+  exitCode: number,
   payload: ReturnType<typeof readSandboxControlPayload> | null
 ): SandboxControlResponse {
+  const outputUnavailable = request.family === 'task-create' && !payload;
   return {
     version: 2,
-    id: requestId,
+    id: request.id,
     phase: 'completed',
-    exitCode: evidence.exitCode,
-    stdout: '',
+    exitCode,
+    stdout: outputUnavailable ? `${JSON.stringify(taskCreateOutputUnavailableResult(request.id))}\n` : '',
     stderr: payload ? '' : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
     error: null,
     outputState: payload ? 'available' : 'unavailable',
@@ -327,7 +323,7 @@ function recoveryResponse(
     const finalization = finalizationRecoveryResponse(manifest, request.id, evidence.exitCode);
     return finalization.status === 'matched' ? finalization.response ?? null : null;
   }
-  return genericRecoveryResponse(request.id, evidence, payload);
+  return genericRecoveryResponse(request, evidence.exitCode, payload);
 }
 
 function terminalMatchesEvidence(
@@ -366,7 +362,7 @@ function terminalMatchesEvidence(
     };
   }
   if (response.outputState === 'unavailable') {
-    const expected = genericRecoveryResponse(request.id, evidence, null);
+    const expected = genericRecoveryResponse(request, evidence.exitCode, null);
     return { valid: JSON.stringify(response) === JSON.stringify(expected), payloadReferenced: false };
   }
   return {
@@ -399,7 +395,7 @@ function publishExecutionResult(
     if (sandboxControlEncodedJsonBytes(inline) <= SANDBOX_CONTROL_MAX_TERMINAL_RECORD_BYTES) {
       terminal = inline;
     }
-    let payload = null;
+    let payload: ReturnType<typeof createSandboxControlPayload> | null = null;
     if (!terminal) {
       try {
         payload = createSandboxControlPayload(manifest, request.id, normalized);
@@ -412,17 +408,7 @@ function publishExecutionResult(
       } catch {
         payload = null;
       }
-      terminal = {
-        version: 2,
-        id: request.id,
-        phase: 'completed',
-        exitCode: normalized.exitCode,
-        stdout: '',
-        stderr: payload ? '' : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: output payload was not retained\n',
-        error: null,
-        outputState: payload ? 'available' : 'unavailable',
-        payload: payload ? payloadReference(payload) : null
-      };
+      terminal = genericRecoveryResponse(request, normalized.exitCode, payload);
     }
   }
   if (!brokerOwns()) return false;
@@ -611,7 +597,13 @@ function delay(ms: number): Promise<void> {
 }
 
 export function sandboxControlSafeEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  return Object.fromEntries(Object.entries(env).filter(([key]) => !key.toUpperCase().startsWith('AGENT_INFRA_CONTROL_')));
+  return Object.fromEntries(Object.entries(env).filter(([key]) => {
+    const normalized = key.toUpperCase();
+    return !normalized.startsWith('AGENT_INFRA_CONTROL_')
+      && normalized !== 'AGENT_INFRA_TASK_ID'
+      && normalized !== 'AGENT_INFRA_RUNTIME_DIR'
+      && normalized !== 'AGENT_INFRA_EXECUTOR_MANIFEST';
+  }));
 }
 
 export async function serveSandboxControl(

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -50,6 +50,12 @@ import type { BrokerOwner } from './lifecycle.ts';
 import { nextSandboxControlBackoff } from './timing.ts';
 import { readTaskFinalizationReceipt } from '../../task/finalization.ts';
 import { resolveTaskRef } from '../../task/resolve-ref.ts';
+import {
+  mergeSandboxTaskView,
+  taskViewAfterFinalization,
+  taskViewForManifest,
+  type SandboxTaskView
+} from './task-view.ts';
 import { taskCreateOutputUnavailableResult } from '../../task/create-service.ts';
 
 type ActiveExecution = {

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -297,7 +297,8 @@ function outputMatchesEvidence(output: string, bytes: number, sha256: string): b
 function genericRecoveryResponse(
   request: SandboxControlRequest,
   exitCode: number,
-  payload: ReturnType<typeof readSandboxControlPayload> | null
+  payload: ReturnType<typeof readSandboxControlPayload> | null,
+  cause: 'publish' | 'recovery' = 'recovery'
 ): SandboxControlResponse {
   const outputUnavailable = request.family === 'task-create' && !payload;
   return {
@@ -306,7 +307,9 @@ function genericRecoveryResponse(
     phase: 'completed',
     exitCode,
     stdout: outputUnavailable ? `${JSON.stringify(taskCreateOutputUnavailableResult(request.id))}\n` : '',
-    stderr: payload ? '' : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
+    stderr: payload ? '' : cause === 'publish'
+      ? 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: output payload was not retained\n'
+      : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
     error: null,
     outputState: payload ? 'available' : 'unavailable',
     payload: payload ? payloadReference(payload) : null
@@ -408,7 +411,7 @@ function publishExecutionResult(
       } catch {
         payload = null;
       }
-      terminal = genericRecoveryResponse(request, normalized.exitCode, payload);
+      terminal = genericRecoveryResponse(request, normalized.exitCode, payload, 'publish');
     }
   }
   if (!brokerOwns()) return false;
@@ -549,7 +552,7 @@ function recoverProcessing(manifest: SandboxControlManifest, broker: BrokerOwner
               || response.payload.stdoutSha256 !== payload.stdoutSha256
               || response.payload.stderrSha256 !== payload.stderrSha256) throw new Error('payload missing or mismatched');
             payloadReferenced = true;
-          } else if (terminal && (response.outputState !== undefined
+          } else if (terminal && ((response.outputState !== undefined && response.outputState !== 'unavailable')
             || response.payload !== undefined && response.payload !== null)) {
             throw new Error('payload state invalid');
           }

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -365,8 +365,10 @@ function terminalMatchesEvidence(
     };
   }
   if (response.outputState === 'unavailable') {
-    const expected = genericRecoveryResponse(request, evidence.exitCode, null);
-    return { valid: JSON.stringify(response) === JSON.stringify(expected), payloadReferenced: false };
+    const causes = ['recovery', 'publish'] as const;
+    const valid = causes.some((cause) => JSON.stringify(response)
+      === JSON.stringify(genericRecoveryResponse(request, evidence.exitCode, null, cause)));
+    return { valid, payloadReferenced: false };
   }
   return {
     valid: response.payload === undefined

--- a/lib/task/create-service.ts
+++ b/lib/task/create-service.ts
@@ -12,6 +12,13 @@ import { verifyTaskEvent } from './verification.ts';
 type TaskCreateStatus = 'applied' | 'no-op' | 'degraded' | 'failed' | 'blocked';
 type TaskCreateOperation = { name: string; status: string; reasonCode: string | null };
 type TaskCreateWarning = { code: string; severity: string; action: string };
+type TaskCreateRecovery = 'none' | 'same-request-id' | 'new-request-id' | 'inspect-domain-state';
+type TaskCreateControl = Readonly<{
+  requestId: string | null;
+  accepted: boolean;
+  recovery: TaskCreateRecovery;
+}>;
+type TaskCreateError = { code: string; message: string; retryable: boolean };
 type TaskCreateResult = Readonly<{
   status: TaskCreateStatus;
   changed: boolean;
@@ -19,7 +26,8 @@ type TaskCreateResult = Readonly<{
   issue: { number: number; url: string } | null;
   operations: readonly TaskCreateOperation[];
   warnings: readonly TaskCreateWarning[];
-  error: { code: string; message: string; retryable: boolean } | null;
+  error: TaskCreateError | null;
+  control?: TaskCreateControl;
 }>;
 
 type CreateTaskOptions = Readonly<{
@@ -41,6 +49,116 @@ const DEFAULT_DEPENDENCIES: TaskCreateDependencies = {
   syncComment: syncPlatformComment,
   addWarning: applyWorkflowWarningIntent
 };
+
+function invalidTaskCreateResult(): never {
+  throw new Error('TASK_CREATE_RESULT_INVALID');
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  return Object.keys(value).sort().join(',') === [...expected].sort().join(',');
+}
+
+function validTaskReference(value: unknown): boolean {
+  return value === null || (typeof value === 'string' && value.length > 0);
+}
+
+function validTaskCreateError(value: unknown): value is TaskCreateError {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const error = value as Record<string, unknown>;
+  return exactKeys(error, ['code', 'message', 'retryable'])
+    && typeof error.code === 'string' && /^[A-Z][A-Z0-9_]+$/u.test(error.code)
+    && typeof error.message === 'string'
+    && typeof error.retryable === 'boolean';
+}
+
+function validTaskCreateControl(value: unknown): value is TaskCreateControl {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const control = value as Record<string, unknown>;
+  return exactKeys(control, ['accepted', 'recovery', 'requestId'])
+    && validTaskReference(control.requestId)
+    && typeof control.accepted === 'boolean'
+    && ['none', 'same-request-id', 'new-request-id', 'inspect-domain-state'].includes(control.recovery as string);
+}
+
+export function parseTaskCreateResult(value: unknown): TaskCreateResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return invalidTaskCreateResult();
+  const result = value as Record<string, unknown>;
+  if (!exactKeys(result, ['changed', 'control', 'error', 'issue', 'operations', 'status', 'task', 'warnings'])
+    && !exactKeys(result, ['changed', 'error', 'issue', 'operations', 'status', 'task', 'warnings'])) {
+    return invalidTaskCreateResult();
+  }
+  if (!['applied', 'no-op', 'degraded', 'failed', 'blocked'].includes(result.status as string)
+    || typeof result.changed !== 'boolean'
+    || !result.task || typeof result.task !== 'object' || Array.isArray(result.task)
+    || !exactKeys(result.task as Record<string, unknown>, ['id', 'shortId'])
+    || !validTaskReference((result.task as { id?: unknown }).id)
+    || !validTaskReference((result.task as { shortId?: unknown }).shortId)
+    || !Array.isArray(result.operations)
+    || !result.operations.every((operation) => {
+      if (!operation || typeof operation !== 'object' || Array.isArray(operation)) return false;
+      const value = operation as Record<string, unknown>;
+      return exactKeys(value, ['name', 'reasonCode', 'status'])
+        && typeof value.name === 'string' && typeof value.status === 'string'
+        && (value.reasonCode === null || typeof value.reasonCode === 'string');
+    })
+    || !Array.isArray(result.warnings)
+    || !result.warnings.every((warning) => {
+      if (!warning || typeof warning !== 'object' || Array.isArray(warning)) return false;
+      const value = warning as Record<string, unknown>;
+      return exactKeys(value, ['action', 'code', 'severity'])
+        && typeof value.action === 'string' && typeof value.code === 'string' && typeof value.severity === 'string';
+    })
+    || (result.issue !== null && (
+      !result.issue || typeof result.issue !== 'object' || Array.isArray(result.issue)
+      || !exactKeys(result.issue as Record<string, unknown>, ['number', 'url'])
+      || !Number.isSafeInteger((result.issue as { number?: unknown }).number)
+      || ((result.issue as { number: number }).number) <= 0
+      || typeof (result.issue as { url?: unknown }).url !== 'string'
+    ))
+    || (result.error !== null && !validTaskCreateError(result.error))
+    || ('control' in result && !validTaskCreateControl(result.control))) {
+    return invalidTaskCreateResult();
+  }
+  if (result.status === 'blocked' && !(result.error as TaskCreateError | null)?.retryable) return invalidTaskCreateResult();
+  if (result.status === 'failed' && !(result.error as TaskCreateError | null)) return invalidTaskCreateResult();
+  return result as unknown as TaskCreateResult;
+}
+
+export function projectTaskCreateResult(result: TaskCreateResult, control: TaskCreateControl): TaskCreateResult {
+  return { ...result, control };
+}
+
+export function taskCreateExitCode(result: Pick<TaskCreateResult, 'status'>): number {
+  return result.status === 'blocked' ? 2 : result.status === 'failed' ? 1 : 0;
+}
+
+export function taskCreateFailure(
+  error: TaskCreateError,
+  control?: TaskCreateControl
+): TaskCreateResult {
+  return {
+    status: error.retryable ? 'blocked' : 'failed',
+    changed: false,
+    task: { id: null, shortId: null },
+    issue: null,
+    operations: [],
+    warnings: [],
+    error,
+    ...(control ? { control } : {})
+  };
+}
+
+export function taskCreateOutputUnavailableResult(requestId: string): TaskCreateResult {
+  return taskCreateFailure({
+    code: 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE',
+    message: 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: task-create result output was not retained; inspect domain state before retrying',
+    retryable: false
+  }, {
+    requestId,
+    accepted: true,
+    recovery: 'inspect-domain-state'
+  });
+}
 
 async function verifyCreatedTask(repoRoot: string, taskId: string): Promise<{ operation: TaskCreateOperation; error: TaskCreateResult['error'] }> {
   const verification = await verifyTaskEvent(
@@ -91,10 +209,7 @@ async function createTask(value: unknown, options: CreateTaskOptions): Promise<T
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const code = /^([A-Z][A-Z0-9_]+)/.exec(message)?.[1] ?? 'TASK_CREATE_FAILED';
-    return {
-      status: 'failed', changed: false, task: { id: null, shortId: null }, issue: null,
-      operations: [], warnings: [], error: { code, message, retryable: code === 'TASK_CREATE_LOCK_TIMEOUT' }
-    };
+    return taskCreateFailure({ code, message, retryable: code === 'TASK_CREATE_LOCK_TIMEOUT' });
   }
 
   const operations: TaskCreateOperation[] = [{
@@ -168,4 +283,14 @@ async function createTask(value: unknown, options: CreateTaskOptions): Promise<T
 }
 
 export { createTask };
-export type { CreateTaskOptions, TaskCreateDependencies, TaskCreateOperation, TaskCreateResult, TaskCreateStatus, TaskCreateWarning };
+export type {
+  CreateTaskOptions,
+  TaskCreateControl,
+  TaskCreateDependencies,
+  TaskCreateError,
+  TaskCreateOperation,
+  TaskCreateRecovery,
+  TaskCreateResult,
+  TaskCreateStatus,
+  TaskCreateWarning
+};

--- a/templates/.agents/skills/create-task/SKILL.en.md
+++ b/templates/.agents/skills/create-task/SKILL.en.md
@@ -126,6 +126,14 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 - `blocked`: retain the candidate and retry the same file after the transient problem is fixed.
 - `failed`: report the stable error code. Never modify and retry a candidate under the same idempotency key.
 
+A controlled invocation may return `control` request evidence: `accepted: true`
+with `recovery: none` means the current result can be consumed; `accepted: false`
+with `recovery: new-request-id` means the request was not admitted and the same
+candidate may be retried with a new outer request ID after the transient problem
+is fixed; `recovery: same-request-id` or `recovery: inspect-domain-state` means
+the request was accepted, so do not create a new candidate or replay it
+automatically. Recover with the original request or inspect host task state first.
+
 ### 4. Platform Failure Compatibility
 
 The host service owns platform cascading. The compatibility recovery commands remain visible in the host warning and are not run from the sandbox:

--- a/templates/.agents/skills/create-task/SKILL.zh-CN.md
+++ b/templates/.agents/skills/create-task/SKILL.zh-CN.md
@@ -125,6 +125,13 @@ date "+%Y-%m-%d %H:%M:%S%z" | sed 's/\([+-][0-9][0-9]\)\([0-9][0-9]\)$/\1:\2/'
 - `blocked`：保留 candidate 文件，修复暂态问题后用同一文件重试。
 - `failed`：报告稳定错误码；幂等冲突时不得改写原 key 或原 candidate 后重试。
 
+受控调用可能在结果中返回 `control` 请求证据：`accepted: true` 且
+`recovery: none` 表示可以消费当前结果；`accepted: false` 且
+`recovery: new-request-id` 表示请求尚未受理，暂态问题恢复后才能用同一份
+candidate 和新的 outer request ID 重试；`recovery: same-request-id` 或
+`recovery: inspect-domain-state` 表示请求已经受理，不得创建新的 candidate 或
+自动重放，必须先使用原 request 检查结果或宿主任务状态。
+
 ### 4. 平台失败兼容说明
 
 平台级联由宿主服务完成。兼容的人工恢复命令仍由宿主 warning 指引，不在沙箱内执行：

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -2194,7 +2194,7 @@ test('broker restart accepts an existing unavailable task-create terminal', asyn
     const terminal = {
       version: 2, id: requestId, phase: 'completed', exitCode: 0,
       stdout: `${JSON.stringify(taskCreateOutputUnavailableResult(requestId))}\n`,
-      stderr: 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
+      stderr: 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: output payload was not retained\n',
       error: null, outputState: 'unavailable', payload: null
     };
     fs.writeFileSync(path.join(manifest.channelDir, 'responses', `${requestId}.json`), `${JSON.stringify(terminal)}\n`);

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -2146,7 +2146,17 @@ test('broker recovery returns inspectable task-create output when the payload is
 
     const recovered = spawnSync(process.execPath, [
       '--experimental-strip-types', '--no-warnings', path.resolve('bin/internal-cli.ts'), 'sandbox-control', 'recover', requestId
-    ], { cwd: path.resolve('.'), encoding: 'utf8', env: { ...process.env, AGENT_INFRA_CONTROL_DIR: manifest.channelDir } });
+    ], {
+      cwd: path.resolve('.'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        AGENT_INFRA_CONTROL_TOKEN: manifest.token,
+        AGENT_INFRA_CONTROL_GENERATION: manifest.generation,
+        AGENT_INFRA_CONTROL_DIR: manifest.channelDir,
+        AGENT_INFRA_CONTROL_STATUS_DIR: manifest.publicStatusDir
+      }
+    });
     assert.equal(recovered.status, 1, recovered.stderr || recovered.stdout);
     assert.equal(recovered.stdout, response.stdout);
   } finally {

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -1980,6 +1980,7 @@ test('branch-only broker persists a typed task-create request on the host', asyn
 
     const [requestId] = fs.readdirSync(path.join(root, 'control', 'consumed'));
     assert.ok(requestId);
+    assert.deepEqual(result.control, { requestId, accepted: true, recovery: 'none' });
     fs.writeFileSync(path.join(channelDir, 'requests', `${requestId}.json`), `${JSON.stringify({
       version: 2, id: requestId, token, generation, issuedAt: Date.now(), expiresAt: Date.now() + 2_000,
       family: 'task-create', candidate
@@ -2078,6 +2079,76 @@ test('broker recovery preserves terminal responses and marks unaccepted claims r
       if (child.exitCode !== null || child.signalCode !== null) resolve();
       else child.once('exit', () => resolve());
     });
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('broker recovery returns inspectable task-create output when the payload is unavailable', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-task-create-recovery-'));
+  const requestId = '99999999-9999-4999-8999-999999999999';
+  try {
+    const branch = initializeRepository(root);
+    const manifestPath = writeControlManifest(root, branch, 'task-create-recovery-generation');
+    const manifest = readSandboxControlManifest(manifestPath);
+    const processingDirectory = path.join(manifest.processingDir, requestId);
+    fs.mkdirSync(processingDirectory, { recursive: true });
+    const issuedAt = Date.now() - 1_000;
+    const candidate = {
+      version: 1 as const,
+      idempotencyKey: '12345678-1234-4123-8123-123456789abc',
+      agent: 'codex' as const,
+      title: 'Recover task-create output',
+      type: 'feature' as const,
+      branchSlug: 'recover-task-create-output',
+      priority: 'Medium' as const,
+      effort: 'Low' as const,
+      description: 'Recover a task-create result after the broker loses its payload.',
+      taskInput: {
+        sources: [], facts: [], constraints: [], decisions: [], alternatives: [],
+        acceptanceCriteria: [], openQuestions: []
+      }
+    };
+    fs.writeFileSync(path.join(processingDirectory, 'request.json'), `${JSON.stringify({
+      version: 3, id: requestId, token: manifest.token, generation: manifest.generation,
+      issuedAt, expiresAt: issuedAt + 2_000, family: 'task-create', candidate,
+      controllerProcess: null, controllerProof: null
+    })}\n`);
+    fs.writeFileSync(path.join(processingDirectory, 'execution.json'), `${JSON.stringify({
+      version: 2, generation: manifest.generation, requestId, nonce: 'task-create-recovery-nonce',
+      child: { pid: 999_999_999, startTime: 0, processGroupId: null }, phase: 'running', updatedAt: Date.now()
+    })}\n`);
+    writeSandboxControlReservation(manifest, requestId, { logicalRecords: 0, bytes: 0 });
+    writeSandboxControlResultEvidence(manifest, requestId, { exitCode: 0, stdout: 'lost task-create output\n', stderr: '' });
+
+    const controller = new AbortController();
+    const server = serveSandboxControl(manifestPath, controller.signal, {
+      inspectContainer: async () => ({ state: 'found', id: 'container-id', running: true, labels: {} }),
+      bindingCheck: () => null
+    });
+    await waitForStatusStateAsync(manifest.publicStatusDir, 'healthy', 5_000);
+    const responsePath = path.join(manifest.channelDir, 'responses', `${requestId}.json`);
+    waitForFile(responsePath, 5_000);
+    const response = JSON.parse(fs.readFileSync(responsePath, 'utf8')) as Record<string, unknown>;
+    assert.equal(response.phase, 'completed');
+    assert.equal(response.exitCode, 0);
+    assert.equal(response.outputState, 'unavailable');
+    const result = JSON.parse(String(response.stdout));
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error.code, 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE');
+    assert.deepEqual(result.control, { requestId, accepted: true, recovery: 'inspect-domain-state' });
+    assert.equal(result.task.id, null);
+    assert.equal(result.task.shortId, null);
+    assert.equal(recoverSandboxControl(requestId, { channelDir: manifest.channelDir, timeoutMs: 100 }).stdout, response.stdout);
+    assert.equal(fs.existsSync(processingDirectory), false);
+    controller.abort();
+    await server;
+
+    const recovered = spawnSync(process.execPath, [
+      '--experimental-strip-types', '--no-warnings', path.resolve('bin/internal-cli.ts'), 'sandbox-control', 'recover', requestId
+    ], { cwd: path.resolve('.'), encoding: 'utf8', env: { ...process.env, AGENT_INFRA_CONTROL_DIR: manifest.channelDir } });
+    assert.equal(recovered.status, 1, recovered.stderr || recovered.stdout);
+    assert.equal(recovered.stdout, response.stdout);
+  } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/tests/integration/cli/sandbox-control.test.ts
+++ b/tests/integration/cli/sandbox-control.test.ts
@@ -35,6 +35,7 @@ import { serveSandboxControl } from '../../../lib/sandbox/control/server.ts';
 import { captureSandboxAuthority } from '../../../lib/sandbox/engines/authority.ts';
 import { startSandboxControlBroker } from '../../../lib/sandbox/recovery.ts';
 import { getProcessStartTime, isProcessAlive } from '../../../lib/server/process-state.ts';
+import { taskCreateOutputUnavailableResult } from '../../../lib/task/create-service.ts';
 import { onPlatforms } from '../../helpers.ts';
 
 function waitForFile(filePath: string, timeoutMs: number): void {
@@ -2148,6 +2149,70 @@ test('broker recovery returns inspectable task-create output when the payload is
     ], { cwd: path.resolve('.'), encoding: 'utf8', env: { ...process.env, AGENT_INFRA_CONTROL_DIR: manifest.channelDir } });
     assert.equal(recovered.status, 1, recovered.stderr || recovered.stdout);
     assert.equal(recovered.stdout, response.stdout);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('broker restart accepts an existing unavailable task-create terminal', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-infra-task-create-terminal-recovery-'));
+  const requestId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  try {
+    const branch = initializeRepository(root);
+    const manifestPath = writeControlManifest(root, branch, 'task-create-terminal-generation');
+    const manifest = readSandboxControlManifest(manifestPath);
+    const processingDirectory = path.join(manifest.processingDir, requestId);
+    fs.mkdirSync(processingDirectory, { recursive: true });
+    fs.mkdirSync(path.join(manifest.channelDir, 'responses'), { recursive: true });
+    const issuedAt = Date.now() - 1_000;
+    const candidate = {
+      version: 1 as const,
+      idempotencyKey: '12345678-1234-4123-8123-123456789abc',
+      agent: 'codex' as const,
+      title: 'Read an existing task-create terminal',
+      type: 'feature' as const,
+      branchSlug: 'read-existing-task-create-terminal',
+      priority: 'Medium' as const,
+      effort: 'Low' as const,
+      description: 'Keep a published unavailable terminal across broker restart.',
+      taskInput: {
+        sources: [], facts: [], constraints: [], decisions: [], alternatives: [],
+        acceptanceCriteria: [], openQuestions: []
+      }
+    };
+    fs.writeFileSync(path.join(processingDirectory, 'request.json'), `${JSON.stringify({
+      version: 3, id: requestId, token: manifest.token, generation: manifest.generation,
+      issuedAt, expiresAt: issuedAt + 2_000, family: 'task-create', candidate,
+      controllerProcess: null, controllerProof: null
+    })}\n`);
+    fs.writeFileSync(path.join(processingDirectory, 'execution.json'), `${JSON.stringify({
+      version: 2, generation: manifest.generation, requestId, nonce: 'task-create-terminal-nonce',
+      child: { pid: 999_999_999, startTime: 0, processGroupId: null }, phase: 'running', updatedAt: Date.now()
+    })}\n`);
+    writeSandboxControlReservation(manifest, requestId, { logicalRecords: 0, bytes: 0 });
+    writeSandboxControlResultEvidence(manifest, requestId, { exitCode: 0, stdout: 'lost task-create output\n', stderr: '' });
+    const terminal = {
+      version: 2, id: requestId, phase: 'completed', exitCode: 0,
+      stdout: `${JSON.stringify(taskCreateOutputUnavailableResult(requestId))}\n`,
+      stderr: 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
+      error: null, outputState: 'unavailable', payload: null
+    };
+    fs.writeFileSync(path.join(manifest.channelDir, 'responses', `${requestId}.json`), `${JSON.stringify(terminal)}\n`);
+
+    const controller = new AbortController();
+    const server = serveSandboxControl(manifestPath, controller.signal, {
+      inspectContainer: async () => ({ state: 'found', id: 'container-id', running: true, labels: {} }),
+      bindingCheck: () => null
+    });
+    await waitForStatusStateAsync(manifest.publicStatusDir, 'healthy', 5_000);
+    const deadline = Date.now() + 5_000;
+    while (fs.existsSync(processingDirectory) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(fs.existsSync(processingDirectory), false);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(manifest.channelDir, 'responses', `${requestId}.json`), 'utf8')), terminal);
+    controller.abort();
+    await server;
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/integration/cli/task-control-dual-mode.test.ts
+++ b/tests/integration/cli/task-control-dual-mode.test.ts
@@ -12,6 +12,7 @@ import {
   createSandboxExecutorExecutionContext,
   dispatchTaskControlOperation
 } from '../../../lib/task/control-authority.ts';
+import { classifySandboxControlEnvironment } from '../../../lib/sandbox/control/client.ts';
 import { issueHumanOverride } from '../../../lib/task/human-override.ts';
 import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
 
@@ -147,6 +148,33 @@ test('task-bound marker requires its runtime binding before entering the client'
   }));
   assert.equal(result.status, 1);
   assert.equal(JSON.parse(result.stdout).error.code, 'TASK_CONTROL_TRANSPORT_INVALID');
+});
+
+test('shared sandbox control environment classification is fail-closed and distinguishes workspace modes', () => {
+  const base = {
+    AGENT_INFRA_CONTROL_TOKEN: 'token',
+    AGENT_INFRA_CONTROL_GENERATION: 'generation',
+    AGENT_INFRA_CONTROL_DIR: '/control',
+    AGENT_INFRA_CONTROL_STATUS_DIR: '/status'
+  };
+  assert.equal(classifySandboxControlEnvironment(cleanEnv()).kind, 'direct');
+  assert.equal(classifySandboxControlEnvironment(cleanEnv(base)).kind, 'controlled');
+  assert.equal(classifySandboxControlEnvironment(cleanEnv({
+    ...base,
+    AGENT_INFRA_TASK_ID: TASK_ID,
+    AGENT_INFRA_RUNTIME_DIR: '/runtime'
+  })).kind, 'controlled');
+
+  for (const env of [
+    { AGENT_INFRA_CONTROL_TOKEN: 'token' },
+    { AGENT_INFRA_TASK_ID: TASK_ID },
+    { ...base, AGENT_INFRA_RUNTIME_DIR: '/runtime' },
+    { ...base, AGENT_INFRA_TASK_ID: TASK_ID },
+    { ...base, AGENT_INFRA_EXECUTOR_MANIFEST: '/manifest' },
+    { ...base, AGENT_INFRA_CONTROL_CONTROLLER_BINDING: '{}' }
+  ]) {
+    assert.equal(classifySandboxControlEnvironment(cleanEnv(env)).kind, 'invalid');
+  }
 });
 
 const TASK_ID = 'TASK-20260809-010203';

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -10,7 +10,10 @@ import { canonicalTaskCreateCandidate, validateTaskCreateCandidate } from '../..
 
 const internalCli = path.resolve('bin/internal-cli.ts');
 const hostEnvironment = Object.fromEntries(
-  Object.entries(process.env).filter(([key]) => !key.startsWith('AGENT_INFRA_CONTROL_'))
+  Object.entries(process.env).filter(([key]) => !key.startsWith('AGENT_INFRA_CONTROL_')
+    && key !== 'AGENT_INFRA_TASK_ID'
+    && key !== 'AGENT_INFRA_RUNTIME_DIR'
+    && key !== 'AGENT_INFRA_EXECUTOR_MANIFEST')
 );
 
 function fixture(): string {
@@ -120,6 +123,37 @@ test('task-create internal CLI rejects symbolic-link input without writing', () 
     });
     assert.equal(result.status, 1);
     assert.equal(JSON.parse(result.stdout).error.code, 'TASK_CREATE_INPUT_INVALID');
+    assert.deepEqual(fs.readdirSync(path.join(root, '.agents', 'workspace', 'active')), []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-create internal CLI returns controlled recovery evidence when the broker is unavailable', () => {
+  const root = fixture();
+  const input = path.join(root, 'candidate.json');
+  fs.writeFileSync(input, JSON.stringify(candidate()));
+  try {
+    const result = spawnSync(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...hostEnvironment,
+        AGENT_INFRA_CONTROL_TOKEN: 'controlled-token',
+        AGENT_INFRA_CONTROL_GENERATION: 'controlled-generation',
+        AGENT_INFRA_CONTROL_DIR: path.join(root, 'control'),
+        AGENT_INFRA_CONTROL_STATUS_DIR: path.join(root, 'status')
+      }
+    });
+    assert.equal(result.status, 2);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.status, 'blocked');
+    assert.equal(payload.error.code, 'SANDBOX_CONTROL_BROKER_UNAVAILABLE');
+    assert.deepEqual(payload.control, {
+      requestId: null,
+      accepted: false,
+      recovery: 'new-request-id'
+    });
     assert.deepEqual(fs.readdirSync(path.join(root, '.agents', 'workspace', 'active')), []);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -43,6 +43,78 @@ function candidate() {
       acceptanceCriteria: ['A task is persisted.'], openQuestions: []
     }
   };
+}
+
+async function waitForRequestAsync(requestsDir: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const request = fs.readdirSync(requestsDir).find((name) => name.endsWith('.json'));
+    if (request) return request;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for a request in ${requestsDir}`);
+}
+
+async function runControlledTaskCreate(responseFor: (requestId: string) => object): Promise<{
+  requestId: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const root = fixture();
+  const input = path.join(root, 'candidate.json');
+  const channelDir = path.join(root, 'control');
+  const requestsDir = path.join(channelDir, 'requests');
+  const responsesDir = path.join(channelDir, 'responses');
+  const statusDir = path.join(root, 'status');
+  const generation = 'task-create-test-generation';
+  fs.writeFileSync(input, JSON.stringify(candidate()));
+  fs.mkdirSync(requestsDir, { recursive: true });
+  fs.mkdirSync(responsesDir);
+  fs.mkdirSync(statusDir);
+  fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
+    version: 2,
+    generation,
+    broker: { pid: process.pid, startTime: 0, brokerId: 'task-create-test-broker' },
+    state: 'healthy',
+    reasonCode: null,
+    activeRequestId: null,
+    updatedAt: Date.now()
+  })}\n`);
+  const child = spawn(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
+    cwd: root,
+    env: {
+      ...hostEnvironment,
+      AGENT_INFRA_CONTROL_TOKEN: 'task-create-test-token',
+      AGENT_INFRA_CONTROL_GENERATION: generation,
+      AGENT_INFRA_CONTROL_DIR: channelDir,
+      AGENT_INFRA_CONTROL_STATUS_DIR: statusDir
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+  child.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+  const result = new Promise<number>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) => resolve(code ?? 1));
+  });
+  try {
+    const requestName = await waitForRequestAsync(requestsDir, 2_000);
+    const requestId = requestName.slice(0, -5);
+    fs.writeFileSync(path.join(responsesDir, `${requestId}.accepted.json`), `${JSON.stringify({
+      version: 2, id: requestId, phase: 'accepted', exitCode: null, stdout: '', stderr: '', error: null
+    })}\n`);
+    fs.writeFileSync(path.join(responsesDir, `${requestId}.json`), `${JSON.stringify(responseFor(requestId))}\n`);
+    return { requestId, exitCode: await result, stdout, stderr };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+    await result.catch(() => undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 test('task-create internal CLI persists a task and replays as no-op', () => {
@@ -158,4 +230,35 @@ test('task-create internal CLI returns controlled recovery evidence when the bro
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('task-create preserves accepted evidence for a broker result-unknown terminal', async () => {
+  const result = await runControlledTaskCreate((requestId) => ({
+    version: 2, id: requestId, phase: 'rejected', exitCode: null, stdout: '',
+    stderr: 'SANDBOX_CONTROL_RESULT_UNKNOWN: accepted execution ended without a provable result\n',
+    error: { code: 'SANDBOX_CONTROL_RESULT_UNKNOWN', message: 'SANDBOX_CONTROL_RESULT_UNKNOWN: result unknown', retryable: false }
+  }));
+  assert.equal(result.exitCode, 1, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.error.code, 'SANDBOX_CONTROL_RESULT_UNKNOWN');
+  assert.deepEqual(payload.control, {
+    requestId: result.requestId,
+    accepted: true,
+    recovery: 'same-request-id'
+  });
+});
+
+test('task-create preserves accepted evidence when an accepted terminal response is invalid', async () => {
+  const result = await runControlledTaskCreate((requestId) => ({
+    version: 2, id: requestId, phase: 'completed', exitCode: 0, stdout: '', stderr: '', error: null,
+    outputState: 'available', payload: null
+  }));
+  assert.equal(result.exitCode, 1, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.error.code, 'SANDBOX_CONTROL_RESPONSE_INVALID');
+  assert.deepEqual(payload.control, {
+    requestId: result.requestId,
+    accepted: true,
+    recovery: 'same-request-id'
+  });
 });

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -76,13 +76,14 @@ async function runControlledTaskCreate(
   fs.mkdirSync(responsesDir);
   fs.mkdirSync(statusDir);
   fs.writeFileSync(path.join(statusDir, 'status.json'), `${JSON.stringify({
-    version: 2,
+    version: 3,
     generation,
     broker: { pid: process.pid, startTime: 0, brokerId: 'task-create-test-broker' },
     state: 'healthy',
     reasonCode: null,
     activeRequestId: null,
-    updatedAt: Date.now()
+    updatedAt: Date.now(),
+    taskView: { state: 'not-applicable', taskId: null, observedSource: null, receipt: null, reasonCode: null }
   })}\n`);
   const child = spawn(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
     cwd: root,

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -55,7 +55,10 @@ async function waitForRequestAsync(requestsDir: string, timeoutMs: number): Prom
   throw new Error(`Timed out waiting for a request in ${requestsDir}`);
 }
 
-async function runControlledTaskCreate(responseFor: (requestId: string) => object): Promise<{
+async function runControlledTaskCreate(
+  responseFor: (requestId: string) => object,
+  options: { removeAcceptedMarkerAfterTerminal?: boolean } = {}
+): Promise<{
   requestId: string;
   exitCode: number;
   stdout: string;
@@ -109,6 +112,9 @@ async function runControlledTaskCreate(responseFor: (requestId: string) => objec
       version: 2, id: requestId, phase: 'accepted', exitCode: null, stdout: '', stderr: '', error: null
     })}\n`);
     fs.writeFileSync(path.join(responsesDir, `${requestId}.json`), `${JSON.stringify(responseFor(requestId))}\n`);
+    if (options.removeAcceptedMarkerAfterTerminal) {
+      fs.rmSync(path.join(responsesDir, `${requestId}.accepted.json`));
+    }
     return { requestId, exitCode: await result, stdout, stderr };
   } finally {
     if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
@@ -252,7 +258,7 @@ test('task-create preserves accepted evidence when an accepted terminal response
   const result = await runControlledTaskCreate((requestId) => ({
     version: 2, id: requestId, phase: 'completed', exitCode: 0, stdout: '', stderr: '', error: null,
     outputState: 'available', payload: null
-  }));
+  }), { removeAcceptedMarkerAfterTerminal: true });
   assert.equal(result.exitCode, 1, result.stderr || result.stdout);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.error.code, 'SANDBOX_CONTROL_RESPONSE_INVALID');

--- a/tests/unit/task/create.test.ts
+++ b/tests/unit/task/create.test.ts
@@ -12,7 +12,13 @@ import {
   validateTaskCreateCandidate,
   type TaskCreateCandidateV1
 } from '../../../lib/task/create.ts';
-import { createTask } from '../../../lib/task/create-service.ts';
+import {
+  createTask,
+  parseTaskCreateResult,
+  projectTaskCreateResult,
+  taskCreateExitCode,
+  taskCreateOutputUnavailableResult
+} from '../../../lib/task/create-service.ts';
 import { lockKey } from '../../../lib/task/task-execution-lock.ts';
 
 const candidate: TaskCreateCandidateV1 = {
@@ -267,4 +273,46 @@ test('platform failure preserves the local task and records a warning intent', a
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('task-create result projection preserves control recovery evidence without changing the domain result', async () => {
+  const root = fixture();
+  try {
+    const domainResult = await createTask(candidate, {
+      repoRoot: root,
+      agentInfraVersion: 'v0.9.5'
+    });
+    const projected = projectTaskCreateResult(domainResult, {
+      requestId: '0123456789abcdef0123456789abcdef',
+      accepted: true,
+      recovery: 'none'
+    });
+
+    assert.deepEqual(projected.task, domainResult.task);
+    assert.deepEqual(projected.control, {
+      requestId: '0123456789abcdef0123456789abcdef',
+      accepted: true,
+      recovery: 'none'
+    });
+    assert.deepEqual(parseTaskCreateResult(projected), projected);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-create output-unavailable fallback is a failed result with inspectable recovery evidence', () => {
+  const result = taskCreateOutputUnavailableResult('fedcba9876543210fedcba9876543210');
+  assert.equal(result.status, 'failed');
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.task, { id: null, shortId: null });
+  assert.equal(result.issue, null);
+  assert.deepEqual(result.control, {
+    requestId: 'fedcba9876543210fedcba9876543210',
+    accepted: true,
+    recovery: 'inspect-domain-state'
+  });
+  assert.equal(result.error?.code, 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE');
+  assert.equal(result.error?.retryable, false);
+  assert.equal(taskCreateExitCode(result), 1);
+  assert.deepEqual(parseTaskCreateResult(result), result);
 });


### PR DESCRIPTION
## 摘要

修复受控沙箱执行 task-create 时，broker terminal 发布与 accepted marker 清理之间的竞态，以及 broker 重启后 publish 形状的 unavailable terminal 无法完成恢复的问题。

## 主要变更

- terminal 文件出现后保留 request-scoped accepted/recovery evidence，即使 accepted marker 已被清理。
- broker restart 对 publish 和 recovery 两种 canonical unavailable terminal 做严格 evidence-bound reconciliation。
- 增加 marker cleanup race 和 publish-shaped terminal restart 回归测试。
- 保持现有 task-bound、branch-only、fail-closed 和幂等边界。

## 验证

- `npm run build`
- `npm run typecheck`
- `npm run test:smoke:fast`：1583/1583 通过
- `npm run test:smoke`：1583/1583 通过
- 受影响测试：68/68 通过
- `npm test`：3005 通过、1 个已知差异外失败、7 个跳过；失败位于 `tests/integration/cli/sandbox-worktree-safety.test.ts:232`，错误为 `SANDBOX_CONTROL_REMOVAL_TARGET_MISMATCH`
- `review-code-r4.md`：Approved；0 blocker、0 major、0 minor

## 待人工验证

真实 Docker/宿主 broker 故障矩阵及 macOS 专属路径仍需维护者验证，包括 accepted terminal 异常、payload unavailable、broker restart、request ID recovery、receipt/audit 和无重复 mutation。

## 其他信息

关联 Issue：#980（已创建并绑定）；Issue 创建失败告警 WW-1 已 resolved。

Generated with AI assistance

Closes #980
