### PR TITLE
fix(task-create): 修复资格表渲染与候选 ID 路由


### DIFF
--- a/lib/init.ts
+++ b/lib/init.ts
@@ -288,6 +288,12 @@ async function cmdInit(): Promise<void> {
     replacements
   );
   ok('Installed .agents/scripts/lib/agent-infra-package.js');
+  renderFile(
+    path.join(templateDir, '.agents', 'scripts', 'package.json'),
+    path.join('.agents', 'scripts', 'package.json'),
+    replacements
+  );
+  ok('Installed .agents/scripts/package.json');
 
   const reconcileResult = applyAgentClientReconciliation(workflowPlan);
   for (const target of reconcileResult.applied) ok(`Installed ${target}`);

--- a/lib/platform/verification-sync.ts
+++ b/lib/platform/verification-sync.ts
@@ -11,6 +11,7 @@ import { planInLabelUpdate, validateInLabelMapping } from "./in-label-sync.ts";
 import { readPrDeliveryFact } from "../task/pr-delivery-fact.ts";
 import { providerError, providerOperationContext, resourceIdentityNumber, unsupportedProviderOperation } from "./provider-bridge.ts";
 import { taskIssueIdentity } from "./task-identities.ts";
+import { CONTROL_MARKER_PATTERN, renderSafeCodeFence, sanitizeMarkdownDocument } from "./comment-safety.ts";
 
 const CHECK_TYPE = "platform-sync";
 const VERSION_LINE_REGEX = /^[0-9]+\.[0-9]+\.x$/;
