### PR TITLE
fix(lifecycle): 为遗留 lifecycle started 状态提供安全恢复


### DIFF
--- a/lib/agent-clients/adapters/codex-lifecycle/store.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/store.ts
@@ -43,9 +43,21 @@ type ActiveCodexLifecycleEvidenceQuery = Readonly<{
 const LOCK_RETRY_MS = 10;
 const LOCK_TIMEOUT_MS = 1_000;
 const LOCK_STALE_MS = 30_000;
+const RECOVERY_CONSUMER_RE = /^lifecycle-recovery:([^:\r\n]+):([^:\r\n]+)$/u;
 
 function digest(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function isRecoveryConsumer(value: string): boolean {
+  return RECOVERY_CONSUMER_RE.test(value);
+}
+
+function recoveryConsumer(taskId: string, receiptId: string): string {
+  if (!/^[^:\r\n]+$/u.test(taskId) || !/^[^:\r\n]+$/u.test(receiptId)) {
+    throw new Error('Codex lifecycle recovery claim identity is invalid');
+  }
+  return `lifecycle-recovery:${taskId}:${receiptId}`;
 }
 
 function readRecord(file: string): StoredCodexLifecycle {
@@ -254,7 +266,7 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
     return readRecord(matches[0]!);
   }
 
-  function consume(
+  function consumeInternal(
     childThreadId: string,
     consumer: string,
     expectedHookDefinitionHash?: string
@@ -292,6 +304,31 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
     });
   }
 
+  function consume(
+    childThreadId: string,
+    consumer: string,
+    expectedHookDefinitionHash?: string
+  ): StoredCodexLifecycle {
+    if (!consumer.trim()) throw new Error('Codex lifecycle consumer is required');
+    if (consumer.startsWith('lifecycle-recovery:')) {
+      throw new Error('Codex lifecycle recovery claims require claimRecovery');
+    }
+    return consumeInternal(childThreadId, consumer, expectedHookDefinitionHash);
+  }
+
+  function claimRecovery(
+    childThreadId: string,
+    taskId: string,
+    receiptId: string,
+    expectedHookDefinitionHash?: string
+  ): StoredCodexLifecycle {
+    return consumeInternal(
+      childThreadId,
+      recoveryConsumer(taskId, receiptId),
+      expectedHookDefinitionHash
+    );
+  }
+
   function releaseRecovery(childThreadId: string, consumer: string): boolean {
     if (!/^lifecycle-recovery:[^:\r\n]+:[^:\r\n]+$/.test(consumer)) return false;
     return withWriteLock(() => {
@@ -311,7 +348,7 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
       for (const file of recordFiles(root)) {
         const current = readRecord(file);
         if (current.updatedAt >= cutoff) continue;
-        if (current.consumer?.startsWith('lifecycle-recovery:')) continue;
+        if (current.consumer && isRecoveryConsumer(current.consumer)) continue;
         if (current.consumer || ['invalid', 'expired', 'stop-ready'].includes(current.state.status)) {
           fs.unlinkSync(file);
           changed += 1;
@@ -331,7 +368,7 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
     });
   }
 
-  return Object.freeze({ root, apply, applyToSpawn, consume, releaseRecovery, expireBefore, findByParent, read });
+  return Object.freeze({ root, apply, applyToSpawn, consume, claimRecovery, releaseRecovery, expireBefore, findByParent, read });
 }
 
 export { createCodexLifecycleStore, hasActiveCodexLifecycleEvidence };

--- a/lib/agent-clients/adapters/codex-lifecycle/store.ts
+++ b/lib/agent-clients/adapters/codex-lifecycle/store.ts
@@ -249,7 +249,8 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
 
   function read(childThreadId: string): StoredCodexLifecycle {
     const matches = findByChild(childThreadId);
-    if (matches.length !== 1) throw new Error(`Codex lifecycle child '${childThreadId}' was not found uniquely`);
+    if (matches.length === 0) throw new Error(`Codex lifecycle child '${childThreadId}' was not found uniquely`);
+    if (matches.length > 1) throw new Error(`Codex lifecycle child '${childThreadId}' is ambiguous`);
     return readRecord(matches[0]!);
   }
 
@@ -291,12 +292,26 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
     });
   }
 
