### PR TITLE
refactor(platform): 统一 Issue/PR 留言安全渲染与内容转义


### DIFF
--- a/lib/platform/comment-safety.ts
+++ b/lib/platform/comment-safety.ts
@@ -1,0 +1,233 @@
+type SanitizationError = { code: 'COMMENT_DOCUMENT_INVALID'; message: string; offset: number };
+type SanitizationResult<T> = { ok: true; value: T } | { ok: false; error: SanitizationError };
+type SanitizationOptions = { reservedMarkers?: readonly RegExp[] };
+type PlaceholderSplit = { prefix: string; suffix: string };
+type FenceRange = { start: number; end: number };
+type Line = { start: number; end: number; text: string };
+
+const CONTROL_MARKER_PATTERN = /<!--\s*(?:sync-issue|sync-pr|last-commit)\b[\s\S]*?-->|<!--\s*canonical-pr-change-report\s*-->/gi;
+
+function ok<T>(value: T): SanitizationResult<T> {
+  return { ok: true, value };
+}
+
+function invalid(message: string, offset: number): SanitizationResult<never> {
+  return { ok: false, error: { code: 'COMMENT_DOCUMENT_INVALID', message, offset } };
+}
+
+function normalized(value: string): string {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+function linesOf(value: string): Line[] {
+  const lines: Line[] = [];
+  let start = 0;
+  while (start < value.length) {
+    const newline = value.indexOf('\n', start);
+    const end = newline === -1 ? value.length : newline;
+    lines.push({ start, end: newline === -1 ? end : newline + 1, text: value.slice(start, end) });
+    start = newline === -1 ? value.length : newline + 1;
+  }
+  if (value.length === 0) lines.push({ start: 0, end: 0, text: '' });
+  return lines;
+}
+
+function openingFence(line: string): { character: '`' | '~'; length: number } | null | 'invalid' {
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  if (!match) return null;
+  const character = match[1]![0] as '`' | '~';
+  const info = match[2]!;
+  if (character === '`' && info.includes('`')) return 'invalid';
+  return { character, length: match[1]!.length };
+}
+
+function closesFence(line: string, fence: { character: '`' | '~'; length: number }): boolean {
+  const escaped = fence.character === '`' ? '`' : '~';
+  return new RegExp(`^ {0,3}${escaped}{${fence.length},}[ \\t]*$`).test(line);
+}
+
+function fenceRanges(value: string): SanitizationResult<FenceRange[]> {
+  const ranges: FenceRange[] = [];
+  let fence: { character: '`' | '~'; length: number; start: number } | null = null;
+  for (const line of linesOf(value)) {
+    if (!fence) {
+      const opening = openingFence(line.text);
+      if (opening === 'invalid') return invalid('fenced code info string is invalid', line.start);
+      if (opening) fence = { ...opening, start: line.start };
+      continue;
+    }
+    if (closesFence(line.text, fence)) {
+      ranges.push({ start: fence.start, end: line.end });
+      fence = null;
+    }
+  }
+  if (fence) return invalid('fenced code block is not closed', fence.start);
+  return ok(ranges);
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeHtmlText(value: string): string {
+  return escapeHtml(value);
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return escapeHtml(value);
+}
+
+function escapeMarkdownLiteral(value: string): string {
+  return value.replace(/[\\`*_{}\[\]()#+.!|<>-]/g, '\\$&');
+}
+
+function markerSafe(value: string, markers: readonly RegExp[]): string {
+  let result = value;
+  for (const marker of markers) {
+    const flags = marker.flags.includes('g') ? marker.flags : `${marker.flags}g`;
+    const pattern = new RegExp(marker.source, flags);
+    result = result.replace(pattern, (match) => escapeHtmlText(match));
+  }
+  return result;
+}
+
+function tagEnd(value: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let index = start + 1; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (quote) {
+      if (character === quote) quote = null;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function isMarkdownAutolink(value: string, start: number): boolean {
+  const end = value.indexOf('>', start + 1);
+  if (end === -1) return false;
+  const target = value.slice(start + 1, end);
+  return /^(?:https?:\/\/|mailto:)[^<>\s]+$/i.test(target)
+    || /^[^<>\s@]+@[^<>\s@]+\.[^<>\s@]+$/.test(target);
+}
+
+function sanitizeOutside(value: string, baseOffset: number): SanitizationResult<string> {
+  let result = '';
+  let index = 0;
+  while (index < value.length) {
+    if (value.startsWith('<!--', index)) {
+      const end = value.indexOf('-->', index + 4);
+      if (end === -1) return invalid('HTML comment is not closed', baseOffset + index);
+      const token = value.slice(index, end + 3);
+      result += escapeHtmlText(token);
+      index = end + 3;
+      continue;
+    }
+    if (value[index] === '<' && isMarkdownAutolink(value, index)) {
+      const end = value.indexOf('>', index + 1);
+      result += value.slice(index, end + 1);
+      index = end + 1;
+      continue;
+    }
+    if (value[index] === '<' && /[\\/!?A-Za-z]/.test(value[index + 1] || '')) {
+      const end = tagEnd(value, index);
+      if (end === -1) return invalid('HTML-like tag is not closed', baseOffset + index);
+      result += escapeHtmlText(value.slice(index, end + 1));
+      index = end + 1;
+      continue;
+    }
+    result += value[index]!;
+    index += 1;
+  }
+  return ok(result);
+}
+
+function sanitizeMarkdownDocument(value: string, options: SanitizationOptions = {}): SanitizationResult<string> {
+  const source = normalized(value);
+  const ranges = fenceRanges(source);
+  if (!ranges.ok) return ranges;
+  const markers = options.reservedMarkers || [];
+  let result = '';
+  let cursor = 0;
+  for (const range of ranges.value) {
+    const outside = sanitizeOutside(source.slice(cursor, range.start), cursor);
+    if (!outside.ok) return outside;
+    result += outside.value;
+    result += markerSafe(source.slice(range.start, range.end), markers);
+    cursor = range.end;
+  }
+  const tail = sanitizeOutside(source.slice(cursor), cursor);
+  if (!tail.ok) return tail;
+  return ok(result + tail.value);
+}
+
+function renderSafeCodeFence(value: string, language = '', reservedMarkers: readonly RegExp[] = [CONTROL_MARKER_PATTERN]): string {
+  const content = markerSafe(normalized(value), reservedMarkers);
+  const longestRun = Math.max(0, ...(content.match(/`+/g) || []).map((run) => run.length));
+  const delimiter = '`'.repeat(Math.max(3, longestRun + 1));
+  const suffix = content.endsWith('\n') ? '' : '\n';
+  return `${delimiter}${language}\n${content}${suffix}${delimiter}`;
+}
+
+function commentRangesOutsideFences(source: string, ranges: readonly FenceRange[]): SanitizationResult<Array<{ start: number; end: number }>> {
+  const comments: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+  for (const fence of [...ranges, { start: source.length, end: source.length }]) {
+    const segment = source.slice(cursor, fence.start);
+    let index = 0;
+    while (index < segment.length) {
+      const opening = segment.indexOf('<!--', index);
+      if (opening === -1) break;
+      const absoluteStart = cursor + opening;
+      const closing = segment.indexOf('-->', opening + 4);
+      if (closing === -1) return invalid('HTML comment is not closed', absoluteStart);
+      comments.push({ start: absoluteStart, end: cursor + closing + 3 });
+      index = closing + 3;
+    }
+    cursor = fence.end;
+  }
+  return ok(comments);
+}
+
+function splitDocumentPlaceholder(value: string, placeholder: string): SanitizationResult<PlaceholderSplit> {
+  const source = normalized(value);
+  const ranges = fenceRanges(source);
+  if (!ranges.ok) return ranges;
+  const positions: number[] = [];
+  let cursor = source.indexOf(placeholder);
+  while (cursor !== -1) {
+    positions.push(cursor);
+    cursor = source.indexOf(placeholder, cursor + placeholder.length);
+  }
+  if (positions.length !== 1) return invalid('document must contain exactly one placeholder', positions[1] ?? positions[0] ?? source.length);
+  const position = positions[0]!;
+  if (ranges.value.some((range) => position >= range.start && position < range.end)) {
+    return invalid('placeholder must be outside fenced code', position);
+  }
+  const comments = commentRangesOutsideFences(source, ranges.value);
+  if (!comments.ok) return comments;
+  const containing = comments.value.find((comment) => position >= comment.start && position < comment.end);
+  if (containing && (containing.start !== position || containing.end !== position + placeholder.length)) {
+    return invalid('placeholder must not be nested in another HTML comment', position);
+  }
+  return ok({ prefix: source.slice(0, position), suffix: source.slice(position + placeholder.length) });
+}
+
+export {
+  CONTROL_MARKER_PATTERN,
+  escapeHtmlAttribute,
+  escapeHtmlText,
+  escapeMarkdownLiteral,
+  renderSafeCodeFence,
+  sanitizeMarkdownDocument,
+  splitDocumentPlaceholder
+};
+export type { SanitizationError, SanitizationOptions, SanitizationResult };

--- a/lib/platform/comment-safety.ts
+++ b/lib/platform/comment-safety.ts
@@ -7,6 +7,7 @@ type FenceRange = {
   end: number;
   openingEnd: number;
   closingStart: number;
+  character: '`' | '~';
   opening: string;
   closing: string;
 };
@@ -69,6 +70,7 @@ function fenceRanges(value: string): SanitizationResult<FenceRange[]> {
         end: line.end,
         openingEnd: fence.openingEnd,
         closingStart: line.start,
+        character: fence.character,
         opening: value.slice(fence.start, fence.openingEnd),
         closing: value.slice(line.start, line.end)
       });