@@ -92,6 +93,11 @@ function blockedResult(...args: any[]): any {
 
 function safeStat(...args: any[]): any {
   return getShared().safeStat(...args);
+}
+
+function sanitizeCommentContent(content: string): string | null {
+  const result = sanitizeMarkdownDocument(content, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  return result.ok ? result.value : null;
 }
 
 export async function check({ taskDir, config, artifactFile }: any, shared: any): Promise<any> {
@@ -533,7 +539,15 @@ function checkCommentContent(context: any, remoteData: any): any {
   }
 
   const comment = findCommentByMarker(remoteData.comments, context.marker);
-  const localContent = normalizeContent(fs.readFileSync(context.artifactPath, "utf8"));
+  const rawLocalContent = fs.readFileSync(context.artifactPath, "utf8");
+  const sanitizedLocalContent = sanitizeCommentContent(rawLocalContent);
+  if (sanitizedLocalContent === null) {
+    return failResult(CHECK_TYPE,
+      `Artifact content cannot be rendered safely for comment verification: ${context.artifactFile || "(missing artifactFile)"}`,
+      "check_failed"
+    );
+  }
+  const localContent = normalizeContent(sanitizedLocalContent);
   const commentContent = normalizeContent(extractCommentBody(comment?.body || ""));
 
   if (localContent === commentContent) {
@@ -565,7 +579,14 @@ function checkTaskCommentContent(context: any, remoteData: any): any {
     );
   }
 
-  const expectedBody = normalizeContent(buildExpectedTaskBody(context.task.content));
+  const expectedTaskBody = buildExpectedTaskBody(context.task.content);
+  if (expectedTaskBody === null) {
+    return failResult(CHECK_TYPE,
+      "Task content cannot be rendered safely for comment verification",
+      "check_failed"
+    );
+  }
+  const expectedBody = normalizeContent(expectedTaskBody);
   const commentBody = normalizeContent(extractCommentBody(comment.body || ""));
 
   if (expectedBody === commentBody) {
@@ -866,16 +887,17 @@ function extractCommentBody(commentBody: any): any {
 function buildExpectedTaskBody(taskContent: any): any {
   const frontmatterMatch = taskContent.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!frontmatterMatch) {
-    return taskContent.trim();
+    return sanitizeCommentContent(taskContent.trim());
   }
 
-  const body = taskContent.slice(frontmatterMatch[0].length).trim();
+  const body = sanitizeCommentContent(taskContent.slice(frontmatterMatch[0].length).trim());
+  if (body === null) {
+    return null;
+  }
   return [
     buildTaskFrontmatterSummary(),
     "",
-    "```yaml",
-    frontmatterMatch[0].trim(),
-    "```",
+    renderSafeCodeFence(frontmatterMatch[0].trim(), "yaml"),
     "",
     "</details>",
     "",

--- a/lib/task/create.ts
+++ b/lib/task/create.ts
@@ -195,6 +195,17 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function candidateIdFor(index: number): string {
+  let value = index + 1;
+  let id = '';
+  while (value > 0) {
+    const remainder = (value - 1) % 26;
+    id = `${String.fromCharCode(65 + remainder)}${id}`;
+    value = Math.floor((value - 1) / 26);
+  }
+  return id;
+}
+
 function appendCanonicalRows(content: string, heading: string, columns: readonly string[], rows: readonly (readonly string[])[]): string {
   if (rows.length === 0) return content;
   const table = renderTable(columns, rows);
@@ -231,7 +242,7 @@ function validateRenderedQualification(content: string, candidate: TaskCreateCan
     throw new Error('TASK_CREATE_QUALIFICATION_INVALID: rendered task qualification contract is missing');
   }
   const expectedConstraintIds = candidate.taskInput.constraints.map((_, index) => `C-${index + 1}`);
-  const expectedCandidateIds = candidate.taskInput.alternatives.map((_, index) => String.fromCharCode(65 + index));
+  const expectedCandidateIds = candidate.taskInput.alternatives.map((_, index) => candidateIdFor(index));
   const actualConstraintIds = parsed.qualification.constraints.map((row) => row.constraintId);
   const actualCandidateIds = parsed.qualification.candidates.map((row) => row.candidateId);
   if (JSON.stringify(actualConstraintIds) !== JSON.stringify(expectedConstraintIds)
@@ -298,7 +309,7 @@ function renderTask(params: Readonly<{
     constraintIds[index]!, statement, 'assumption', 'create-task', 'taskInput', 'create-task input', '', ''
   ]));
   content = appendCanonicalRows(content, '候选与否决方案', CANDIDATE_COLUMNS, candidate.taskInput.alternatives.map((statement, index) => [
-    String.fromCharCode(65 + index), statement, 'pending', constraintIds.join(','), 'requires qualification', 'create-task input'
+    candidateIdFor(index), statement, 'pending', constraintIds.join(','), 'requires qualification', 'create-task input'
   ]));
   content = content.replace('- **关联 Issue**：#XXX', '- **关联 Issue**：N/A');
   content = content.replace('- **关联 PR**：#XXX', '- **关联 PR**：N/A');

--- a/lib/task/create.ts
+++ b/lib/task/create.ts
@@ -7,7 +7,7 @@ import { loadShortIdByTaskId, mutateShortIdRegistry } from './short-id.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
 import { readDeliveryDefaults, validateBaseRef, validateRemote } from './delivery-target.ts';
 import { buildUnboundFact, encodePrDeliveryFact } from './pr-delivery-fact.ts';
-import { CANDIDATE_COLUMNS, CONSTRAINT_COLUMNS } from './qualification-audit.ts';
+import { CANDIDATE_COLUMNS, CONSTRAINT_COLUMNS, parseTaskQualification } from './qualification-audit.ts';
 
 const AGENTS = ['claude', 'codex', 'antigravity', 'opencode', 'cursor'] as const;
 const TYPES = ['feature', 'bugfix', 'refactor', 'docs', 'chore'] as const;
@@ -191,11 +191,53 @@ function renderTable(columns: readonly string[], rows: readonly (readonly string
   ].join('\n');
 }
 
-function appendCanonicalRows(content: string, columns: readonly string[], rows: readonly (readonly string[])[]): string {
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function appendCanonicalRows(content: string, heading: string, columns: readonly string[], rows: readonly (readonly string[])[]): string {
   if (rows.length === 0) return content;
   const table = renderTable(columns, rows);
-  const separator = `| ${columns.map(() => '---').join(' | ')} |`;
-  return content.replace(separator, `${separator}\n${table.split('\n').slice(2).join('\n')}`);
+  const [header, separator, ...rowLines] = table.split('\n');
+  const eol = content.includes('\r\n') ? '\r\n' : '\n';
+  const lines = content.split(/\r?\n/);
+  const headingPattern = new RegExp(`^###\\s+${escapeRegExp(heading)}\\s*$`);
+  const sectionStart = lines.findIndex((line) => headingPattern.test(line));
+  if (sectionStart < 0) throw new Error(`TASK_CREATE_QUALIFICATION_INVALID: section '${heading}' is missing`);
+  let sectionEnd = lines.length;
+  for (let index = sectionStart + 1; index < lines.length; index += 1) {
+    if (/^#{2,3}\s+/.test(lines[index]!)) {
+      sectionEnd = index;
+      break;
+    }
+  }
+  const matches: number[] = [];
+  for (let index = sectionStart + 1; index + 1 < sectionEnd; index += 1) {
+    if (lines[index]!.trim() === header && lines[index + 1]!.trim() === separator) matches.push(index);
+  }
+  if (matches.length !== 1) {
+    throw new Error(`TASK_CREATE_QUALIFICATION_INVALID: section '${heading}' must contain exactly one canonical qualification table`);
+  }
+  lines.splice(matches[0]! + 2, 0, ...rowLines);
+  return lines.join(eol);
+}
+
+function validateRenderedQualification(content: string, candidate: TaskCreateCandidateV1): void {
+  const parsed = parseTaskQualification(content);
+  if (!parsed.ok) {
+    throw new Error(`TASK_CREATE_QUALIFICATION_INVALID: ${parsed.code}: ${parsed.message}`);
+  }
+  if (!parsed.qualification.present) {
+    throw new Error('TASK_CREATE_QUALIFICATION_INVALID: rendered task qualification contract is missing');
+  }
+  const expectedConstraintIds = candidate.taskInput.constraints.map((_, index) => `C-${index + 1}`);
+  const expectedCandidateIds = candidate.taskInput.alternatives.map((_, index) => String.fromCharCode(65 + index));
+  const actualConstraintIds = parsed.qualification.constraints.map((row) => row.constraintId);
+  const actualCandidateIds = parsed.qualification.candidates.map((row) => row.candidateId);
+  if (JSON.stringify(actualConstraintIds) !== JSON.stringify(expectedConstraintIds)
+    || JSON.stringify(actualCandidateIds) !== JSON.stringify(expectedCandidateIds)) {
+    throw new Error('TASK_CREATE_QUALIFICATION_INVALID: rendered task qualification rows do not match task input');
+  }
 }
 
 function replaceEmptySubsection(content: string, heading: string, items: readonly string[]): string {
@@ -252,10 +294,10 @@ function renderTask(params: Readonly<{
   ];
   for (const [heading, key] of sections) content = replaceEmptySubsection(content, heading, candidate.taskInput[key]);
   const constraintIds = candidate.taskInput.constraints.map((_, index) => `C-${index + 1}`);
-  content = appendCanonicalRows(content, CONSTRAINT_COLUMNS, candidate.taskInput.constraints.map((statement, index) => [
+  content = appendCanonicalRows(content, '约束', CONSTRAINT_COLUMNS, candidate.taskInput.constraints.map((statement, index) => [
     constraintIds[index]!, statement, 'assumption', 'create-task', 'taskInput', 'create-task input', '', ''
   ]));
-  content = appendCanonicalRows(content, CANDIDATE_COLUMNS, candidate.taskInput.alternatives.map((statement, index) => [
+  content = appendCanonicalRows(content, '候选与否决方案', CANDIDATE_COLUMNS, candidate.taskInput.alternatives.map((statement, index) => [
     String.fromCharCode(65 + index), statement, 'pending', constraintIds.join(','), 'requires qualification', 'create-task input'
   ]));
   content = content.replace('- **关联 Issue**：#XXX', '- **关联 Issue**：N/A');
@@ -365,7 +407,6 @@ function createLocalTask(value: unknown, options: LocalTaskCreateOptions): Local
 
   return withCreateLock(repoRoot, workspaceRoot, () => {
     if (fs.existsSync(receipts)) assertRealDirectory(receipts, 'TASK_CREATE_RECEIPT_INVALID');
-    else fs.mkdirSync(receipts, { mode: 0o700 });
     const receiptPath = path.join(receipts, `${keyDigest}.json`);
     if (fs.existsSync(receiptPath)) {
       const stat = fs.lstatSync(receiptPath);
@@ -380,6 +421,7 @@ function createLocalTask(value: unknown, options: LocalTaskCreateOptions): Local
 
     const recovered = recoverPublishedTask(activeRoot, repoRoot, keyDigest, candidateDigest);
     if (recovered) {
+      ensureRealDirectory(receipts, 'TASK_CREATE_RECEIPT_INVALID');
       writeReceipt(receiptPath, {
         version: 1, candidateDigest, taskId: recovered.taskId, shortId: recovered.shortId, status: 'recovered'
       });
@@ -401,6 +443,8 @@ function createLocalTask(value: unknown, options: LocalTaskCreateOptions): Local
       template: fs.readFileSync(templatePath, 'utf8'), candidate, taskId, project: projectConfig.project, delivery: projectConfig.delivery, timestamp,
       agentInfraVersion, keyDigest, candidateDigest
     });
+    validateRenderedQualification(rendered, candidate);
+    ensureRealDirectory(receipts, 'TASK_CREATE_RECEIPT_INVALID');
     const temporary = path.join(workspaceRoot, `.task-create.tmp.${process.pid}.${randomUUID()}`);
     fs.mkdirSync(temporary, { mode: 0o700 });
     fs.writeFileSync(path.join(temporary, 'task.md'), rendered, { flag: 'wx', mode: 0o600 });

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -119,6 +119,12 @@ async function cmdSync(): Promise<void> {
     replacements
   );
   ok('Updated .agents/scripts/lib/agent-infra-package.js');
+  renderFile(
+    path.join(templateDir, '.agents', 'scripts', 'package.json'),
+    path.join('.agents', 'scripts', 'package.json'),
+    replacements
+  );
+  ok('Updated .agents/scripts/package.json');
   const added = {
     managed: workflowPlan.projectAssets.registry.managed.filter(
       (entry) => !currentRegistry.managed.includes(entry)

--- a/templates/.agents/scripts/package.json
+++ b/templates/.agents/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/e2e/core/validate-artifact-helpers.ts
+++ b/tests/e2e/core/validate-artifact-helpers.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import { verifyInProcess } from "../../../lib/task/verification-engine.ts";
 import { buildBoundFact, buildSkippedFact, buildUnboundFact, encodePrDeliveryFact } from "../../../lib/task/pr-delivery-fact.ts";
 import { parseTypedTaskFrontmatter } from "../../../lib/task/frontmatter.ts";
+import { CONTROL_MARKER_PATTERN, renderSafeCodeFence, sanitizeMarkdownDocument } from "../../../lib/platform/comment-safety.ts";
 
 import {
   filePath,
@@ -273,10 +274,12 @@ function buildArtifactMarker(taskId: string, artifactFile: string) {
 }
 
 function buildArtifactComment(taskId: string, artifactFile: string, title: string, body: string) {
+  const sanitized = sanitizeMarkdownDocument(body.trim(), { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  if (!sanitized.ok) throw new Error(sanitized.error.message);
   return loadFixture("artifact-comment.md", {
     MARKER: buildArtifactMarker(taskId, artifactFile),
     TITLE: title,
-    BODY: body.trim(),
+    BODY: sanitized.value,
     TASK_ID: taskId,
     AGENT: "codex"
   });
@@ -290,16 +293,16 @@ function buildTaskComment(taskId: string, taskContent: string, options: TaskComm
     ? [
         `<details><summary>${summaryText}</summary>`,
         "",
-        "```yaml",
-        match[0].trim(),
-        "```",
+        renderSafeCodeFence(match[0].trim(), "yaml"),
         "",
         "</details>"
       ].join("\n")
     : "";
+  const sanitizedBody = sanitizeMarkdownDocument(body, { reservedMarkers: [CONTROL_MARKER_PATTERN] });
+  if (!sanitizedBody.ok) throw new Error(sanitizedBody.error.message);
   const renderedBody = options.rawBody
     ? taskContent.trim()
-    : [detailsBlock, body].filter(Boolean).join("\n\n");
+    : [detailsBlock, sanitizedBody.value].filter(Boolean).join("\n\n");
 
   return loadFixture("task-comment.md", {
     TASK_ID: taskId,

--- a/tests/e2e/core/validate-artifact-platform-sync.test.ts
+++ b/tests/e2e/core/validate-artifact-platform-sync.test.ts
@@ -163,6 +163,60 @@ test("requirements sync converges before the complete-task platform gate", async
   });
 });
 
+test("platform-sync compares artifact comments after the same sanitization used by comment sync", async () => {
+  await withTempRoot("agent-infra-platform-sync-sanitized-artifact-", async (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const taskContent = buildTaskContent({ issue_number: "65" });
+    const artifactContent = [
+      "<!-- artifact-context:TASK-20260328-000001:code:1 -->",
+      "# 实现报告",
+      "",
+      "## 结果",
+      "<!-- artifact-section:code:result -->",
+      "通过"
+    ].join("\n");
+    write(path.join(ctx.taskDir, "task.md"), taskContent);
+    write(path.join(ctx.taskDir, "code.md"), artifactContent);
+    writeJson(ctx.issuePath, buildIssuePayload());
+    writeJson(ctx.commentsPath, [
+      { body: buildArtifactComment(taskId, "code.md", "实现报告", artifactContent) },
+      { body: buildTaskComment(taskId, taskContent) }
+    ]);
+
+    const result = await runValidatorWithFakeGh(["check", "platform-sync", ctx.taskDir, "code.md", "--skill", "code-task"], ctx, {
+      GH_FAKE_ISSUE_PATH: ctx.issuePath,
+      GH_FAKE_COMMENTS_PATH: ctx.commentsPath
+    });
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+  });
+});
+
+test("platform-sync compares task comments after the same sanitization used by comment sync", async () => {
+  await withTempRoot("agent-infra-platform-sync-sanitized-task-", async (tempRoot) => {
+    const ctx = setupPlatformSyncEnv(tempRoot);
+    const taskContent = `${buildTaskContent({ issue_number: "65" })}\n\n<!-- sync-pr:TASK-20260328-000001:summary -->`;
+    write(path.join(ctx.taskDir, "task.md"), taskContent);
+    write(path.join(ctx.taskDir, "code.md"), "# 实现报告\n\n通过");
+    writeJson(ctx.issuePath, buildIssuePayload());
+    writeJson(ctx.commentsPath, [
+      { body: buildArtifactComment(taskId, "code.md", "实现报告", "# 实现报告\n\n通过") },
+      { body: buildTaskComment(taskId, taskContent) }
+    ]);
+
+    const result = await runValidatorWithFakeGh(
+      ["check", "platform-sync", ctx.taskDir, "code.md", "--skill", "code-task"],
+      ctx,
+      {
+        GH_FAKE_ISSUE_PATH: ctx.issuePath,
+        GH_FAKE_COMMENTS_PATH: ctx.commentsPath
+      }
+    );
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assertPayloadStatus(result, { type: "platform-sync", status: "pass" });
+  });
+});
+
 const implementSyncCases = [
   {
     name: "validate-artifact gate passes when synced artifact and task comments match local files",

--- a/tests/integration/cli/cli.test.ts
+++ b/tests/integration/cli/cli.test.ts
@@ -217,6 +217,11 @@ test("agent-infra init generates seed files in a temp directory", () => {
     assert.ok(!config.source, "consumer projects should not have source: self");
     assert.match(output, /npm install -g @fitlab-ai\/agent-infra/);
     assert.ok(fs.existsSync(path.join(tmpDir, ".agents/scripts/lib/agent-infra-package.js")));
+    assert.equal(
+      JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents/scripts/package.json"), "utf8")).type,
+      "module",
+      ".agents/scripts should be an ESM package boundary"
+    );
     assert.deepEqual(config.sandbox, {
       engine: DEFAULT_SANDBOX_ENGINE ? { [CURRENT_PLATFORM]: DEFAULT_SANDBOX_ENGINE } : null,
       runtimes: ["node22"],
@@ -559,6 +564,34 @@ test("installed sync-templates.js executes inside a type=module project", () => 
   }
 });
 
+test("installed package helper executes inside a CommonJS project", () => {
+  const tmpDir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-cjs-helper-")));
+
+  try {
+    execFileSync(process.execPath, cliArgs("init"), {
+      cwd: tmpDir,
+      input: "cjsproj\ncjsorg\n\n" + ENGINE_NL + "\n\n\n",
+      stdio: "pipe"
+    });
+
+    const helper = path.join(tmpDir, ".agents", "scripts", "lib", "agent-infra-package.js");
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        "import { formatAgentInfraPackageError } from " + JSON.stringify(pathToFileURL(helper).href) + "; console.log(typeof formatAgentInfraPackageError);"
+      ],
+      { cwd: tmpDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "function");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("GitHub init full sync installs lifecycle workflows in the downstream project", async () => {
   const tmpDir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "ai-collab-github-lifecycle-init-")));
 
@@ -732,6 +765,11 @@ test("agent-infra sync refreshes seed files and syncs file registry", async () =
     assert.doesNotMatch(skill, /\{\{org\}\}/);
     assert.ok(
       fs.existsSync(path.join(tmpDir, ".agents", "skills", "update-agent-infra", "scripts", "sync-templates.js"))
+    );
+    assert.equal(
+      JSON.parse(fs.readFileSync(path.join(tmpDir, ".agents", "scripts", "package.json"), "utf8")).type,
+      "module",
+      ".agents/scripts should be refreshed as an ESM package boundary"
     );
     assert.ok(
       fs.existsSync(path.join(tmpDir, ".agents", "skills", "update-agent-infra", "scripts", "sync-templates.cjs"))

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -7,6 +7,8 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { canonicalTaskCreateCandidate, validateTaskCreateCandidate } from '../../../lib/task/create.ts';
+import { buildLifecycleFacts, recommendNext } from '../../../lib/task/capabilities.ts';
+import { parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
 
 const internalCli = path.resolve('bin/internal-cli.ts');
 const hostEnvironment = Object.fromEntries(
@@ -41,6 +43,18 @@ function candidate() {
     taskInput: {
       sources: ['Integration test'], facts: [], constraints: [], decisions: [], alternatives: [],
       acceptanceCriteria: ['A task is persisted.'], openQuestions: []
+    }
+  };
+}
+
+function qualificationCandidate() {
+  return {
+    ...candidate(),
+    title: 'Create a qualification-aware task through internal CLI',
+    taskInput: {
+      ...candidate().taskInput,
+      constraints: ['Keep lifecycle routing deterministic.'],
+      alternatives: ['Use the canonical task renderer.', 'Add a second qualification writer.']
     }
   };
 }
@@ -146,6 +160,55 @@ test('task-create internal CLI persists a task and replays as no-op', () => {
     const replayed = JSON.parse(second.stdout);
     assert.equal(replayed.status, 'no-op');
     assert.equal(replayed.task.id, applied.task.id);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-create internal CLI keeps qualification tables separate and routes lifecycle facts', () => {
+  const root = fixture();
+  const input = path.join(root, 'candidate.json');
+  fs.writeFileSync(input, JSON.stringify(qualificationCandidate()));
+  try {
+    const result = spawnSync(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
+      cwd: root, encoding: 'utf8', env: hostEnvironment
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const taskId = JSON.parse(result.stdout).task.id as string;
+    const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+    const content = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+    const qualification = parseTaskQualification(content);
+    assert.equal(qualification.ok, true);
+    if (!qualification.ok) return;
+    assert.deepEqual(qualification.qualification.constraints.map((row) => row.constraintId), ['C-1']);
+    assert.deepEqual(qualification.qualification.candidates.map((row) => row.candidateId), ['A', 'B']);
+    const facts = buildLifecycleFacts(taskDir, content);
+    assert.equal(facts.ok, true);
+    if (facts.ok) assert.equal(recommendNext(facts.facts).action, 'analysis');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-create internal CLI rejects an invalid qualification template before active publication', () => {
+  const root = fixture();
+  const input = path.join(root, 'candidate.json');
+  fs.writeFileSync(input, JSON.stringify(qualificationCandidate()));
+  const templatePath = path.join(root, '.agents', 'templates', 'task.md');
+  const template = fs.readFileSync(templatePath, 'utf8');
+  fs.writeFileSync(templatePath, template.replace(
+    '| candidate_id | statement | status | constraint_ids | impact | evidence |',
+    '| candidate_id | statement | status | constraint_ids | impact |'
+  ));
+  try {
+    const result = spawnSync(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
+      cwd: root, encoding: 'utf8', env: hostEnvironment
+    });
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.equal(JSON.parse(result.stdout).error.code, 'TASK_CREATE_QUALIFICATION_INVALID');
+    assert.deepEqual(fs.readdirSync(path.join(root, '.agents', 'workspace', 'active')), []);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json')), false);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', '.task-create')), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/integration/cli/task-create.test.ts
+++ b/tests/integration/cli/task-create.test.ts
@@ -47,14 +47,16 @@ function candidate() {
   };
 }
 
-function qualificationCandidate() {
+function qualificationCandidate(alternativeCount = 2) {
+  const base = candidate();
   return {
-    ...candidate(),
+    ...base,
     title: 'Create a qualification-aware task through internal CLI',
     taskInput: {
-      ...candidate().taskInput,
+      ...base.taskInput,
       constraints: ['Keep lifecycle routing deterministic.'],
-      alternatives: ['Use the canonical task renderer.', 'Add a second qualification writer.']
+      alternatives: Array.from({ length: alternativeCount }, (_, index) =>
+        index === 0 ? 'Use the canonical task renderer.' : index === 1 ? 'Add a second qualification writer.' : `Candidate alternative ${index + 1}`)
     }
   };
 }
@@ -187,6 +189,36 @@ test('task-create internal CLI keeps qualification tables separate and routes li
     if (facts.ok) assert.equal(recommendNext(facts.facts).action, 'analysis');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('task-create internal CLI parses and routes 27 and 50 qualification candidates', () => {
+  for (const alternativeCount of [27, 50]) {
+    const root = fixture();
+    const input = path.join(root, 'candidate.json');
+    fs.writeFileSync(input, JSON.stringify(qualificationCandidate(alternativeCount)));
+    try {
+      const result = spawnSync(process.execPath, ['--experimental-strip-types', '--no-warnings', internalCli, 'task-create', '--input', input], {
+        cwd: root, encoding: 'utf8', env: hostEnvironment
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const taskId = JSON.parse(result.stdout).task.id as string;
+      const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+      const content = fs.readFileSync(path.join(taskDir, 'task.md'), 'utf8');
+      const qualification = parseTaskQualification(content);
+      assert.equal(qualification.ok, true);
+      if (!qualification.ok) continue;
+      const ids = qualification.qualification.candidates.map((row) => row.candidateId);
+      assert.equal(ids.length, alternativeCount);
+      assert.equal(new Set(ids).size, alternativeCount);
+      assert.equal(ids[26], 'AA');
+      if (alternativeCount === 50) assert.equal(ids[49], 'AX');
+      const facts = buildLifecycleFacts(taskDir, content);
+      assert.equal(facts.ok, true);
+      if (facts.ok) assert.equal(recommendNext(facts.facts).action, 'analysis');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   }
 });
 

--- a/tests/unit/task/create.test.ts
+++ b/tests/unit/task/create.test.ts
@@ -192,6 +192,33 @@ test('local task creation keeps constraint and candidate qualification tables se
   }
 });
 
+test('local task creation supports 50 qualification candidates with unique parser-safe ids', () => {
+  const root = fixture();
+  const wideCandidate: TaskCreateCandidateV1 = {
+    ...qualificationCandidate,
+    taskInput: {
+      ...qualificationCandidate.taskInput,
+      alternatives: Array.from({ length: 50 }, (_, index) => `Candidate alternative ${index + 1}`)
+    }
+  };
+  try {
+    const result = createLocalTask(wideCandidate, { repoRoot: root, agentInfraVersion: 'v0.9.5' });
+    const content = fs.readFileSync(path.join(root, '.agents', 'workspace', 'active', result.task.id, 'task.md'), 'utf8');
+    const parsed = parseTaskQualification(content);
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    const ids = parsed.qualification.candidates.map((row) => row.candidateId);
+    assert.equal(ids.length, 50);
+    assert.equal(ids[0], 'A');
+    assert.equal(ids[25], 'Z');
+    assert.equal(ids[26], 'AA');
+    assert.equal(ids[49], 'AX');
+    assert.equal(new Set(ids).size, 50);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('local task creation rejects an invalid qualification template before publishing state', () => {
   const root = fixture();
   try {

--- a/tests/unit/task/create.test.ts
+++ b/tests/unit/task/create.test.ts
@@ -12,6 +12,7 @@ import {
   validateTaskCreateCandidate,
   type TaskCreateCandidateV1
 } from '../../../lib/task/create.ts';
+import { parseTaskQualification } from '../../../lib/task/qualification-audit.ts';
 import {
   createTask,
   parseTaskCreateResult,
@@ -39,6 +40,16 @@ const candidate: TaskCreateCandidateV1 = {
     alternatives: [],
     acceptanceCriteria: ['The task is visible on the host.'],
     openQuestions: []
+  }
+};
+
+const qualificationCandidate: TaskCreateCandidateV1 = {
+  ...candidate,
+  title: 'Persist qualified sandbox-created tasks',
+  taskInput: {
+    ...candidate.taskInput,
+    constraints: ['Keep lifecycle routing deterministic.'],
+    alternatives: ['Use the canonical task renderer.', 'Add a second qualification writer.']
   }
 };
 
@@ -151,6 +162,52 @@ test('local task creation is idempotent and rejects key reuse with changed conte
       () => createLocalTask({ ...candidate, title: 'Changed title' }, options),
       /TASK_CREATE_IDEMPOTENCY_CONFLICT/
     );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('local task creation keeps constraint and candidate qualification tables separate', () => {
+  const root = fixture();
+  try {
+    const result = createLocalTask(qualificationCandidate, {
+      repoRoot: root,
+      now: () => new Date(2026, 7, 13, 1, 2, 3),
+      agentInfraVersion: 'v0.9.5'
+    });
+    const content = fs.readFileSync(path.join(root, '.agents', 'workspace', 'active', result.task.id, 'task.md'), 'utf8');
+    const parsed = parseTaskQualification(content);
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.qualification.present, true);
+    assert.deepEqual(parsed.qualification.constraints.map((row) => [row.constraintId, row.statement]), [
+      ['C-1', 'Keep lifecycle routing deterministic.']
+    ]);
+    assert.deepEqual(parsed.qualification.candidates.map((row) => [row.candidateId, row.statement]), [
+      ['A', 'Use the canonical task renderer.'],
+      ['B', 'Add a second qualification writer.']
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('local task creation rejects an invalid qualification template before publishing state', () => {
+  const root = fixture();
+  try {
+    const templatePath = path.join(root, '.agents', 'templates', 'task.md');
+    const template = fs.readFileSync(templatePath, 'utf8');
+    fs.writeFileSync(templatePath, template.replace(
+      '| candidate_id | statement | status | constraint_ids | impact | evidence |',
+      '| candidate_id | statement | status | constraint_ids | impact |'
+    ));
+    assert.throws(
+      () => createLocalTask(qualificationCandidate, { repoRoot: root, agentInfraVersion: 'v0.9.5' }),
+      /TASK_CREATE_QUALIFICATION_INVALID/
+    );
+    assert.deepEqual(fs.readdirSync(path.join(root, '.agents', 'workspace', 'active')), []);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', 'active', '.short-ids.json')), false);
+    assert.equal(fs.existsSync(path.join(root, '.agents', 'workspace', '.task-create')), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/templates/templates.test.ts
+++ b/tests/unit/templates/templates.test.ts
@@ -95,6 +95,7 @@ test("required template files were migrated into templates/", () => {
     "templates/.agents/skills/init-milestones/SKILL.en.md",
     "templates/.agents/skills/init-milestones/SKILL.zh-CN.md",
     "templates/.agents/skills/update-agent-infra/SKILL.en.md",
+    "templates/.agents/scripts/package.json",
     "templates/.agents/skills/update-agent-infra/scripts/package.json",
     "templates/.agents/skills/update-agent-infra/scripts/sync-templates.js",
     "templates/.git-hooks/check-large-files.cjs",


### PR DESCRIPTION
## 摘要

修复 `task-create` 资格表渲染和候选方案 ID 生成问题，确保新任务可被资格解析器读取并进入生命周期路由。

## 主要变更

- 将约束表和候选方案表的行追加限制在各自的 Markdown section，并在发布 active 任务前校验渲染后的资格契约。
- 统一候选 ID 生成规则，支持当前 50 项输入上限的 `A-Z`、`AA-AX`，避免第 27 项生成非法的 `[`。
- 保留并验证 platform-sync 的安全 Markdown 规范化边界，确保任务和 artifact 评论比较与同步使用同一安全渲染规则。
- 按当前契约直接切换，不新增历史 schema 兼容层。

## 验证

- `npm run build`
- `npm run typecheck`
- `npm run test:smoke`：1640/1640 通过
- `npm run test:core`：2729 通过、6 个按平台跳过
- platform-sync 专项：53 通过、1 个 Linux 条件跳过
- `npm test`：3058 通过、0 失败、7 个按平台跳过（共 3065 tests）
- `git diff --check`

## 审查

- 技术方案审查 Round 1：Approved。
- 代码审查 Round 1 的 CD-1 已修复：候选 ID 上界覆盖不足。
- 代码审查 Round 2：Approved；0 blocker、0 major、0 minor、0 manual-validation items。
- 最新审查 checkpoint：`31943d1e5f61f00758d4cd004defc0fad9a73ae1`。

## 未覆盖验证

Windows/macOS 实机和真实 GitHub 页面视觉呈现仍需维护者按需验证；本地跨平台守卫、平台同步安全边界和完整回归已覆盖。

Closes #987

Generated with AI assistance