+  function releaseRecovery(childThreadId: string, consumer: string): boolean {
+    if (!/^lifecycle-recovery:[^:\r\n]+:[^:\r\n]+$/.test(consumer)) return false;
+    return withWriteLock(() => {
+      const matches = findByChild(childThreadId);
+      if (matches.length !== 1) return false;
+      const file = matches[0]!;
+      const current = readRecord(file);
+      if (current.state.status !== 'stop-ready' || current.consumer !== consumer || !current.consumedAt) return false;
+      fs.unlinkSync(file);
+      return true;
+    });
+  }
+
   function expireBefore(cutoff: string): number {
     return withWriteLock(() => {
       let changed = 0;
       for (const file of recordFiles(root)) {
         const current = readRecord(file);
         if (current.updatedAt >= cutoff) continue;
+        if (current.consumer?.startsWith('lifecycle-recovery:')) continue;
         if (current.consumer || ['invalid', 'expired', 'stop-ready'].includes(current.state.status)) {
           fs.unlinkSync(file);
           changed += 1;
@@ -316,7 +331,7 @@ function createCodexLifecycleStore(options: CodexLifecycleStoreOptions) {
     });
   }
 
-  return Object.freeze({ root, apply, applyToSpawn, consume, expireBefore, findByParent, read });
+  return Object.freeze({ root, apply, applyToSpawn, consume, releaseRecovery, expireBefore, findByParent, read });
 }
 
 export { createCodexLifecycleStore, hasActiveCodexLifecycleEvidence };

--- a/lib/fs/durable-write.ts
+++ b/lib/fs/durable-write.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 export function fsyncDirectory(directory: string): void {
+  if (process.platform === 'win32') return;
   const descriptor = fs.openSync(directory, 'r');
   try { fs.fsyncSync(descriptor); } finally { fs.closeSync(descriptor); }
 }

--- a/lib/internal/task-lifecycle.ts
+++ b/lib/internal/task-lifecycle.ts
@@ -7,9 +7,10 @@ import {
 import { lifecycleIntentCatalog } from '../task/lifecycle.ts';
 import { detectRepoRoot, resolveTaskRef } from '../task/resolve-ref.ts';
 import type { TaskLifecycleResult } from '../task/lifecycle.ts';
+import type { LifecycleRecoveryResult } from '../task/lifecycle-recovery.ts';
 import { ensureInternalHandlerRoute, internalHandlerRoute } from './cli-route-inventory.ts';
 
-const USAGE = `Usage: agent-infra-internal task-lifecycle <N | TASK-id> <intent> --agent <agent> [intent flags] [--dry-run]\n\nIntents: ${lifecycleIntentCatalog.join(', ')}\nOverride: --override-ticket <ticket> --override-target <target> --override-scope <scope>\n`;
+const USAGE = `Usage: agent-infra-internal task-lifecycle <N | TASK-id> <intent> --agent <agent> [intent flags] [--dry-run]\n\nIntents: ${lifecycleIntentCatalog.join(', ')}\nrecover-started: --stage <stage> --round <round> --artifact <artifact> --reason <reason>\nOverride: --override-ticket <ticket> --override-target <target> --override-scope <scope>\n`;
 
 function usageFailure(message: string): void {
   process.stdout.write(`${JSON.stringify({ status: 'failed', changed: false, error: { code: 'LIFECYCLE_PAYLOAD_INVALID', message } })}\n`);
@@ -61,9 +62,9 @@ async function taskLifecycle(args: string[] = []): Promise<void> {
   const result = await dispatchTaskControlOperation(
     createDirectHostExecutionContext({ repoRoot }),
     operation
-  ) as TaskLifecycleResult & { humanOverride?: unknown };
+  ) as (TaskLifecycleResult | LifecycleRecoveryResult) & { humanOverride?: unknown };
   process.stdout.write(`${JSON.stringify(result)}\n`);
-  if (result.status === 'failed') process.exitCode = 1;
+  if (result.status === 'failed' || result.status === 'owner-unknown' || result.status === 'conflict') process.exitCode = 1;
 }
 
 export { taskLifecycle };

--- a/lib/sandbox/control/protocol.ts
+++ b/lib/sandbox/control/protocol.ts
@@ -131,6 +131,11 @@ export type SandboxControlResponse = Readonly<{
   outputState?: 'available' | 'unavailable';
   payload?: SandboxControlPayloadReference | null;
 }>;
+export type SandboxControlRecoveryWarning = Readonly<{
+  code: string;
+  message: string;
+  action: string;
+}>;
 export type SandboxControlStatus = Readonly<{
   version: 3; generation: string; broker: ProcessIdentity & { brokerId: string };
   state: 'starting' | 'healthy' | 'busy' | 'parked'; reasonCode: string | null;

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -597,7 +597,7 @@ function readCommittedCriticalPhases(manifest: SandboxControlManifest, requestId
   });
 }
 
-function recoveryResponse(
+export function recoveryResponse(
   manifest: SandboxControlManifest,
   manifestPath: string,
   request: SandboxControlRequest,

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -12,6 +12,7 @@ import {
   SANDBOX_CONTROL_MAX_RESPONSE_BYTES,
   SANDBOX_CONTROL_MAX_TERMINAL_RECORD_BYTES,
   type SandboxControlManifest,
+  type SandboxControlRecoveryWarning,
   type SandboxControlRequest,
   type SandboxControlResponse,
   type SandboxControlTimingPolicy
@@ -369,11 +370,12 @@ function outputMatchesEvidence(output: string, bytes: number, sha256: string): b
     && createHash('sha256').update(output, 'utf8').digest('hex') === sha256;
 }
 
-function genericRecoveryResponse(
+export function genericRecoveryResponse(
   request: SandboxControlRequest,
   exitCode: number,
   payload: ReturnType<typeof readSandboxControlPayload> | null,
-  cause: 'publish' | 'recovery' = 'recovery'
+  cause: 'publish' | 'recovery' = 'recovery',
+  warning: SandboxControlRecoveryWarning | null = null
 ): SandboxControlResponse {
   const outputUnavailable = request.family === 'task-create' && !payload;
   return {
@@ -382,9 +384,11 @@ function genericRecoveryResponse(
     phase: 'completed',
     exitCode,
     stdout: outputUnavailable ? `${JSON.stringify(taskCreateOutputUnavailableResult(request.id))}\n` : '',
-    stderr: payload ? '' : cause === 'publish'
-      ? 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: output payload was not retained\n'
-      : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
+    stderr: payload ? '' : warning
+      ? `${warning.code}: ${warning.message}\nAction: ${warning.action}\n`
+      : cause === 'publish'
+        ? 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: output payload was not retained\n'
+        : 'SANDBOX_CONTROL_OUTPUT_UNAVAILABLE: broker restarted after executor completion\n',
     error: null,
     outputState: payload ? 'available' : 'unavailable',
     payload: payload ? payloadReference(payload) : null
@@ -653,7 +657,7 @@ function recoveryResponse(
     if (finalization?.status !== 'matched') return null;
     return finalization.response ?? null;
   }
-  return genericRecoveryResponse(request, evidence.exitCode, payload);
+  return genericRecoveryResponse(request, evidence.exitCode, payload, 'recovery', terminalResult.warning ?? null);
 }
 
 function terminalMatchesEvidence(
@@ -697,7 +701,7 @@ function terminalMatchesEvidence(
   if (response.outputState === 'unavailable') {
     const causes = ['recovery', 'publish'] as const;
     const valid = causes.some((cause) => JSON.stringify(response)
-      === JSON.stringify(genericRecoveryResponse(request, evidence.exitCode, null, cause)));
+      === JSON.stringify(genericRecoveryResponse(request, evidence.exitCode, null, cause, terminalResult?.warning ?? null)));
     return { valid, payloadReferenced: false };
   }
   return {
@@ -716,7 +720,7 @@ function publishExecutionResult(
   brokerOwns: () => boolean
 ): boolean {
   const normalized = sanitizeSandboxControlResult(manifest, result);
-  writeSandboxControlTerminalResult(manifest, {
+  const terminalResult = writeSandboxControlTerminalResult(manifest, {
     id: request.id,
     family: request.family,
     operation: operationKey(request, normalized.stdout)
@@ -753,7 +757,7 @@ function publishExecutionResult(
       } catch {
         payload = null;
       }
-      terminal = genericRecoveryResponse(request, normalized.exitCode, payload, 'publish');
+      terminal = genericRecoveryResponse(request, normalized.exitCode, payload, 'publish', terminalResult.warning ?? null);
     }
   }
   if (!brokerOwns()) return false;

--- a/lib/sandbox/control/server.ts
+++ b/lib/sandbox/control/server.ts
@@ -62,6 +62,7 @@ import {
   SANDBOX_CONTROL_REQUIRED_COMPLETION_PHASES
 } from '../../task/control-recovery.ts';
 import { readRun } from '../../task/orchestration.ts';
+import { readLifecycleRecoveryDomainEvidence } from '../../task/lifecycle-recovery.ts';
 import { captureRepositorySnapshot } from '../../task/workspace-snapshot.ts';
 import { parseTypedTaskFrontmatter } from '../../task/frontmatter.ts';
 import { readLifecycleJournalEvidence } from '../../task/lifecycle.ts';
@@ -504,6 +505,21 @@ function readRecoveryDomain(
   }
 
   if (operation.family === 'task-lifecycle') {
+    if (operation.intent === 'recover-started') {
+      try {
+        if (!('args' in request)) return { domain: null };
+        const parsed = parseTaskControlOperation('task-lifecycle', request.args);
+        if (parsed.family !== 'task-lifecycle' || parsed.request.intent !== 'recover-started') {
+          return { domain: null };
+        }
+        return {
+          domain: readLifecycleRecoveryDomainEvidence(manifest.repoRoot, parsed.request, terminalResult),
+          journal: readLifecycleJournalEvidence(manifest.repoRoot, taskRef!)
+        };
+      } catch {
+        return { domain: null };
+      }
+    }
     if (!taskRef || !terminalResult.targetState) return { domain: null };
     const journal = readLifecycleJournalEvidence(manifest.repoRoot, taskRef);
     try {

--- a/lib/sandbox/control/state.ts
+++ b/lib/sandbox/control/state.ts
@@ -1,5 +1,6 @@
 import { isCompletionEvidence, type CleanCompletionEvidence } from '../../task/orchestration.ts';
 import { parseControlOutput } from '../../task/control-recovery.ts';
+import { isRecoveryWarning } from '../../task/recovery-warning.ts';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -117,15 +118,6 @@ export type SandboxControlTerminalResult = Readonly<{
   warning?: SandboxControlRecoveryWarning | null;
 }>;
 
-function isSandboxControlRecoveryWarning(value: unknown): value is SandboxControlRecoveryWarning {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const warning = value as Record<string, unknown>;
-  return Object.keys(warning).sort().join(',') === 'action,code,message'
-    && [warning.code, warning.message, warning.action].every((field) => (
-      typeof field === 'string' && field.length > 0 && field.trim() === field && !/[\r\n]/u.test(field)
-    ));
-}
-
 export function terminalResultPath(manifest: SandboxControlManifest, requestId: string): string {
   if (!/^[a-f0-9-]{16,64}$/u.test(requestId)) throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
   return path.join(manifest.processingDir, requestId, 'terminal-result.json');
@@ -141,7 +133,7 @@ export function createSandboxControlTerminalResult(
     ? nested.run as Record<string, unknown> : null;
   const rawCompletion = nested.completionEvidence ?? run?.completionEvidence;
   const operation = request.operation ?? (typeof nested.intent === 'string' ? nested.intent : null) ?? '';
-  const warning = isSandboxControlRecoveryWarning(nested.warning) ? nested.warning : null;
+  const warning = isRecoveryWarning(nested.warning) ? nested.warning : null;
   return {
     version: 1,
     requestId: request.id,
@@ -186,7 +178,7 @@ export function readSandboxControlTerminalResult(filePath: string): SandboxContr
   if (value.completionEvidence !== null && !isCompletionEvidence(value.completionEvidence)) {
     throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
   }
-  if (value.warning !== undefined && value.warning !== null && !isSandboxControlRecoveryWarning(value.warning)) {
+  if (value.warning !== undefined && value.warning !== null && !isRecoveryWarning(value.warning)) {
     throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
   }
   if (value.changed === undefined) {

--- a/lib/sandbox/control/state.ts
+++ b/lib/sandbox/control/state.ts
@@ -14,6 +14,7 @@ import type {
   SandboxControlPayload,
   SandboxControlReservation,
   SandboxControlResultEvidence,
+  SandboxControlRecoveryWarning,
   SandboxControlStatus
 } from './protocol.ts';
 import {
@@ -113,7 +114,17 @@ export type SandboxControlTerminalResult = Readonly<{
   status: string;
   changed: boolean | null;
   completionEvidence: CleanCompletionEvidence | null;
+  warning?: SandboxControlRecoveryWarning | null;
 }>;
+
+function isSandboxControlRecoveryWarning(value: unknown): value is SandboxControlRecoveryWarning {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const warning = value as Record<string, unknown>;
+  return Object.keys(warning).sort().join(',') === 'action,code,message'
+    && [warning.code, warning.message, warning.action].every((field) => (
+      typeof field === 'string' && field.length > 0 && field.trim() === field && !/[\r\n]/u.test(field)
+    ));
+}
 
 export function terminalResultPath(manifest: SandboxControlManifest, requestId: string): string {
   if (!/^[a-f0-9-]{16,64}$/u.test(requestId)) throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
@@ -130,6 +141,7 @@ export function createSandboxControlTerminalResult(
     ? nested.run as Record<string, unknown> : null;
   const rawCompletion = nested.completionEvidence ?? run?.completionEvidence;
   const operation = request.operation ?? (typeof nested.intent === 'string' ? nested.intent : null) ?? '';
+  const warning = isSandboxControlRecoveryWarning(nested.warning) ? nested.warning : null;
   return {
     version: 1,
     requestId: request.id,
@@ -139,7 +151,8 @@ export function createSandboxControlTerminalResult(
     targetState: typeof nested.targetState === 'string' ? nested.targetState : null,
     status: typeof nested.status === 'string' ? nested.status : 'completed',
     changed: typeof nested.changed === 'boolean' ? nested.changed : null,
-    completionEvidence: isCompletionEvidence(rawCompletion) ? rawCompletion : null
+    completionEvidence: isCompletionEvidence(rawCompletion) ? rawCompletion : null,
+    ...(warning ? { warning } : {})
   };
 }
 
@@ -171,6 +184,9 @@ export function readSandboxControlTerminalResult(filePath: string): SandboxContr
     throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
   }
   if (value.completionEvidence !== null && !isCompletionEvidence(value.completionEvidence)) {
+    throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
+  }
+  if (value.warning !== undefined && value.warning !== null && !isSandboxControlRecoveryWarning(value.warning)) {
     throw new Error('SANDBOX_CONTROL_TERMINAL_RESULT_INVALID');
   }
   if (value.changed === undefined) {

--- a/lib/task/control-authority.ts
+++ b/lib/task/control-authority.ts
@@ -39,6 +39,12 @@ import {
   type TaskLifecycleRequest,
   type TaskLifecycleResult
 } from './lifecycle.ts';
+import {
+  recoverStartedLifecycleUnderLock,
+  recoveryFailure,
+  type LifecycleRecoveryResult
+} from './lifecycle-recovery.ts';
+import type { LifecycleRecoveryRequest } from './lifecycle-recovery.ts';
 import { locateActivityLog } from './activity-log.ts';
 import { resolveTaskRef, TASK_ID_RE } from './resolve-ref.ts';
 import { TaskExecutionLockError, withTaskExecutionLock } from './task-execution-lock.ts';
@@ -565,7 +571,7 @@ export type TaskControlOperation =
       options?: Omit<OrchestrationOptions, 'repoRoot'>;
     }>;
 
-export type TaskControlDispatchResult = TaskLifecycleResult | TaskFinalizationResult | OrchestrationResult;
+export type TaskControlDispatchResult = TaskLifecycleResult | LifecycleRecoveryResult | TaskFinalizationResult | OrchestrationResult;
 
 export function taskControlOperationKey(operation: TaskControlOperation): string {
   if (operation.family === 'task-finalization') return 'complete';
@@ -712,12 +718,15 @@ function lifecycleTaskId(request: TaskLifecycleControlRequest, repoRoot: string)
 async function applyLifecycleWithAuthority(
   context: TaskControlExecutionContext,
   request: TaskLifecycleControlRequest
-): Promise<TaskLifecycleResult & { humanOverride?: unknown }> {
+): Promise<(TaskLifecycleResult | LifecycleRecoveryResult) & { humanOverride?: unknown }> {
   const conflict = overrideDryRunConflict(request as unknown as Record<string, unknown>);
   if (conflict) {
     return taskLifecycleFailure(request, { code: 'LIFECYCLE_PAYLOAD_INVALID', message: conflict.message });
   }
-  const execute = async (): Promise<TaskLifecycleResult & { humanOverride?: unknown }> => {
+  const execute = async (): Promise<(TaskLifecycleResult | LifecycleRecoveryResult) & { humanOverride?: unknown }> => {
+    if (request.intent === 'recover-started') {
+      return recoverStartedLifecycleUnderLock(request as LifecycleRecoveryRequest, { repoRoot: context.repoRoot });
+    }
     const lifecycleResult = applyTaskLifecycle(request, { repoRoot: context.repoRoot });
     if (lifecycleResult.status !== 'failed' || !request.overrideTicket) return lifecycleResult;
     if (!request.overrideTarget || !request.overrideScope) {
@@ -751,6 +760,9 @@ async function applyLifecycleWithAuthority(
     );
   } catch (error) {
     if (!(error instanceof TaskExecutionLockError)) throw error;
+    if (request.intent === 'recover-started') {
+      return recoveryFailure(request as LifecycleRecoveryRequest, 'owner-unknown', error.code, error.message);
+    }
     return taskLifecycleFailure(request, { code: error.code, message: error.message }, taskId);
   }
 }
@@ -829,7 +841,7 @@ function orchestrationFailure(error: unknown): OrchestrationResult {
 export function dispatchTaskControlOperation(
   context: TaskControlExecutionContext,
   operation: Extract<TaskControlOperation, { family: 'task-lifecycle' }>
-): Promise<TaskLifecycleResult & { humanOverride?: unknown }>;
+): Promise<(TaskLifecycleResult | LifecycleRecoveryResult) & { humanOverride?: unknown }>;
 export function dispatchTaskControlOperation(
   context: TaskControlExecutionContext,
   operation: Extract<TaskControlOperation, { family: 'task-finalization' }>
@@ -892,7 +904,7 @@ function operationInvalid(message: string): never {
 
 const LIFECYCLE_FLAGS = new Set([
   '--agent', '--reason', '--unblock-condition', '--note', '--alert-number', '--staging-dir', '--issue-number',
-  '--override-ticket', '--override-target', '--override-scope', '--dry-run'
+  '--stage', '--round', '--artifact', '--override-ticket', '--override-target', '--override-scope', '--dry-run'
 ]);
 
 const FINALIZATION_FLAGS = new Set(['--agent']);
@@ -972,8 +984,29 @@ export function parseTaskControlOperation(
       ...(value(values, '--override-scope') ? { overrideScope: value(values, '--override-scope') } : {}),
       ...(value(values, '--alert-number') ? { alertNumber: Number(value(values, '--alert-number')) } : {}),
       ...(value(values, '--issue-number') ? { issueNumber: Number(value(values, '--issue-number')) } : {}),
+      ...(value(values, '--stage') ? { stage: value(values, '--stage') } : {}),
+      ...(value(values, '--round') ? { round: Number(value(values, '--round')) } : {}),
+      ...(value(values, '--artifact') ? { artifact: value(values, '--artifact') } : {}),
       ...(values['--dry-run'] === true ? { dryRun: true } : {})
     };
+    if (intent === 'recover-started') {
+      const recoveryFlags = new Set(['--agent', '--stage', '--round', '--artifact', '--reason']);
+      for (const flag of Object.keys(values)) {
+        if (!recoveryFlags.has(flag)) operationInvalid(`option '${flag}' is not supported for recover-started`);
+      }
+      required(values, ['--stage', '--round', '--artifact', '--reason']);
+      const stage = value(values, '--stage');
+      if (!['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'review-code'].includes(stage ?? '')) {
+        operationInvalid('--stage must be a supported lifecycle stage');
+      }
+      const round = Number(value(values, '--round'));
+      if (!Number.isSafeInteger(round) || round < 1) operationInvalid('--round must be a positive integer');
+      if (value(values, '--reason')!.includes('\n') || value(values, '--reason')!.includes('\r')) {
+        operationInvalid('--reason must be a single line');
+      }
+    } else if (values['--stage'] !== undefined || values['--round'] !== undefined || values['--artifact'] !== undefined) {
+      operationInvalid('--stage, --round, and --artifact are only supported for recover-started');
+    }
     return { family, request: input as unknown as TaskLifecycleControlRequest };
   }
 

--- a/lib/task/control-recovery.ts
+++ b/lib/task/control-recovery.ts
@@ -107,6 +107,12 @@ function domainEvidenceMatches(
       && snapshot.worktreeTree === completion.worktreeTree
       && lastReviewedCommit === completion.lastReviewedCommit;
   }
+  if (operation.family === 'task-lifecycle' && operation.intent === 'recover-started') {
+    return result.targetState === 'active'
+      && ['applied', 'no-op'].includes(String(result.status))
+      && domain.recovery === true
+      && domain.targetState === 'active';
+  }
   if (operation.class === 'read-only') return result.changed === false && domain.snapshotValid === true;
   return true;
 }

--- a/lib/task/control-recovery.ts
+++ b/lib/task/control-recovery.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { isCompletionEvidence } from './orchestration.ts';
 import { TASK_WORKFLOW_OPERATIONS } from './workflow-command.ts';
+import { sameRecoveryWarning } from './recovery-warning.ts';
 
 export type ControlRecoveryOutcome = 'not-executed' | 'in-progress' | 'success' | 'failure' | 'unknown' | 'rejected';
 
@@ -109,8 +110,7 @@ function domainEvidenceMatches(
   }
   if (operation.family === 'task-lifecycle' && operation.intent === 'recover-started') {
     const retryRequired = domain.recoveryState === 'retry-required'
-      && JSON.stringify(domain.warning) === JSON.stringify(result.warning)
-      && typeof result.warning === 'object' && result.warning !== null;
+      && sameRecoveryWarning(domain.warning, result.warning);
     return result.targetState === 'active'
       && ['applied', 'no-op'].includes(String(result.status))
       && domain.recovery === true

--- a/lib/task/control-recovery.ts
+++ b/lib/task/control-recovery.ts
@@ -108,10 +108,14 @@ function domainEvidenceMatches(
       && lastReviewedCommit === completion.lastReviewedCommit;
   }
   if (operation.family === 'task-lifecycle' && operation.intent === 'recover-started') {
+    const retryRequired = domain.recoveryState === 'retry-required'
+      && JSON.stringify(domain.warning) === JSON.stringify(result.warning)
+      && typeof result.warning === 'object' && result.warning !== null;
     return result.targetState === 'active'
       && ['applied', 'no-op'].includes(String(result.status))
       && domain.recovery === true
-      && domain.targetState === 'active';
+      && domain.targetState === 'active'
+      && (domain.recoveryState === 'released' || retryRequired);
   }
   if (operation.class === 'read-only') return result.changed === false && domain.snapshotValid === true;
   return true;
@@ -165,6 +169,8 @@ export function classifySandboxControlRecovery(input: ControlRecoveryInput): Con
     responseReconstructable: true,
     reasonCode: input.operation.class === 'route.clean-completion' && result.changed === false
       ? 'RECOVERY_ROUTE_COMPLETION_NOOP'
+      : input.operation.intent === 'recover-started' && input.domain?.recoveryState === 'retry-required'
+        ? 'RECOVERY_RELEASE_RETRY_REQUIRED'
       : 'RECOVERY_TERMINAL_AND_DOMAIN_MATCH'
   };
 }

--- a/lib/task/control-recovery.ts
+++ b/lib/task/control-recovery.ts
@@ -53,7 +53,7 @@ export type ControlRecoveryDecision = Readonly<{
   reasonCode: string;
 }>;
 
-const LIFECYCLE_INTENTS = ['block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore'] as const;
+const LIFECYCLE_INTENTS = ['block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore', 'recover-started'] as const;
 const ORCHESTRATION_INTENTS = [
   'begin-or-resume', 'route.read', 'route.clean-completion', 'status', 'prepare', 'dispatch',
   'await-activation', 'recover-prepared', 'hook-start', 'hook-stop', 'advance', 'pause'

--- a/lib/task/delegation-receipts.ts
+++ b/lib/task/delegation-receipts.ts
@@ -186,7 +186,8 @@ function isDelegationHostEvidence(value: unknown): value is DelegationHostEviden
 function hasCurrentCodexEvidence(receipt: DelegationReceipt): boolean {
   const provenance = receipt.lifecycleProvenance;
   if (!provenance) return false;
-  const activated = ['activated', 'stage-completed', 'sealed', 'consumed'].includes(receipt.status);
+  const activated = ['activated', 'stage-completed', 'sealed', 'consumed'].includes(receipt.status)
+    || (receipt.status === 'aborted' && receipt.activatedAt !== null);
   if (!activated) return receipt.hostEvidence === null;
   const host = receipt.hostEvidence;
   if (
@@ -219,6 +220,12 @@ function hasCurrentCodexEvidence(receipt: DelegationReceipt): boolean {
       && host.consumer === receipt.id
       && exactText(host.consumedAt);
   }
+  if (receipt.status === 'aborted') {
+    return Number.isSafeInteger(host.stopRevision)
+      && (host.stopRevision as number) > host.startRevision
+      && host.consumer?.startsWith('lifecycle-recovery:') === true
+      && exactText(host.consumedAt);
+  }
   return host.stopRevision === null && host.consumer === null && host.consumedAt === null;
 }
 
@@ -244,7 +251,8 @@ function hasStatusBoundEvidence(receipt: DelegationReceipt): boolean {
   const dispatchComplete = dispatchFields.every((field) => field !== null);
   if (!dispatchEmpty && !dispatchComplete) return false;
 
-  const beforeActivation = ['prepared', 'aborted', 'expired'].includes(receipt.status);
+  const beforeActivation = ['prepared', 'expired'].includes(receipt.status)
+    || (receipt.status === 'aborted' && receipt.activatedAt === null);
   if (beforeActivation) {
     return receipt.parentId === null
       && receipt.childId === null
@@ -280,6 +288,21 @@ function hasStatusBoundEvidence(receipt: DelegationReceipt): boolean {
       && receipt.changedPaths.length === 0
       && receipt.sealedAt === null
       && receipt.consumedAt === null;
+  }
+
+  if (receipt.status === 'aborted') {
+    const host = receipt.hostEvidence;
+    return receipt.agent === null
+      && receipt.afterFingerprint === null
+      && receipt.changedPaths.length === 0
+      && receipt.sealedAt === null
+      && receipt.consumedAt === null
+      && host !== null
+      && host !== undefined
+      && Number.isSafeInteger(host.stopRevision)
+      && (host.stopRevision as number) > host.startRevision
+      && host.consumer?.startsWith('lifecycle-recovery:') === true
+      && exactText(host.consumedAt);
   }
 
   if (
@@ -584,6 +607,53 @@ function abortPreparedDelegation(receipt: DelegationReceipt): ReceiptResult {
   };
 }
 
+function abortActivatedDelegation(
+  receipt: DelegationReceipt,
+  event: Readonly<{ childId: string; stopRevision: number; consumer: string; consumedAt: string }>
+): ReceiptResult {
+  if (receipt.status !== 'activated') {
+    return fail('DELEGATION_STATE_INVALID', `delegation ${receipt.id} is ${receipt.status}, expected activated`);
+  }
+  if (
+    receipt.client !== 'codex'
+    || !receipt.lifecycleProvenance
+    || receipt.hostEvidence?.kind !== 'codex-lifecycle-v2'
+    || typeof receipt.lifecycleProvenance.controllerInstanceDigest !== 'string'
+    || typeof receipt.lifecycleProvenance.controlGeneration !== 'string'
+    || typeof receipt.hostEvidence.controllerInstanceDigest !== 'string'
+    || typeof receipt.hostEvidence.controlGeneration !== 'string'
+  ) {
+    return fail('DELEGATION_RECOVERY_EVIDENCE_INVALID', 'activated delegation lacks the current Codex controller binding');
+  }
+  if (
+    event.childId !== receipt.childId
+    || !Number.isSafeInteger(event.stopRevision)
+    || event.stopRevision <= receipt.hostEvidence.startRevision
+    || event.consumer !== `lifecycle-recovery:${receipt.taskId}:${receipt.id}`
+    || !exactText(event.consumedAt)
+  ) {
+    return fail('DELEGATION_RECOVERY_EVIDENCE_INVALID', 'recovery stop evidence does not match the activated delegation');
+  }
+  return {
+    ok: true,
+    receipt: Object.freeze({
+      ...receipt,
+      status: 'aborted' as const,
+      agent: null,
+      afterFingerprint: null,
+      changedPaths: Object.freeze([]),
+      sealedAt: null,
+      consumedAt: null,
+      hostEvidence: Object.freeze({
+        ...receipt.hostEvidence,
+        stopRevision: event.stopRevision,
+        consumer: event.consumer,
+        consumedAt: event.consumedAt
+      })
+    })
+  };
+}
+
 function completeDelegationStage(
   receipt: DelegationReceipt,
   event: Readonly<{ stage: DelegationStage; round: number; artifact: string; agent: string }>
@@ -666,6 +736,7 @@ function consumeDelegation(receipt: DelegationReceipt, options: { now?: () => st
 
 export {
   activateDelegation,
+  abortActivatedDelegation,
   abortPreparedDelegation,
   completeDelegationStage,
   consumeDelegation,

--- a/lib/task/delegation-receipts.ts
+++ b/lib/task/delegation-receipts.ts
@@ -223,7 +223,7 @@ function hasCurrentCodexEvidence(receipt: DelegationReceipt): boolean {
   if (receipt.status === 'aborted') {
     return Number.isSafeInteger(host.stopRevision)
       && (host.stopRevision as number) > host.startRevision
-      && host.consumer?.startsWith('lifecycle-recovery:') === true
+      && host.consumer === `lifecycle-recovery:${receipt.taskId}:${receipt.id}`
       && exactText(host.consumedAt);
   }
   return host.stopRevision === null && host.consumer === null && host.consumedAt === null;
@@ -301,7 +301,7 @@ function hasStatusBoundEvidence(receipt: DelegationReceipt): boolean {
       && host !== undefined
       && Number.isSafeInteger(host.stopRevision)
       && (host.stopRevision as number) > host.startRevision
-      && host.consumer?.startsWith('lifecycle-recovery:') === true
+      && host.consumer === `lifecycle-recovery:${receipt.taskId}:${receipt.id}`
       && exactText(host.consumedAt);
   }
 

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -1,0 +1,595 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createCodexLifecycleStore } from '../agent-clients/adapters/codex-lifecycle/store.ts';
+import type { StoredCodexLifecycle } from '../agent-clients/adapters/codex-lifecycle/store.ts';
+import { managedDelegationRole } from './delegation-receipts.ts';
+import type { DelegationReceipt } from './delegation-receipts.ts';
+import { normalizeAgentToken } from '../agent-clients/tokens.ts';
+import { artifactName, parseArtifactName } from './artifact-name.ts';
+import { locateActivityLog, pairEntries } from './activity-log.ts';
+import type { LogEntry, StepRow } from './activity-log.ts';
+import { captureTaskWriteMetadata, writeTask } from './write.ts';
+import { parseTypedTaskFrontmatter } from './frontmatter.ts';
+import { resolveTaskRef, TASK_ID_RE } from './resolve-ref.ts';
+import { resolveAgentRuntimeStoreRoot } from '../runtime/agent-runtime.ts';
+import {
+  recoverActivatedOrchestrationDelegationUnderLock,
+  readRun
+} from './orchestration.ts';
+import type { OrchestrationOptions, OrchestrationRun } from './orchestration.ts';
+
+const RECOVERY_NOTE_PREFIX = 'lifecycle-recovery:v1 ';
+const RECOVERY_STAGES = ['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'review-code'] as const;
+const ACTIONS: Readonly<Record<typeof RECOVERY_STAGES[number], string>> = {
+  analysis: 'Analyze Task',
+  'review-analysis': 'Review Analysis',
+  plan: 'Plan Task',
+  'review-plan': 'Review Plan',
+  code: 'Code Task',
+  'review-code': 'Review Code'
+};
+const RECOVERY_NOTE_KEYS = [
+  'version', 'taskId', 'stage', 'round', 'artifact', 'startedAgent', 'receiptId', 'childId',
+  'stopRevision', 'consumer', 'consumedAt', 'owner', 'reason'
+] as const;
+
+type RecoveryStage = (typeof RECOVERY_STAGES)[number];
+type LifecycleRecoveryRequest = Readonly<{
+  taskRef: string;
+  intent: 'recover-started';
+  agent: string;
+  stage: RecoveryStage;
+  round: number;
+  artifact: string;
+  reason: string;
+}>;
+type RecoveryWarning = Readonly<{ code: string; message: string; action: string }>;
+type LifecycleRecoveryResult = Readonly<{
+  status: 'applied' | 'no-op' | 'owner-unknown' | 'conflict';
+  changed: boolean;
+  requestRef: string;
+  intent: 'recover-started';
+  taskId: string | null;
+  stage: RecoveryStage | null;
+  round: number | null;
+  artifact: string | null;
+  receiptId: string | null;
+  childId: string | null;
+  warning: RecoveryWarning | null;
+  error: Readonly<{ code: string; message: string }> | null;
+}>;
+type LifecycleRecoveryOptions = Readonly<{
+  repoRoot?: string;
+  now?: () => string;
+  orchestration?: Pick<OrchestrationOptions, 'diagnosticLog' | 'now'>;
+  lifecycleStore?: ReturnType<typeof createCodexLifecycleStore>;
+  releaseRecovery?: (childThreadId: string, consumer: string) => boolean;
+}>;
+
+type RecoveryNote = Readonly<{
+  version: 1;
+  taskId: string;
+  stage: RecoveryStage;
+  round: number;
+  artifact: string;
+  startedAgent: string;
+  receiptId: string;
+  childId: string;
+  stopRevision: number;
+  consumer: string;
+  consumedAt: string;
+  owner: 'terminated';
+  reason: string;
+}>;
+
+function text(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.trim() === value && !/[\r\n]/u.test(value);
+}
+
+function timestamp(value: unknown): value is string {
+  return text(value) && Number.isFinite(Date.parse(value));
+}
+
+function recoveryConsumer(taskId: string, receiptId: string): string {
+  return `lifecycle-recovery:${taskId}:${receiptId}`;
+}
+
+function actionPattern(stage: RecoveryStage, round: number): RegExp {
+  const escaped = ACTIONS[stage].replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return new RegExp(`^${escaped} \\(Round ${round}(?:, (?:fix for review-code(?:-r[2-9]|-r[1-9]\\d+)?.md|decision II-[1-9]\\d*))?\\)$`, 'u');
+}
+
+function baseStep(step: string): string {
+  return step.replace(/\s*\[(?:started|aborted)\]\s*$/u, '');
+}
+
+function isRecoveryStage(value: unknown): value is RecoveryStage {
+  return (RECOVERY_STAGES as readonly string[]).includes(value as string);
+}
+
+function parseRecoveryNote(note: string): RecoveryNote | null {
+  if (!note.startsWith(RECOVERY_NOTE_PREFIX)) return null;
+  let value: unknown;
+  try { value = JSON.parse(note.slice(RECOVERY_NOTE_PREFIX.length)); }
+  catch { return null; }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(',') !== [...RECOVERY_NOTE_KEYS].sort().join(',')) return null;
+  if (
+    record.version !== 1
+    || typeof record.taskId !== 'string' || !TASK_ID_RE.test(record.taskId)
+    || !isRecoveryStage(record.stage)
+    || !Number.isSafeInteger(record.round) || (record.round as number) < 1
+    || !text(record.artifact)
+    || !text(record.startedAgent)
+    || !text(record.receiptId)
+    || !text(record.childId)
+    || !Number.isSafeInteger(record.stopRevision) || (record.stopRevision as number) < 1
+    || !text(record.consumer)
+    || !timestamp(record.consumedAt)
+    || record.owner !== 'terminated'
+    || !text(record.reason)
+  ) return null;
+  const parsedArtifact = parseArtifactName(record.artifact);
+  if (!parsedArtifact || parsedArtifact.family !== record.stage || parsedArtifact.round !== record.round) return null;
+  if (record.consumer !== recoveryConsumer(record.taskId, record.receiptId)) return null;
+  return record as RecoveryNote;
+}
+
+function renderRecoveryNote(note: RecoveryNote): string {
+  return `${RECOVERY_NOTE_PREFIX}${JSON.stringify(note)}`;
+}
+
+function result(
+  request: LifecycleRecoveryRequest,
+  status: LifecycleRecoveryResult['status'],
+  extra: Partial<LifecycleRecoveryResult> = {}
+): LifecycleRecoveryResult {
+  return {
+    status,
+    changed: status === 'applied',
+    requestRef: request.taskRef,
+    intent: request.intent,
+    taskId: null,
+    stage: request.stage,
+    round: request.round,
+    artifact: request.artifact,
+    receiptId: null,
+    childId: null,
+    warning: null,
+    error: null,
+    ...extra
+  };
+}
+
+function failure(
+  request: LifecycleRecoveryRequest,
+  status: 'owner-unknown' | 'conflict',
+  code: string,
+  message: string,
+  extra: Partial<LifecycleRecoveryResult> = {}
+): LifecycleRecoveryResult {
+  return result(request, status, { error: { code, message }, ...extra });
+}
+
+function recoveryFailure(
+  request: LifecycleRecoveryRequest,
+  status: 'owner-unknown' | 'conflict',
+  code: string,
+  message: string
+): LifecycleRecoveryResult {
+  return failure(request, status, code, message);
+}
+
+function normalizeRequest(request: LifecycleRecoveryRequest): LifecycleRecoveryRequest | { code: string; message: string } {
+  if (
+    !request || typeof request !== 'object'
+    || request.intent !== 'recover-started'
+    || typeof request.taskRef !== 'string' || !request.taskRef.trim()
+    || typeof request.agent !== 'string'
+    || !isRecoveryStage(request.stage)
+    || !Number.isSafeInteger(request.round) || request.round < 1
+    || typeof request.artifact !== 'string'
+    || typeof request.reason !== 'string' || !request.reason.trim() || /[\r\n]/u.test(request.reason)
+  ) return { code: 'RECOVERY_PAYLOAD_INVALID', message: 'recover-started requires a task, agent, stage, round, artifact, and single-line reason' };
+  const agent = normalizeAgentToken(request.agent);
+  if (!agent) return { code: 'RECOVERY_PAYLOAD_INVALID', message: 'recovery agent is not a recognized agent token' };
+  const expectedArtifact = artifactName(request.stage, request.round);
+  if (request.artifact !== expectedArtifact) {
+    return { code: 'RECOVERY_PAYLOAD_INVALID', message: `artifact must be ${expectedArtifact} for ${request.stage} round ${request.round}` };
+  }
+  return { ...request, agent, reason: request.reason.trim() };
+}
+
+function targetRows(sectionEntries: readonly LogEntry[], stage: RecoveryStage, round: number): {
+  rows: StepRow[];
+  recoveryEntries: LogEntry[];
+} {
+  const pattern = actionPattern(stage, round);
+  const rows = pairEntries([...sectionEntries]).filter((row) => pattern.test(row.step));
+  const recoveryEntries = sectionEntries.filter((entry) => entry.step.endsWith(' [aborted]') && pattern.test(baseStep(entry.step)));
+  return { rows, recoveryEntries };
+}
+
+function matchingReceipt(run: OrchestrationRun, taskId: string, request: LifecycleRecoveryRequest, receiptId?: string): DelegationReceipt | null {
+  const candidates = [
+    ...(run.pendingDelegation ? [run.pendingDelegation] : []),
+    ...run.receipts
+  ].filter((receipt) => receipt.taskId === taskId
+    && receipt.stage === request.stage
+    && receipt.round === request.round
+    && receipt.artifact === request.artifact
+    && (receiptId === undefined || receipt.id === receiptId));
+  return candidates.length === 1 ? candidates[0]! : null;
+}
+
+function validateStopRecord(
+  record: StoredCodexLifecycle,
+  receipt: DelegationReceipt,
+  consumer: string
+): { ok: true; stopRevision: number; consumedAt: string } | { ok: false; code: string; message: string } {
+  const start = record.state.startEvidence;
+  const stop = record.state.stopEvidence;
+  const provenance = receipt.lifecycleProvenance;
+  const host = receipt.hostEvidence;
+  if (
+    receipt.client !== 'codex'
+    || !provenance
+    || host?.kind !== 'codex-lifecycle-v2'
+    || !start
+    || !stop
+    || record.state.status !== 'stop-ready'
+    || stop.terminalStatus !== 'completed'
+    || stop.hookStopObserved !== true
+    || start.childThreadId !== receipt.childId
+    || start.parentThreadId !== receipt.parentId
+    || managedDelegationRole(start.nativeAgent) !== receipt.role
+    || start.hookDefinitionHash !== provenance.hookDefinitionHash
+    || host.hookDefinitionHash !== provenance.hookDefinitionHash
+    || host.capabilitySessionId !== provenance.capabilitySessionId
+    || host.capabilityTurnId !== provenance.capabilityTurnId
+    || host.capabilityToolUseId !== provenance.capabilityToolUseId
+    || host.spawnToolUseId !== start.spawnToolUseId
+    || !host.spawnObservedAt
+    || !record.spawnObservedAt
+    || host.spawnObservedAt !== record.spawnObservedAt
+    || host.controllerInstanceDigest !== provenance.controllerInstanceDigest
+    || host.controlGeneration !== provenance.controlGeneration
+    || typeof host.controllerInstanceDigest !== 'string'
+    || typeof host.controlGeneration !== 'string'
+    || host.startRevision < 1
+    || record.revision <= host.startRevision
+  ) return { ok: false, code: 'RECOVERY_STOP_EVIDENCE_INVALID', message: 'Codex stop evidence does not match the managed activated receipt' };
+  if (record.state.child?.childThreadId !== receipt.childId || record.state.stop?.childThreadId !== receipt.childId) {
+    return { ok: false, code: 'RECOVERY_STOP_EVIDENCE_INVALID', message: 'Codex stop evidence child identity is inconsistent' };
+  }
+  if (record.consumer !== null && record.consumer !== consumer) {
+    return { ok: false, code: 'RECOVERY_CONSUMER_CONFLICT', message: `Codex lifecycle evidence was consumed by '${record.consumer}'` };
+  }
+  if (record.consumer === null) return { ok: true, stopRevision: record.revision, consumedAt: '' };
+  if (receipt.status === 'activated' && record.consumer === consumer && record.consumedAt) {
+    return { ok: true, stopRevision: record.revision, consumedAt: record.consumedAt };
+  }
+  if (
+    record.consumer !== consumer
+    || !record.consumedAt
+    || receipt.hostEvidence?.stopRevision !== record.revision
+    || receipt.hostEvidence.consumer !== consumer
+    || receipt.hostEvidence.consumedAt !== record.consumedAt
+  ) return { ok: false, code: 'RECOVERY_REFERENCE_CONFLICT', message: 'recovery receipt references do not match the protected lifecycle claim' };
+  return { ok: true, stopRevision: record.revision, consumedAt: record.consumedAt };
+}
+
+function readLifecycleStore(
+  options: LifecycleRecoveryOptions,
+  repoRoot: string
+): ReturnType<typeof createCodexLifecycleStore> {
+  if (options.lifecycleStore) return options.lifecycleStore;
+  return createCodexLifecycleStore({
+    root: resolveAgentRuntimeStoreRoot({ repoRoot, store: 'lifecycle' }),
+    cliVersion: 'recovery',
+    now: options.now
+  });
+}
+
+function readStoredEvidence(
+  store: ReturnType<typeof createCodexLifecycleStore>,
+  childId: string
+): StoredCodexLifecycle | { missing: true } | { error: Error } {
+  try {
+    return store.read(childId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('was not found uniquely')) return { missing: true };
+    return { error: error instanceof Error ? error : new Error(message) };
+  }
+}
+
+function taskNote(
+  taskId: string,
+  request: LifecycleRecoveryRequest,
+  receipt: DelegationReceipt,
+  stopRevision: number,
+  consumer: string,
+  consumedAt: string
+): RecoveryNote {
+  return {
+    version: 1,
+    taskId,
+    stage: request.stage,
+    round: request.round,
+    artifact: request.artifact,
+    startedAgent: request.agent,
+    receiptId: receipt.id,
+    childId: receipt.childId!,
+    stopRevision,
+    consumer,
+    consumedAt,
+    owner: 'terminated',
+    reason: request.reason
+  };
+}
+
+function releaseResult(
+  request: LifecycleRecoveryRequest,
+  taskId: string,
+  receipt: DelegationReceipt,
+  released: boolean,
+  previousChange: boolean
+): LifecycleRecoveryResult {
+  if (released) return result(request, 'applied', { taskId, receiptId: receipt.id, childId: receipt.childId });
+  return result(request, 'applied', {
+    changed: previousChange,
+    taskId,
+    receiptId: receipt.id,
+    childId: receipt.childId,
+    warning: {
+      code: 'RECOVERY_RELEASE_RETRY_REQUIRED',
+      message: 'recovery receipt and Activity Log are complete but the protected lifecycle claim could not be released',
+      action: 'retry recover-started with the same selector and reason'
+    }
+  });
+}
+
+function matchingPostActivationAbortedReceipts(
+  run: OrchestrationRun,
+  taskId: string,
+  request: LifecycleRecoveryRequest
+): DelegationReceipt[] {
+  return run.receipts.filter((receipt) => receipt.status === 'aborted'
+    && receipt.activatedAt !== null
+    && receipt.agent === null
+    && receipt.taskId === taskId
+    && receipt.stage === request.stage
+    && receipt.round === request.round
+    && receipt.artifact === request.artifact);
+}
+
+function sameRecoveryNote(left: RecoveryNote, right: RecoveryNote): boolean {
+  return left.version === right.version
+    && left.taskId === right.taskId
+    && left.stage === right.stage
+    && left.round === right.round
+    && left.artifact === right.artifact
+    && left.startedAgent === right.startedAgent
+    && left.receiptId === right.receiptId
+    && left.childId === right.childId
+    && left.stopRevision === right.stopRevision
+    && left.consumer === right.consumer
+    && left.consumedAt === right.consumedAt
+    && left.owner === right.owner
+    && left.reason === right.reason;
+}
+
+function verifyRecoveryCommit(
+  taskMdPath: string,
+  taskDir: string,
+  taskId: string,
+  request: LifecycleRecoveryRequest,
+  note: RecoveryNote,
+  options: LifecycleRecoveryOptions
+): { ok: true; receipt: DelegationReceipt } | { ok: false; message: string } {
+  try {
+    const content = fs.readFileSync(taskMdPath, 'utf8');
+    parseTypedTaskFrontmatter(content);
+    const section = locateActivityLog(content);
+    if (!section) return { ok: false, message: 'recovery Activity Log cannot be reread uniquely' };
+    const targets = targetRows(section.entries, request.stage, request.round);
+    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
+    if (targets.recoveryEntries.length !== 1 || paired.length !== 1 || paired[0]!.done !== targets.recoveryEntries[0]!.time) {
+      return { ok: false, message: 'recovery Activity Log does not contain one completed started/aborted pair' };
+    }
+    const logged = parseRecoveryNote(targets.recoveryEntries[0]!.note);
+    if (!logged || !sameRecoveryNote(logged, note)) {
+      return { ok: false, message: 'recovery Activity Log note changed during commit verification' };
+    }
+    const run = readRun(taskDir, options.orchestration);
+    if (!run || run.status !== 'running' || run.pendingDelegation !== null) {
+      return { ok: false, message: 'orchestration recovery state is not running with no pending delegation' };
+    }
+    const receipts = matchingPostActivationAbortedReceipts(run, taskId, request);
+    if (receipts.length !== 1 || receipts[0]!.id !== note.receiptId) {
+      return { ok: false, message: 'orchestration recovery state does not contain one matching aborted receipt' };
+    }
+    const receipt = receipts[0]!;
+    if (
+      receipt.childId !== note.childId
+      || receipt.hostEvidence?.stopRevision !== note.stopRevision
+      || receipt.hostEvidence.consumer !== note.consumer
+      || receipt.hostEvidence.consumedAt !== note.consumedAt
+    ) return { ok: false, message: 'orchestration recovery references changed during commit verification' };
+    const store = readLifecycleStore(options, options.repoRoot ?? path.resolve(taskDir, '../../../..'));
+    const stored = readStoredEvidence(store, note.childId);
+    if ('error' in stored) return { ok: false, message: stored.error.message };
+    if ('missing' in stored) return { ok: false, message: 'protected lifecycle claim disappeared before release' };
+    const evidence = validateStopRecord(stored, receipt, note.consumer);
+    if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
+      return { ok: false, message: evidence.ok ? 'protected lifecycle claim references changed during commit verification' : evidence.message };
+    }
+    return { ok: true, receipt };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function recoverStartedLifecycleUnderLock(
+  requestInput: LifecycleRecoveryRequest,
+  options: LifecycleRecoveryOptions = {}
+): LifecycleRecoveryResult {
+  const normalized = normalizeRequest(requestInput);
+  if ('code' in normalized) return failure(requestInput, 'conflict', normalized.code, normalized.message);
+  const request = normalized;
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return failure(request, 'conflict', resolved.code, resolved.message);
+  const taskId = resolved.taskId;
+  let content: string;
+  try { content = fs.readFileSync(resolved.taskMdPath, 'utf8'); }
+  catch (error) { return failure(request, 'owner-unknown', 'RECOVERY_TASK_READ_FAILED', String(error), { taskId }); }
+  try { parseTypedTaskFrontmatter(content); }
+  catch (error) { return failure(request, 'conflict', 'RECOVERY_TASK_INVALID', error instanceof Error ? error.message : String(error), { taskId }); }
+  const section = locateActivityLog(content);
+  if (!section) return failure(request, 'conflict', 'RECOVERY_LOG_INVALID', 'task has no unique Activity Log section', { taskId });
+  const targets = targetRows(section.entries, request.stage, request.round);
+  const open = targets.rows.filter((row) => row.started !== '' && row.done === '');
+  if (open.length > 1 || targets.recoveryEntries.length > 1) {
+    return failure(request, 'conflict', 'RECOVERY_SELECTOR_AMBIGUOUS', 'recovery selector does not identify one lifecycle attempt', { taskId });
+  }
+  let run: OrchestrationRun | null;
+  try { run = readRun(resolved.taskDir, options.orchestration); }
+  catch (error) { return failure(request, 'owner-unknown', 'RECOVERY_ORCHESTRATION_UNKNOWN', String(error), { taskId }); }
+  if (!run) return failure(request, 'owner-unknown', 'RECOVERY_ORCHESTRATION_MISSING', 'no orchestration run exists for the open lifecycle execution', { taskId });
+
+  if (open.length === 0) {
+    if (targets.recoveryEntries.length !== 1) {
+      return failure(request, 'conflict', 'RECOVERY_TERMINAL_MISSING', 'there is no matching open or structured recovery lifecycle row', { taskId });
+    }
+    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
+    if (paired.length !== 1 || paired[0]!.done !== targets.recoveryEntries[0]!.time) {
+      return failure(request, 'conflict', 'RECOVERY_LOG_CONFLICT', 'recovery terminal row is not paired with the matching started row', { taskId });
+    }
+    const note = parseRecoveryNote(targets.recoveryEntries[0]!.note);
+    if (!note || note.taskId !== taskId || note.stage !== request.stage || note.round !== request.round || note.artifact !== request.artifact || note.startedAgent !== request.agent || note.reason !== request.reason) {
+      return failure(request, 'conflict', 'RECOVERY_NOTE_INVALID', 'recovery Activity Log note does not match the selector', { taskId });
+    }
+    if (run.status !== 'running' || run.pendingDelegation !== null) {
+      return failure(request, 'conflict', 'RECOVERY_ORCHESTRATION_INVALID', 'completed recovery state must be running with no pending delegation', { taskId });
+    }
+    const postActivationReceipts = matchingPostActivationAbortedReceipts(run, taskId, request);
+    if (postActivationReceipts.length !== 1) {
+      return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'there is not one unique post-activation aborted receipt', { taskId });
+    }
+    const receipt = matchingReceipt(run, taskId, request, note.receiptId);
+    if (!receipt || receipt.status !== 'aborted' || receipt.agent !== null || receipt.childId !== note.childId) {
+      return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'there is not one matching post-activation aborted receipt', { taskId, receiptId: note.receiptId, childId: note.childId });
+    }
+    const consumer = recoveryConsumer(taskId, receipt.id);
+    if (note.consumer !== consumer || receipt.hostEvidence?.stopRevision !== note.stopRevision || receipt.hostEvidence.consumer !== consumer || receipt.hostEvidence.consumedAt !== note.consumedAt) {
+      return failure(request, 'conflict', 'RECOVERY_REFERENCE_CONFLICT', 'recovery receipt and Activity Log references do not match', { taskId, receiptId: receipt.id, childId: receipt.childId });
+    }
+    const store = readLifecycleStore(options, resolved.repoRoot);
+    const stored = readStoredEvidence(store, note.childId);
+    if ('error' in stored) return failure(request, 'owner-unknown', 'RECOVERY_STORE_UNKNOWN', stored.error.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+    if ('missing' in stored) return result(request, 'no-op', { taskId, receiptId: receipt.id, childId: receipt.childId });
+    if (stored.consumer === null || !stored.consumedAt) {
+      return failure(request, 'conflict', 'RECOVERY_REFERENCE_CONFLICT', 'complete recovery facts do not reference the protected recovery claim', { taskId, receiptId: receipt.id, childId: receipt.childId });
+    }
+    const evidence = validateStopRecord(stored, receipt, consumer);
+    if (!evidence.ok) return failure(request, evidence.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', evidence.code, evidence.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+    let released = false;
+    try { released = (options.releaseRecovery ?? store.releaseRecovery)(note.childId, consumer); }
+    catch (error) {
+      return releaseResult(request, taskId, receipt, false, false);
+    }
+    return releaseResult(request, taskId, receipt, released, false);
+  }
+
+  const started = open[0]!;
+  if (normalizeAgentToken(started.agent) !== request.agent || started.note !== 'started') {
+    return failure(request, 'conflict', 'RECOVERY_SELECTOR_MISMATCH', 'open started lifecycle row does not match the recovery selector', { taskId });
+  }
+  if (targets.recoveryEntries.length > 0) {
+    return failure(request, 'conflict', 'RECOVERY_LOG_CONFLICT', 'open lifecycle execution already has a recovery terminal row', { taskId });
+  }
+  const pending = run.pendingDelegation;
+  const recovered = run.receipts.filter((candidate) => candidate.status === 'aborted'
+    && candidate.activatedAt !== null
+    && candidate.agent === null
+    && candidate.taskId === taskId
+    && candidate.stage === request.stage
+    && candidate.round === request.round
+    && candidate.artifact === request.artifact);
+  if (pending && recovered.length > 0) {
+    return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'open lifecycle execution has both a pending and an aborted matching delegation', { taskId });
+  }
+  const receipt = pending ?? (recovered.length === 1 ? recovered[0]! : null);
+  if (!receipt || (pending && (receipt.status !== 'activated' || receipt.client !== 'codex')) || (!pending && receipt.status !== 'aborted')) {
+    return failure(request, 'owner-unknown', 'RECOVERY_DELEGATION_UNAVAILABLE', 'open lifecycle execution is not backed by one matching activated Codex delegation', { taskId });
+  }
+  if (normalizeAgentToken(started.agent) !== normalizeAgentToken(receipt.client)) {
+    return failure(request, 'conflict', 'RECOVERY_SELECTOR_MISMATCH', 'started agent does not match the delegation client', { taskId, receiptId: receipt.id, childId: receipt.childId });
+  }
+  const consumer = recoveryConsumer(taskId, receipt.id);
+  const store = readLifecycleStore(options, resolved.repoRoot);
+  const stored = readStoredEvidence(store, receipt.childId ?? '');
+  if ('error' in stored) return failure(request, 'owner-unknown', 'RECOVERY_STORE_UNKNOWN', stored.error.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+  if ('missing' in stored) return failure(request, 'owner-unknown', 'RECOVERY_STOP_EVIDENCE_MISSING', 'matching Codex lifecycle stop evidence is missing', { taskId, receiptId: receipt.id, childId: receipt.childId });
+  const evidence = validateStopRecord(stored, receipt, consumer);
+  if (!evidence.ok) return failure(request, evidence.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', evidence.code, evidence.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+  let claimed = stored;
+  if (stored.consumer === null) {
+    try { claimed = store.consume(receipt.childId!, consumer, receipt.hostEvidence?.hookDefinitionHash); }
+    catch (error) { return failure(request, 'owner-unknown', 'RECOVERY_CLAIM_FAILED', error instanceof Error ? error.message : String(error), { taskId, receiptId: receipt.id, childId: receipt.childId }); }
+  }
+  const stopRevision = claimed.revision;
+  const consumedAt = claimed.consumedAt;
+  if (!consumedAt) return failure(request, 'owner-unknown', 'RECOVERY_CLAIM_INVALID', 'protected lifecycle claim has no consumed timestamp', { taskId, receiptId: receipt.id, childId: receipt.childId });
+  if (receipt.status === 'activated') {
+    const recoveredRun = recoverActivatedOrchestrationDelegationUnderLock(taskId, {
+      receiptId: receipt.id,
+      stage: request.stage,
+      round: request.round,
+      artifact: request.artifact,
+      startedAgent: request.agent,
+      childId: receipt.childId!,
+      stopRevision,
+      consumer,
+      consumedAt
+    }, { ...options.orchestration, repoRoot: resolved.repoRoot, now: options.now });
+    if (recoveredRun.status === 'failed' || !recoveredRun.run) {
+      return failure(request, 'owner-unknown', recoveredRun.error?.code ?? 'RECOVERY_ORCHESTRATION_FAILED', recoveredRun.error?.message ?? 'orchestration recovery failed', { taskId, receiptId: receipt.id, childId: receipt.childId });
+    }
+  }
+  const note = taskNote(taskId, request, receipt, stopRevision, consumer, consumedAt);
+  const metadata = captureTaskWriteMetadata();
+  const updatedBody = `${section.body ? `${section.body}\n` : ''}- ${metadata.timestamp} — **${baseStep(started.step)} [aborted]** by ${request.agent} — ${renderRecoveryNote(note)}`;
+  const written = writeTask({
+    taskRef: taskId,
+    expectedState: 'active',
+    mutations: [{ kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: section.heading, body: updatedBody }]
+  }, { repoRoot: resolved.repoRoot, metadataProvider: () => metadata });
+  if (written.status === 'failed') {
+    return failure(request, 'owner-unknown', 'RECOVERY_LOG_WRITE_FAILED', written.error.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+  }
+  const verified = verifyRecoveryCommit(resolved.taskMdPath, resolved.taskDir, taskId, request, note, options);
+  if (!verified.ok) {
+    return failure(request, 'owner-unknown', 'RECOVERY_COMMIT_VERIFY_FAILED', verified.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+  }
+  let released = false;
+  try { released = (options.releaseRecovery ?? store.releaseRecovery)(receipt.childId!, consumer); }
+  catch { released = false; }
+  if (!released) {
+    return releaseResult(request, taskId, receipt, false, true);
+  }
+  return result(request, 'applied', { taskId, receiptId: receipt.id, childId: receipt.childId });
+}
+
+export {
+  RECOVERY_NOTE_PREFIX,
+  parseRecoveryNote,
+  recoveryFailure,
+  recoveryConsumer,
+  recoverStartedLifecycleUnderLock,
+  renderRecoveryNote
+};
+export type { LifecycleRecoveryOptions, LifecycleRecoveryRequest, LifecycleRecoveryResult, RecoveryNote, RecoveryStage };

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -435,6 +435,20 @@ function recoveryRunIsStable(run: OrchestrationRun | null): run is Orchestration
   return run !== null && run.status === 'running' && run.pendingDelegation === null;
 }
 
+function recoveryTerminalFailureStatus(code: string): 'owner-unknown' | 'conflict' {
+  switch (code) {
+    case 'RECOVERY_LOG_CONFLICT':
+    case 'RECOVERY_NOTE_INVALID':
+    case 'RECOVERY_ORCHESTRATION_INVALID':
+    case 'RECOVERY_RECEIPT_INVALID':
+    case 'RECOVERY_REFERENCE_CONFLICT':
+    case 'RECOVERY_CONSUMER_CONFLICT':
+      return 'conflict';
+    default:
+      return 'owner-unknown';
+  }
+}
+
 function readRecoveryTerminalFacts(
   section: Readonly<{ entries: readonly LogEntry[] }>,
   taskId: string,
@@ -580,7 +594,7 @@ function recoverStartedLifecycleUnderLock(
     const store = readLifecycleStore(options, resolved.repoRoot);
     const facts = readRecoveryTerminalFacts(section, taskId, request, run, store);
     if (!facts.ok) {
-      return failure(request, facts.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', facts.code, facts.message, { taskId });
+      return failure(request, recoveryTerminalFailureStatus(facts.code), facts.code, facts.message, { taskId });
     }
     const { note, receipt, consumer, stored } = facts.facts;
     if (!stored) return result(request, 'no-op', { taskId, receiptId: receipt.id, childId: receipt.childId });

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -18,6 +18,8 @@ import {
   readRun
 } from './orchestration.ts';
 import type { OrchestrationOptions, OrchestrationRun } from './orchestration.ts';
+import { isRecoveryWarning, sameRecoveryWarning } from './recovery-warning.ts';
+import type { RecoveryWarning } from './recovery-warning.ts';
 
 const RECOVERY_NOTE_PREFIX = 'lifecycle-recovery:v1 ';
 const RECOVERY_STAGES = ['analysis', 'review-analysis', 'plan', 'review-plan', 'code', 'review-code'] as const;
@@ -44,7 +46,6 @@ type LifecycleRecoveryRequest = Readonly<{
   artifact: string;
   reason: string;
 }>;
-type RecoveryWarning = Readonly<{ code: string; message: string; action: string }>;
 type RecoveryCommitVerification = { ok: true; receipt: DelegationReceipt } | { ok: false; message: string };
 type LifecycleRecoveryResult = Readonly<{
   status: 'applied' | 'no-op' | 'owner-unknown' | 'conflict';
@@ -93,23 +94,28 @@ type RecoveryNote = Readonly<{
   owner: 'terminated';
   reason: string;
 }>;
+type RecoveryTerminalFacts = Readonly<{
+  note: RecoveryNote;
+  receipt: DelegationReceipt;
+  consumer: string;
+  stored: StoredCodexLifecycle | null;
+}>;
+type RecoveryTerminalFactsResult =
+  | { ok: true; facts: RecoveryTerminalFacts }
+  | { ok: false; code: string; message: string };
+
+const RECOVERY_RELEASE_RETRY_WARNING: RecoveryWarning = Object.freeze({
+  code: 'RECOVERY_RELEASE_RETRY_REQUIRED',
+  message: 'recovery receipt and Activity Log are complete but the protected lifecycle claim could not be released',
+  action: 'retry recover-started with the same selector and reason'
+});
 
 function text(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.trim() === value && !/[\r\n]/u.test(value);
 }
 
-function isRecoveryWarning(value: unknown): value is RecoveryWarning {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const warning = value as Record<string, unknown>;
-  return Object.keys(warning).sort().join(',') === 'action,code,message'
-    && text(warning.code) && text(warning.message) && text(warning.action);
-}
-
 function isReleaseRetryWarning(value: unknown): value is RecoveryWarning {
-  return isRecoveryWarning(value)
-    && value.code === 'RECOVERY_RELEASE_RETRY_REQUIRED'
-    && value.message === 'recovery receipt and Activity Log are complete but the protected lifecycle claim could not be released'
-    && value.action === 'retry recover-started with the same selector and reason';
+  return sameRecoveryWarning(value, RECOVERY_RELEASE_RETRY_WARNING);
 }
 
 function timestamp(value: unknown): value is string {
@@ -238,18 +244,6 @@ function targetRows(sectionEntries: readonly LogEntry[], stage: RecoveryStage, r
   return { rows, recoveryEntries };
 }
 
-function matchingReceipt(run: OrchestrationRun, taskId: string, request: LifecycleRecoveryRequest, receiptId?: string): DelegationReceipt | null {
-  const candidates = [
-    ...(run.pendingDelegation ? [run.pendingDelegation] : []),
-    ...run.receipts
-  ].filter((receipt) => receipt.taskId === taskId
-    && receipt.stage === request.stage
-    && receipt.round === request.round
-    && receipt.artifact === request.artifact
-    && (receiptId === undefined || receipt.id === receiptId));
-  return candidates.length === 1 ? candidates[0]! : null;
-}
-
 function validateStopRecord(
   record: StoredCodexLifecycle,
   receipt: DelegationReceipt,
@@ -370,12 +364,22 @@ function releaseResult(
     taskId,
     receiptId: receipt.id,
     childId: receipt.childId,
-    warning: {
-      code: 'RECOVERY_RELEASE_RETRY_REQUIRED',
-      message: 'recovery receipt and Activity Log are complete but the protected lifecycle claim could not be released',
-      action: 'retry recover-started with the same selector and reason'
-    }
+    warning: RECOVERY_RELEASE_RETRY_WARNING
   });
+}
+
+function isPostActivationAbortedReceipt(
+  receipt: DelegationReceipt,
+  taskId: string,
+  request: LifecycleRecoveryRequest
+): boolean {
+  return receipt.status === 'aborted'
+    && receipt.activatedAt !== null
+    && receipt.agent === null
+    && receipt.taskId === taskId
+    && receipt.stage === request.stage
+    && receipt.round === request.round
+    && receipt.artifact === request.artifact;
 }
 
 function matchingPostActivationAbortedReceipts(
@@ -383,13 +387,7 @@ function matchingPostActivationAbortedReceipts(
   taskId: string,
   request: LifecycleRecoveryRequest
 ): DelegationReceipt[] {
-  return run.receipts.filter((receipt) => receipt.status === 'aborted'
-    && receipt.activatedAt !== null
-    && receipt.agent === null
-    && receipt.taskId === taskId
-    && receipt.stage === request.stage
-    && receipt.round === request.round
-    && receipt.artifact === request.artifact);
+  return run.receipts.filter((receipt) => isPostActivationAbortedReceipt(receipt, taskId, request));
 }
 
 function sameRecoveryNote(left: RecoveryNote, right: RecoveryNote): boolean {
@@ -408,6 +406,76 @@ function sameRecoveryNote(left: RecoveryNote, right: RecoveryNote): boolean {
     && left.reason === right.reason;
 }
 
+function recoveryNoteMatchesRequest(
+  note: RecoveryNote,
+  taskId: string,
+  request: LifecycleRecoveryRequest
+): boolean {
+  return note.taskId === taskId
+    && note.stage === request.stage
+    && note.round === request.round
+    && note.artifact === request.artifact
+    && note.startedAgent === request.agent
+    && note.reason === request.reason;
+}
+
+function recoveryReferencesMatch(
+  receipt: DelegationReceipt,
+  note: RecoveryNote,
+  consumer: string
+): boolean {
+  return receipt.childId === note.childId
+    && note.consumer === consumer
+    && receipt.hostEvidence?.stopRevision === note.stopRevision
+    && receipt.hostEvidence.consumer === consumer
+    && receipt.hostEvidence.consumedAt === note.consumedAt;
+}
+
+function recoveryRunIsStable(run: OrchestrationRun | null): run is OrchestrationRun {
+  return run !== null && run.status === 'running' && run.pendingDelegation === null;
+}
+
+function readRecoveryTerminalFacts(
+  section: Readonly<{ entries: readonly LogEntry[] }>,
+  taskId: string,
+  request: LifecycleRecoveryRequest,
+  run: OrchestrationRun | null,
+  store: ReturnType<typeof createCodexLifecycleStore>
+): RecoveryTerminalFactsResult {
+  const targets = targetRows(section.entries, request.stage, request.round);
+  const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
+  if (targets.recoveryEntries.length !== 1 || paired.length !== 1
+    || paired[0]!.done !== targets.recoveryEntries[0]!.time) {
+    return { ok: false, code: 'RECOVERY_LOG_CONFLICT', message: 'recovery Activity Log does not contain one completed started/aborted pair' };
+  }
+  const note = parseRecoveryNote(targets.recoveryEntries[0]!.note);
+  if (!note || !recoveryNoteMatchesRequest(note, taskId, request)) {
+    return { ok: false, code: 'RECOVERY_NOTE_INVALID', message: 'recovery Activity Log note does not match the selector' };
+  }
+  if (!recoveryRunIsStable(run)) {
+    return { ok: false, code: 'RECOVERY_ORCHESTRATION_INVALID', message: 'completed recovery state must be running with no pending delegation' };
+  }
+  const receipts = matchingPostActivationAbortedReceipts(run, taskId, request);
+  if (receipts.length !== 1 || receipts[0]!.id !== note.receiptId) {
+    return { ok: false, code: 'RECOVERY_RECEIPT_INVALID', message: 'there is not one matching post-activation aborted receipt' };
+  }
+  const receipt = receipts[0]!;
+  const consumer = recoveryConsumer(taskId, receipt.id);
+  if (!recoveryReferencesMatch(receipt, note, consumer)) {
+    return { ok: false, code: 'RECOVERY_REFERENCE_CONFLICT', message: 'recovery receipt and Activity Log references do not match' };
+  }
+  const stored = readStoredEvidence(store, note.childId);
+  if ('error' in stored) return { ok: false, code: 'RECOVERY_STORE_UNKNOWN', message: stored.error.message };
+  if ('missing' in stored) return { ok: true, facts: { note, receipt, consumer, stored: null } };
+  const evidence = validateStopRecord(stored, receipt, consumer);
+  if (!evidence.ok) return evidence;
+  if (stored.consumer !== consumer || !stored.consumedAt
+    || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
+    return { ok: false, code: 'RECOVERY_REFERENCE_CONFLICT', message: 'complete recovery facts do not reference the protected recovery claim' };
+  }
+  return { ok: true, facts: { note, receipt, consumer, stored } };
+}
+
 function verifyRecoveryCommit(
   taskMdPath: string,
   taskDir: string,
@@ -421,39 +489,15 @@ function verifyRecoveryCommit(
     parseTypedTaskFrontmatter(content);
     const section = locateActivityLog(content);
     if (!section) return { ok: false, message: 'recovery Activity Log cannot be reread uniquely' };
-    const targets = targetRows(section.entries, request.stage, request.round);
-    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
-    if (targets.recoveryEntries.length !== 1 || paired.length !== 1 || paired[0]!.done !== targets.recoveryEntries[0]!.time) {
-      return { ok: false, message: 'recovery Activity Log does not contain one completed started/aborted pair' };
-    }
-    const logged = parseRecoveryNote(targets.recoveryEntries[0]!.note);
-    if (!logged || !sameRecoveryNote(logged, note)) {
+    const run = readRun(taskDir, options.orchestration);
+    const store = readLifecycleStore(options, options.repoRoot ?? path.resolve(taskDir, '../../../..'));
+    const facts = readRecoveryTerminalFacts(section, taskId, request, run, store);
+    if (!facts.ok) return { ok: false, message: facts.message };
+    if (!sameRecoveryNote(facts.facts.note, note)) {
       return { ok: false, message: 'recovery Activity Log note changed during commit verification' };
     }
-    const run = readRun(taskDir, options.orchestration);
-    if (!run || run.status !== 'running' || run.pendingDelegation !== null) {
-      return { ok: false, message: 'orchestration recovery state is not running with no pending delegation' };
-    }
-    const receipts = matchingPostActivationAbortedReceipts(run, taskId, request);
-    if (receipts.length !== 1 || receipts[0]!.id !== note.receiptId) {
-      return { ok: false, message: 'orchestration recovery state does not contain one matching aborted receipt' };
-    }
-    const receipt = receipts[0]!;
-    if (
-      receipt.childId !== note.childId
-      || receipt.hostEvidence?.stopRevision !== note.stopRevision
-      || receipt.hostEvidence.consumer !== note.consumer
-      || receipt.hostEvidence.consumedAt !== note.consumedAt
-    ) return { ok: false, message: 'orchestration recovery references changed during commit verification' };
-    const store = readLifecycleStore(options, options.repoRoot ?? path.resolve(taskDir, '../../../..'));
-    const stored = readStoredEvidence(store, note.childId);
-    if ('error' in stored) return { ok: false, message: stored.error.message };
-    if ('missing' in stored) return { ok: false, message: 'protected lifecycle claim disappeared before release' };
-    const evidence = validateStopRecord(stored, receipt, note.consumer);
-    if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
-      return { ok: false, message: evidence.ok ? 'protected lifecycle claim references changed during commit verification' : evidence.message };
-    }
-    return { ok: true, receipt };
+    if (!facts.facts.stored) return { ok: false, message: 'protected lifecycle claim disappeared before release' };
+    return { ok: true, receipt: facts.facts.receipt };
   } catch (error) {
     return { ok: false, message: error instanceof Error ? error.message : String(error) };
   }
@@ -484,33 +528,11 @@ export function readLifecycleRecoveryDomainEvidence(
     parseTypedTaskFrontmatter(content);
     const section = locateActivityLog(content);
     if (!section) return recoveryDomainFailure();
-    const targets = targetRows(section.entries, request.stage, request.round);
-    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
-    if (targets.recoveryEntries.length !== 1 || paired.length !== 1
-      || paired[0]!.done !== targets.recoveryEntries[0]!.time) return recoveryDomainFailure();
-    const note = parseRecoveryNote(targets.recoveryEntries[0]!.note);
-    if (!note || note.taskId !== resolved.taskId || note.stage !== request.stage
-      || note.round !== request.round || note.artifact !== request.artifact
-      || note.startedAgent !== request.agent || note.reason !== request.reason) return recoveryDomainFailure();
     const run = readRun(resolved.taskDir);
-    if (!run || run.status !== 'running' || run.pendingDelegation !== null) return recoveryDomainFailure();
-    const receipts = matchingPostActivationAbortedReceipts(run, resolved.taskId, request);
-    if (receipts.length !== 1 || receipts[0]!.id !== note.receiptId) return recoveryDomainFailure();
-    const receipt = receipts[0]!;
-    const consumer = recoveryConsumer(resolved.taskId, receipt.id);
-    if (receipt.childId !== note.childId || note.consumer !== consumer
-      || receipt.hostEvidence?.stopRevision !== note.stopRevision
-      || receipt.hostEvidence.consumer !== consumer
-      || receipt.hostEvidence.consumedAt !== note.consumedAt) return recoveryDomainFailure();
     const store = readLifecycleStore(options, repoRoot);
-    const stored = readStoredEvidence(store, note.childId);
-    if ('error' in stored) return recoveryDomainFailure();
-    if ('missing' in stored) return { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' };
-    if (stored.consumer !== consumer || !stored.consumedAt) return recoveryDomainFailure();
-    const evidence = validateStopRecord(stored, receipt, consumer);
-    if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
-      return recoveryDomainFailure();
-    }
+    const facts = readRecoveryTerminalFacts(section, resolved.taskId, request, run, store);
+    if (!facts.ok) return recoveryDomainFailure();
+    if (!facts.facts.stored) return { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' };
     if (!isReleaseRetryWarning(terminalResult.warning)) return recoveryDomainFailure();
     return {
       consistent: true,
@@ -555,38 +577,13 @@ function recoverStartedLifecycleUnderLock(
     if (targets.recoveryEntries.length !== 1) {
       return failure(request, 'conflict', 'RECOVERY_TERMINAL_MISSING', 'there is no matching open or structured recovery lifecycle row', { taskId });
     }
-    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
-    if (paired.length !== 1 || paired[0]!.done !== targets.recoveryEntries[0]!.time) {
-      return failure(request, 'conflict', 'RECOVERY_LOG_CONFLICT', 'recovery terminal row is not paired with the matching started row', { taskId });
-    }
-    const note = parseRecoveryNote(targets.recoveryEntries[0]!.note);
-    if (!note || note.taskId !== taskId || note.stage !== request.stage || note.round !== request.round || note.artifact !== request.artifact || note.startedAgent !== request.agent || note.reason !== request.reason) {
-      return failure(request, 'conflict', 'RECOVERY_NOTE_INVALID', 'recovery Activity Log note does not match the selector', { taskId });
-    }
-    if (run.status !== 'running' || run.pendingDelegation !== null) {
-      return failure(request, 'conflict', 'RECOVERY_ORCHESTRATION_INVALID', 'completed recovery state must be running with no pending delegation', { taskId });
-    }
-    const postActivationReceipts = matchingPostActivationAbortedReceipts(run, taskId, request);
-    if (postActivationReceipts.length !== 1) {
-      return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'there is not one unique post-activation aborted receipt', { taskId });
-    }
-    const receipt = matchingReceipt(run, taskId, request, note.receiptId);
-    if (!receipt || receipt.status !== 'aborted' || receipt.agent !== null || receipt.childId !== note.childId) {
-      return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'there is not one matching post-activation aborted receipt', { taskId, receiptId: note.receiptId, childId: note.childId });
-    }
-    const consumer = recoveryConsumer(taskId, receipt.id);
-    if (note.consumer !== consumer || receipt.hostEvidence?.stopRevision !== note.stopRevision || receipt.hostEvidence.consumer !== consumer || receipt.hostEvidence.consumedAt !== note.consumedAt) {
-      return failure(request, 'conflict', 'RECOVERY_REFERENCE_CONFLICT', 'recovery receipt and Activity Log references do not match', { taskId, receiptId: receipt.id, childId: receipt.childId });
-    }
     const store = readLifecycleStore(options, resolved.repoRoot);
-    const stored = readStoredEvidence(store, note.childId);
-    if ('error' in stored) return failure(request, 'owner-unknown', 'RECOVERY_STORE_UNKNOWN', stored.error.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
-    if ('missing' in stored) return result(request, 'no-op', { taskId, receiptId: receipt.id, childId: receipt.childId });
-    if (stored.consumer === null || !stored.consumedAt) {
-      return failure(request, 'conflict', 'RECOVERY_REFERENCE_CONFLICT', 'complete recovery facts do not reference the protected recovery claim', { taskId, receiptId: receipt.id, childId: receipt.childId });
+    const facts = readRecoveryTerminalFacts(section, taskId, request, run, store);
+    if (!facts.ok) {
+      return failure(request, facts.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', facts.code, facts.message, { taskId });
     }
-    const evidence = validateStopRecord(stored, receipt, consumer);
-    if (!evidence.ok) return failure(request, evidence.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', evidence.code, evidence.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
+    const { note, receipt, consumer, stored } = facts.facts;
+    if (!stored) return result(request, 'no-op', { taskId, receiptId: receipt.id, childId: receipt.childId });
     let released = false;
     try { released = (options.releaseRecovery ?? store.releaseRecovery)(note.childId, consumer); }
     catch (error) {
@@ -603,13 +600,7 @@ function recoverStartedLifecycleUnderLock(
     return failure(request, 'conflict', 'RECOVERY_LOG_CONFLICT', 'open lifecycle execution already has a recovery terminal row', { taskId });
   }
   const pending = run.pendingDelegation;
-  const recovered = run.receipts.filter((candidate) => candidate.status === 'aborted'
-    && candidate.activatedAt !== null
-    && candidate.agent === null
-    && candidate.taskId === taskId
-    && candidate.stage === request.stage
-    && candidate.round === request.round
-    && candidate.artifact === request.artifact);
+  const recovered = run.receipts.filter((candidate) => isPostActivationAbortedReceipt(candidate, taskId, request));
   if (pending && recovered.length > 0) {
     return failure(request, 'conflict', 'RECOVERY_RECEIPT_INVALID', 'open lifecycle execution has both a pending and an aborted matching delegation', { taskId });
   }

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -105,6 +105,13 @@ function isRecoveryWarning(value: unknown): value is RecoveryWarning {
     && text(warning.code) && text(warning.message) && text(warning.action);
 }
 
+function isReleaseRetryWarning(value: unknown): value is RecoveryWarning {
+  return isRecoveryWarning(value)
+    && value.code === 'RECOVERY_RELEASE_RETRY_REQUIRED'
+    && value.message === 'recovery receipt and Activity Log are complete but the protected lifecycle claim could not be released'
+    && value.action === 'retry recover-started with the same selector and reason';
+}
+
 function timestamp(value: unknown): value is string {
   return text(value) && Number.isFinite(Date.parse(value));
 }
@@ -462,10 +469,13 @@ export function readLifecycleRecoveryDomainEvidence(
   terminalResult: Readonly<{ status: string; changed: boolean | null; targetState: string | null; warning?: unknown | null }>,
   options: Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'now'> = {}
 ): Readonly<Record<string, unknown>> {
+  const terminalStateValid = terminalResult.status === 'no-op'
+    ? terminalResult.changed === false
+    : terminalResult.status === 'applied'
+      && (terminalResult.changed === true || (terminalResult.changed === false && isReleaseRetryWarning(terminalResult.warning)));
   const normalized = normalizeRequest(requestInput);
   if ('code' in normalized || terminalResult.targetState !== 'active'
-    || !['applied', 'no-op'].includes(terminalResult.status)
-    || terminalResult.changed !== (terminalResult.status === 'applied')) return recoveryDomainFailure();
+    || !terminalStateValid) return recoveryDomainFailure();
   const request = normalized;
   const resolved = resolveTaskRef(request.taskRef, { repoRoot });
   if (!resolved.ok) return recoveryDomainFailure();
@@ -501,7 +511,7 @@ export function readLifecycleRecoveryDomainEvidence(
     if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
       return recoveryDomainFailure();
     }
-    if (!isRecoveryWarning(terminalResult.warning)) return recoveryDomainFailure();
+    if (!isReleaseRetryWarning(terminalResult.warning)) return recoveryDomainFailure();
     return {
       consistent: true,
       recovery: true,

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -48,6 +48,7 @@ type RecoveryWarning = Readonly<{ code: string; message: string; action: string 
 type LifecycleRecoveryResult = Readonly<{
   status: 'applied' | 'no-op' | 'owner-unknown' | 'conflict';
   changed: boolean;
+  targetState: 'active';
   requestRef: string;
   intent: 'recover-started';
   taskId: string | null;
@@ -149,6 +150,7 @@ function result(
   return {
     status,
     changed: status === 'applied',
+    targetState: 'active',
     requestRef: request.taskRef,
     intent: request.intent,
     taskId: null,
@@ -433,6 +435,61 @@ function verifyRecoveryCommit(
   }
 }
 
+function recoveryDomainFailure(): Readonly<Record<string, unknown>> {
+  return { consistent: false, recovery: true, targetState: 'active' };
+}
+
+export function readLifecycleRecoveryDomainEvidence(
+  repoRoot: string,
+  requestInput: LifecycleRecoveryRequest,
+  terminalResult: Readonly<{ status: string; changed: boolean | null; targetState: string | null }>,
+  options: Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'now'> = {}
+): Readonly<Record<string, unknown>> {
+  const normalized = normalizeRequest(requestInput);
+  if ('code' in normalized || terminalResult.targetState !== 'active'
+    || !['applied', 'no-op'].includes(terminalResult.status)
+    || terminalResult.changed !== (terminalResult.status === 'applied')) return recoveryDomainFailure();
+  const request = normalized;
+  const resolved = resolveTaskRef(request.taskRef, { repoRoot });
+  if (!resolved.ok) return recoveryDomainFailure();
+  try {
+    const content = fs.readFileSync(resolved.taskMdPath, 'utf8');
+    parseTypedTaskFrontmatter(content);
+    const section = locateActivityLog(content);
+    if (!section) return recoveryDomainFailure();
+    const targets = targetRows(section.entries, request.stage, request.round);
+    const paired = targets.rows.filter((row) => row.started !== '' && row.done !== '');
+    if (targets.recoveryEntries.length !== 1 || paired.length !== 1
+      || paired[0]!.done !== targets.recoveryEntries[0]!.time) return recoveryDomainFailure();
+    const note = parseRecoveryNote(targets.recoveryEntries[0]!.note);
+    if (!note || note.taskId !== resolved.taskId || note.stage !== request.stage
+      || note.round !== request.round || note.artifact !== request.artifact
+      || note.startedAgent !== request.agent || note.reason !== request.reason) return recoveryDomainFailure();
+    const run = readRun(resolved.taskDir);
+    if (!run || run.status !== 'running' || run.pendingDelegation !== null) return recoveryDomainFailure();
+    const receipts = matchingPostActivationAbortedReceipts(run, resolved.taskId, request);
+    if (receipts.length !== 1 || receipts[0]!.id !== note.receiptId) return recoveryDomainFailure();
+    const receipt = receipts[0]!;
+    const consumer = recoveryConsumer(resolved.taskId, receipt.id);
+    if (receipt.childId !== note.childId || note.consumer !== consumer
+      || receipt.hostEvidence?.stopRevision !== note.stopRevision
+      || receipt.hostEvidence.consumer !== consumer
+      || receipt.hostEvidence.consumedAt !== note.consumedAt) return recoveryDomainFailure();
+    const store = readLifecycleStore(options, repoRoot);
+    const stored = readStoredEvidence(store, note.childId);
+    if ('error' in stored) return recoveryDomainFailure();
+    if ('missing' in stored) return { consistent: true, recovery: true, targetState: 'active' };
+    if (stored.consumer !== consumer || !stored.consumedAt) return recoveryDomainFailure();
+    const evidence = validateStopRecord(stored, receipt, consumer);
+    if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
+      return recoveryDomainFailure();
+    }
+    return { consistent: true, recovery: true, targetState: 'active' };
+  } catch {
+    return recoveryDomainFailure();
+  }
+}
+
 function recoverStartedLifecycleUnderLock(
   requestInput: LifecycleRecoveryRequest,
   options: LifecycleRecoveryOptions = {}
@@ -538,7 +595,7 @@ function recoverStartedLifecycleUnderLock(
   if (!evidence.ok) return failure(request, evidence.code === 'RECOVERY_CONSUMER_CONFLICT' ? 'conflict' : 'owner-unknown', evidence.code, evidence.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
   let claimed = stored;
   if (stored.consumer === null) {
-    try { claimed = store.consume(receipt.childId!, consumer, receipt.hostEvidence?.hookDefinitionHash); }
+    try { claimed = store.claimRecovery(receipt.childId!, taskId, receipt.id, receipt.hostEvidence?.hookDefinitionHash); }
     catch (error) { return failure(request, 'owner-unknown', 'RECOVERY_CLAIM_FAILED', error instanceof Error ? error.message : String(error), { taskId, receiptId: receipt.id, childId: receipt.childId }); }
   }
   const stopRevision = claimed.revision;

--- a/lib/task/lifecycle-recovery.ts
+++ b/lib/task/lifecycle-recovery.ts
@@ -45,6 +45,7 @@ type LifecycleRecoveryRequest = Readonly<{
   reason: string;
 }>;
 type RecoveryWarning = Readonly<{ code: string; message: string; action: string }>;
+type RecoveryCommitVerification = { ok: true; receipt: DelegationReceipt } | { ok: false; message: string };
 type LifecycleRecoveryResult = Readonly<{
   status: 'applied' | 'no-op' | 'owner-unknown' | 'conflict';
   changed: boolean;
@@ -66,6 +67,15 @@ type LifecycleRecoveryOptions = Readonly<{
   orchestration?: Pick<OrchestrationOptions, 'diagnosticLog' | 'now'>;
   lifecycleStore?: ReturnType<typeof createCodexLifecycleStore>;
   releaseRecovery?: (childThreadId: string, consumer: string) => boolean;
+  writeTask?: typeof writeTask;
+  verifyRecoveryCommit?: (
+    taskMdPath: string,
+    taskDir: string,
+    taskId: string,
+    request: LifecycleRecoveryRequest,
+    note: RecoveryNote,
+    options: LifecycleRecoveryOptions
+  ) => RecoveryCommitVerification;
 }>;
 
 type RecoveryNote = Readonly<{
@@ -86,6 +96,13 @@ type RecoveryNote = Readonly<{
 
 function text(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.trim() === value && !/[\r\n]/u.test(value);
+}
+
+function isRecoveryWarning(value: unknown): value is RecoveryWarning {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const warning = value as Record<string, unknown>;
+  return Object.keys(warning).sort().join(',') === 'action,code,message'
+    && text(warning.code) && text(warning.message) && text(warning.action);
 }
 
 function timestamp(value: unknown): value is string {
@@ -391,7 +408,7 @@ function verifyRecoveryCommit(
   request: LifecycleRecoveryRequest,
   note: RecoveryNote,
   options: LifecycleRecoveryOptions
-): { ok: true; receipt: DelegationReceipt } | { ok: false; message: string } {
+): RecoveryCommitVerification {
   try {
     const content = fs.readFileSync(taskMdPath, 'utf8');
     parseTypedTaskFrontmatter(content);
@@ -442,7 +459,7 @@ function recoveryDomainFailure(): Readonly<Record<string, unknown>> {
 export function readLifecycleRecoveryDomainEvidence(
   repoRoot: string,
   requestInput: LifecycleRecoveryRequest,
-  terminalResult: Readonly<{ status: string; changed: boolean | null; targetState: string | null }>,
+  terminalResult: Readonly<{ status: string; changed: boolean | null; targetState: string | null; warning?: unknown | null }>,
   options: Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'now'> = {}
 ): Readonly<Record<string, unknown>> {
   const normalized = normalizeRequest(requestInput);
@@ -478,13 +495,20 @@ export function readLifecycleRecoveryDomainEvidence(
     const store = readLifecycleStore(options, repoRoot);
     const stored = readStoredEvidence(store, note.childId);
     if ('error' in stored) return recoveryDomainFailure();
-    if ('missing' in stored) return { consistent: true, recovery: true, targetState: 'active' };
+    if ('missing' in stored) return { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' };
     if (stored.consumer !== consumer || !stored.consumedAt) return recoveryDomainFailure();
     const evidence = validateStopRecord(stored, receipt, consumer);
     if (!evidence.ok || evidence.stopRevision !== note.stopRevision || evidence.consumedAt !== note.consumedAt) {
       return recoveryDomainFailure();
     }
-    return { consistent: true, recovery: true, targetState: 'active' };
+    if (!isRecoveryWarning(terminalResult.warning)) return recoveryDomainFailure();
+    return {
+      consistent: true,
+      recovery: true,
+      targetState: 'active',
+      recoveryState: 'retry-required',
+      warning: terminalResult.warning
+    };
   } catch {
     return recoveryDomainFailure();
   }
@@ -620,7 +644,7 @@ function recoverStartedLifecycleUnderLock(
   const note = taskNote(taskId, request, receipt, stopRevision, consumer, consumedAt);
   const metadata = captureTaskWriteMetadata();
   const updatedBody = `${section.body ? `${section.body}\n` : ''}- ${metadata.timestamp} — **${baseStep(started.step)} [aborted]** by ${request.agent} — ${renderRecoveryNote(note)}`;
-  const written = writeTask({
+  const written = (options.writeTask ?? writeTask)({
     taskRef: taskId,
     expectedState: 'active',
     mutations: [{ kind: 'section', aliases: ['活动日志', 'Activity Log'], heading: section.heading, body: updatedBody }]
@@ -628,7 +652,7 @@ function recoverStartedLifecycleUnderLock(
   if (written.status === 'failed') {
     return failure(request, 'owner-unknown', 'RECOVERY_LOG_WRITE_FAILED', written.error.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
   }
-  const verified = verifyRecoveryCommit(resolved.taskMdPath, resolved.taskDir, taskId, request, note, options);
+  const verified = (options.verifyRecoveryCommit ?? verifyRecoveryCommit)(resolved.taskMdPath, resolved.taskDir, taskId, request, note, options);
   if (!verified.ok) {
     return failure(request, 'owner-unknown', 'RECOVERY_COMMIT_VERIFY_FAILED', verified.message, { taskId, receiptId: receipt.id, childId: receipt.childId });
   }

--- a/lib/task/lifecycle.ts
+++ b/lib/task/lifecycle.ts
@@ -17,7 +17,7 @@ import { validateCurrentTaskContract } from './current-contract.ts';
 import { isValidAgentInfraVersion } from '../version.ts';
 
 const lifecycleIntentCatalog = [
-  'block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore'
+  'block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore', 'recover-started'
 ] as const;
 const lifecycleFailureCatalog = [
   'LIFECYCLE_DIRECTORY_RENAME_FAILED',
@@ -55,7 +55,8 @@ type TaskLifecycleRequest =
   | { taskRef: string; intent: 'complete'; agent: string; dryRun?: boolean }
   | { taskRef: string; intent: 'close-codescan'; agent: string; alertNumber: number; reason: string; dryRun?: boolean }
   | { taskRef: string; intent: 'close-dependabot'; agent: string; alertNumber: number; reason: string; dryRun?: boolean }
-  | { taskRef: string; intent: 'restore'; agent: string; stagingDir: string; issueNumber: number; dryRun?: boolean };
+  | { taskRef: string; intent: 'restore'; agent: string; stagingDir: string; issueNumber: number; dryRun?: boolean }
+  | { taskRef: string; intent: 'recover-started'; agent: string; stage: 'analysis' | 'review-analysis' | 'plan' | 'review-plan' | 'code' | 'review-code'; round: number; artifact: string; reason: string; dryRun?: boolean };
 
 type HotState = 'active' | 'blocked' | 'completed';
 type SourceState = HotState | 'staging';
@@ -206,6 +207,7 @@ function actionAndNote(request: TaskLifecycleRequest, restoredFiles = 0): { acti
   if (request.intent === 'complete') return { action: 'Complete Task', note: 'Task moved to completed/' };
   if (request.intent === 'close-codescan') return { action: 'Close Codescan', note: `Code Scanning alert #${request.alertNumber} dismissed: ${request.reason}` };
   if (request.intent === 'close-dependabot') return { action: 'Close Dependabot', note: `Dependabot alert #${request.alertNumber} dismissed: ${request.reason}` };
+  if (request.intent === 'recover-started') return { action: 'Recover Started', note: request.reason };
   return { action: 'Restore Task', note: `Restored ${restoredFiles} files from Issue #${request.issueNumber}` };
 }
 
@@ -410,6 +412,9 @@ function removeCopiedSource(source: string, target: string): void {
 }
 
 function applyTaskLifecycle(requestInput: TaskLifecycleRequest, options: TaskLifecycleOptions = {}): TaskLifecycleResult {
+  if (requestInput.intent === 'recover-started') {
+    return failed(requestInput, { code: 'LIFECYCLE_RECOVERY_REQUIRES_AUTHORITY', message: 'recover-started must be dispatched through task control authority' });
+  }
   const normalized = normalizedRequest(requestInput);
   if ('code' in normalized) return failed(requestInput, normalized);
   const request = normalized;

--- a/lib/task/orchestration.ts
+++ b/lib/task/orchestration.ts
@@ -11,6 +11,7 @@ import type { LedgerDocument } from './ledger.ts';
 import { resolveTaskRef } from './resolve-ref.ts';
 import {
   activateDelegation,
+  abortActivatedDelegation,
   abortPreparedDelegation,
   completeDelegationStage,
   consumeDelegation,
@@ -59,6 +60,7 @@ import { hasOpenLifecycleExecution } from './activity-log.ts';
 import { invalidationBlocks } from './invalidation.ts';
 import type { InvalidationDocument } from './invalidation.ts';
 import type { LifecycleAction, LifecycleFacts } from './capabilities.ts';
+import { normalizeAgentToken } from '../agent-clients/tokens.ts';
 
 type OrchestrationStatus = 'running' | 'paused' | 'completed';
 type ModelPolicySource = Readonly<{
@@ -1444,6 +1446,68 @@ function recoverPreparedOrchestrationDelegation(
   }
 }
 
+function recoverActivatedOrchestrationDelegationUnderLock(
+  taskRef: string,
+  event: Readonly<{
+    receiptId: string;
+    stage: DelegationStage;
+    round: number;
+    artifact: string;
+    startedAgent: string;
+    childId: string;
+    stopRevision: number;
+    consumer: string;
+    consumedAt: string;
+  }>,
+  options: OrchestrationOptions = {}
+): OrchestrationResult {
+  const resolved = resolveTaskRef(taskRef, { repoRoot: options.repoRoot });
+  if (!resolved.ok) return failed(resolved.code, resolved.message, resolved.taskId);
+  const run = readRun(resolved.taskDir, options);
+  if (!run) return failed('ORCHESTRATION_RUN_MISSING', 'no orchestration run exists', resolved.taskId);
+  const matches = [
+    ...(run.pendingDelegation ? [run.pendingDelegation] : []),
+    ...run.receipts.filter((receipt) => receipt.id === event.receiptId)
+  ];
+  const receipt = matches.find((candidate) => candidate.id === event.receiptId);
+  if (!receipt) return failed('ORCHESTRATION_DELEGATION_MISSING', 'recovery receipt does not exist', resolved.taskId);
+  if (
+    receipt.taskId !== resolved.taskId
+    || receipt.stage !== event.stage
+    || receipt.round !== event.round
+    || receipt.artifact !== event.artifact
+    || receipt.childId !== event.childId
+    || normalizeAgentToken(event.startedAgent) !== normalizeAgentToken(receipt.client)
+  ) {
+    return failed('ORCHESTRATION_PROVENANCE_MISMATCH', 'recovery selector does not match the delegation receipt', resolved.taskId);
+  }
+  if (receipt.status === 'aborted' && run.pendingDelegation === null) {
+    return { status: run.status, changed: false, taskId: resolved.taskId, run, next: null, error: null };
+  }
+  if (run.pendingDelegation?.id !== receipt.id || receipt.status !== 'activated') {
+    return failed('ORCHESTRATION_RECOVERY_UNSAFE', 'recovery requires one matching activated pending delegation', resolved.taskId);
+  }
+  if (run.receipts.some((candidate) => candidate.id === receipt.id)) {
+    return failed('ORCHESTRATION_RECEIPT_DUPLICATE', 'recovery receipt already exists in the completed receipt history', resolved.taskId);
+  }
+  const aborted = abortActivatedDelegation(receipt, {
+    childId: event.childId,
+    stopRevision: event.stopRevision,
+    consumer: event.consumer,
+    consumedAt: event.consumedAt
+  });
+  if (!aborted.ok) return failed(aborted.code, aborted.message, resolved.taskId);
+  const updated = withUpdatedRun(run, {
+    status: 'running',
+    pause: null,
+    nextStage: null,
+    pendingDelegation: null,
+    receipts: Object.freeze([...run.receipts, aborted.receipt])
+  }, options.now);
+  saveRun(resolved.taskDir, updated);
+  return { status: 'running', changed: true, taskId: resolved.taskId, run: updated, next: null, error: null };
+}
+
 function completeOrchestrationStage(
   taskRef: string,
   event: Parameters<typeof completeDelegationStage>[1],
@@ -1598,6 +1662,7 @@ export {
   readRun,
   reconcileMatchingOrchestrationDelegation,
   recoverPreparedOrchestrationDelegation,
+  recoverActivatedOrchestrationDelegationUnderLock,
   routeOrchestration,
   sealMatchingOrchestrationDelegation,
   sealMatchingOrchestrationDelegationWithHostEvidence,

--- a/lib/task/recovery-warning.ts
+++ b/lib/task/recovery-warning.ts
@@ -1,0 +1,21 @@
+export type RecoveryWarning = Readonly<{ code: string; message: string; action: string }>;
+
+function warningText(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.trim() === value && !/[\r\n]/u.test(value);
+}
+
+export function isRecoveryWarning(value: unknown): value is RecoveryWarning {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const warning = value as Record<string, unknown>;
+  return Object.keys(warning).sort().join(',') === 'action,code,message'
+    && warningText(warning.code)
+    && warningText(warning.message)
+    && warningText(warning.action);
+}
+
+export function sameRecoveryWarning(left: unknown, right: unknown): boolean {
+  return isRecoveryWarning(left) && isRecoveryWarning(right)
+    && left.code === right.code
+    && left.message === right.message
+    && left.action === right.action;
+}

--- a/tests/integration/cli/task-lifecycle.test.ts
+++ b/tests/integration/cli/task-lifecycle.test.ts
@@ -86,6 +86,19 @@ test('task-lifecycle CLI rejects unknown and duplicate options as one JSON failu
   }
 });
 
+test('task-lifecycle recover-started exposes a structured owner-unknown result', () => {
+  const f = fixture();
+  const result = run(f.root, [
+    TASK_ID, 'recover-started', '--agent', 'codex', '--stage', 'code', '--round', '1',
+    '--artifact', 'code.md', '--reason', 'managed child termination requires evidence'
+  ]);
+  assert.equal(result.status, 1);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, 'owner-unknown');
+  assert.equal(parsed.error.code, 'RECOVERY_ORCHESTRATION_MISSING');
+  assert.equal(fs.existsSync(path.join(f.root, '.agents', 'workspace', 'completed', TASK_ID)), false);
+});
+
 const RESTORE_TASK_ID = 'TASK-20260202-000002';
 
 function stagingFixture({ initGit = true } = {}) {

--- a/tests/integration/core/durable-write.test.ts
+++ b/tests/integration/core/durable-write.test.ts
@@ -19,6 +19,14 @@ test('durable publication distinguishes replacement from immutable creation', on
   assert.deepEqual(fs.readdirSync(root), ['record']);
 });
 
+test('durable publication remains usable when Windows cannot fsync a directory', onPlatforms('win32'), (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'durable-write-windows-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const target = path.join(root, 'record');
+  writeDurableFile(target, 'windows', { mode: 0o600, replace: true });
+  assert.equal(fs.readFileSync(target, 'utf8'), 'windows');
+});
+
 test('durable publication preserves the target and cleans temporary files on sync failure', onPlatforms('linux', 'darwin'), (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'durable-write-failure-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/tests/integration/platform-smoke/core/durable-write.test.ts
+++ b/tests/integration/platform-smoke/core/durable-write.test.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { writeDurableFile } from '../../../lib/fs/durable-write.ts';
-import { onPlatforms } from '../../helpers.ts';
+import { writeDurableFile } from '../../../../lib/fs/durable-write.ts';
+import { onPlatforms } from '../../../helpers.ts';
 
 test('durable publication distinguishes replacement from immutable creation', onPlatforms('linux', 'darwin'), (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'durable-write-'));

--- a/tests/unit/cli/task-lifecycle.test.ts
+++ b/tests/unit/cli/task-lifecycle.test.ts
@@ -33,7 +33,7 @@ function fixture(state: 'active' | 'blocked' = 'active') {
 
 test('lifecycle catalog exposes the approved closed intent set', () => {
   assert.deepEqual(lifecycleIntentCatalog, [
-    'block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore'
+    'block', 'activate', 'cancel', 'complete', 'close-codescan', 'close-dependabot', 'restore', 'recover-started'
   ]);
 });
 

--- a/tests/unit/core/codex-lifecycle-store.test.ts
+++ b/tests/unit/core/codex-lifecycle-store.test.ts
@@ -175,3 +175,41 @@ test('Codex lifecycle store marks stale active evidence expired before cleanup',
   assert.equal(store.expireBefore('2026-08-13T01:30:00.000Z'), 1);
   assert.throws(() => store.read('child'), /not found uniquely/);
 });
+
+test('Codex lifecycle store preserves and releases a recovery-owned stop-ready claim', () => {
+  const root = temporaryRoot();
+  let now = '2026-08-14T00:00:00.000Z';
+  const store = createCodexLifecycleStore({ root, cliVersion: '0.147.0', now: () => now });
+  store.apply({
+    type: 'hook-spawn', sessionId: 'parent', turnId: 'turn', toolUseId: 'tool',
+    nativeAgent: 'agent-infra-lifecycle-executor', hookDefinitionHash: 'hash'
+  });
+  store.apply({
+    type: 'hook-child', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child',
+    parentThreadId: 'parent', nativeAgent: 'agent-infra-lifecycle-executor'
+  });
+  store.apply({
+    type: 'app-thread', childThreadId: 'child', parentThreadId: 'parent',
+    forkedFromId: null, sourceParentThreadId: 'parent',
+    nativeAgent: 'agent-infra-lifecycle-executor'
+  });
+  store.apply({
+    type: 'app-settings', childThreadId: 'child', model: 'model', reasoningEffort: 'high'
+  });
+  store.apply({
+    type: 'app-terminal', childThreadId: 'child', turnId: 'child-turn', status: 'completed'
+  });
+  store.apply({
+    type: 'hook-stop', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child',
+    nativeAgent: 'agent-infra-lifecycle-executor'
+  });
+
+  const consumer = 'lifecycle-recovery:TASK-20260101-000001:receipt-1';
+  assert.equal(store.consume('child', consumer, 'hash').consumer, consumer);
+
+  now = '2026-08-15T00:00:00.000Z';
+  assert.equal(store.expireBefore('2026-08-14T12:00:00.000Z'), 0);
+  assert.equal(store.read('child').consumer, consumer);
+  assert.equal(store.releaseRecovery('child', consumer), true);
+  assert.throws(() => store.read('child'), /not found uniquely/);
+});

--- a/tests/unit/core/codex-lifecycle-store.test.ts
+++ b/tests/unit/core/codex-lifecycle-store.test.ts
@@ -205,7 +205,8 @@ test('Codex lifecycle store preserves and releases a recovery-owned stop-ready c
   });
 
   const consumer = 'lifecycle-recovery:TASK-20260101-000001:receipt-1';
-  assert.equal(store.consume('child', consumer, 'hash').consumer, consumer);
+  assert.throws(() => store.consume('child', consumer, 'hash'), /require claimRecovery/);
+  assert.equal(store.claimRecovery('child', 'TASK-20260101-000001', 'receipt-1', 'hash').consumer, consumer);
 
   now = '2026-08-15T00:00:00.000Z';
   assert.equal(store.expireBefore('2026-08-14T12:00:00.000Z'), 0);

--- a/tests/unit/core/delegation-receipts.test.ts
+++ b/tests/unit/core/delegation-receipts.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   activateDelegation,
+  abortActivatedDelegation,
   completeDelegationStage,
   consumeDelegation,
   dispatchDelegation,
@@ -184,6 +185,51 @@ test('persisted Codex receipts require lifecycle provenance and status-bound hos
     ...sealed.receipt,
     hostEvidence: { ...sealed.receipt.hostEvidence, consumer: 'other' }
   }), false);
+});
+
+test('activated Codex receipts support only controller-bound recovery aborts', () => {
+  const provenance = {
+    ...codexProvenance,
+    controllerInstanceDigest: 'e'.repeat(64),
+    controlGeneration: 'generation-1'
+  } as const;
+  const prepared = dispatched(prepareDelegation({
+    ...input,
+    client: 'codex',
+    workspaceSnapshotScope: 'task',
+    lifecycleProvenance: provenance
+  }, { id: () => 'delegation-recovery' }));
+  const activated = activateDelegation(prepared, {
+    nativeAgent: 'agent-infra-lifecycle-reviewer',
+    childId: 'child-recovery',
+    parentId: 'parent-codex',
+    spawnMode: 'fresh',
+    actualModel: 'review-model',
+    actualReasoningEffort: 'high',
+    hostEvidence: {
+      kind: 'codex-lifecycle-v2',
+      startRevision: 4,
+      ...provenance,
+      spawnToolUseId: 'spawn-tool',
+      spawnObservedAt: '2099-01-01T00:00:00.500Z'
+    }
+  }, { now: () => '2099-01-01T00:00:01.000Z', monotonicNow: () => 2 });
+  assert.equal(activated.ok, true);
+  if (!activated.ok) return;
+  const aborted = abortActivatedDelegation(activated.receipt, {
+    childId: 'child-recovery',
+    stopRevision: 7,
+    consumer: 'lifecycle-recovery:TASK-20260101-000001:delegation-recovery',
+    consumedAt: '2099-01-01T00:00:02.000Z'
+  });
+  assert.equal(aborted.ok, true);
+  if (!aborted.ok) return;
+  assert.equal(aborted.receipt.status, 'aborted');
+  assert.equal(aborted.receipt.agent, null);
+  assert.equal(isDelegationReceipt(aborted.receipt), true);
+  assert.equal(abortActivatedDelegation(activated.receipt, {
+    childId: 'child-recovery', stopRevision: 7, consumer: 'ordinary-consumer', consumedAt: '2099-01-01T00:00:02.000Z'
+  }).ok, false);
 });
 
 test('delegation dispatch allows a sixty-second default activation window', () => {

--- a/tests/unit/core/delegation-receipts.test.ts
+++ b/tests/unit/core/delegation-receipts.test.ts
@@ -227,6 +227,14 @@ test('activated Codex receipts support only controller-bound recovery aborts', (
   assert.equal(aborted.receipt.status, 'aborted');
   assert.equal(aborted.receipt.agent, null);
   assert.equal(isDelegationReceipt(aborted.receipt), true);
+  assert.equal(isDelegationReceipt({
+    ...aborted.receipt,
+    hostEvidence: { ...aborted.receipt.hostEvidence!, consumer: 'lifecycle-recovery:TASK-20260101-000001:other-receipt' }
+  }), false);
+  assert.equal(isDelegationReceipt({
+    ...aborted.receipt,
+    hostEvidence: { ...aborted.receipt.hostEvidence!, consumer: 'lifecycle-recovery:TASK-20260101-000002:delegation-recovery' }
+  }), false);
   assert.equal(abortActivatedDelegation(activated.receipt, {
     childId: 'child-recovery', stopRevision: 7, consumer: 'ordinary-consumer', consumedAt: '2099-01-01T00:00:02.000Z'
   }).ok, false);

--- a/tests/unit/core/task-control-authority.test.ts
+++ b/tests/unit/core/task-control-authority.test.ts
@@ -73,3 +73,28 @@ test('authority parser owns lifecycle and finalization command shapes', () => {
     /TASK_CONTROL_OPERATION_INVALID: unknown option '--unknown'/
   );
 });
+
+test('authority parser requires the recovery selector and rejects it for normal lifecycle intents', () => {
+  const recovery = parseTaskControlOperation('task-lifecycle', [
+    'TASK-20260809-010203', 'recover-started', '--agent', 'codex', '--stage', 'code',
+    '--round', '2', '--artifact', 'code-r2.md', '--reason', 'child terminated before result'
+  ]);
+  assert.equal(recovery.family, 'task-lifecycle');
+  if (recovery.family !== 'task-lifecycle') throw new Error('unexpected lifecycle operation family');
+  assert.deepEqual(recovery.request, {
+    taskRef: 'TASK-20260809-010203', intent: 'recover-started', agent: 'codex',
+    stage: 'code', round: 2, artifact: 'code-r2.md', reason: 'child terminated before result'
+  });
+  assert.throws(
+    () => parseTaskControlOperation('task-lifecycle', [
+      'TASK-20260809-010203', 'recover-started', '--agent', 'codex', '--stage', 'code'
+    ]),
+    /option '--round' is required/u
+  );
+  assert.throws(
+    () => parseTaskControlOperation('task-lifecycle', [
+      'TASK-20260809-010203', 'cancel', '--agent', 'codex', '--reason', 'obsolete', '--stage', 'code'
+    ]),
+    /only supported for recover-started/u
+  );
+});

--- a/tests/unit/sandbox/control-server.test.ts
+++ b/tests/unit/sandbox/control-server.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { genericRecoveryResponse } from '../../../lib/sandbox/control/server.ts';
+import type { SandboxControlRecoveryWarning, SandboxControlRequest } from '../../../lib/sandbox/control/protocol.ts';
+
+test('server recovery response retains release retry warning when output payload is unavailable', () => {
+  const request = {
+    version: 3,
+    id: 'a'.repeat(32),
+    token: 'token',
+    generation: 'generation-1',
+    issuedAt: 1,
+    expiresAt: 2,
+    controllerProcess: null,
+    controllerProof: null,
+    family: 'task-lifecycle',
+    args: ['TASK-20260904-002407', 'recover-started', '--agent', 'codex', '--stage', 'code', '--round', '1', '--artifact', 'code.md', '--reason', 'response loss']
+  } as SandboxControlRequest;
+  const warning: SandboxControlRecoveryWarning = {
+    code: 'RECOVERY_RELEASE_RETRY_REQUIRED',
+    message: 'protected claim could not be released',
+    action: 'retry recover-started'
+  };
+
+  const response = genericRecoveryResponse(request, 0, null, 'recovery', warning);
+
+  assert.equal(response.outputState, 'unavailable');
+  assert.equal(response.stdout, '');
+  assert.match(response.stderr, /RECOVERY_RELEASE_RETRY_REQUIRED/u);
+  assert.match(response.stderr, /Action: retry recover-started/u);
+});

--- a/tests/unit/sandbox/control-server.test.ts
+++ b/tests/unit/sandbox/control-server.test.ts
@@ -1,8 +1,98 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
-import { genericRecoveryResponse } from '../../../lib/sandbox/control/server.ts';
-import type { SandboxControlRecoveryWarning, SandboxControlRequest } from '../../../lib/sandbox/control/protocol.ts';
+import { createCodexLifecycleStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/store.ts';
+import { activateOrchestrationDelegation, beginOrResumeOrchestration, dispatchOrchestrationDelegation, prepareOrchestrationDelegation, readRun } from '../../../lib/task/orchestration.ts';
+import { recoverStartedLifecycleUnderLock } from '../../../lib/task/lifecycle-recovery.ts';
+import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
+import { genericRecoveryResponse, recoveryResponse } from '../../../lib/sandbox/control/server.ts';
+import type { SandboxControlManifest, SandboxControlRecoveryWarning, SandboxControlRequest, SandboxControlResultEvidence } from '../../../lib/sandbox/control/protocol.ts';
+import { createSandboxControlTerminalResult } from '../../../lib/sandbox/control/state.ts';
+import { writeSandboxControlTransition } from '../../../lib/sandbox/control/audit.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+const RECOVERY_REASON = 'native child terminated before result was known';
+const MODEL_POLICY = {
+  executor: { model: 'executor-model', reasoningEffort: 'high' },
+  reviewer: { model: 'reviewer-model', reasoningEffort: 'high' }
+} as const;
+const PROVENANCE = {
+  protocolVersion: 3,
+  packageVersion: '0.9.16-alpha.0',
+  internalExecutableBuildHash: 'a'.repeat(64),
+  lifecycleContractHash: 'b'.repeat(64),
+  hookDefinitionHash: 'hook-hash',
+  hookSource: 'project' as const,
+  hookSourcePathDigest: 'c'.repeat(64),
+  hookSourceHash: 'd'.repeat(64),
+  capabilitySessionId: 'parent',
+  capabilityTurnId: 'parent-turn',
+  capabilityToolUseId: 'capability-tool',
+  controllerInstanceDigest: 'e'.repeat(64),
+  controlGeneration: 'generation-1'
+} as const;
+
+function recoveryFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-control-server-recovery-'));
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', TASK_ID);
+  const runtimeRoot = path.join(root, '.agents', 'workspace', '.runtime', 'codex-lifecycle');
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${TASK_ID}\nstatus: active\ncurrent_step: requirement-analysis\nassigned_to: codex\nupdated_at: old\nagent_infra_version: v0.9.16-alpha.0\n---\n\n# Task\n\n## Review Disagreement Ledger\n\n| id | stage | round | severity | status | evidence |\n|----|-------|-------|----------|--------|----------|\n\n## Activity Log\n`);
+  const store = createCodexLifecycleStore({ root: runtimeRoot, cliVersion: '0.147.0', now: () => '2026-01-01T00:00:00.200Z' });
+  store.apply({ type: 'hook-spawn', sessionId: 'parent', turnId: 'parent-turn', toolUseId: 'spawn-tool', nativeAgent: 'agent-infra-lifecycle-executor', hookDefinitionHash: 'hook-hash', requestedModel: 'executor-model', requestedReasoningEffort: 'high' });
+  store.apply({ type: 'hook-child', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child', parentThreadId: 'parent', nativeAgent: 'agent-infra-lifecycle-executor' });
+  store.apply({ type: 'app-thread', childThreadId: 'child', parentThreadId: 'parent', forkedFromId: null, sourceParentThreadId: 'parent', nativeAgent: 'agent-infra-lifecycle-executor' });
+  store.apply({ type: 'app-settings', childThreadId: 'child', model: 'executor-model', reasoningEffort: 'high' });
+  store.apply({ type: 'app-terminal', childThreadId: 'child', turnId: 'child-turn', status: 'completed' });
+  store.apply({ type: 'hook-stop', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child', nativeAgent: 'agent-infra-lifecycle-executor' });
+  assert.equal(beginOrResumeOrchestration(TASK_ID, { repoRoot: root, client: 'codex', modelPolicy: MODEL_POLICY, id: () => 'run-1', now: () => '2026-01-01T00:00:00.000Z' }).status, 'running');
+  assert.equal(prepareOrchestrationDelegation(TASK_ID, { client: 'codex', requestedModel: 'executor-model', requestedReasoningEffort: 'high', lifecycleProvenance: PROVENANCE }, { repoRoot: root, supportsLifecycleDelegation: () => true, captureWorkspace: () => 'before-tree', id: () => 'receipt-1', now: () => '2026-01-01T00:00:00.100Z', monotonicNow: () => 10 }).status, 'running');
+  assert.equal(dispatchOrchestrationDelegation(TASK_ID, { repoRoot: root, now: () => '2026-01-01T00:00:00.150Z', monotonicNow: () => 20 }).status, 'running');
+  assert.equal(activateOrchestrationDelegation(TASK_ID, { nativeAgent: 'agent-infra-lifecycle-executor', childId: 'child', parentId: 'parent', spawnMode: 'fresh', actualModel: 'executor-model', actualReasoningEffort: 'high', hostEvidence: { kind: 'codex-lifecycle-v2', startRevision: 4, ...PROVENANCE, spawnToolUseId: 'spawn-tool', spawnObservedAt: '2026-01-01T00:00:00.200Z' } }, { repoRoot: root, now: () => '2026-01-01T00:00:00.300Z', monotonicNow: () => 30 }).status, 'running');
+  fs.appendFileSync(path.join(taskDir, 'task.md'), `- 2026-01-01 00:00:00+00:00 — **Analyze Task (Round 1) [started]** by codex — started\n`);
+  return { root, taskDir, store };
+}
+
+function recoveryManifest(f: ReturnType<typeof recoveryFixture>): SandboxControlManifest {
+  const controlRoot = path.join(f.root, 'control');
+  const channelDir = path.join(controlRoot, 'channel');
+  const publicStatusDir = path.join(controlRoot, 'public');
+  const processingDir = path.join(controlRoot, 'processing');
+  for (const directory of [channelDir, publicStatusDir, processingDir]) fs.mkdirSync(directory, { recursive: true });
+  return {
+    engine: 'test', repoRoot: f.root, worktreeRoot: f.root, project: 'project', container: 'container',
+    containerIdentity: { id: 'container-id', labels: {} }, authorityEvidence: {} as SandboxControlManifest['authorityEvidence'], branch: 'feature',
+    mode: 'task-bound', taskId: TASK_ID, token: 'token', generation: 'generation-1', controlRootId: 'a'.repeat(96),
+    channelDir, publicStatusDir, processingDir, runtimeDir: path.join(controlRoot, 'runtime')
+  };
+}
+
+function recoveryRequest(id: string): SandboxControlRequest {
+  return {
+    version: 3, id, token: 'token', generation: 'generation-1', issuedAt: 1, expiresAt: 2,
+    controllerProcess: null, controllerProof: null, family: 'task-lifecycle',
+    args: [TASK_ID, 'recover-started', '--agent', 'codex', '--stage', 'analysis', '--round', '1', '--artifact', 'analysis.md', '--reason', RECOVERY_REASON]
+  };
+}
+
+function resultEvidence(id: string): SandboxControlResultEvidence {
+  const empty = crypto.createHash('sha256').update('').digest('hex');
+  return { version: 1, id, generation: 'generation-1', exitCode: 0, stdoutBytes: 0, stderrBytes: 0, stdoutSha256: empty, stderrSha256: empty, captureState: 'metadata-only' };
+}
+
+function terminalFor(manifest: SandboxControlManifest, request: SandboxControlRequest, output: unknown) {
+  return createSandboxControlTerminalResult(manifest, { id: request.id, family: request.family, operation: 'recover-started' }, JSON.stringify(output));
+}
+
+function commitPhases(manifest: SandboxControlManifest, requestId: string): void {
+  writeSandboxControlTransition(manifest, { requestId, phase: 'completed' });
+  writeSandboxControlTransition(manifest, { requestId, phase: 'evidence-written' });
+  writeSandboxControlTransition(manifest, { requestId, phase: 'publish-authorized' });
+}
 
 test('server recovery response retains release retry warning when output payload is unavailable', () => {
   const request = {
@@ -29,4 +119,61 @@ test('server recovery response retains release retry warning when output payload
   assert.equal(response.stdout, '');
   assert.match(response.stderr, /RECOVERY_RELEASE_RETRY_REQUIRED/u);
   assert.match(response.stderr, /Action: retry recover-started/u);
+});
+
+test('server recovery wiring rebuilds consecutive release failures and converges after release', () => {
+  const f = recoveryFixture();
+  const manifest = recoveryManifest(f);
+  const manifestPath = path.join(path.dirname(manifest.publicStatusDir), 'manifest.json');
+  const request = recoveryRequest('b'.repeat(32));
+  commitPhases(manifest, request.id);
+  const recover = (releaseRecovery?: (child: string, consumer: string) => boolean) => withTaskExecutionLock(
+    f.root,
+    TASK_ID,
+    'test.recover-started',
+    () => recoverStartedLifecycleUnderLock(
+      {
+        taskRef: TASK_ID,
+        intent: 'recover-started',
+        agent: 'codex',
+        stage: 'analysis',
+        round: 1,
+        artifact: 'analysis.md',
+        reason: RECOVERY_REASON
+      },
+      { repoRoot: f.root, lifecycleStore: f.store, releaseRecovery }
+    )
+  );
+  try {
+    const first = recover(() => false);
+    assert.equal(first.status, 'applied', JSON.stringify(first));
+    const firstTerminal = terminalFor(manifest, request, first);
+    const firstResponse = recoveryResponse(manifest, manifestPath, request, resultEvidence(request.id), null, firstTerminal);
+    assert.ok(firstResponse);
+    assert.match(firstResponse.stderr, /RECOVERY_RELEASE_RETRY_REQUIRED/u);
+    assert.match(firstResponse.stderr, /Action: retry recover-started with the same selector and reason/u);
+
+    const second = recover(() => false);
+    assert.equal(second.status, 'applied', JSON.stringify(second));
+    assert.equal(second.changed, false);
+    const secondTerminal = terminalFor(manifest, request, second);
+    const secondResponse = recoveryResponse(manifest, manifestPath, request, resultEvidence(request.id), null, secondTerminal);
+    assert.ok(secondResponse);
+    assert.equal(secondResponse.outputState, 'unavailable');
+    assert.match(secondResponse.stderr, /RECOVERY_RELEASE_RETRY_REQUIRED/u);
+    assert.match(secondResponse.stderr, /Action: retry recover-started with the same selector and reason/u);
+
+    const released = recover((child, consumer) => f.store.releaseRecovery(child, consumer));
+    assert.equal(released.status, 'applied', JSON.stringify(released));
+    const releasedTerminal = terminalFor(manifest, request, released);
+    const releasedResponse = recoveryResponse(manifest, manifestPath, request, resultEvidence(request.id), null, releasedTerminal);
+    assert.ok(releasedResponse);
+    assert.match(releasedResponse.stderr, /SANDBOX_CONTROL_OUTPUT_UNAVAILABLE/u);
+    assert.doesNotMatch(releasedResponse.stderr, /RECOVERY_RELEASE_RETRY_REQUIRED/u);
+    assert.equal(recover().status, 'no-op');
+    assert.equal(readRun(f.taskDir)?.receipts.filter((receipt) => receipt.status === 'aborted').length, 1);
+    assert.equal((fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8').match(/lifecycle-recovery:v1 /gu) ?? []).length, 1);
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/sandbox/control-state.test.ts
+++ b/tests/unit/sandbox/control-state.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createSandboxControlTerminalResult
+} from '../../../lib/sandbox/control/state.ts';
+import type { SandboxControlManifest } from '../../../lib/sandbox/control/protocol.ts';
+
+test('sandbox terminal evidence preserves recover-started target state for response loss', () => {
+  const manifest = { generation: 'generation-1', taskId: 'TASK-20260904-002407' } as SandboxControlManifest;
+  const result = createSandboxControlTerminalResult(
+    manifest,
+    { id: 'a'.repeat(32), family: 'task-lifecycle', operation: 'recover-started' },
+    `${JSON.stringify({ status: 'applied', changed: true, targetState: 'active' })}\n`
+  );
+
+  assert.equal(result.status, 'applied');
+  assert.equal(result.changed, true);
+  assert.equal(result.targetState, 'active');
+});

--- a/tests/unit/sandbox/control-state.test.ts
+++ b/tests/unit/sandbox/control-state.test.ts
@@ -11,10 +11,16 @@ test('sandbox terminal evidence preserves recover-started target state for respo
   const result = createSandboxControlTerminalResult(
     manifest,
     { id: 'a'.repeat(32), family: 'task-lifecycle', operation: 'recover-started' },
-    `${JSON.stringify({ status: 'applied', changed: true, targetState: 'active' })}\n`
+    `${JSON.stringify({
+      status: 'applied', changed: true, targetState: 'active',
+      warning: { code: 'RECOVERY_RELEASE_RETRY_REQUIRED', message: 'claim retained', action: 'retry recover-started' }
+    })}\n`
   );
 
   assert.equal(result.status, 'applied');
   assert.equal(result.changed, true);
   assert.equal(result.targetState, 'active');
+  assert.deepEqual(result.warning, {
+    code: 'RECOVERY_RELEASE_RETRY_REQUIRED', message: 'claim retained', action: 'retry recover-started'
+  });
 });

--- a/tests/unit/task/control-authority.test.ts
+++ b/tests/unit/task/control-authority.test.ts
@@ -8,6 +8,10 @@ import test from 'node:test';
 import { pathToFileURL } from 'node:url';
 
 import { createCodexCapabilityStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/capability-store.ts';
+import { applyTaskEvent } from '../../../lib/task/events.ts';
+import { createDirectHostExecutionContext, dispatchTaskControlOperation, parseTaskControlOperation } from '../../../lib/task/control-authority.ts';
+import type { TaskControlOperation } from '../../../lib/task/control-authority.ts';
+import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
 import {
   consumeLifecycleRecoveryAttestation,
   issueLifecycleRecoveryAttestation,
@@ -388,4 +392,51 @@ test('lifecycle recovery compensates a retained expired capability tombstone aft
   assert.equal(store.findByRecoveryOperation(selector.operationId)[0]?.status, 'consumed');
   fs.rmSync(root, { recursive: true, force: true });
   fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test('production recovery authority and task-event share one task lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lifecycle-authority-competition-'));
+  const taskId = 'TASK-20260101-000009';
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', taskId);
+  const taskPath = path.join(taskDir, 'task.md');
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(taskPath, [
+    '---', `id: ${taskId}`, 'status: active', 'current_step: code',
+    'assigned_to: codex', 'updated_at: 2026-01-01 00:00:00+00:00', 'agent_infra_version: v0.9.16-alpha.0',
+    '---', '', '# Recovery fixture', '', '## Activity Log', ''
+  ].join('\n'));
+  const recoveryOperation = parseTaskControlOperation('task-lifecycle', [
+    taskId, 'recover-started', '--agent', 'codex', '--stage', 'code', '--round', '1',
+    '--artifact', 'code.md', '--reason', 'competing recovery request'
+  ]);
+  let recoveryPromise: Promise<unknown> | undefined;
+  let eventResult: ReturnType<typeof applyTaskEvent> | undefined;
+  const taskBefore = fs.readFileSync(taskPath, 'utf8');
+  try {
+    withTaskExecutionLock(root, taskId, 'test-holder', () => {
+      recoveryPromise = dispatchTaskControlOperation(
+        createDirectHostExecutionContext({ repoRoot: root }),
+        recoveryOperation as Extract<TaskControlOperation, { family: 'task-lifecycle' }>
+      );
+      eventResult = applyTaskEvent({
+        taskRef: taskId,
+        event: 'plan.completed',
+        agent: 'codex',
+        initiator: 'model',
+        requestId: 'competition:task-event',
+        reasonCode: 'user-request',
+        artifact: 'plan.md',
+        artifactSha256: 'a'.repeat(64),
+        semanticDigest: 'b'.repeat(64)
+      }, { repoRoot: root });
+    });
+    const recoveryResult = await recoveryPromise! as { status: string; error?: { code?: string } | null };
+    assert.equal(recoveryResult.status, 'owner-unknown');
+    assert.equal(recoveryResult.error?.code, 'ORCHESTRATION_LOCK_BUSY');
+    assert.equal(eventResult?.status, 'failed');
+    assert.equal(eventResult?.error?.code, 'EVENT_TRANSITION_INVALID');
+    assert.deepEqual(fs.readFileSync(taskPath, 'utf8'), taskBefore);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/task/control-recovery.test.ts
+++ b/tests/unit/task/control-recovery.test.ts
@@ -74,7 +74,7 @@ test('every registered mutation requires a matching domain contract', () => {
       ...(operation.intent === 'recover-started' ? { targetState: 'active' } : {})
     };
     const domain = operation.intent === 'recover-started'
-      ? { consistent: true, recovery: true, targetState: 'active' }
+      ? { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' }
       : { consistent: true };
     assert.equal(classifySandboxControlRecovery({
       operation,
@@ -97,11 +97,38 @@ test('recover-started response-loss recovery requires durable target and domain 
     requestId: binding.requestId, generation: binding.generation, taskId: binding.taskId,
     intentDigest: binding.intentDigest, status: 'applied', changed: true, targetState: 'active'
   };
-  const valid = { consistent: true, recovery: true, targetState: 'active' };
+  const valid = { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' };
   assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: result, domain: valid, criticalPhases }).outcome, 'success');
   assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: result, domain: { consistent: true }, criticalPhases }).outcome, 'unknown');
   assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: { ...result, targetState: null }, domain: valid, criticalPhases }).outcome, 'unknown');
   assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: { ...result, status: 'no-op', changed: false }, domain: valid, criticalPhases }).outcome, 'success');
+});
+
+test('recover-started response-loss recovery preserves a release retry warning', () => {
+  const operation = findSandboxControlRecoveryOperation('task-lifecycle', 'recover-started')!;
+  const binding = operationRecoveryBinding('g'.repeat(32), 'generation-8', 'TASK-20260904-002407', operation.family, operation.intent);
+  const warning = {
+    code: 'RECOVERY_RELEASE_RETRY_REQUIRED',
+    message: 'protected claim could not be released',
+    action: 'retry recover-started'
+  };
+  const result = {
+    requestId: binding.requestId, generation: binding.generation, taskId: binding.taskId,
+    intentDigest: binding.intentDigest, status: 'applied', changed: true, targetState: 'active', warning
+  };
+  const domain = {
+    consistent: true, recovery: true, targetState: 'active', recoveryState: 'retry-required', warning
+  };
+  const decision = classifySandboxControlRecovery({
+    operation, binding, startedCommitted: true, terminalResult: result, domain, criticalPhases
+  });
+  assert.deepEqual(decision, {
+    outcome: 'success', responseReconstructable: true, reasonCode: 'RECOVERY_RELEASE_RETRY_REQUIRED'
+  });
+  assert.equal(classifySandboxControlRecovery({
+    operation, binding, startedCommitted: true, terminalResult: { ...result, warning: undefined },
+    domain, criticalPhases
+  }).outcome, 'unknown');
 });
 
 test('recovery matrix distinguishes explicit failure, journal partial state, and read-only changes', () => {

--- a/tests/unit/task/control-recovery.test.ts
+++ b/tests/unit/task/control-recovery.test.ts
@@ -137,6 +137,22 @@ test('recover-started response-loss recovery preserves a release retry warning',
     domain,
     criticalPhases
   }).reasonCode, 'RECOVERY_RELEASE_RETRY_REQUIRED');
+  assert.equal(classifySandboxControlRecovery({
+    operation,
+    binding,
+    startedCommitted: true,
+    terminalResult: { ...result, warning: { action: warning.action, message: warning.message, code: warning.code } },
+    domain,
+    criticalPhases
+  }).outcome, 'success');
+  assert.equal(classifySandboxControlRecovery({
+    operation,
+    binding,
+    startedCommitted: true,
+    terminalResult: { ...result, warning: { ...warning, extra: 'unexpected' } },
+    domain,
+    criticalPhases
+  }).outcome, 'unknown');
 });
 
 test('recovery matrix distinguishes explicit failure, journal partial state, and read-only changes', () => {

--- a/tests/unit/task/control-recovery.test.ts
+++ b/tests/unit/task/control-recovery.test.ts
@@ -129,6 +129,14 @@ test('recover-started response-loss recovery preserves a release retry warning',
     operation, binding, startedCommitted: true, terminalResult: { ...result, warning: undefined },
     domain, criticalPhases
   }).outcome, 'unknown');
+  assert.equal(classifySandboxControlRecovery({
+    operation,
+    binding,
+    startedCommitted: true,
+    terminalResult: { ...result, changed: false },
+    domain,
+    criticalPhases
+  }).reasonCode, 'RECOVERY_RELEASE_RETRY_REQUIRED');
 });
 
 test('recovery matrix distinguishes explicit failure, journal partial state, and read-only changes', () => {

--- a/tests/unit/task/control-recovery.test.ts
+++ b/tests/unit/task/control-recovery.test.ts
@@ -69,20 +69,39 @@ test('every registered mutation requires a matching domain contract', () => {
     );
     const result = {
       requestId: binding.requestId, generation: binding.generation, taskId: binding.taskId,
-      intentDigest: binding.intentDigest, status: 'completed', changed: true
+      intentDigest: binding.intentDigest, status: operation.intent === 'recover-started' ? 'applied' : 'completed',
+      changed: true,
+      ...(operation.intent === 'recover-started' ? { targetState: 'active' } : {})
     };
+    const domain = operation.intent === 'recover-started'
+      ? { consistent: true, recovery: true, targetState: 'active' }
+      : { consistent: true };
     assert.equal(classifySandboxControlRecovery({
       operation,
       binding,
       startedCommitted: true,
       terminalResult: result,
-      domain: { consistent: true },
+      domain,
       criticalPhases,
     }).outcome, 'success', operation.intent);
     assert.equal(classifySandboxControlRecovery({
       operation, binding, startedCommitted: true, terminalResult: result
     }).outcome, 'unknown', `${operation.family}:${operation.intent} missing domain`);
   }
+});
+
+test('recover-started response-loss recovery requires durable target and domain evidence', () => {
+  const operation = findSandboxControlRecoveryOperation('task-lifecycle', 'recover-started')!;
+  const binding = operationRecoveryBinding('f'.repeat(32), 'generation-7', 'TASK-20260904-002407', operation.family, operation.intent);
+  const result = {
+    requestId: binding.requestId, generation: binding.generation, taskId: binding.taskId,
+    intentDigest: binding.intentDigest, status: 'applied', changed: true, targetState: 'active'
+  };
+  const valid = { consistent: true, recovery: true, targetState: 'active' };
+  assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: result, domain: valid, criticalPhases }).outcome, 'success');
+  assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: result, domain: { consistent: true }, criticalPhases }).outcome, 'unknown');
+  assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: { ...result, targetState: null }, domain: valid, criticalPhases }).outcome, 'unknown');
+  assert.equal(classifySandboxControlRecovery({ operation, binding, startedCommitted: true, terminalResult: { ...result, status: 'no-op', changed: false }, domain: valid, criticalPhases }).outcome, 'success');
 });
 
 test('recovery matrix distinguishes explicit failure, journal partial state, and read-only changes', () => {

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createCodexLifecycleStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/store.ts';
+import { activateOrchestrationDelegation, beginOrResumeOrchestration, dispatchOrchestrationDelegation, prepareOrchestrationDelegation, readRun } from '../../../lib/task/orchestration.ts';
+import { recoverStartedLifecycleUnderLock } from '../../../lib/task/lifecycle-recovery.ts';
+import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
+
+const TASK_ID = 'TASK-20260101-000001';
+const MODEL_POLICY = {
+  executor: { model: 'executor-model', reasoningEffort: 'high' },
+  reviewer: { model: 'reviewer-model', reasoningEffort: 'high' }
+} as const;
+const PROVENANCE = {
+  protocolVersion: 3,
+  packageVersion: '0.9.16-alpha.0',
+  internalExecutableBuildHash: 'a'.repeat(64),
+  lifecycleContractHash: 'b'.repeat(64),
+  hookDefinitionHash: 'hook-hash',
+  hookSource: 'project' as const,
+  hookSourcePathDigest: 'c'.repeat(64),
+  hookSourceHash: 'd'.repeat(64),
+  capabilitySessionId: 'parent',
+  capabilityTurnId: 'parent-turn',
+  capabilityToolUseId: 'capability-tool',
+  controllerInstanceDigest: 'e'.repeat(64),
+  controlGeneration: 'generation-1'
+} as const;
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lifecycle-recovery-'));
+  const taskDir = path.join(root, '.agents', 'workspace', 'active', TASK_ID);
+  const storeRoot = path.join(root, 'runtime-lifecycle');
+  fs.mkdirSync(taskDir, { recursive: true });
+  fs.writeFileSync(path.join(taskDir, 'task.md'), `---\nid: ${TASK_ID}\nstatus: active\ncurrent_step: requirement-analysis\nassigned_to: codex\nupdated_at: old\nagent_infra_version: v0.9.16-alpha.0\n---\n\n# Task\n\n## Review Disagreement Ledger\n\n| id | stage | round | severity | status | evidence |\n|----|-------|-------|----------|--------|----------|\n\n## Activity Log\n`);
+  const store = createCodexLifecycleStore({ root: storeRoot, cliVersion: '0.147.0', now: () => '2026-01-01T00:00:00.200Z' });
+  store.apply({ type: 'hook-spawn', sessionId: 'parent', turnId: 'parent-turn', toolUseId: 'spawn-tool', nativeAgent: 'agent-infra-lifecycle-executor', hookDefinitionHash: 'hook-hash', requestedModel: 'executor-model', requestedReasoningEffort: 'high' });
+  store.apply({ type: 'hook-child', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child', parentThreadId: 'parent', nativeAgent: 'agent-infra-lifecycle-executor' });
+  store.apply({ type: 'app-thread', childThreadId: 'child', parentThreadId: 'parent', forkedFromId: null, sourceParentThreadId: 'parent', nativeAgent: 'agent-infra-lifecycle-executor' });
+  store.apply({ type: 'app-settings', childThreadId: 'child', model: 'executor-model', reasoningEffort: 'high' });
+  store.apply({ type: 'app-terminal', childThreadId: 'child', turnId: 'child-turn', status: 'completed' });
+  store.apply({ type: 'hook-stop', sessionId: 'parent', turnId: 'child-turn', childThreadId: 'child', nativeAgent: 'agent-infra-lifecycle-executor' });
+  const begin = beginOrResumeOrchestration(TASK_ID, { repoRoot: root, client: 'codex', modelPolicy: MODEL_POLICY, id: () => 'run-1', now: () => '2026-01-01T00:00:00.000Z' });
+  assert.equal(begin.status, 'running');
+  const prepared = prepareOrchestrationDelegation(TASK_ID, { client: 'codex', requestedModel: 'executor-model', requestedReasoningEffort: 'high', lifecycleProvenance: PROVENANCE }, { repoRoot: root, supportsLifecycleDelegation: () => true, captureWorkspace: () => 'before-tree', id: () => 'receipt-1', now: () => '2026-01-01T00:00:00.100Z', monotonicNow: () => 10 });
+  assert.equal(prepared.status, 'running', JSON.stringify(prepared));
+  const dispatched = dispatchOrchestrationDelegation(TASK_ID, { repoRoot: root, now: () => '2026-01-01T00:00:00.150Z', monotonicNow: () => 20 });
+  assert.equal(dispatched.status, 'running', JSON.stringify(dispatched));
+  const activated = activateOrchestrationDelegation(TASK_ID, { nativeAgent: 'agent-infra-lifecycle-executor', childId: 'child', parentId: 'parent', spawnMode: 'fresh', actualModel: 'executor-model', actualReasoningEffort: 'high', hostEvidence: { kind: 'codex-lifecycle-v2', startRevision: 4, ...PROVENANCE, spawnToolUseId: 'spawn-tool', spawnObservedAt: '2026-01-01T00:00:00.200Z' } }, { repoRoot: root, now: () => '2026-01-01T00:00:00.300Z', monotonicNow: () => 30 });
+  assert.equal(activated.status, 'running', JSON.stringify(activated));
+  fs.appendFileSync(path.join(taskDir, 'task.md'), '- 2026-01-01 00:00:00+00:00 — **Analyze Task (Round 1) [started]** by codex — started\n');
+  return { root, taskDir, store };
+}
+
+function recover(f: ReturnType<typeof fixture>, releaseRecovery?: (child: string, consumer: string) => boolean) {
+  return withTaskExecutionLock(path.resolve(f.taskDir, '../../../..'), TASK_ID, 'test.recover-started', () => recoverStartedLifecycleUnderLock({ taskRef: TASK_ID, intent: 'recover-started', agent: 'codex', stage: 'analysis', round: 1, artifact: 'analysis.md', reason: 'native child terminated before result was known' }, { repoRoot: path.resolve(f.taskDir, '../../../..'), lifecycleStore: f.store, releaseRecovery }));
+}
+
+test('recover-started claims, aborts, logs, releases, and replays as no-op', () => {
+  const f = fixture();
+  try {
+    const first = recover(f);
+    assert.equal(first.status, 'applied', JSON.stringify(first));
+    assert.equal(first.changed, true);
+    assert.throws(() => f.store.read('child'), /not found uniquely/u);
+    assert.equal(readRun(f.taskDir)?.pendingDelegation, null);
+    assert.equal(readRun(f.taskDir)?.receipts[0]?.status, 'aborted');
+    const content = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+    assert.match(content, /Analyze Task \(Round 1\) \[aborted\]/u);
+    assert.match(content, /lifecycle-recovery:v1 /u);
+    assert.equal(recover(f).status, 'no-op');
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('recover-started retries release after a terminal mutation whose release failed', () => {
+  const f = fixture();
+  try {
+    const first = recover(f, () => false);
+    assert.equal(first.status, 'applied', JSON.stringify(first));
+    assert.equal(first.warning?.code, 'RECOVERY_RELEASE_RETRY_REQUIRED');
+    assert.notEqual(f.store.read('child').consumer, null);
+    const second = recover(f, (child, consumer) => f.store.releaseRecovery(child, consumer));
+    assert.equal(second.status, 'applied');
+    assert.throws(() => f.store.read('child'), /not found uniquely/u);
+    assert.equal(recover(f).status, 'no-op');
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -201,6 +201,27 @@ test('recover-started retries release after a terminal mutation whose release fa
   }
 });
 
+test('recover-started replays a claim-only cleanup boundary', () => {
+  const f = fixture();
+  try {
+    const consumer = `lifecycle-recovery:${TASK_ID}:receipt-1`;
+    const claimed = f.store.claimRecovery('child', TASK_ID, 'receipt-1', 'hook-hash');
+    assert.equal(claimed.consumer, consumer);
+    assert.equal(f.store.expireBefore('2099-01-01T00:00:00.000Z'), 0);
+    assert.equal(f.store.read('child').consumer, consumer);
+
+    const recovered = recover(f);
+    assert.equal(recovered.status, 'applied', JSON.stringify(recovered));
+    assert.equal(recovered.changed, true);
+    assert.throws(() => f.store.read('child'), /not found uniquely/u);
+    assert.equal(readRun(f.taskDir)?.receipts.filter((receipt) => receipt.status === 'aborted').length, 1);
+    assert.equal((fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8').match(/lifecycle-recovery:v1 /gu) ?? []).length, 1);
+    assert.equal(recover(f).status, 'no-op');
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
 test('recover-started preserves retry evidence after consecutive release failures', () => {
   const f = fixture();
   try {

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -201,6 +201,78 @@ test('recover-started retries release after a terminal mutation whose release fa
   }
 });
 
+test('recover-started preserves retry evidence after consecutive release failures', () => {
+  const f = fixture();
+  try {
+    const first = recover(f, () => false);
+    assert.equal(first.status, 'applied', JSON.stringify(first));
+    assert.equal(first.changed, true);
+    const second = recover(f, () => false);
+    assert.equal(second.status, 'applied', JSON.stringify(second));
+    assert.equal(second.changed, false);
+    assert.deepEqual(readLifecycleRecoveryDomainEvidence(
+      f.root,
+      recoveryRequest,
+      { status: 'applied', changed: false, targetState: 'active', warning: second.warning },
+      { lifecycleStore: f.store }
+    ), {
+      consistent: true,
+      recovery: true,
+      targetState: 'active',
+      recoveryState: 'retry-required',
+      warning: second.warning
+    });
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('recover-started replays each persisted boundary without duplicating recovery facts', () => {
+  const failedWrite = {
+    status: 'failed',
+    requestRef: TASK_ID,
+    expectedState: 'active',
+    taskId: TASK_ID,
+    taskMdPath: null,
+    actualState: 'active',
+    changed: false,
+    operations: [],
+    timestamp: null,
+    agentInfraVersion: null,
+    error: { code: 'TASK_READ_FAILED', message: 'injected log write failure' }
+  } as ReturnType<typeof writeTask>;
+
+  const beforeLog = fixture();
+  try {
+    const first = recover(beforeLog, undefined, {}, { writeTask: () => failedWrite });
+    assert.equal(first.error?.code, 'RECOVERY_LOG_WRITE_FAILED');
+    assert.equal(readRun(beforeLog.taskDir)?.receipts.length, 1);
+    const retried = recover(beforeLog);
+    assert.equal(retried.status, 'applied', JSON.stringify(retried));
+    assert.equal(readRun(beforeLog.taskDir)?.receipts.length, 1);
+    assert.equal((fs.readFileSync(path.join(beforeLog.taskDir, 'task.md'), 'utf8').match(/lifecycle-recovery:v1 /gu) ?? []).length, 1);
+  } finally {
+    fs.rmSync(beforeLog.root, { recursive: true, force: true });
+  }
+
+  const beforeRelease = fixture();
+  try {
+    const first = recover(beforeRelease, undefined, {}, { verifyRecoveryCommit: () => ({ ok: false, message: 'injected commit verification failure' }) });
+    assert.equal(first.error?.code, 'RECOVERY_COMMIT_VERIFY_FAILED');
+    assert.equal(readRun(beforeRelease.taskDir)?.receipts.length, 1);
+    const retried = recover(beforeRelease, () => false);
+    assert.equal(retried.status, 'applied', JSON.stringify(retried));
+    assert.equal(retried.warning?.code, 'RECOVERY_RELEASE_RETRY_REQUIRED');
+    assert.equal(readRun(beforeRelease.taskDir)?.receipts.length, 1);
+    assert.equal((fs.readFileSync(path.join(beforeRelease.taskDir, 'task.md'), 'utf8').match(/lifecycle-recovery:v1 /gu) ?? []).length, 1);
+    const released = recover(beforeRelease, (child, consumer) => beforeRelease.store.releaseRecovery(child, consumer));
+    assert.equal(released.status, 'applied', JSON.stringify(released));
+    assert.equal(recover(beforeRelease).status, 'no-op');
+  } finally {
+    fs.rmSync(beforeRelease.root, { recursive: true, force: true });
+  }
+});
+
 test('recover-started reports every durable recovery failure code', () => {
   const failedWrite = {
     status: 'failed',

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -6,7 +6,11 @@ import test from 'node:test';
 
 import { createCodexLifecycleStore } from '../../../lib/agent-clients/adapters/codex-lifecycle/store.ts';
 import { activateOrchestrationDelegation, beginOrResumeOrchestration, dispatchOrchestrationDelegation, prepareOrchestrationDelegation, readRun } from '../../../lib/task/orchestration.ts';
-import { recoverStartedLifecycleUnderLock } from '../../../lib/task/lifecycle-recovery.ts';
+import {
+  readLifecycleRecoveryDomainEvidence,
+  recoverStartedLifecycleUnderLock
+} from '../../../lib/task/lifecycle-recovery.ts';
+import type { LifecycleRecoveryRequest } from '../../../lib/task/lifecycle-recovery.ts';
 import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
@@ -55,8 +59,22 @@ function fixture() {
   return { root, taskDir, store };
 }
 
-function recover(f: ReturnType<typeof fixture>, releaseRecovery?: (child: string, consumer: string) => boolean) {
-  return withTaskExecutionLock(path.resolve(f.taskDir, '../../../..'), TASK_ID, 'test.recover-started', () => recoverStartedLifecycleUnderLock({ taskRef: TASK_ID, intent: 'recover-started', agent: 'codex', stage: 'analysis', round: 1, artifact: 'analysis.md', reason: 'native child terminated before result was known' }, { repoRoot: path.resolve(f.taskDir, '../../../..'), lifecycleStore: f.store, releaseRecovery }));
+const recoveryRequest: LifecycleRecoveryRequest = {
+  taskRef: TASK_ID,
+  intent: 'recover-started',
+  agent: 'codex',
+  stage: 'analysis',
+  round: 1,
+  artifact: 'analysis.md',
+  reason: 'native child terminated before result was known'
+};
+
+function recover(
+  f: ReturnType<typeof fixture>,
+  releaseRecovery?: (child: string, consumer: string) => boolean,
+  overrides: Partial<LifecycleRecoveryRequest> = {}
+) {
+  return withTaskExecutionLock(path.resolve(f.taskDir, '../../../..'), TASK_ID, 'test.recover-started', () => recoverStartedLifecycleUnderLock({ ...recoveryRequest, ...overrides }, { repoRoot: path.resolve(f.taskDir, '../../../..'), lifecycleStore: f.store, releaseRecovery }));
 }
 
 test('recover-started claims, aborts, logs, releases, and replays as no-op', () => {
@@ -71,7 +89,80 @@ test('recover-started claims, aborts, logs, releases, and replays as no-op', () 
     const content = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
     assert.match(content, /Analyze Task \(Round 1\) \[aborted\]/u);
     assert.match(content, /lifecycle-recovery:v1 /u);
+    assert.deepEqual(readLifecycleRecoveryDomainEvidence(
+      f.root,
+      recoveryRequest,
+      { status: 'applied', changed: true, targetState: 'active' },
+      { lifecycleStore: f.store }
+    ), { consistent: true, recovery: true, targetState: 'active' });
     assert.equal(recover(f).status, 'no-op');
+    assert.deepEqual(readLifecycleRecoveryDomainEvidence(
+      f.root,
+      recoveryRequest,
+      { status: 'no-op', changed: false, targetState: 'active' },
+      { lifecycleStore: f.store }
+    ), { consistent: true, recovery: true, targetState: 'active' });
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('recover-started fails closed for selector, ownership, orchestration, and ambiguity conflicts', () => {
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string][] = [
+    ['selector mismatch', () => undefined, 'RECOVERY_SELECTOR_MISMATCH'],
+    ['other consumer', (f) => { f.store.consume('child', 'other-consumer'); }, 'RECOVERY_CONSUMER_CONFLICT'],
+    ['orchestration missing', (f) => { fs.rmSync(path.join(f.taskDir, 'orchestration.json')); }, 'RECOVERY_ORCHESTRATION_MISSING'],
+    ['ambiguous selector', (f) => { fs.appendFileSync(path.join(f.taskDir, 'task.md'), '- 2026-01-01 00:00:00+00:00 — **Analyze Task (Round 1) [started]** by codex — started\n'); }, 'RECOVERY_SELECTOR_AMBIGUOUS']
+  ];
+  for (const [name, run, expected] of cases) {
+    const f = fixture();
+    try {
+      run(f);
+      const result = name === 'selector mismatch' ? recover(f, undefined, { agent: 'claude' }) : recover(f);
+      assert.equal(result.error?.code, expected, name);
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('recover-started rejects expired, invalid, and tampered durable evidence', () => {
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string][] = [
+    ['expired stop evidence', (f) => { assert.equal(f.store.expireBefore('2099-01-01T00:00:00.000Z'), 1); }, 'RECOVERY_STOP_EVIDENCE_MISSING'],
+    ['invalid store record', (f) => {
+      const file = fs.readdirSync(f.store.root).find((entry) => /^[a-f0-9]{64}\.json$/u.test(entry));
+      assert.ok(file);
+      fs.writeFileSync(path.join(f.store.root, file!), '{invalid\n');
+    }, 'RECOVERY_STORE_UNKNOWN'],
+    ['duplicate terminal', (f) => {
+      const first = recover(f);
+      assert.equal(first.status, 'applied');
+      const updated = fs.readFileSync(path.join(f.taskDir, 'task.md'), 'utf8');
+      const line = updated.split('\n').find((entry) => entry.includes(' [aborted]') && entry.includes('lifecycle-recovery:v1 '));
+      assert.ok(line);
+      fs.appendFileSync(path.join(f.taskDir, 'task.md'), `${line}\n`);
+    }, 'RECOVERY_SELECTOR_AMBIGUOUS']
+  ];
+  for (const [name, setup, expected] of cases) {
+    const f = fixture();
+    try {
+      setup(f);
+      const result = recover(f);
+      assert.equal(result.error?.code, expected, name);
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('recover-started respects task execution lock competition', () => {
+  const f = fixture();
+  try {
+    withTaskExecutionLock(f.root, TASK_ID, 'test-holder', () => {
+      assert.throws(() => recover(f), (error: unknown) => (
+        error instanceof Error && (error as { code?: string }).code === 'ORCHESTRATION_LOCK_BUSY'
+      ));
+    });
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
   }

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -113,18 +113,19 @@ test('recover-started claims, aborts, logs, releases, and replays as no-op', () 
 });
 
 test('recover-started fails closed for selector, ownership, orchestration, and ambiguity conflicts', () => {
-  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string][] = [
-    ['selector mismatch', () => undefined, 'RECOVERY_SELECTOR_MISMATCH'],
-    ['other consumer', (f) => { f.store.consume('child', 'other-consumer'); }, 'RECOVERY_CONSUMER_CONFLICT'],
-    ['orchestration missing', (f) => { fs.rmSync(path.join(f.taskDir, 'orchestration.json')); }, 'RECOVERY_ORCHESTRATION_MISSING'],
-    ['ambiguous selector', (f) => { fs.appendFileSync(path.join(f.taskDir, 'task.md'), '- 2026-01-01 00:00:00+00:00 — **Analyze Task (Round 1) [started]** by codex — started\n'); }, 'RECOVERY_SELECTOR_AMBIGUOUS']
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string, 'owner-unknown' | 'conflict'][] = [
+    ['selector mismatch', () => undefined, 'RECOVERY_SELECTOR_MISMATCH', 'conflict'],
+    ['other consumer', (f) => { f.store.consume('child', 'other-consumer'); }, 'RECOVERY_CONSUMER_CONFLICT', 'conflict'],
+    ['orchestration missing', (f) => { fs.rmSync(path.join(f.taskDir, 'orchestration.json')); }, 'RECOVERY_ORCHESTRATION_MISSING', 'owner-unknown'],
+    ['ambiguous selector', (f) => { fs.appendFileSync(path.join(f.taskDir, 'task.md'), '- 2026-01-01 00:00:00+00:00 — **Analyze Task (Round 1) [started]** by codex — started\n'); }, 'RECOVERY_SELECTOR_AMBIGUOUS', 'conflict']
   ];
-  for (const [name, run, expected] of cases) {
+  for (const [name, run, expected, expectedStatus] of cases) {
     const f = fixture();
     try {
       run(f);
       const result = name === 'selector mismatch' ? recover(f, undefined, { agent: 'claude' }) : recover(f);
       assert.equal(result.error?.code, expected, name);
+      assert.equal(result.status, expectedStatus, name);
     } finally {
       fs.rmSync(f.root, { recursive: true, force: true });
     }
@@ -132,13 +133,13 @@ test('recover-started fails closed for selector, ownership, orchestration, and a
 });
 
 test('recover-started rejects expired, invalid, and tampered durable evidence', () => {
-  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string][] = [
-    ['expired stop evidence', (f) => { assert.equal(f.store.expireBefore('2099-01-01T00:00:00.000Z'), 1); }, 'RECOVERY_STOP_EVIDENCE_MISSING'],
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string, 'owner-unknown' | 'conflict'][] = [
+    ['expired stop evidence', (f) => { assert.equal(f.store.expireBefore('2099-01-01T00:00:00.000Z'), 1); }, 'RECOVERY_STOP_EVIDENCE_MISSING', 'owner-unknown'],
     ['invalid store record', (f) => {
       const file = fs.readdirSync(f.store.root).find((entry) => /^[a-f0-9]{64}\.json$/u.test(entry));
       assert.ok(file);
       fs.writeFileSync(path.join(f.store.root, file!), '{invalid\n');
-    }, 'RECOVERY_STORE_UNKNOWN'],
+    }, 'RECOVERY_STORE_UNKNOWN', 'owner-unknown'],
     ['duplicate terminal', (f) => {
       const first = recover(f);
       assert.equal(first.status, 'applied');
@@ -146,14 +147,15 @@ test('recover-started rejects expired, invalid, and tampered durable evidence', 
       const line = updated.split('\n').find((entry) => entry.includes(' [aborted]') && entry.includes('lifecycle-recovery:v1 '));
       assert.ok(line);
       fs.appendFileSync(path.join(f.taskDir, 'task.md'), `${line}\n`);
-    }, 'RECOVERY_SELECTOR_AMBIGUOUS']
+    }, 'RECOVERY_SELECTOR_AMBIGUOUS', 'conflict']
   ];
-  for (const [name, setup, expected] of cases) {
+  for (const [name, setup, expected, expectedStatus] of cases) {
     const f = fixture();
     try {
       setup(f);
       const result = recover(f);
       assert.equal(result.error?.code, expected, name);
+      assert.equal(result.status, expectedStatus, name);
     } finally {
       fs.rmSync(f.root, { recursive: true, force: true });
     }
@@ -309,7 +311,7 @@ test('recover-started reports every durable recovery failure code', () => {
     error: { code: 'TASK_READ_FAILED', message: 'log write failed' }
   } as ReturnType<typeof writeTask>;
   type RecoveryTestOptions = Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'writeTask' | 'verifyRecoveryCommit'>;
-  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string, ((f: ReturnType<typeof fixture>) => RecoveryTestOptions)?][] = [
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string, 'owner-unknown' | 'conflict', ((f: ReturnType<typeof fixture>) => RecoveryTestOptions)?][] = [
     ['invalid stop evidence', (f) => {
       const file = fs.readdirSync(f.store.root).find((entry) => /^[a-f0-9]{64}\.json$/u.test(entry));
       assert.ok(file);
@@ -318,8 +320,8 @@ test('recover-started reports every durable recovery failure code', () => {
       };
       record.state.stopEvidence.hookStopObserved = false;
       fs.writeFileSync(path.join(f.store.root, file!), `${JSON.stringify(record)}\n`);
-    }, 'RECOVERY_STOP_EVIDENCE_INVALID'],
-    ['unknown orchestration', (f) => { fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), '{invalid\n'); }, 'RECOVERY_ORCHESTRATION_UNKNOWN'],
+    }, 'RECOVERY_STOP_EVIDENCE_INVALID', 'owner-unknown'],
+    ['unknown orchestration', (f) => { fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), '{invalid\n'); }, 'RECOVERY_ORCHESTRATION_UNKNOWN', 'owner-unknown'],
     ['delegation unavailable', (f) => {
       const file = path.join(f.taskDir, 'orchestration.json');
       const run = JSON.parse(fs.readFileSync(file, 'utf8')) as {
@@ -329,15 +331,15 @@ test('recover-started reports every durable recovery failure code', () => {
       run.pendingDelegation = null;
       run.receipts = [];
       fs.writeFileSync(file, `${JSON.stringify(run)}\n`);
-    }, 'RECOVERY_DELEGATION_UNAVAILABLE'],
-    ['claim failed', () => undefined, 'RECOVERY_CLAIM_FAILED', (f) => ({
+    }, 'RECOVERY_DELEGATION_UNAVAILABLE', 'owner-unknown'],
+    ['claim failed', () => undefined, 'RECOVERY_CLAIM_FAILED', 'owner-unknown', (f) => ({
       lifecycleStore: {
         ...f.store,
         claimRecovery: () => { throw new Error('claim failed'); }
       } as ReturnType<typeof createCodexLifecycleStore>
     })],
-    ['log write failed', () => undefined, 'RECOVERY_LOG_WRITE_FAILED', () => ({ writeTask: () => failedWrite })],
-    ['commit verification failed', () => undefined, 'RECOVERY_COMMIT_VERIFY_FAILED', () => ({
+    ['log write failed', () => undefined, 'RECOVERY_LOG_WRITE_FAILED', 'owner-unknown', () => ({ writeTask: () => failedWrite })],
+    ['commit verification failed', () => undefined, 'RECOVERY_COMMIT_VERIFY_FAILED', 'owner-unknown', () => ({
       verifyRecoveryCommit: () => ({ ok: false, message: 'commit verification failed' })
     })],
     ['reference conflict', (f) => {
@@ -349,14 +351,15 @@ test('recover-started reports every durable recovery failure code', () => {
       };
       run.receipts[0]!.hostEvidence.stopRevision = 999;
       fs.writeFileSync(file, `${JSON.stringify(run)}\n`);
-    }, 'RECOVERY_REFERENCE_CONFLICT']
+    }, 'RECOVERY_REFERENCE_CONFLICT', 'conflict']
   ];
-  for (const [name, setup, expected, optionsForFixture] of cases) {
+  for (const [name, setup, expected, expectedStatus, optionsForFixture] of cases) {
     const f = fixture();
     try {
       setup(f);
       const result = recover(f, undefined, {}, optionsForFixture?.(f));
       assert.equal(result.error?.code, expected, name);
+      assert.equal(result.status, expectedStatus, name);
     } finally {
       fs.rmSync(f.root, { recursive: true, force: true });
     }

--- a/tests/unit/task/lifecycle-recovery.test.ts
+++ b/tests/unit/task/lifecycle-recovery.test.ts
@@ -10,8 +10,9 @@ import {
   readLifecycleRecoveryDomainEvidence,
   recoverStartedLifecycleUnderLock
 } from '../../../lib/task/lifecycle-recovery.ts';
-import type { LifecycleRecoveryRequest } from '../../../lib/task/lifecycle-recovery.ts';
+import type { LifecycleRecoveryOptions, LifecycleRecoveryRequest } from '../../../lib/task/lifecycle-recovery.ts';
 import { withTaskExecutionLock } from '../../../lib/task/task-execution-lock.ts';
+import { writeTask } from '../../../lib/task/write.ts';
 
 const TASK_ID = 'TASK-20260101-000001';
 const MODEL_POLICY = {
@@ -72,9 +73,13 @@ const recoveryRequest: LifecycleRecoveryRequest = {
 function recover(
   f: ReturnType<typeof fixture>,
   releaseRecovery?: (child: string, consumer: string) => boolean,
-  overrides: Partial<LifecycleRecoveryRequest> = {}
+  overrides: Partial<LifecycleRecoveryRequest> = {},
+  options: Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'writeTask' | 'verifyRecoveryCommit'> = {}
 ) {
-  return withTaskExecutionLock(path.resolve(f.taskDir, '../../../..'), TASK_ID, 'test.recover-started', () => recoverStartedLifecycleUnderLock({ ...recoveryRequest, ...overrides }, { repoRoot: path.resolve(f.taskDir, '../../../..'), lifecycleStore: f.store, releaseRecovery }));
+  return withTaskExecutionLock(path.resolve(f.taskDir, '../../../..'), TASK_ID, 'test.recover-started', () => recoverStartedLifecycleUnderLock(
+    { ...recoveryRequest, ...overrides },
+    { repoRoot: path.resolve(f.taskDir, '../../../..'), lifecycleStore: f.store, releaseRecovery, ...options }
+  ));
 }
 
 test('recover-started claims, aborts, logs, releases, and replays as no-op', () => {
@@ -94,14 +99,14 @@ test('recover-started claims, aborts, logs, releases, and replays as no-op', () 
       recoveryRequest,
       { status: 'applied', changed: true, targetState: 'active' },
       { lifecycleStore: f.store }
-    ), { consistent: true, recovery: true, targetState: 'active' });
+    ), { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' });
     assert.equal(recover(f).status, 'no-op');
     assert.deepEqual(readLifecycleRecoveryDomainEvidence(
       f.root,
       recoveryRequest,
       { status: 'no-op', changed: false, targetState: 'active' },
       { lifecycleStore: f.store }
-    ), { consistent: true, recovery: true, targetState: 'active' });
+    ), { consistent: true, recovery: true, targetState: 'active', recoveryState: 'released' });
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
   }
@@ -175,11 +180,92 @@ test('recover-started retries release after a terminal mutation whose release fa
     assert.equal(first.status, 'applied', JSON.stringify(first));
     assert.equal(first.warning?.code, 'RECOVERY_RELEASE_RETRY_REQUIRED');
     assert.notEqual(f.store.read('child').consumer, null);
+    assert.deepEqual(readLifecycleRecoveryDomainEvidence(
+      f.root,
+      recoveryRequest,
+      { status: 'applied', changed: true, targetState: 'active', warning: first.warning },
+      { lifecycleStore: f.store }
+    ), {
+      consistent: true,
+      recovery: true,
+      targetState: 'active',
+      recoveryState: 'retry-required',
+      warning: first.warning
+    });
     const second = recover(f, (child, consumer) => f.store.releaseRecovery(child, consumer));
     assert.equal(second.status, 'applied');
     assert.throws(() => f.store.read('child'), /not found uniquely/u);
     assert.equal(recover(f).status, 'no-op');
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('recover-started reports every durable recovery failure code', () => {
+  const failedWrite = {
+    status: 'failed',
+    requestRef: TASK_ID,
+    expectedState: 'active',
+    taskId: TASK_ID,
+    taskMdPath: null,
+    actualState: 'active',
+    changed: false,
+    operations: [],
+    timestamp: null,
+    agentInfraVersion: null,
+    error: { code: 'TASK_READ_FAILED', message: 'log write failed' }
+  } as ReturnType<typeof writeTask>;
+  type RecoveryTestOptions = Pick<LifecycleRecoveryOptions, 'lifecycleStore' | 'writeTask' | 'verifyRecoveryCommit'>;
+  const cases: readonly [string, (f: ReturnType<typeof fixture>) => void, string, ((f: ReturnType<typeof fixture>) => RecoveryTestOptions)?][] = [
+    ['invalid stop evidence', (f) => {
+      const file = fs.readdirSync(f.store.root).find((entry) => /^[a-f0-9]{64}\.json$/u.test(entry));
+      assert.ok(file);
+      const record = JSON.parse(fs.readFileSync(path.join(f.store.root, file!), 'utf8')) as {
+        state: { stopEvidence: { hookStopObserved: boolean } };
+      };
+      record.state.stopEvidence.hookStopObserved = false;
+      fs.writeFileSync(path.join(f.store.root, file!), `${JSON.stringify(record)}\n`);
+    }, 'RECOVERY_STOP_EVIDENCE_INVALID'],
+    ['unknown orchestration', (f) => { fs.writeFileSync(path.join(f.taskDir, 'orchestration.json'), '{invalid\n'); }, 'RECOVERY_ORCHESTRATION_UNKNOWN'],
+    ['delegation unavailable', (f) => {
+      const file = path.join(f.taskDir, 'orchestration.json');
+      const run = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+        pendingDelegation: unknown;
+        receipts: readonly unknown[];
+      };
+      run.pendingDelegation = null;
+      run.receipts = [];
+      fs.writeFileSync(file, `${JSON.stringify(run)}\n`);
+    }, 'RECOVERY_DELEGATION_UNAVAILABLE'],
+    ['claim failed', () => undefined, 'RECOVERY_CLAIM_FAILED', (f) => ({
+      lifecycleStore: {
+        ...f.store,
+        claimRecovery: () => { throw new Error('claim failed'); }
+      } as ReturnType<typeof createCodexLifecycleStore>
+    })],
+    ['log write failed', () => undefined, 'RECOVERY_LOG_WRITE_FAILED', () => ({ writeTask: () => failedWrite })],
+    ['commit verification failed', () => undefined, 'RECOVERY_COMMIT_VERIFY_FAILED', () => ({
+      verifyRecoveryCommit: () => ({ ok: false, message: 'commit verification failed' })
+    })],
+    ['reference conflict', (f) => {
+      const first = recover(f, () => false);
+      assert.equal(first.status, 'applied');
+      const file = path.join(f.taskDir, 'orchestration.json');
+      const run = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+        receipts: Array<{ hostEvidence: { stopRevision: number } }>;
+      };
+      run.receipts[0]!.hostEvidence.stopRevision = 999;
+      fs.writeFileSync(file, `${JSON.stringify(run)}\n`);
+    }, 'RECOVERY_REFERENCE_CONFLICT']
+  ];
+  for (const [name, setup, expected, optionsForFixture] of cases) {
+    const f = fixture();
+    try {
+      setup(f);
+      const result = recover(f, undefined, {}, optionsForFixture?.(f));
+      assert.equal(result.error?.code, expected, name);
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true });
+    }
   }
 });


### PR DESCRIPTION
## 摘要

为仅保留 lifecycle `started` 事件且执行者已消失的场景提供显式、安全、可审计的恢复路径，解除永久 `EXECUTION_BUSY`，并在执行者存活或结果未知时保持 fail-closed。

## 主要变更

- 增加 lifecycle recovery 状态机、持久化 claim/receipt 与 Activity Log 终态收敛。
- 加固 sandbox/control authority、任务锁和 recovery response wiring，覆盖重启、响应丢失、持久化边界失败及竞争场景。
- 保持同 consumer 幂等，释放后的重复恢复请求收敛为 no-op。
- 补充 claim-only cleanup/replay 回归测试，验证 protected claim、唯一 aborted receipt/log、claim release 与重复 replay。

## 验证

- `npm run typecheck`
- `npm run test:smoke:fast` — 1387 通过、0 失败
- `npm run test:smoke` — 1387 通过、0 失败
- `npm run test:core` — 2970 通过、6 跳过、0 失败
- `npm test` — 3302 通过、7 跳过、0 失败
- `git diff --check`

## 审查范围

完整分支差异已完成代码审查；Round 5 的 CD-4 claim-only cleanup/replay finding 已闭环，当前无阻塞项、主要问题或次要问题。真实宿主 crash/broker kill、非 Linux 实机及真实历史 legacy 样本仍需维护者按环境验证。

Closes #994

Generated with AI assistance