--- a/lib/platform/comment-safety.ts
+++ b/lib/platform/comment-safety.ts
@@ -2,7 +2,14 @@ type SanitizationError = { code: 'COMMENT_DOCUMENT_INVALID'; message: string; of
 type SanitizationResult<T> = { ok: true; value: T } | { ok: false; error: SanitizationError };
 type SanitizationOptions = { reservedMarkers?: readonly RegExp[] };
 type PlaceholderSplit = { prefix: string; suffix: string };
-type FenceRange = { start: number; end: number };
+type FenceRange = {
+  start: number;
+  end: number;
+  openingEnd: number;
+  closingStart: number;
+  opening: string;
+  closing: string;
+};
 type Line = { start: number; end: number; text: string };
 
 const CONTROL_MARKER_PATTERN = /<!--\s*(?:sync-issue|sync-pr|last-commit)\b[\s\S]*?-->|<!--\s*canonical-pr-change-report\s*-->/gi;
@@ -48,16 +55,23 @@ function closesFence(line: string, fence: { character: '`' | '~'; length: number
 
 function fenceRanges(value: string): SanitizationResult<FenceRange[]> {
   const ranges: FenceRange[] = [];
-  let fence: { character: '`' | '~'; length: number; start: number } | null = null;
+  let fence: { character: '`' | '~'; length: number; start: number; openingEnd: number } | null = null;
   for (const line of linesOf(value)) {
     if (!fence) {
       const opening = openingFence(line.text);
       if (opening === 'invalid') return invalid('fenced code info string is invalid', line.start);
-      if (opening) fence = { ...opening, start: line.start };
+      if (opening) fence = { ...opening, start: line.start, openingEnd: line.end };
       continue;
     }
     if (closesFence(line.text, fence)) {
-      ranges.push({ start: fence.start, end: line.end });
+      ranges.push({
+        start: fence.start,
+        end: line.end,
+        openingEnd: fence.openingEnd,
+        closingStart: line.start,
+        opening: value.slice(fence.start, fence.openingEnd),
+        closing: value.slice(line.start, line.end)
+      });
       fence = null;
     }
   }
@@ -226,8 +240,9 @@ export {
   escapeHtmlAttribute,
   escapeHtmlText,
   escapeMarkdownLiteral,
+  fenceRanges,
   renderSafeCodeFence,
   sanitizeMarkdownDocument,
   splitDocumentPlaceholder
 };
-export type { SanitizationError, SanitizationOptions, SanitizationResult };
+export type { FenceRange, SanitizationError, SanitizationOptions, SanitizationResult };

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -16,6 +16,7 @@ import {
 } from './provider-bridge.ts';
 import { resourceIdentityNumber } from './resource-identity.ts';
 import { taskIssueIdentity, taskIssueIdentityError } from './task-identities.ts';
+import { CONTROL_MARKER_PATTERN, renderSafeCodeFence, sanitizeMarkdownDocument } from './comment-safety.ts';
 
 type RemoteComment = { id: number | string; body: string; user?: { login?: string } };
 type RenderedChunk = { marker: string; body: string; content: string; part: number; total: number };
@@ -66,15 +67,22 @@ function splitFrontmatter(content: string): { frontmatter: string | null; body: 
   return { frontmatter: match[1]!, body: content.slice(match[0].length).replace(/^\r?\n/, '') };
 }
 
+function sanitizeCommentBody(value: string, label: string): string {
+  const result = sanitizeMarkdownDocument(value, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  if (!result.ok) throw new Error(`${result.error.code}: ${label}: ${result.error.message} at offset ${result.error.offset}`);
+  return result.value;
+}
+
 function footer(agent: string, taskId: string): string {
   return `---\n*由 ${agent} 自动生成 · 内部追踪：${taskId}*`;
 }
 
 function renderTaskComment(content: string, taskId: string, agent: string): string {
   const split = splitFrontmatter(content);
+  const safeBody = sanitizeCommentBody(split.body, 'task body');
   const taskBody = split.frontmatter === null
-    ? split.body
-    : `<details><summary>元数据 (frontmatter)</summary>\n\n\`\`\`yaml\n---\n${split.frontmatter}\n---\n\`\`\`\n\n</details>\n\n${split.body}`;
+    ? safeBody
+    : `<details><summary>元数据 (frontmatter)</summary>\n\n${renderSafeCodeFence(`---\n${split.frontmatter}\n---`, 'yaml')}\n\n</details>\n\n${safeBody}`;
   return normalizeCommentContent([
     MARKERS.task(taskId),
     '## 任务文件',
@@ -161,8 +169,9 @@ function chunkArtifactComment(input: {
 }): RenderedChunk[] {
   const byteLimit = input.byteLimit || 60_000;
   const identity = artifactIdentity(input.artifact);
+  const safeBody = sanitizeCommentBody(input.body, 'artifact body');
   const single = buildArtifactChunk(
-    input.taskId, identity.stem, identity.title, input.agent, input.body, 1, 1, false, Boolean(input.backfill)
+    input.taskId, identity.stem, identity.title, input.agent, safeBody, 1, 1, false, Boolean(input.backfill)
   );
   if (Buffer.byteLength(single.body, 'utf8') <= byteLimit) return [single];
 
@@ -173,7 +182,7 @@ function chunkArtifactComment(input: {
       input.taskId, identity.stem, identity.title, input.agent, '', total, total, true, Boolean(input.backfill)
     );
     const available = byteLimit - Buffer.byteLength(probe.body, 'utf8');
-    pieces = chunkByUtf8(input.body, available);
+    pieces = chunkByUtf8(safeBody, available);
     if (pieces.length === total) break;
     total = pieces.length;
   }
@@ -224,7 +233,7 @@ function hasResolvedPlatformContext(context: PlatformResult): boolean {
 
 function bodyEnvelope(marker: string, title: string, taskId: string, agent: string, body: string): string {
   return normalizeCommentContent([
-    marker, `## ${title}`, '', `> **${agent}** · ${taskId}`, '', body.replace(/\n+$/, ''), '', footer(agent, taskId)
+    marker, `## ${title}`, '', `> **${agent}** · ${taskId}`, '', sanitizeCommentBody(body, `${title} body`).replace(/\n+$/, ''), '', footer(agent, taskId)
   ].join('\n'));
 }
 
@@ -334,6 +343,15 @@ async function syncPlatformComment(taskRef: string, options: SyncOptions): Promi
       error: { code: 'ISSUE_NOT_LINKED', message: 'Task has no valid issue_number', retryable: false }
     });
   }
+  let desired: RenderedChunk[];
+  try {
+    desired = expectedComments(resolved.taskId, taskContent, resolved.taskDir, options);
+  } catch (error) {
+    return platformResult('failed', {
+      resource: { kind: 'issue', number: resourceIdentityNumber(issueIdentityFromTask) },
+      error: { code: 'COMMENT_PAYLOAD_INVALID', message: error instanceof Error ? error.message : String(error), retryable: false }
+    });
+  }
   const loaded = await resolvePlatformProviderContext({ cwd: resolved.repoRoot, client: options.client });
   const context = loaded.ok ? loaded.value.context : loaded.context;
   if (!hasResolvedPlatformContext(context) || !loaded.ok) return context;
@@ -356,16 +374,6 @@ async function syncPlatformComment(taskRef: string, options: SyncOptions): Promi
     });
   }
 
-  let desired: RenderedChunk[];
-  try {
-    desired = expectedComments(resolved.taskId, taskContent, resolved.taskDir, options);
-  } catch (error) {
-    return platformResult('failed', {
-      ...contextFields(context),
-      resource: { kind: 'issue', number: issue },
-      error: { code: 'COMMENT_PAYLOAD_INVALID', message: error instanceof Error ? error.message : String(error), retryable: false }
-    });
-  }
   const existing = relatedComments(listed.value, markerPrefix(resolved.taskId, options));
   if (!validateRelatedMarkerSet(existing, markerPrefix(resolved.taskId, options)).ok) {
     return platformResult('failed', {

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -16,7 +16,13 @@ import {
 } from './provider-bridge.ts';
 import { resourceIdentityNumber } from './resource-identity.ts';
 import { taskIssueIdentity, taskIssueIdentityError } from './task-identities.ts';
-import { CONTROL_MARKER_PATTERN, renderSafeCodeFence, sanitizeMarkdownDocument } from './comment-safety.ts';
+import {
+  CONTROL_MARKER_PATTERN,
+  fenceRanges,
+  renderSafeCodeFence,
+  sanitizeMarkdownDocument
+} from './comment-safety.ts';
+import type { FenceRange } from './comment-safety.ts';
 
 type RemoteComment = { id: number | string; body: string; user?: { login?: string } };
 type RenderedChunk = { marker: string; body: string; content: string; part: number; total: number };
@@ -104,13 +110,16 @@ function artifactIdentity(artifact: string): { stem: string; title: string } {
   return { stem, title: `${base}（Round ${round}）` };
 }
 
-function chunkByUtf8(content: string, maxBytes: number): string[] {
+type SourceChunk = { content: string; start: number; end: number };
+
+function chunkByUtf8(content: string, maxBytes: number): SourceChunk[] {
   if (maxBytes <= 0) throw new Error('comment byte limit is too small');
-  const chunks: string[] = [];
-  let remaining = content;
-  while (remaining) {
+  const chunks: SourceChunk[] = [];
+  let start = 0;
+  while (start < content.length) {
+    const remaining = content.slice(start);
     if (Buffer.byteLength(remaining, 'utf8') <= maxBytes) {
-      chunks.push(remaining);
+      chunks.push({ content: remaining, start, end: content.length });
       break;
     }
     let bytes = 0;
@@ -125,10 +134,22 @@ function chunkByUtf8(content: string, maxBytes: number): string[] {
     }
     const cut = newlineIndex > 0 ? newlineIndex : index;
     if (cut === 0) throw new Error('comment byte limit cannot fit one Unicode code point');
-    chunks.push(remaining.slice(0, cut));
-    remaining = remaining.slice(cut);
+    chunks.push({ content: remaining.slice(0, cut), start, end: start + cut });
+    start += cut;
   }
-  return chunks.length > 0 ? chunks : [''];
+  return chunks.length > 0 ? chunks : [{ content: '', start: 0, end: 0 }];
+}
+
+function independentChunkContent(piece: SourceChunk, fences: readonly FenceRange[]): string {
+  const openingFence = fences.find((fence) => piece.start > fence.start && piece.start < fence.end);
+  const closingFence = fences.find((fence) => piece.end > fence.start && piece.end < fence.end);
+  let content = piece.content;
+  if (openingFence) content = openingFence.opening + content;
+  if (closingFence) {
+    if (!content.endsWith('\n')) content += '\n';
+    content += closingFence.closing;
+  }
+  return content;
 }
 
 function buildArtifactChunk(
@@ -140,7 +161,8 @@ function buildArtifactChunk(
   part: number,
   total: number,
   chunked: boolean,
-  backfill: boolean
+  backfill: boolean,
+  renderedContent = content
 ): RenderedChunk {
   const marker = chunked ? MARKERS.artifactChunk(taskId, stem, part, total) : MARKERS.artifact(taskId, stem);
   const heading = chunked ? `## ${title}（${part}/${total}）` : `## ${title}`;
@@ -152,7 +174,7 @@ function buildArtifactChunk(
     '',
     `> **${agent}** · ${taskId}`,
     '',
-    content,
+    renderedContent,
     '',
     footer(agent, taskId)
   ].join('\n'));
@@ -176,23 +198,37 @@ function chunkArtifactComment(input: {
   if (Buffer.byteLength(single.body, 'utf8') <= byteLimit) return [single];
 
   let total = 2;
-  let pieces: string[] = [];
+  let payloadLimit = Number.POSITIVE_INFINITY;
+  const ranges = fenceRanges(safeBody);
+  if (!ranges.ok) throw new Error(`${ranges.error.code}: artifact body: ${ranges.error.message} at offset ${ranges.error.offset}`);
   for (;;) {
     const probe = buildArtifactChunk(
       input.taskId, identity.stem, identity.title, input.agent, '', total, total, true, Boolean(input.backfill)
     );
     const available = byteLimit - Buffer.byteLength(probe.body, 'utf8');
-    pieces = chunkByUtf8(safeBody, available);
-    if (pieces.length === total) break;
-    total = pieces.length;
+    const sourceLimit = Math.min(available, payloadLimit);
+    if (sourceLimit <= 0) throw new Error('comment byte limit is too small for an artifact chunk');
+    const pieces = chunkByUtf8(safeBody, sourceLimit);
+    if (pieces.length !== total) {
+      total = pieces.length;
+      continue;
+    }
+    const chunks = pieces.map((piece, index) => buildArtifactChunk(
+      input.taskId,
+      identity.stem,
+      identity.title,
+      input.agent,
+      piece.content,
+      index + 1,
+      total,
+      true,
+      Boolean(input.backfill),
+      independentChunkContent(piece, ranges.value)
+    ));
+    const overflow = Math.max(...chunks.map((chunk) => Buffer.byteLength(chunk.body, 'utf8') - byteLimit));
+    if (overflow <= 0) return chunks;
+    payloadLimit = sourceLimit - overflow;
   }
-  return pieces.map((content, index) => {
-    const chunk = buildArtifactChunk(
-      input.taskId, identity.stem, identity.title, input.agent, content, index + 1, total, true, Boolean(input.backfill)
-    );
-    if (Buffer.byteLength(chunk.body, 'utf8') > byteLimit) throw new Error('rendered comment exceeds byte limit');
-    return chunk;
-  });
 }
 
 function findMarkerComments(comments: RemoteComment[], marker: string): RemoteComment[] {

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -162,29 +162,63 @@ function sourceSlice(piece: SourceChunk, start: number, end: number): string {
   return piece.content.slice(Math.max(0, start - piece.start), Math.max(0, end - piece.start));
 }
 
-function renderOversizedFenceChunk(piece: SourceChunk, fence: FenceRange, maxBytes: number): string {
-  const code = sourceSlice(piece, Math.max(piece.start, fence.openingEnd), Math.min(piece.end, fence.closingStart));
-  const delimiter = boundedFence(code, fence.character, maxBytes);
-  if (!delimiter) return escapeHtmlText(piece.content);
+function renderOversizedFenceChunk(piece: SourceChunk, fences: readonly FenceRange[], maxBytes: number): string {
+  const insertions = new Map<number, string[]>();
+  const omitted: Array<{ start: number; end: number }> = [];
+  const insert = (position: number, value: string) => {
+    const values = insertions.get(position) || [];
+    values.push(value);
+    insertions.set(position, values);
+  };
 
+  for (const fence of fences) {
+    if (piece.end <= fence.start || piece.start >= fence.end) continue;
+    const oversized = Buffer.byteLength(fence.opening, 'utf8') > maxBytes
+      || Buffer.byteLength(fence.closing, 'utf8') > maxBytes;
+    if (!oversized) {
+      if (piece.start > fence.start && piece.start < fence.end) insert(piece.start, fence.opening);
+      if (piece.end > fence.start && piece.end < fence.end) insert(piece.end, fence.closing);
+      continue;
+    }
+
+    const code = sourceSlice(piece, Math.max(piece.start, fence.openingEnd), Math.min(piece.end, fence.closingStart));
+    const delimiter = boundedFence(code, fence.character, maxBytes);
+    if (!delimiter) return escapeHtmlText(piece.content);
+    insert(Math.max(piece.start, fence.start), delimiter.opening);
+    insert(Math.min(piece.end, fence.end), delimiter.closing);
+    const openingStart = Math.max(piece.start, fence.start);
+    const openingEnd = Math.min(piece.end, fence.openingEnd);
+    if (openingStart < openingEnd) omitted.push({ start: openingStart, end: openingEnd });
+    const closingStart = Math.max(piece.start, fence.closingStart);
+    const closingEnd = Math.min(piece.end, fence.end);
+    if (closingStart < closingEnd) omitted.push({ start: closingStart, end: closingEnd });
+  }
+
+  const boundaries = new Set<number>([piece.start, piece.end]);
+  for (const position of insertions.keys()) boundaries.add(position);
+  for (const range of omitted) {
+    boundaries.add(range.start);
+    boundaries.add(range.end);
+  }
+  const points = [...boundaries].sort((left, right) => left - right);
   let content = '';
-  if (piece.start < fence.start) content += sourceSlice(piece, piece.start, Math.min(piece.end, fence.start));
-  if (piece.end > fence.start && piece.start < fence.end) {
-    content += delimiter.opening;
-    content += code;
-    if (!content.endsWith('\n')) content += '\n';
-    content += delimiter.closing;
-    if (piece.end > fence.end) content += sourceSlice(piece, fence.end, piece.end);
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index]!;
+    for (const value of insertions.get(point) || []) content += value;
+    const next = points[index + 1];
+    if (next === undefined) continue;
+    const skipped = omitted.some((range) => range.start <= point && next <= range.end);
+    if (!skipped) content += sourceSlice(piece, point, next);
   }
   return content;
 }
 
 function independentChunkContent(piece: SourceChunk, fences: readonly FenceRange[], maxBytes: number): string {
-  const oversizedFence = fences.find((fence) =>
+  const oversizedFence = fences.some((fence) =>
     piece.end > fence.start && piece.start < fence.end
     && (Buffer.byteLength(fence.opening, 'utf8') > maxBytes || Buffer.byteLength(fence.closing, 'utf8') > maxBytes)
   );
-  if (oversizedFence) return renderOversizedFenceChunk(piece, oversizedFence, maxBytes);
+  if (oversizedFence) return renderOversizedFenceChunk(piece, fences, maxBytes);
   const openingFence = fences.find((fence) => piece.start > fence.start && piece.start < fence.end);
   const closingFence = fences.find((fence) => piece.end > fence.start && piece.end < fence.end);
   let content = piece.content;

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -163,11 +163,11 @@ function sourceSlice(piece: SourceChunk, start: number, end: number): string {
 }
 
 function renderOversizedFenceChunk(piece: SourceChunk, fences: readonly FenceRange[], maxBytes: number): string {
-  const insertions = new Map<number, string[]>();
+  const insertions = new Map<number, Array<{ value: string; ensureLineStart: boolean }>>();
   const omitted: Array<{ start: number; end: number }> = [];
-  const insert = (position: number, value: string) => {
+  const insert = (position: number, value: string, ensureLineStart = false) => {
     const values = insertions.get(position) || [];
-    values.push(value);
+    values.push({ value, ensureLineStart });
     insertions.set(position, values);
   };
 
@@ -177,7 +177,7 @@ function renderOversizedFenceChunk(piece: SourceChunk, fences: readonly FenceRan
       || Buffer.byteLength(fence.closing, 'utf8') > maxBytes;
     if (!oversized) {
       if (piece.start > fence.start && piece.start < fence.end) insert(piece.start, fence.opening);
-      if (piece.end > fence.start && piece.end < fence.end) insert(piece.end, fence.closing);
+      if (piece.end > fence.start && piece.end < fence.end) insert(piece.end, fence.closing, true);
       continue;
     }
 
@@ -185,7 +185,7 @@ function renderOversizedFenceChunk(piece: SourceChunk, fences: readonly FenceRan
     const delimiter = boundedFence(code, fence.character, maxBytes);
     if (!delimiter) return escapeHtmlText(piece.content);
     insert(Math.max(piece.start, fence.start), delimiter.opening);
-    insert(Math.min(piece.end, fence.end), delimiter.closing);
+    insert(Math.min(piece.end, fence.end), delimiter.closing, true);
     const openingStart = Math.max(piece.start, fence.start);
     const openingEnd = Math.min(piece.end, fence.openingEnd);
     if (openingStart < openingEnd) omitted.push({ start: openingStart, end: openingEnd });
@@ -204,7 +204,10 @@ function renderOversizedFenceChunk(piece: SourceChunk, fences: readonly FenceRan
   let content = '';
   for (let index = 0; index < points.length; index += 1) {
     const point = points[index]!;
-    for (const value of insertions.get(point) || []) content += value;
+    for (const insertion of insertions.get(point) || []) {
+      if (insertion.ensureLineStart && content.length > 0 && !content.endsWith('\n')) content += '\n';
+      content += insertion.value;
+    }
     const next = points[index + 1];
     if (next === undefined) continue;
     const skipped = omitted.some((range) => range.start <= point && next <= range.end);

--- a/lib/platform/issue-comments.ts
+++ b/lib/platform/issue-comments.ts
@@ -18,6 +18,7 @@ import { resourceIdentityNumber } from './resource-identity.ts';
 import { taskIssueIdentity, taskIssueIdentityError } from './task-identities.ts';
 import {
   CONTROL_MARKER_PATTERN,
+  escapeHtmlText,
   fenceRanges,
   renderSafeCodeFence,
   sanitizeMarkdownDocument
@@ -140,7 +141,50 @@ function chunkByUtf8(content: string, maxBytes: number): SourceChunk[] {
   return chunks.length > 0 ? chunks : [{ content: '', start: 0, end: 0 }];
 }
 
-function independentChunkContent(piece: SourceChunk, fences: readonly FenceRange[]): string {
+function longestFenceLineRun(content: string, character: '`' | '~'): number {
+  const pattern = new RegExp(`^ {0,3}(${character}+)[ \\t]*(?:\\n|$)`, 'gm');
+  let longest = 0;
+  for (const match of content.matchAll(pattern)) longest = Math.max(longest, match[1]!.length);
+  return longest;
+}
+
+function boundedFence(content: string, sourceCharacter: '`' | '~', maxBytes: number): { opening: string; closing: string } | null {
+  const candidates: Array<'`' | '~'> = sourceCharacter === '`' ? ['~', '`'] : ['`', '~'];
+  for (const character of candidates) {
+    const length = Math.max(3, longestFenceLineRun(content, character) + 1);
+    const delimiter = character.repeat(length);
+    if (Buffer.byteLength(delimiter, 'utf8') * 2 + 2 <= maxBytes) return { opening: `${delimiter}\n`, closing: `${delimiter}\n` };
+  }
+  return null;
+}
+
+function sourceSlice(piece: SourceChunk, start: number, end: number): string {
+  return piece.content.slice(Math.max(0, start - piece.start), Math.max(0, end - piece.start));
+}
+
+function renderOversizedFenceChunk(piece: SourceChunk, fence: FenceRange, maxBytes: number): string {
+  const code = sourceSlice(piece, Math.max(piece.start, fence.openingEnd), Math.min(piece.end, fence.closingStart));
+  const delimiter = boundedFence(code, fence.character, maxBytes);
+  if (!delimiter) return escapeHtmlText(piece.content);
+
+  let content = '';
+  if (piece.start < fence.start) content += sourceSlice(piece, piece.start, Math.min(piece.end, fence.start));
+  if (piece.end > fence.start && piece.start < fence.end) {
+    content += delimiter.opening;
+    content += code;
+    if (!content.endsWith('\n')) content += '\n';
+    content += delimiter.closing;
+    if (piece.end > fence.end) content += sourceSlice(piece, fence.end, piece.end);
+  }
+  return content;
+}
+
+function independentChunkContent(piece: SourceChunk, fences: readonly FenceRange[], maxBytes: number): string {
+  const oversizedFence = fences.find((fence) =>
+    piece.end > fence.start && piece.start < fence.end
+    && (Buffer.byteLength(fence.opening, 'utf8') > maxBytes || Buffer.byteLength(fence.closing, 'utf8') > maxBytes)
+  );
+  if (oversizedFence) return renderOversizedFenceChunk(piece, oversizedFence, maxBytes);
   const openingFence = fences.find((fence) => piece.start > fence.start && piece.start < fence.end);
   const closingFence = fences.find((fence) => piece.end > fence.start && piece.end < fence.end);
   let content = piece.content;
@@ -223,7 +267,7 @@ function chunkArtifactComment(input: {
       total,
       true,
       Boolean(input.backfill),
-      independentChunkContent(piece, ranges.value)
+      independentChunkContent(piece, ranges.value, sourceLimit)
     ));
     const overflow = Math.max(...chunks.map((chunk) => Buffer.byteLength(chunk.body, 'utf8') - byteLimit));
     if (overflow <= 0) return chunks;

--- a/lib/platform/pr-change-report.ts
+++ b/lib/platform/pr-change-report.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
+import { escapeHtmlText } from './comment-safety.ts';
 
 const REPORT_FILE_NAME = 'pr-change-report.json';
 const REPORT_VERSION = 1 as const;
@@ -483,22 +484,15 @@ function representativePath(file: ChangeFile): string {
   return file.newPath || file.oldPath || '';
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;')
-    .replaceAll('\r', '\\r')
-    .replaceAll('\n', '\\n');
+function escapeReportText(value: string): string {
+  return escapeHtmlText(value).replaceAll('\r', '\\r').replaceAll('\n', '\\n');
 }
 
 function renderRepresentativePath(file: ChangeFile): string {
   const paths = file.oldPath && file.newPath && file.oldPath !== file.newPath
     ? [file.oldPath, file.newPath]
     : [representativePath(file)];
-  return paths.map((filePath) => `<code>${escapeHtml(filePath)}</code>`).join(' → ');
+  return paths.map((filePath) => `<code>${escapeReportText(filePath)}</code>`).join(' → ');
 }
 
 function representativeScore(file: ChangeFile, metric: 'lines' | 'bytes'): number {
@@ -551,12 +545,12 @@ function renderEvidence(evidence: Evidence): string {
         ? `:${evidence.startLine}`
         : `:${evidence.startLine}-${evidence.endLine}`
       : `:${evidence.startLine ?? evidence.endLine}`;
-  return `  - 证据：<code>${escapeHtml(evidence.path)}</code>${location}：${escapeHtml(evidence.detail)}`;
+  return `  - 证据：<code>${escapeReportText(evidence.path)}</code>${location}：${escapeReportText(evidence.detail)}`;
 }
 
 function renderPrechecks(checks: Precheck[]): string[] {
   return checks.flatMap((check) => [
-    `- **${PRECHECK_LABELS[check.id]}（${check.id}）**：${check.verdict === 'pass' ? '通过' : '需复核'}。${escapeHtml(check.rationale)}`,
+    `- **${PRECHECK_LABELS[check.id]}（${check.id}）**：${check.verdict === 'pass' ? '通过' : '需复核'}。${escapeReportText(check.rationale)}`,
     ...check.evidence.slice(0, 1).map(renderEvidence)
   ]);
 }

--- a/lib/platform/pr-summary.ts
+++ b/lib/platform/pr-summary.ts
@@ -11,6 +11,7 @@ import type { PrDeliveryFact } from '../task/pr-delivery-fact.ts';
 import { resolvePlatformProviderContext } from './context.ts';
 import type { LoadedContext, PlatformClient } from './context.ts';
 import { normalizeCommentContent } from './issue-comments.ts';
+import { CONTROL_MARKER_PATTERN, escapeHtmlText, sanitizeMarkdownDocument, splitDocumentPlaceholder } from './comment-safety.ts';
 import { platformResult } from './types.ts';
 import type { PlatformResult } from './types.ts';
 import type { OperationWarning } from '../task/operation-outcome.ts';
@@ -19,6 +20,7 @@ import type { PlatformChangeRequestSnapshot } from './adapters.ts';
 import type { ChangeRequestSnapshot } from './provider-contract.ts';
 import {
   buildPrChangeReport,
+  CANONICAL_REPORT_PLACEHOLDER,
   readPrChangeReport,
   replaceCanonicalReportPlaceholder,
   runMechanicalChangeReport,
@@ -57,11 +59,7 @@ function summaryMarker(taskId: string): string {
 }
 
 function escapeSummaryAuditText(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\r\n?/g, '\n');
+  return escapeHtmlText(value).replace(/\r\n?/g, '\n');
 }
 
 function renderSummaryAuditLine(value: string): string {
@@ -528,7 +526,30 @@ async function syncPullRequestSummary(
       if (!report.ok) return fail('failed', context, platformError(report.error));
       const checked = currentReportCheck(report.value, initial.value, taskContent, resolved.repoRoot);
       if (!checked.ok) return fail('failed', context, checked.error);
-      const replaced = replaceCanonicalReportPlaceholder(options.body, report.value);
+      const placeholder = CANONICAL_REPORT_PLACEHOLDER;
+      const split = splitDocumentPlaceholder(options.body, placeholder);
+      if (!split.ok) return fail('failed', context, {
+        code: 'PR_SUMMARY_BODY_CONTRACT_INVALID',
+        message: split.error.message,
+        retryable: false
+      });
+      const prefix = sanitizeMarkdownDocument(split.value.prefix, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+      const suffix = sanitizeMarkdownDocument(split.value.suffix, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+      if (!prefix.ok) {
+        return fail('failed', context, {
+          code: 'PR_SUMMARY_BODY_CONTRACT_INVALID',
+          message: `${prefix.error.message} at offset ${prefix.error.offset}`,
+          retryable: false
+        });
+      }
+      if (!suffix.ok) {
+        return fail('failed', context, {
+          code: 'PR_SUMMARY_BODY_CONTRACT_INVALID',
+          message: `${suffix.error.message} at offset ${suffix.error.offset}`,
+          retryable: false
+        });
+      }
+      const replaced = replaceCanonicalReportPlaceholder(`${prefix.value}${placeholder}${suffix.value}`, report.value);
       if (!replaced.ok) return fail('failed', context, platformError(replaced.error));
       const desired = buildPullRequestSummary(resolved.taskId, replaced.value, initial.value.head.sha, renderHumanOverrideAudit(taskContent));
       if (!isSafeSummaryEnvelope(desired, resolved.taskId)) return fail('failed', context, {

--- a/tests/integration/cli/platform-comment.test.ts
+++ b/tests/integration/cli/platform-comment.test.ts
@@ -90,6 +90,37 @@ test('platform-comment preserves source content including local-looking artifact
   }
 });
 
+test('platform-comment CLI encodes mixed-case HTML and rejects malformed content before remote writes', () => {
+  const f = fixture();
+  try {
+    const taskPath = path.join(f.root, '.agents', 'workspace', 'active', f.taskId, 'task.md');
+    fs.appendFileSync(taskPath, [
+      '',
+      '<TaBlE>unsafe</TaBlE>',
+      '',
+      '```html',
+      '<TaBlE>example</TaBlE>',
+      '<!-- sync-issue:TASK-1:task -->',
+      '```',
+      ''
+    ].join('\n'));
+    const rendered = runComment(['sync', f.taskId, '--kind', 'task', '--agent', 'codex'], f);
+    assert.equal(rendered.status, 0, rendered.stderr || rendered.stdout);
+    const comments = JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')) as Array<{ body: string }>;
+    assert.match(comments[0]!.body, /&lt;TaBlE&gt;unsafe&lt;\/TaBlE&gt;/);
+    assert.match(comments[0]!.body, /<TaBlE>example<\/TaBlE>/);
+    assert.match(comments[0]!.body, /&lt;!-- sync-issue:TASK-1:task --&gt;/);
+
+    fs.writeFileSync(taskPath, `${fs.readFileSync(taskPath, 'utf8')}\n<BadTag\n`);
+    const rejected = runComment(['sync', f.taskId, '--kind', 'task', '--agent', 'codex'], f);
+    assert.equal(rejected.status, 1);
+    assert.equal(JSON.parse(rejected.stdout).error.code, 'COMMENT_PAYLOAD_INVALID');
+    assert.equal(JSON.parse(fs.readFileSync(f.commentsPath, 'utf8')).length, 1);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
 test('platform task comment sync transports receipt evidence with the task document', () => {
   const f = fixture();
   try {

--- a/tests/unit/platform/comment-safety.test.ts
+++ b/tests/unit/platform/comment-safety.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CONTROL_MARKER_PATTERN,
+  escapeHtmlAttribute,
+  escapeHtmlText,
+  escapeMarkdownLiteral,
+  renderSafeCodeFence,
+  sanitizeMarkdownDocument,
+  splitDocumentPlaceholder
+} from '../../../lib/platform/comment-safety.ts';
+
+test('sanitizes normal Markdown while preserving links and lists', () => {
+  const result = sanitizeMarkdownDocument('- [link](https://example.test)\n\n<https://example.test>\n\n1. item\n');
+  assert.deepEqual(result, { ok: true, value: '- [link](https://example.test)\n\n<https://example.test>\n\n1. item\n' });
+});
+
+test('encodes raw HTML and comments outside fenced code', () => {
+  const result = sanitizeMarkdownDocument('<ScRiPt>alert(1)</ScRiPt>\n<!-- hidden -->\n');
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.value, '&lt;ScRiPt&gt;alert(1)&lt;/ScRiPt&gt;\n&lt;!-- hidden --&gt;\n');
+  }
+});
+
+test('preserves fenced examples but protects reserved control markers', () => {
+  const input = '```html\n<!-- ordinary example -->\n<!-- sync-pr:TASK-1:summary -->\n<div>example</div>\n```\n';
+  const result = sanitizeMarkdownDocument(input, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.match(result.value, /<!-- ordinary example -->/);
+    assert.match(result.value, /&lt;!-- sync-pr:TASK-1:summary --&gt;/);
+    assert.match(result.value, /<div>example<\/div>/);
+  }
+});
+
+test('fails closed for malformed HTML candidates and unclosed fences', () => {
+  const malformedTag = sanitizeMarkdownDocument('<div\n');
+  assert.equal(malformedTag.ok, false);
+  if (!malformedTag.ok) assert.equal(malformedTag.error.code, 'COMMENT_DOCUMENT_INVALID');
+
+  const unclosedFence = sanitizeMarkdownDocument('~~~\nexample\n');
+  assert.equal(unclosedFence.ok, false);
+  if (!unclosedFence.ok) assert.equal(unclosedFence.error.code, 'COMMENT_DOCUMENT_INVALID');
+});
+
+test('sanitization and safe fences are idempotent and UTF-8 safe', () => {
+  const input = '中文🙂 &lt;!-- sync-pr:TASK-1:summary --&gt;\n';
+  const first = sanitizeMarkdownDocument(input, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  const second = sanitizeMarkdownDocument(first.value, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  assert.deepEqual(second, first);
+
+  const fenced = renderSafeCodeFence('line ```\n<!-- sync-pr:TASK-1:summary -->\n', 'yaml', [CONTROL_MARKER_PATTERN]);
+  assert.match(fenced, /````yaml/);
+  assert.match(fenced, /&lt;!-- sync-pr:TASK-1:summary --&gt;/);
+  assert.ok(Buffer.byteLength(fenced, 'utf8') > 0);
+});
+
+test('splits exactly one canonical placeholder only when it is outside fences and comments', () => {
+  const placeholder = '<!-- canonical-pr-change-report -->';
+  const split = splitDocumentPlaceholder(`Summary\n${placeholder}\n`, placeholder);
+  assert.deepEqual(split, { ok: true, value: { prefix: 'Summary\n', suffix: '\n' } });
+
+  for (const invalid of [
+    `Summary\n${placeholder}\n${placeholder}`,
+    `\`\`\`\n${placeholder}\n\`\`\``,
+    `<!-- wrapper ${placeholder} -->`
+  ]) {
+    const result = splitDocumentPlaceholder(invalid, placeholder);
+    assert.equal(result.ok, false);
+  }
+});
+
+test('escapes HTML, attributes, and Markdown literal values', () => {
+  assert.equal(escapeHtmlText(`<x a="b"> & 'q'`), '&lt;x a=&quot;b&quot;&gt; &amp; &#39;q&#39;');
+  assert.equal(escapeHtmlAttribute(`a"b'&<>`), 'a&quot;b&#39;&amp;&lt;&gt;');
+  assert.equal(escapeMarkdownLiteral('a *b* [c] <d>'), 'a \\*b\\* \\[c\\] \\<d\\>');
+});

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -113,6 +113,22 @@ test('artifact chunks keep adjacent fences independently parseable', () => {
   for (const chunk of chunks) assert.equal(sanitizeMarkdownDocument(chunk.body).ok, true);
 });
 
+test('artifact chunks keep oversized fence closers on their own line', () => {
+  const body = [
+    '```' + 'a'.repeat(60_000),
+    'x'.repeat(120_000),
+    '```',
+    'after'
+  ].join('\n');
+  const chunks = chunkArtifactComment({
+    taskId: 'TASK-20260101-000001', artifact: 'code.md', agent: 'codex', body
+  });
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks.map((chunk) => chunk.content).join(''), body);
+  assert.ok(chunks.every((chunk) => Buffer.byteLength(chunk.body, 'utf8') <= 60_000));
+  for (const chunk of chunks) assert.equal(sanitizeMarkdownDocument(chunk.body).ok, true);
+});
+
 test('pr-review artifacts chunk under the pr-review stem with round titles', () => {
   const body = `${'# PR Review\n'.repeat(1)}${'内容 '.repeat(80)}`;
   const chunks = chunkArtifactComment({

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -93,6 +93,26 @@ test('artifact chunks bound oversized fence lines without losing source content'
   }
 });
 
+test('artifact chunks keep adjacent fences independently parseable', () => {
+  const body = [
+    '```' + 'a'.repeat(60_000),
+    '<details>oversized</details>',
+    '```',
+    '```html',
+    '<details>ordinary</details>',
+    'x'.repeat(120_000),
+    '```',
+    'after'
+  ].join('\n');
+  const chunks = chunkArtifactComment({
+    taskId: 'TASK-20260101-000001', artifact: 'code.md', agent: 'codex', body
+  });
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks.map((chunk) => chunk.content).join(''), body);
+  assert.ok(chunks.every((chunk) => Buffer.byteLength(chunk.body, 'utf8') <= 60_000));
+  for (const chunk of chunks) assert.equal(sanitizeMarkdownDocument(chunk.body).ok, true);
+});
+
 test('pr-review artifacts chunk under the pr-review stem with round titles', () => {
   const body = `${'# PR Review\n'.repeat(1)}${'内容 '.repeat(80)}`;
   const chunks = chunkArtifactComment({

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -15,6 +15,7 @@ import {
   validateRelatedMarkerSet
 } from '../../../lib/platform/issue-comments.ts';
 import type { GitHubClient } from '../../../lib/platform/github-client.ts';
+import { sanitizeMarkdownDocument } from '../../../lib/platform/comment-safety.ts';
 
 test('task comments preserve frontmatter and body in reversible details format', () => {
   const task = '---\nid: TASK-20260101-000001\ntype: feature\n---\n\n# Task\n\nBody | `code`\n';
@@ -59,6 +60,21 @@ test('artifact chunking sanitizes dynamic content before applying the byte limit
   });
   assert.match(chunk!.content, /&lt;MiXeD&gt;unsafe&lt;\/MiXeD&gt;/);
   assert.match(chunk!.content, /&lt;!-- sync-issue:TASK-1:task --&gt;/);
+});
+
+test('artifact chunks preserve fenced HTML when each chunk is parsed independently', () => {
+  const body = ['before', '```html', '<details>', 'x'.repeat(1200), '</details>', '```', 'after'].join('\n');
+  const chunks = chunkArtifactComment({
+    taskId: 'TASK-20260101-000001', artifact: 'code.md', agent: 'codex', body, byteLimit: 300
+  });
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks.map((chunk) => chunk.content).join(''), body);
+  assert.ok(chunks.some((chunk) => chunk.body.includes('<details>')));
+  for (const chunk of chunks) {
+    const parsed = sanitizeMarkdownDocument(chunk.body);
+    assert.equal(parsed.ok, true);
+    if (parsed.ok) assert.equal(parsed.value.includes('&lt;/details&gt;'), false);
+  }
 });
 
 test('pr-review artifacts chunk under the pr-review stem with round titles', () => {

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -25,6 +25,22 @@ test('task comments preserve frontmatter and body in reversible details format',
   assert.match(rendered, /# Task\n\nBody \| `code`/);
 });
 
+test('comment renderers encode mixed-case HTML while preserving fenced examples and markers', () => {
+  const rendered = renderTaskComment([
+    '# Task',
+    '',
+    '<DiV data-x="1">unsafe</DiV>',
+    '',
+    '```html',
+    '<DiV>example</DiV>',
+    '<!-- sync-pr:TASK-1:summary -->',
+    '```'
+  ].join('\n'), 'TASK-20260101-000001', 'codex');
+  assert.match(rendered, /&lt;DiV data-x=&quot;1&quot;&gt;unsafe&lt;\/DiV&gt;/);
+  assert.match(rendered, /<DiV>example<\/DiV>/);
+  assert.match(rendered, /&lt;!-- sync-pr:TASK-1:summary --&gt;/);
+});
+
 test('artifact chunking is UTF-8 safe, bounded and lossless', () => {
   const body = `${'中文🙂'.repeat(80)}\n${'x'.repeat(120)}`;
   const chunks = chunkArtifactComment({
@@ -34,6 +50,15 @@ test('artifact chunking is UTF-8 safe, bounded and lossless', () => {
   assert.ok(chunks.every((chunk) => Buffer.byteLength(chunk.body, 'utf8') <= 240));
   assert.equal(chunks.map((chunk) => chunk.content).join(''), body);
   assert.equal(chunks[0]!.marker, MARKERS.artifactChunk('TASK-20260101-000001', 'code', 1, chunks.length));
+});
+
+test('artifact chunking sanitizes dynamic content before applying the byte limit', () => {
+  const [chunk] = chunkArtifactComment({
+    taskId: 'TASK-20260101-000001', artifact: 'code.md', agent: 'codex',
+    body: '<MiXeD>unsafe</MiXeD> <!-- sync-issue:TASK-1:task -->'
+  });
+  assert.match(chunk!.content, /&lt;MiXeD&gt;unsafe&lt;\/MiXeD&gt;/);
+  assert.match(chunk!.content, /&lt;!-- sync-issue:TASK-1:task --&gt;/);
 });
 
 test('pr-review artifacts chunk under the pr-review stem with round titles', () => {
@@ -152,7 +177,25 @@ test('comment sync preserves source @ content', async () => {
   assert.equal(comments.length, 1);
 });
 
-test('comment sync transports artifact content without content validation', async () => {
+test('comment sync rejects malformed content before reading or writing remote comments', async () => {
+  const root = syncFixture();
+  fs.appendFileSync(path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'task.md'), '\n<DiV\n');
+  let calls = 0;
+  const client = {
+    version() { calls += 1; return { ok: true, value: '2.72.0' }; },
+    json() { calls += 1; throw new Error('remote read must not be attempted'); },
+    text() { calls += 1; throw new Error('remote write must not be attempted'); }
+  } as unknown as GitHubClient;
+
+  const result = await syncPlatformComment('TASK-20260101-000001', {
+    kind: 'task', agent: 'codex', cwd: root, client
+  });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error?.code, 'COMMENT_PAYLOAD_INVALID');
+  assert.equal(calls, 0);
+});
+
+test('comment sync transports safe artifact Markdown without changing its link syntax', async () => {
   const root = syncFixture();
   const artifactPath = path.join(root, '.agents', 'workspace', 'active', 'TASK-20260101-000001', 'analysis.md');
   fs.writeFileSync(artifactPath, '# Analysis\n\n[local](/workspace/file.md)\n');

--- a/tests/unit/platform/issue-comments.test.ts
+++ b/tests/unit/platform/issue-comments.test.ts
@@ -77,6 +77,22 @@ test('artifact chunks preserve fenced HTML when each chunk is parsed independent
   }
 });
 
+test('artifact chunks bound oversized fence lines without losing source content', () => {
+  const bodies = [
+    ['```' + 'a'.repeat(60_000), '<details>unsafe</details>', '```', 'after'].join('\n'),
+    ['~~~html', '<details>unsafe</details>', '~'.repeat(60_000), 'after'].join('\n')
+  ];
+  for (const body of bodies) {
+    const chunks = chunkArtifactComment({
+      taskId: 'TASK-20260101-000001', artifact: 'code.md', agent: 'codex', body
+    });
+    assert.ok(chunks.length > 1);
+    assert.equal(chunks.map((chunk) => chunk.content).join(''), body);
+    assert.ok(chunks.every((chunk) => Buffer.byteLength(chunk.body, 'utf8') <= 60_000));
+    for (const chunk of chunks) assert.equal(sanitizeMarkdownDocument(chunk.body).ok, true);
+  }
+});
+
 test('pr-review artifacts chunk under the pr-review stem with round titles', () => {
   const body = `${'# PR Review\n'.repeat(1)}${'内容 '.repeat(80)}`;
   const chunks = chunkArtifactComment({

--- a/tests/unit/platform/pr-summary.test.ts
+++ b/tests/unit/platform/pr-summary.test.ts
@@ -99,6 +99,7 @@ type ResolvedContextClientOptions = {
   deleteCalls?: { value: number };
   commentWrites?: { value: number };
   comments?: Array<{ id: number; body: string }>;
+  writtenBodies?: string[];
   pullRequestFailureAt?: number;
 };
 
@@ -113,7 +114,7 @@ function resolvedContextClient(
   let pullRequestCalls = 0;
   return {
     version: () => ({ ok: true, value: '2.72.0' }),
-    json: (args: string[]) => {
+    json: (args: string[], request?: { input?: string }) => {
       if (args[1] === 'graphql') return { ok: true, value: { data: { viewer: { login: 'codex' } } } };
       if (args[0] === 'api' && args[1] === 'repos/acme/widgets') {
         repositoryCalls += 1;
@@ -138,6 +139,7 @@ function resolvedContextClient(
       if (args.some((value: string) => value.includes('/issues/42/comments'))) {
         if (args.includes('POST') || args.includes('PATCH')) {
           if (options.commentWrites) options.commentWrites.value += 1;
+          if (options.writtenBodies && request?.input) options.writtenBodies.push(JSON.parse(request.input).body);
           return { ok: true, value: { id: 9 } };
         }
         if (failure === 'duplicate') {
@@ -289,6 +291,65 @@ test('summary-sync renders the task-bound report and publishes one canonical com
     assert.equal(result.nextAction, 'watch-pr');
   } finally {
     fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('summary-sync sanitizes the template around the canonical placeholder and protects fenced markers', async () => {
+  const fixture = summaryFixture();
+  const writtenBodies: string[] = [];
+  try {
+    const result = await syncPullRequestSummary(fixture.taskId, {
+      cwd: fixture.root,
+      agent: 'codex',
+      body: [
+        'Intro <ScRiPt>alert(1)</ScRiPt>',
+        '',
+        '```html',
+        '<div>example</div>',
+        '<!-- sync-pr:TASK-1:summary -->',
+        '```',
+        '',
+        '<!-- canonical-pr-change-report -->'
+      ].join('\n'),
+      changeReportFile: fixture.reportPath,
+      primaryResult: 'no_op',
+      client: resolvedContextClient(fixture.root, 'success', fixture.baseSha, fixture.headSha, { writtenBodies })
+    });
+    assert.equal(result.status, 'applied');
+    assert.equal(writtenBodies.length, 1);
+    assert.match(writtenBodies[0]!, /Intro &lt;ScRiPt&gt;alert\(1\)&lt;\/ScRiPt&gt;/);
+    assert.match(writtenBodies[0]!, /&lt;!-- sync-pr:TASK-1:summary --&gt;/);
+    assert.match(writtenBodies[0]!, /<code>README\.md<\/code>/);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('summary-sync rejects missing, duplicated, fenced, and nested placeholders before writing', async () => {
+  for (const body of [
+    'Summary',
+    '<!-- canonical-pr-change-report -->\n<!-- canonical-pr-change-report -->',
+    '```\n<!-- canonical-pr-change-report -->\n```',
+    '<!-- wrapper <!-- canonical-pr-change-report --> -->'
+  ]) {
+    const fixture = summaryFixture();
+    const commentWrites = { value: 0 };
+    try {
+      const result = await syncPullRequestSummary(fixture.taskId, {
+        cwd: fixture.root,
+        agent: 'codex',
+        body,
+        changeReportFile: fixture.reportPath,
+        primaryResult: 'no_op',
+        strict: true,
+        client: resolvedContextClient(fixture.root, 'success', fixture.baseSha, fixture.headSha, { commentWrites })
+      });
+      assert.equal(result.status, 'failed');
+      assert.equal(result.error?.code, 'PR_SUMMARY_BODY_CONTRACT_INVALID');
+      assert.equal(commentWrites.value, 0);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
   }
 });
 


### PR DESCRIPTION
## 摘要

统一 Agent 自有 Issue/PR 留言的动态内容安全边界，保留既有 Markdown、受控 HTML、代码块和同步 marker 契约。

## 主要变更

- 新增共享 comment safety scanner 与上下文转义能力，覆盖任务留言、产物留言、PR 摘要和变更报告。
- 为 UTF-8 分片增加有界、无损且可独立解析的 fenced code 渲染；超长 fence 的 synthetic closing delimiter 始终从新行开始。
- 增加混合大小写 HTML、代码块、marker、同步幂等和超长 fence 组合回归测试。
- 保持 Agent 自有留言所有权边界、current-only 策略和失败关闭行为，不扫描或修改其他用户及机器人的普通留言。

## 验证

- `npm run typecheck`
- `npm run build`
- `npm run test:smoke:fast`：1615/1615 通过
- `npm run test:smoke`：1615/1615 通过
- `npm run test:core`：2690 通过、6 个按平台跳过
- `npm test`：3015 通过、7 个按平台跳过、0 失败
- `git diff --check`

## 审查

- 需求、方案和代码审查均已完成。
- `review-code-r5.md`：Approved；0 blocker、0 major、0 minor、0 manual-validation items。
- 最后审查 checkpoint：`a8740c8addd7465aae7a558309401f4f3ed75714`。

## 未覆盖验证

真实 GitHub 页面 Markdown 视觉呈现、provider 权限和远端历史评论矩阵仍需维护者在合并前按需验证；本 PR 的本地 scanner、分片预算、源内容无损和同步测试均已覆盖。

Closes #969

Generated with AI assistance
